### PR TITLE
Default ts to local install.

### DIFF
--- a/common/changes/default-ts_2016-12-01-18-43.json
+++ b/common/changes/default-ts_2016-12-01-18-43.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/gulp-core-build-typescript",
+      "comment": "Set default TypeScript version to local install.",
+      "type": "patch"
+    }
+  ],
+  "email": "dzearing@microsoft.com"
+}

--- a/gulp-core-build-typescript/src/TypeScriptTask.ts
+++ b/gulp-core-build-typescript/src/TypeScriptTask.ts
@@ -62,6 +62,7 @@ export class TypeScriptTask extends GulpTask<ITypeScriptTaskConfig> {
   public name: string = 'typescript';
 
   public taskConfig: ITypeScriptTaskConfig = {
+    typescript: require('typescript'),
     failBuildOnErrors: true,
     reporter: {
       error: (error: ts.reporter.TypeScriptError): void => {


### PR DESCRIPTION
Noticed that without setting the typescript explicitly, it's defaulting to gulp-typescript's dependency which is really old.