### PR TITLE
Hook the ApiExtractor into both web-library-build & node-library-build

### DIFF
--- a/common/changes/nickpape-start-api-extraction_2017-01-12-00-40.json
+++ b/common/changes/nickpape-start-api-extraction_2017-01-12-00-40.json
@@ -1,0 +1,25 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/web-library-build",
+      "comment": "Enable the ApiExtractor task from gulp-core-build-typescript.",
+      "type": "minor"
+    },
+    {
+      "packageName": "@microsoft/node-library-build",
+      "comment": "Enable the ApiExtractor task from gulp-core-build-typescript.",
+      "type": "minor"
+    },
+    {
+      "packageName": "@microsoft/gulp-core-build-typescript",
+      "comment": "Add a schema for the api-extractor task and change the name.",
+      "type": "patch"
+    },
+    {
+      "packageName": "@microsoft/gulp-core-build",
+      "comment": "Enable the schema for CopyTask.",
+      "type": "patch"
+    }
+  ],
+  "email": "nickpape@microsoft.com"
+}

--- a/common/reviews/api/test-web-library-build.api.ts
+++ b/common/reviews/api/test-web-library-build.api.ts
@@ -1,0 +1,9 @@
+// (undocumented)
+export function add(num1: number, num2: number): number;
+
+// (undocumented)
+export function log(message: string): void;
+
+// (undocumented)
+export function logClass(): void;
+

--- a/gulp-core-build-typescript/src/ApiExtractorTask.ts
+++ b/gulp-core-build-typescript/src/ApiExtractorTask.ts
@@ -63,13 +63,17 @@ export interface IApiExtractorTaskConfig {
  * find the aliased exports of the project. An api-extractor.ts file is generated for the project in the temp folder.
  */
 export class ApiExtractorTask extends GulpTask<IApiExtractorTaskConfig>  {
-  public name: string = 'apiExtractor';
+  public name: string = 'api-extractor';
 
   public taskConfig: IApiExtractorTaskConfig = {
     enabled: false,
     entry: undefined,
     apiReviewFolder: undefined,
     apiJsonFolder: undefined
+  };
+
+  public loadSchema(): Object {
+    return require('./api-extractor.schema.json');
   };
 
   public executeTask(gulp: gulp.Gulp, completeCallback: (error?: string) => void): NodeJS.ReadWriteStream {

--- a/gulp-core-build-typescript/src/api-extractor.schema.json
+++ b/gulp-core-build-typescript/src/api-extractor.schema.json
@@ -1,0 +1,20 @@
+{
+  "title": "api-extractor Configuration",
+  "description": "Generates a report of the Public API exports for a project, and detects changes that impact the SemVer contract",
+
+  "type": "object",
+  "properties": {
+    "enabled": {
+      "description": "Indicates whether the task should be run",
+      "type": "boolean"
+    },
+    "entry": {
+      "description": "The file path of the exported entry point, relative to the project folder",
+      "type": "string"
+    },
+    "apiReviewFolder": {
+      "description": "The file path of the folder containing already approved API files, relative to the project folder",
+      "type": "string"
+    }
+  }
+}

--- a/gulp-core-build/src/tasks/CopyTask.ts
+++ b/gulp-core-build/src/tasks/CopyTask.ts
@@ -24,6 +24,10 @@ export class CopyTask extends GulpTask<ICopyConfig> {
     shouldFlatten: true
   };
 
+  public loadSchema(): Object {
+    return require('./copy.schema.json');
+  };
+
   public executeTask(
     gulp: gulp.Gulp,
     completeCallback: (result?: Object) => void

--- a/node-library-build/src/index.ts
+++ b/node-library-build/src/index.ts
@@ -1,5 +1,5 @@
 import { task, watch, serial, parallel, IExecutable } from '@microsoft/gulp-core-build';
-import { typescript, tslint } from '@microsoft/gulp-core-build-typescript';
+import { typescript, tslint, apiExtractor } from '@microsoft/gulp-core-build-typescript';
 import { instrument, mocha } from '@microsoft/gulp-core-build-mocha';
 
 export * from '@microsoft/gulp-core-build';
@@ -7,8 +7,10 @@ export * from '@microsoft/gulp-core-build-typescript';
 export * from '@microsoft/gulp-core-build-mocha';
 
 // Define default task groups.
-export const buildTasks: IExecutable = task('build', parallel(tslint, typescript));
-export const testTasks: IExecutable = task('test', serial(typescript, mocha));
-export const defaultTasks: IExecutable = task('default', serial(buildTasks, instrument, mocha));
+const buildSubtask: IExecutable = serial(parallel(tslint, typescript), apiExtractor);
+
+export const buildTasks: IExecutable = task('build', buildSubtask);
+export const testTasks: IExecutable = task('test', serial(buildSubtask, mocha));
+export const defaultTasks: IExecutable = task('default', serial(buildSubtask, instrument, mocha));
 
 task('watch', watch('src/**.ts', testTasks));

--- a/test-web-library-build/config/api-extractor.json
+++ b/test-web-library-build/config/api-extractor.json
@@ -1,0 +1,6 @@
+{
+  "enabled": true,
+  "apiReviewFolder": "../common/reviews/api",
+  "apiJsonFolder": "./temp",
+  "entry": "src/test.ts"
+}

--- a/web-library-build/src/index.ts
+++ b/web-library-build/src/index.ts
@@ -8,7 +8,7 @@ import {
   task,
   watch
 } from '@microsoft/gulp-core-build';
-import { typescript, tslint, text } from '@microsoft/gulp-core-build-typescript';
+import { apiExtractor, typescript, tslint, text } from '@microsoft/gulp-core-build-typescript';
 import { sass } from '@microsoft/gulp-core-build-sass';
 import { karma } from '@microsoft/gulp-core-build-karma';
 import { webpack } from '@microsoft/gulp-core-build-webpack';
@@ -35,7 +35,7 @@ const sourceMatch: string[] = [
 ];
 
 // Define default task groups.
-export const compileTsTasks: IExecutable = parallel(typescript, text);
+export const compileTsTasks: IExecutable = parallel(typescript, text, apiExtractor);
 export const buildTasks: IExecutable = task('build', serial(preCopy, sass, parallel(compileTsTasks, text), postCopy));
 export const bundleTasks: IExecutable = task('bundle', serial(buildTasks, webpack));
 export const testTasks: IExecutable = serial(sass, compileTsTasks, karma);
@@ -47,9 +47,9 @@ export const generateShrinkwrapTask: GenerateShrinkwrapTask = new GenerateShrink
 task('validate-shrinkwrap', validateShrinkwrapTask);
 task('generate', generateShrinkwrapTask);
 
-task('test', serial(sass, testTasks));
+task('test', testTasks);
 
-task('test-watch', watch(sourceMatch, serial(sass, compileTsTasks, karma)));
+task('test-watch', watch(sourceMatch, testTasks));
 
 // For watch scenarios like serve, make sure to exclude generated files from src (like *.scss.ts.)
 task('serve',


### PR DESCRIPTION
Hook the ApiExtractor into both web-library-build & node-library-build, and run it on the test project.