### PR TITLE
Introduce an option which remove comments, but only from JS files (no…

### DIFF
--- a/common/changes/nickpape-remove-comments_2016-11-09-19-33.json
+++ b/common/changes/nickpape-remove-comments_2016-11-09-19-33.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/gulp-core-build-typescript",
+      "comment": "Added additional options which will remove comments and one that will turn off sourcemaps",
+      "type": "minor"
+    }
+  ],
+  "email": "nickpape@microsoft.com"
+}

--- a/common/npm-shrinkwrap.json
+++ b/common/npm-shrinkwrap.json
@@ -13,9 +13,9 @@
       "resolved": "https://registry.npmjs.org/@microsoft/gulp-core-build-mocha/-/gulp-core-build-mocha-1.0.0.tgz"
     },
     "@microsoft/gulp-core-build-typescript": {
-      "version": "1.0.1",
+      "version": "1.0.2",
       "from": "@microsoft/gulp-core-build-typescript@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/gulp-core-build-typescript/-/gulp-core-build-typescript-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/@microsoft/gulp-core-build-typescript/-/gulp-core-build-typescript-1.0.2.tgz",
       "dependencies": {
         "lodash": {
           "version": "4.15.0",
@@ -951,6 +951,18 @@
       "version": "1.2.0",
       "from": "decamelize@>=1.1.2 <2.0.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
+    },
+    "decomment": {
+      "version": "0.8.6",
+      "from": "decomment@>=0.8.2 <0.9.0",
+      "resolved": "https://registry.npmjs.org/decomment/-/decomment-0.8.6.tgz",
+      "dependencies": {
+        "esprima": {
+          "version": "2.7.3",
+          "from": "esprima@>=2.7.0 <2.8.0",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz"
+        }
+      }
     },
     "deep-eql": {
       "version": "0.1.3",
@@ -1954,6 +1966,11 @@
         }
       }
     },
+    "gulp-decomment": {
+      "version": "0.1.3",
+      "from": "gulp-decomment@>=0.1.3 <0.2.0",
+      "resolved": "https://registry.npmjs.org/gulp-decomment/-/gulp-decomment-0.1.3.tgz"
+    },
     "gulp-flatten": {
       "version": "0.2.0",
       "from": "gulp-flatten@>=0.2.0 <0.3.0",
@@ -2605,7 +2622,7 @@
     "isarray": {
       "version": "0.0.1",
       "from": "isarray@0.0.1",
-      "resolved": "http://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
     },
     "isbinaryfile": {
       "version": "3.0.1",
@@ -3487,7 +3504,7 @@
     },
     "nan": {
       "version": "2.4.0",
-      "from": "nan@>=2.3.0 <3.0.0",
+      "from": "nan@>=2.3.2 <3.0.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.4.0.tgz"
     },
     "natives": {
@@ -3596,33 +3613,33 @@
     },
     "npmx-gulp-core-build": {
       "version": "0.0.0",
-      "from": "temp_modules/npmx-gulp-core-build",
-      "resolved": "file:temp_modules/npmx-gulp-core-build"
+      "from": "temp_modules\\npmx-gulp-core-build",
+      "resolved": "file:temp_modules\\npmx-gulp-core-build"
     },
     "npmx-gulp-core-build-karma": {
       "version": "0.0.0",
-      "from": "temp_modules/npmx-gulp-core-build-karma",
-      "resolved": "file:temp_modules/npmx-gulp-core-build-karma"
+      "from": "temp_modules\\npmx-gulp-core-build-karma",
+      "resolved": "file:temp_modules\\npmx-gulp-core-build-karma"
     },
     "npmx-gulp-core-build-mocha": {
       "version": "0.0.0",
-      "from": "temp_modules/npmx-gulp-core-build-mocha",
-      "resolved": "file:temp_modules/npmx-gulp-core-build-mocha"
+      "from": "temp_modules\\npmx-gulp-core-build-mocha",
+      "resolved": "file:temp_modules\\npmx-gulp-core-build-mocha"
     },
     "npmx-gulp-core-build-sass": {
       "version": "0.0.0",
-      "from": "temp_modules/npmx-gulp-core-build-sass",
-      "resolved": "file:temp_modules/npmx-gulp-core-build-sass"
+      "from": "temp_modules\\npmx-gulp-core-build-sass",
+      "resolved": "file:temp_modules\\npmx-gulp-core-build-sass"
     },
     "npmx-gulp-core-build-serve": {
       "version": "0.0.0",
-      "from": "temp_modules/npmx-gulp-core-build-serve",
-      "resolved": "file:temp_modules/npmx-gulp-core-build-serve"
+      "from": "temp_modules\\npmx-gulp-core-build-serve",
+      "resolved": "file:temp_modules\\npmx-gulp-core-build-serve"
     },
     "npmx-gulp-core-build-typescript": {
       "version": "0.0.0",
-      "from": "temp_modules/npmx-gulp-core-build-typescript",
-      "resolved": "file:temp_modules/npmx-gulp-core-build-typescript",
+      "from": "temp_modules\\npmx-gulp-core-build-typescript",
+      "resolved": "file:temp_modules\\npmx-gulp-core-build-typescript",
       "dependencies": {
         "lodash": {
           "version": "4.15.0",
@@ -3633,28 +3650,28 @@
     },
     "npmx-gulp-core-build-webpack": {
       "version": "0.0.0",
-      "from": "temp_modules/npmx-gulp-core-build-webpack",
-      "resolved": "file:temp_modules/npmx-gulp-core-build-webpack"
+      "from": "temp_modules\\npmx-gulp-core-build-webpack",
+      "resolved": "file:temp_modules\\npmx-gulp-core-build-webpack"
     },
     "npmx-node-library-build": {
       "version": "0.0.0",
-      "from": "temp_modules/npmx-node-library-build",
-      "resolved": "file:temp_modules/npmx-node-library-build"
+      "from": "temp_modules\\npmx-node-library-build",
+      "resolved": "file:temp_modules\\npmx-node-library-build"
     },
     "npmx-package-deps-hash": {
       "version": "0.0.0",
-      "from": "temp_modules/npmx-package-deps-hash",
-      "resolved": "file:temp_modules/npmx-package-deps-hash"
+      "from": "temp_modules\\npmx-package-deps-hash",
+      "resolved": "file:temp_modules\\npmx-package-deps-hash"
     },
     "npmx-test-web-library-build": {
       "version": "0.0.0",
-      "from": "temp_modules/npmx-test-web-library-build",
-      "resolved": "file:temp_modules/npmx-test-web-library-build"
+      "from": "temp_modules\\npmx-test-web-library-build",
+      "resolved": "file:temp_modules\\npmx-test-web-library-build"
     },
     "npmx-web-build-tools-scripts": {
       "version": "0.0.0",
-      "from": "temp_modules/npmx-web-build-tools-scripts",
-      "resolved": "file:temp_modules/npmx-web-build-tools-scripts",
+      "from": "temp_modules\\npmx-web-build-tools-scripts",
+      "resolved": "file:temp_modules\\npmx-web-build-tools-scripts",
       "dependencies": {
         "camelcase": {
           "version": "3.0.0",
@@ -3675,8 +3692,8 @@
     },
     "npmx-web-library-build": {
       "version": "0.0.0",
-      "from": "temp_modules/npmx-web-library-build",
-      "resolved": "file:temp_modules/npmx-web-library-build",
+      "from": "temp_modules\\npmx-web-library-build",
+      "resolved": "file:temp_modules\\npmx-web-library-build",
       "dependencies": {
         "node-notifier": {
           "version": "4.6.1",

--- a/common/temp_modules/npmx-gulp-core-build-typescript/package.json
+++ b/common/temp_modules/npmx-gulp-core-build-typescript/package.json
@@ -16,6 +16,7 @@
     "gulp": "~3.9.1",
     "gulp-cache": "~0.4.5",
     "gulp-changed": "~1.3.2",
+    "gulp-decomment": "~0.1.3",
     "gulp-plumber": "~1.1.0",
     "gulp-sourcemaps": "~1.6.0",
     "gulp-texttojs": "~1.0.3",

--- a/gulp-core-build-typescript/.vscode/settings.json
+++ b/gulp-core-build-typescript/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "typescript.check.workspaceVersion": false
+}

--- a/gulp-core-build-typescript/README.md
+++ b/gulp-core-build-typescript/README.md
@@ -62,8 +62,8 @@ Optional override of the typescript compiler. Set this to the result of require(
 
 Default: `undefined`
 
-### removeCommentsFromTypeScript
-Removes comments from all generated `.ts` files. Will **not** remove comments from `.d.ts` files.
+### removeCommentsFromJavaScript
+Removes comments from all generated `.js` files. Will **not** remove comments from generated `.d.ts` files.
 
 Default: `false`
 

--- a/gulp-core-build-typescript/README.md
+++ b/gulp-core-build-typescript/README.md
@@ -62,6 +62,11 @@ Optional override of the typescript compiler. Set this to the result of require(
 
 Default: `undefined`
 
+### removeCommentsFromTypeScript
+Removes comments from all generated `.ts` files. Will **not** remove comments from `.d.ts` files.
+
+Default: `false`
+
 # TSLintTask
 ## Usage
 The task for linting the TypeScript code.

--- a/gulp-core-build-typescript/README.md
+++ b/gulp-core-build-typescript/README.md
@@ -67,6 +67,11 @@ Removes comments from all generated `.js` files. Will **not** remove comments fr
 
 Default: `false`
 
+### emitSourceMaps
+If true, creates sourcemap files which are useful for debugging.
+
+Default: `true`
+
 # TSLintTask
 ## Usage
 The task for linting the TypeScript code.

--- a/gulp-core-build-typescript/package.json
+++ b/gulp-core-build-typescript/package.json
@@ -22,6 +22,7 @@
     "gulp": "~3.9.1",
     "gulp-cache": "~0.4.5",
     "gulp-changed": "~1.3.2",
+    "gulp-decomment": "~0.1.3",
     "gulp-plumber": "~1.1.0",
     "gulp-sourcemaps": "~1.6.0",
     "gulp-texttojs": "~1.0.3",

--- a/gulp-core-build-typescript/src/TypeScriptTask.ts
+++ b/gulp-core-build-typescript/src/TypeScriptTask.ts
@@ -201,7 +201,7 @@ export class TypeScriptTask extends GulpTask<ITypeScriptTaskConfig> {
     // tslint:disable-next-line:typedef
     let jsResult = (this.taskConfig.removeCommentsFromJavaScript
       ? tsResult.js.pipe(require('gulp-decomment')({
-        space: !!this.taskConfig.emitSourceMaps
+        space: !!this.taskConfig.emitSourceMaps /* turn comments into spaces to preserve sourcemaps */
       }))
       : tsResult.js);
 

--- a/gulp-core-build-typescript/src/TypeScriptTask.ts
+++ b/gulp-core-build-typescript/src/TypeScriptTask.ts
@@ -201,7 +201,7 @@ export class TypeScriptTask extends GulpTask<ITypeScriptTaskConfig> {
     // tslint:disable-next-line:typedef
     let jsResult = (this.taskConfig.removeCommentsFromJavaScript
       ? tsResult.js.pipe(require('gulp-decomment')({
-        space: true /* leave this on for sourcemaps */
+        space: !!this.taskConfig.emitSourceMaps
       }))
       : tsResult.js);
 

--- a/gulp-core-build-typescript/src/TypeScriptTask.ts
+++ b/gulp-core-build-typescript/src/TypeScriptTask.ts
@@ -94,8 +94,8 @@ export class TypeScriptTask extends GulpTask<ITypeScriptTaskConfig> {
       'src/**/*.json',
       'src/**/*.jsx'
     ],
-    removeCommentsFromJavaScript: true,
-    emitSourceMaps: false
+    removeCommentsFromJavaScript: false,
+    emitSourceMaps: true
   };
 
   private _tsProject: ts.Project;

--- a/gulp-core-build-typescript/src/TypeScriptTask.ts
+++ b/gulp-core-build-typescript/src/TypeScriptTask.ts
@@ -88,7 +88,7 @@ export class TypeScriptTask extends GulpTask<ITypeScriptTaskConfig> {
       'src/**/*.json',
       'src/**/*.jsx'
     ],
-    removeCommentsFromTypeScript: true
+    removeCommentsFromTypeScript: false
   };
 
   private _tsProject: ts.Project;

--- a/gulp-core-build-typescript/src/TypeScriptTask.ts
+++ b/gulp-core-build-typescript/src/TypeScriptTask.ts
@@ -47,9 +47,9 @@ export interface ITypeScriptTaskConfig {
   /* tslint:enable:no-any */
 
   /**
-   * Removes comments from all generated `.ts` files. Will **not** remove comments from `.d.ts` files.
+   * Removes comments from all generated `.js` files. Will **not** remove comments from generated `.d.ts` files.
    */
-  removeCommentsFromTypeScript?: boolean;
+  removeCommentsFromJavaScript?: boolean;
 }
 
 export class TypeScriptTask extends GulpTask<ITypeScriptTaskConfig> {
@@ -88,7 +88,7 @@ export class TypeScriptTask extends GulpTask<ITypeScriptTaskConfig> {
       'src/**/*.json',
       'src/**/*.jsx'
     ],
-    removeCommentsFromTypeScript: false
+    removeCommentsFromJavaScript: false
   };
 
   private _tsProject: ts.Project;
@@ -147,7 +147,7 @@ export class TypeScriptTask extends GulpTask<ITypeScriptTaskConfig> {
       .pipe(ts(tsProject, undefined, this.taskConfig.reporter));
 
     // tslint:disable-next-line:typedef
-    const jsResult = (this.taskConfig.removeCommentsFromTypeScript
+    let jsResult = (this.taskConfig.removeCommentsFromJavaScript
       ? tsResult.js.pipe(require('gulp-decomment')({
         space: true /* leave this on for sourcemaps */
       }))
@@ -182,7 +182,7 @@ export class TypeScriptTask extends GulpTask<ITypeScriptTaskConfig> {
         .pipe(ts(tsAMDProject, undefined, this.taskConfig.reporter));
 
       // tslint:disable-next-line:typedef
-      const jsResult = (this.taskConfig.removeCommentsFromTypeScript
+      jsResult = (this.taskConfig.removeCommentsFromJavaScript
         ? tsResult.js.pipe(require('gulp-decomment')({
           space: true /* leave this on for sourcemaps */
         }))


### PR DESCRIPTION
Introduce an option which remove comments, but only from HS files (no… .d.ts files)

This is useful since we have had cases where we don't want to add a comment to the lib/ folder's output of JS files. We couldn't use the compiler option as it would have removed comments from .d.ts and thus intellisense.