### PR TITLE
SASS should write a warning if a regular .scss file is used  when useCSSModules=true

### DIFF
--- a/common/changes/nickpape-tslint-should-warn-when-using-regular-css_2016-12-08-00-38.json
+++ b/common/changes/nickpape-tslint-should-warn-when-using-regular-css_2016-12-08-00-38.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/gulp-core-build-sass",
+      "comment": "Add an additional option called `warnOnNonCSSModules` which will warn about files that do not end with .scss",
+      "type": "minor"
+    }
+  ],
+  "email": "nickpape@microsoft.com"
+}

--- a/gulp-core-build-sass/README.md
+++ b/gulp-core-build-sass/README.md
@@ -27,15 +27,20 @@ An array of glob patterns for locating SASS files.
 **Default:** `['src/**/*.scss']`
 
 ### useCSSModules
-If this option is specified, files ending with `.module.scss` extension will automatically
-generate a corresponding TypeScript file. All classes will be appended with a hash
-to help ensure uniqueness on a page. This file can be imported directly, and will
-contain an object describing the mangled class names.
+If this option is specified, ALL files will be treated as a `module.scss` and will
+automatically generate a corresponding TypeScript file. All classes will be
+appended with a hash to help ensure uniqueness on a page. This file can be
+imported directly, and will contain an object describing the mangled class names.
 
 **Default:** `false`
 
 ### dropCssFiles
 If this is false, then we do not create `.css` files in the `lib` directory.
+
+**Default:** `false`
+
+### warnOnNonCSSModules
+If files are matched by sassMatch which do not end in .module.scss, log a warning.
 
 **Default:** `false`
 

--- a/gulp-core-build-sass/src/SassTask.ts
+++ b/gulp-core-build-sass/src/SassTask.ts
@@ -3,6 +3,8 @@ import gulp = require('gulp');
 import * as gulpUtil from 'gulp-util';
 import { EOL } from 'os';
 import { splitStyles } from '@microsoft/load-themed-styles';
+import through2 = require('through2');
+import * as path from 'path';
 /* tslint:disable:typedef */
 const merge = require('merge2');
 /* tslint:enable:typedef */
@@ -16,7 +18,7 @@ export interface ISassTaskConfig {
   postamble?: string;
   /** An array of glob patterns for locating SASS files. */
   sassMatch?: string[];
-  /** 
+  /**
    * If this option is specified, files ending with .module.scss extension will
    * automatically generate a corresponding TypeScript file. All classes will be
    * appended with a hash to help ensure uniqueness on a page. This file can be
@@ -76,7 +78,13 @@ export class SassTask extends GulpTask<ISassTaskConfig> {
 
     if (this.taskConfig.useCSSModules) {
       this.logVerbose('Generating css modules.');
-      return this._processFiles(gulp, srcPattern, completeCallback, modulePostCssPlugins);
+      return this._processFiles(gulp, srcPattern, completeCallback, modulePostCssPlugins,
+        (file: gulpUtil.File) => {
+          if (!path.basename(file.path).match(/module\.css$/)) {
+            this.logWarning(`${file.path}: filename should end with module.scss`);
+          }
+        }
+      );
     } else {
       moduleSrcPattern.forEach((value: string) => srcPattern.push(`!${value}`));
 
@@ -90,8 +98,9 @@ export class SassTask extends GulpTask<ISassTaskConfig> {
     srcPattern: string[],
     /* tslint:disable:no-any */
     completeCallback: (result?: any) => void,
-    postCSSPlugins: any[]
+    postCSSPlugins: any[],
     /* tslint:enable:no-any */
+    checkFile?: (file: gulpUtil.File) => void
   ): NodeJS.ReadWriteStream {
     /* tslint:disable:typedef */
     const changed = require('gulp-changed');
@@ -106,7 +115,21 @@ export class SassTask extends GulpTask<ISassTaskConfig> {
 
     const tasks: NodeJS.ReadWriteStream[] = [];
 
-    const baseTask: NodeJS.ReadWriteStream = gulp.src(srcPattern)
+    const srcStream: NodeJS.ReadWriteStream = gulp.src(srcPattern);
+
+    const checkedStream: NodeJS.ReadWriteStream = (checkFile ?
+      srcStream.pipe(through2.obj(
+        // tslint:disable-next-line:no-function-expression
+        function (file: gulpUtil.File, encoding: string, callback: (p?: Object) => void): void {
+          // tslint:disable-next-line:no-unused-expression
+          checkFile(file);
+          this.push(file);
+          callback();
+        }
+      ))
+      : srcStream);
+
+    const baseTask: NodeJS.ReadWriteStream = checkedStream
       .pipe(changed('src', { extension: scssTsExtName }))
       .pipe(sass.sync({
         importer: (url: string, prev: string, done: boolean): Object => ({ file: _patchSassUrl(url) })

--- a/gulp-core-build-sass/src/SassTask.ts
+++ b/gulp-core-build-sass/src/SassTask.ts
@@ -31,7 +31,7 @@ export interface ISassTaskConfig {
    */
   dropCssFiles?: boolean;
   /**
-   * If files are matched by sassMatch which do not end in .module.scss, throw a warning.
+   * If files are matched by sassMatch which do not end in .module.scss, log a warning.
    */
   warnOnNonCSSModules?: boolean;
 }

--- a/gulp-core-build-sass/src/SassTask.ts
+++ b/gulp-core-build-sass/src/SassTask.ts
@@ -24,7 +24,7 @@ export interface ISassTaskConfig {
    * appended with a hash to help ensure uniqueness on a page. This file can be
    * imported directly, and will contain an object describing the mangled class names.
    */
-  treatAllFilesAsCSSModules?: boolean;
+  useCSSModules?: boolean;
   /**
    * If true, we will generate a CSS in the lib folder. If false, the CSS is directly embedded
    * into the TypeScript file
@@ -47,7 +47,7 @@ export class SassTask extends GulpTask<ISassTaskConfig> {
     sassMatch: [
       'src/**/*.scss'
     ],
-    treatAllFilesAsCSSModules: false,
+    useCSSModules: false,
     dropCssFiles: false,
     warnOnNonCSSModules: false
   };
@@ -90,10 +90,9 @@ export class SassTask extends GulpTask<ISassTaskConfig> {
 
     console.log('warnOnNonCSSModules: ' + this.taskConfig.warnOnNonCSSModules);
 
-    if (this.taskConfig.treatAllFilesAsCSSModules) {
+    if (this.taskConfig.useCSSModules) {
       this.logVerbose('Generating css modules.');
-      return this._processFiles(gulp, srcPattern, completeCallback, modulePostCssPlugins,
-        this.taskConfig.warnOnNonCSSModules ? checkFilenameForCSSModule : undefined);
+      return this._processFiles(gulp, srcPattern, completeCallback, modulePostCssPlugins);
     } else {
       const moduleSrcPattern: string[] = srcPattern.map((value: string) => value.replace('.scss', '.module.scss'));
       moduleSrcPattern.forEach((value: string) => srcPattern.push(`!${value}`));

--- a/gulp-core-build-sass/src/SassTask.ts
+++ b/gulp-core-build-sass/src/SassTask.ts
@@ -82,9 +82,13 @@ export class SassTask extends GulpTask<ISassTaskConfig> {
 
     const checkFilenameForCSSModule: (file: gulpUtil.File) => void = (file: gulpUtil.File) => {
       if (!path.basename(file.path).match(/module\.scss$/)) {
-        this.logWarning(`${file.path}: filename should end with module.scss`);
+
+        const filepath: string = path.relative(this.buildConfig.rootPath, file.path);
+        this.logWarning(`${filepath}: filename should end with module.scss`);
       }
     };
+
+    console.log('warnOnNonCSSModules: ' + this.taskConfig.warnOnNonCSSModules);
 
     if (this.taskConfig.treatAllFilesAsCSSModules) {
       this.logVerbose('Generating css modules.');
@@ -94,9 +98,9 @@ export class SassTask extends GulpTask<ISassTaskConfig> {
       const moduleSrcPattern: string[] = srcPattern.map((value: string) => value.replace('.scss', '.module.scss'));
       moduleSrcPattern.forEach((value: string) => srcPattern.push(`!${value}`));
 
-      return merge(this._processFiles(gulp, srcPattern, completeCallback, postCSSPlugins),
-                   this._processFiles(gulp, moduleSrcPattern, completeCallback, modulePostCssPlugins,
-                     this.taskConfig.warnOnNonCSSModules ? checkFilenameForCSSModule : undefined));
+      return merge(this._processFiles(gulp, srcPattern, completeCallback, postCSSPlugins,
+                     this.taskConfig.warnOnNonCSSModules ? checkFilenameForCSSModule : undefined),
+                   this._processFiles(gulp, moduleSrcPattern, completeCallback, modulePostCssPlugins));
     }
   }
 
@@ -129,6 +133,7 @@ export class SassTask extends GulpTask<ISassTaskConfig> {
         // tslint:disable-next-line:no-function-expression
         function (file: gulpUtil.File, encoding: string, callback: (p?: Object) => void): void {
           // tslint:disable-next-line:no-unused-expression
+
           checkFile(file);
           this.push(file);
           callback();

--- a/test-web-library-build/gulpfile.js
+++ b/test-web-library-build/gulpfile.js
@@ -3,7 +3,7 @@
 let path = require('path');
 let build = require('@microsoft/web-library-build');
 
-build.sass.setConfig({ useCSSModules: true });
+build.sass.setConfig({ treatAllFilesAsCSSModules: true });
 build.webpack.setConfig({ configPath: null });
 build.karma.setConfig({ configPath: null });
 

--- a/test-web-library-build/gulpfile.js
+++ b/test-web-library-build/gulpfile.js
@@ -3,7 +3,7 @@
 let path = require('path');
 let build = require('@microsoft/web-library-build');
 
-build.sass.setConfig({ treatAllFilesAsCSSModules: true });
+build.sass.setConfig({ useCSSModules: true });
 build.webpack.setConfig({ configPath: null });
 build.karma.setConfig({ configPath: null });
 


### PR DESCRIPTION
SASS should write a warning if a regular .scss file is used  when useCSSModules=true