### PR TITLE
Enable PackageDependencies.json in npmx.json

### DIFF
--- a/common/reviews/PackageDependencies.json
+++ b/common/reviews/PackageDependencies.json
@@ -1,0 +1,303 @@
+// DO NOT ADD COMMENTS IN THIS FILE.  They will be lost when the NPMX tool resaves it.
+{
+  "settings": {
+    "ignoredNpmScopes": [
+      "@types"
+    ]
+  },
+  "browserPackages": [],
+  "nonBrowserPackages": [
+    {
+      "name": "@microsoft/gulp-core-build",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
+      "name": "@microsoft/gulp-core-build-karma",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
+      "name": "@microsoft/gulp-core-build-mocha",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
+      "name": "@microsoft/gulp-core-build-sass",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
+      "name": "@microsoft/gulp-core-build-serve",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
+      "name": "@microsoft/gulp-core-build-typescript",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
+      "name": "@microsoft/gulp-core-build-webpack",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
+      "name": "@microsoft/load-themed-styles",
+      "allowedCategories": [ "libraries", "other" ]
+    },
+    {
+      "name": "@microsoft/node-library-build",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
+      "name": "@microsoft/web-library-build",
+      "allowedCategories": [ "other" ]
+    },
+    {
+      "name": "autoprefixer",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
+      "name": "chai",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
+      "name": "deasync",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
+      "name": "del",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
+      "name": "end-of-stream",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
+      "name": "es6-promise",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
+      "name": "express",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
+      "name": "fs-extra",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
+      "name": "fsevents",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
+      "name": "gulp",
+      "allowedCategories": [ "libraries", "other" ]
+    },
+    {
+      "name": "gulp-cache",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
+      "name": "gulp-changed",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
+      "name": "gulp-clean-css",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
+      "name": "gulp-clip-empty-files",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
+      "name": "gulp-clone",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
+      "name": "gulp-connect",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
+      "name": "gulp-decomment",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
+      "name": "gulp-flatten",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
+      "name": "gulp-if",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
+      "name": "gulp-istanbul",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
+      "name": "gulp-karma",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
+      "name": "gulp-mocha",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
+      "name": "gulp-open",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
+      "name": "gulp-plumber",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
+      "name": "gulp-postcss",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
+      "name": "gulp-replace",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
+      "name": "gulp-sass",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
+      "name": "gulp-sourcemaps",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
+      "name": "gulp-texttojs",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
+      "name": "gulp-typescript",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
+      "name": "gulp-util",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
+      "name": "istanbul-instrumenter-loader",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
+      "name": "karma",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
+      "name": "karma-coverage",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
+      "name": "karma-mocha",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
+      "name": "karma-mocha-clean-reporter",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
+      "name": "karma-phantomjs-launcher",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
+      "name": "karma-sinon-chai",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
+      "name": "karma-webpack",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
+      "name": "lodash",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
+      "name": "lodash.merge",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
+      "name": "lolex",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
+      "name": "md5",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
+      "name": "merge2",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
+      "name": "mocha",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
+      "name": "node-forge",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
+      "name": "node-notifier",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
+      "name": "object-assign",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
+      "name": "phantomjs-polyfill",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
+      "name": "phantomjs-prebuilt",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
+      "name": "postcss-modules",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
+      "name": "pretty-hrtime",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
+      "name": "rimraf",
+      "allowedCategories": [ "libraries", "other" ]
+    },
+    {
+      "name": "semver",
+      "allowedCategories": [ "libraries", "other" ]
+    },
+    {
+      "name": "sinon",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
+      "name": "sinon-chai",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
+      "name": "sudo",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
+      "name": "through2",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
+      "name": "tslint",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
+      "name": "tslint-microsoft-contrib",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
+      "name": "typescript",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
+      "name": "webpack",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
+      "name": "yargs",
+      "allowedCategories": [ "libraries", "other" ]
+    }
+  ]
+}

--- a/npmx.json
+++ b/npmx.json
@@ -4,10 +4,13 @@
   "nodeSupportedVersionRange": ">=4.3.0",
   "commonFolder": "common",
   "projectFolderMinDepth": 1,
+  "reviewCategories": [ "libraries", "other" ],
+  "packageReviewFile": "common/reviews/PackageDependencies.json",
   "projects": [
     {
       "packageName": "@microsoft/gulp-core-build",
       "projectFolder": "gulp-core-build",
+      "reviewCategory": "libraries",
       "shouldPublish": true,
       "cyclicDependencyProjects": [
         "@microsoft/node-library-build"
@@ -16,6 +19,7 @@
     {
       "packageName": "@microsoft/gulp-core-build-karma",
       "projectFolder": "gulp-core-build-karma",
+      "reviewCategory": "libraries",
       "shouldPublish": true,
       "cyclicDependencyProjects": [
         "@microsoft/node-library-build"
@@ -24,6 +28,7 @@
     {
       "packageName": "@microsoft/gulp-core-build-mocha",
       "projectFolder": "gulp-core-build-mocha",
+      "reviewCategory": "libraries",
       "shouldPublish": true,
       "cyclicDependencyProjects": [
         "@microsoft/node-library-build"
@@ -32,6 +37,7 @@
     {
       "packageName": "@microsoft/gulp-core-build-sass",
       "projectFolder": "gulp-core-build-sass",
+      "reviewCategory": "libraries",
       "shouldPublish": true,
       "cyclicDependencyProjects": [
         "@microsoft/node-library-build"
@@ -40,6 +46,7 @@
     {
       "packageName": "@microsoft/gulp-core-build-serve",
       "projectFolder": "gulp-core-build-serve",
+      "reviewCategory": "libraries",
       "shouldPublish": true,
       "cyclicDependencyProjects": [
         "@microsoft/node-library-build"
@@ -48,6 +55,7 @@
     {
       "packageName": "@microsoft/gulp-core-build-typescript",
       "projectFolder": "gulp-core-build-typescript",
+      "reviewCategory": "libraries",
       "shouldPublish": true,
       "cyclicDependencyProjects": [
         "@microsoft/node-library-build"
@@ -56,6 +64,7 @@
     {
       "packageName": "@microsoft/gulp-core-build-webpack",
       "projectFolder": "gulp-core-build-webpack",
+      "reviewCategory": "libraries",
       "cyclicDependencyProjects": [
         "@microsoft/node-library-build"
       ]
@@ -63,25 +72,30 @@
     {
       "packageName": "@microsoft/package-deps-hash",
       "projectFolder": "package-deps-hash",
+      "reviewCategory": "libraries",
       "shouldPublish": true
     },
     {
       "packageName": "@microsoft/node-library-build",
       "projectFolder": "node-library-build",
+      "reviewCategory": "libraries",
       "shouldPublish": true
     },
     {
       "packageName": "@microsoft/web-library-build",
       "projectFolder": "web-library-build",
+      "reviewCategory": "libraries",
       "shouldPublish": true
     },
     {
       "packageName": "web-build-tools-scripts",
+      "reviewCategory": "other",
       "projectFolder": "scripts"
     },
     {
       "packageName": "test-web-library-build",
-      "projectFolder": "test-web-library-build"
+      "projectFolder": "test-web-library-build",
+      "reviewCategory": "other"
     }
   ]
 }


### PR DESCRIPTION
This turns on the package dependency tracking for web-build-tools.  When someone proposes a change to PackageDependencies.json (i.e. to introduce a new NPM package), we should ask the standard questions:

- How many additional dependencies does it bring in?
- What is the license?
- Do we already have an existing alternative?
- Maturity / code quality of package
- How compatible is its API with TypeScript conventions?

The goal of this process:

- Avoids low quality libraries, which have caused trouble in the past
- Avoids redundant libraries, which is increase learning curve for developers and degrades performance
- Raises awareness about the new library, so other devs can make use of it
- Helps avoid "npm install" sprawl, which is a major factor affecting our CI build times