### PR TITLE
[show_uncaughterrors] Dump out uncaughtException whether verbose or not.

### DIFF
--- a/common/changes/show_uncaughterrors_2016-11-17-00-29.json
+++ b/common/changes/show_uncaughterrors_2016-11-17-00-29.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/gulp-core-build",
+      "comment": "Dump out uncaught exception whether verbose or not.",
+      "type": "patch"
+    }
+  ],
+  "email": "microsoft@microsoft.com"
+}

--- a/gulp-core-build/src/logging.ts
+++ b/gulp-core-build/src/logging.ts
@@ -309,9 +309,7 @@ function wireUpProcessErrorHandling(): void {
     process.on('uncaughtException',
       (err: Error) => {
         'use strict';
-        if (isVerbose()) {
-          console.error(err);
-        }
+        console.error(err);
 
         _writeTaskError(err);
         writeSummary(() => {


### PR DESCRIPTION
Build failed with uncaught exception does not show enough information for diagnosis. If it is unexpected and uncaught, it should be dumped out in full whether verbose or not to help figure out the root issue.