### PR TITLE
added toString and altered check for end JsDoc sequence

### DIFF
--- a/api-extractor/src/DebugRun.ts
+++ b/api-extractor/src/DebugRun.ts
@@ -2,43 +2,20 @@
 //       IT IS INVOKED BY THE "Run.cmd" AND "Debug.cmd" BATCH FILES.
 
 import * as ts from 'typescript';
+import * as os from 'os';
 import Analyzer from './Analyzer';
 import ApiFileGenerator from './generators/ApiFileGenerator';
 import ApiJsonGenerator from './generators/ApiJsonGenerator';
-import { IDocItem } from './IDocItem';
-import { IApiDefinitionReference } from './IApiDefinitionReference';
-import { IDocElement, IParam } from './IDocElement';
-import DocItemLoader from './DocItemLoader';
-import DocElementParser from './DocElementParser';
-import TestFileComparer from './TestFileComparer';
-import JsonFile from './JsonFile';
-import ApiStructuredType from './definitions/ApiStructuredType';
-import ApiDocumentation from './definitions/ApiDocumentation';
-import Tokenizer from './Tokenizer';
 
-let docs: string = '{@link @microsoft/sp-core-library:Guid.equals | Guid equals}';
-let tokenizer: Tokenizer = new Tokenizer(docs, console.log);
-/* tslint:disable:no-unused-variable */
-const linkResult: IDocElement[] = DocElementParser.parse(tokenizer, console.log);
-
-const analyzer: Analyzer = new Analyzer();
+const analyzer: Analyzer = new Analyzer(
+  (message: string, fileName: string, lineNumber: number): void => {
+    console.log(`TypeScript error: ${message}` + os.EOL
+      + `  ${fileName}#${lineNumber}`);
+  }
+);
 
 /**
- * Dummy class wrapping ApiDocumentation to test its protected methods
- */
-let myDocumentedClass: ApiStructuredType;
-class TestApiDocumentation extends ApiDocumentation {
-  constructor() {
-    super(myDocumentedClass, analyzer.docItemLoader, (msg: string) => { return; });
-  }
-
-  public parseParam(_tokenizer: Tokenizer): IParam {
-    return this._parseParam(_tokenizer);
-  }
-}
-
-/**
- * Debugging inheritdoc expression parser. 
+ * Debugging inheritdoc expression parser.
  * Analyzer on example2 is needed for testing the parser.
  */
 analyzer.analyze({
@@ -48,9 +25,9 @@ analyzer.analyze({
     moduleResolution: ts.ModuleResolutionKind.NodeJs,
     experimentalDecorators: true,
     jsx: ts.JsxEmit.React,
-    rootDir: './testInputs/example2'
+    rootDir: ''
   },
-  entryPointFile: './testInputs/example2/index.ts', // local/bundles/platform-exports.ts',
+  entryPointFile: '', // local/bundles/platform-exports.ts',
   otherFiles: []
 });
 
@@ -59,58 +36,3 @@ apiFileGenerator.writeApiFile('./lib/DebugRun.api.ts', analyzer);
 
 const apiJsonGenerator: ApiJsonGenerator = new ApiJsonGenerator();
 apiJsonGenerator.writeJsonFile('./lib/DebugRun.json', analyzer);
-
-myDocumentedClass = analyzer.package.getSortedMemberItems()
-  .filter(apiItem => apiItem.name === 'MyDocumentedClass')[0] as ApiStructuredType;
-const apiDoc: TestApiDocumentation = new TestApiDocumentation();
-
-docs = '@param x - The height in {@link http://wikipedia.org/pixel_units}';
-tokenizer = new Tokenizer(docs, console.log);
-// ApiDocumentation gets the @param token before calling parseParam()
-tokenizer.getToken();
-apiDoc.parseParam(tokenizer);
-
-/**
- * Put test cases here
- */
-let apiReferenceExpr: string = '@microsoft/sp-core-library:Guid.equals';
-let actual: IApiDefinitionReference;
-actual = ApiDocumentation.parseApiReferenceExpression(apiReferenceExpr, apiDoc.reportError);
-
-apiReferenceExpr = '@microsoft/sp-core-library:Guid';
-actual = ApiDocumentation.parseApiReferenceExpression(apiReferenceExpr, apiDoc.reportError);
-
-apiReferenceExpr = 'sp-core-library:Guid';
-actual = ApiDocumentation.parseApiReferenceExpression(apiReferenceExpr, apiDoc.reportError);
-
-apiReferenceExpr = 'Guid.equals';
-actual = ApiDocumentation.parseApiReferenceExpression(apiReferenceExpr, apiDoc.reportError);
-
-apiReferenceExpr = 'Guid';
-actual = ApiDocumentation.parseApiReferenceExpression(apiReferenceExpr, apiDoc.reportError);
-
-// Should report error
-apiReferenceExpr = 'sp-core-library:Guid:equals';
-try {
-  actual = ApiDocumentation.parseApiReferenceExpression(apiReferenceExpr, apiDoc.reportError);
-} catch (error) {
-  console.log(error);
-}
-
-/**
- * Debugging DocItemLoader
- */
-const apiDefinitionRef: IApiDefinitionReference = {
-  scopeName: '@microsoft',
-  packageName: 'sp-core-library',
-  exportName: 'DisplayMode',
-  memberName: ''
-};
-
-const docItemLoader: DocItemLoader = new DocItemLoader('./testInputs/example2');
-/* tslint:disable:no-unused-variable */
-const apiDocItemNotInCache: IDocItem = docItemLoader.getItem(apiDefinitionRef);
-JsonFile.saveJsonFile('./lib/inheritedDoc-output.json', JSON.stringify(apiDocItemNotInCache));
-TestFileComparer.assertFileMatchesExpected('./lib/inheritedDoc-output.json', './testInputs/inheritedDoc-output.json');
-/* tslint:disable:no-unused-variable */
-const apiDocItemInCache: IDocItem = docItemLoader.getItem(apiDefinitionRef);

--- a/api-extractor/src/DebugRun.ts
+++ b/api-extractor/src/DebugRun.ts
@@ -27,7 +27,7 @@ analyzer.analyze({
     jsx: ts.JsxEmit.React,
     rootDir: ''
   },
-  entryPointFile: '', // local/bundles/platform-exports.ts',
+  entryPointFile: '',
   otherFiles: []
 });
 

--- a/api-extractor/src/TypeScriptHelpers.ts
+++ b/api-extractor/src/TypeScriptHelpers.ts
@@ -18,7 +18,7 @@ export default class TypeScriptHelpers {
   /**
    * End sequence is '*\/'.
    */
-  public static jsDocEndRegEx: RegExp = /\s*\*\//g;
+  public static jsDocEndRegEx: RegExp = /\s*\*\/\s*$/g;
 
   /**
    * Intermediate lines of JSDoc comment character.

--- a/api-extractor/src/TypeScriptHelpers.ts
+++ b/api-extractor/src/TypeScriptHelpers.ts
@@ -18,7 +18,7 @@ export default class TypeScriptHelpers {
   /**
    * End sequence is '*\/'.
    */
-  public static jsDocEndRegEx: RegExp = /^\s*\*\//g;
+  public static jsDocEndRegEx: RegExp = /\s*\*\//g;
 
   /**
    * Intermediate lines of JSDoc comment character.
@@ -68,10 +68,16 @@ export default class TypeScriptHelpers {
       const lastJsDocIndex: number = nodeJsDocObjects.length - 1;
       const jsDocFullText: string = nodeJsDocObjects[lastJsDocIndex].getText();
       const jsDocLines: string[] = jsDocFullText.split(TypeScriptHelpers.newLineRegEx);
-      const jsDocStartSeqExists: boolean = TypeScriptHelpers.jsDocStartRegEx.test(jsDocLines[0]);
-      const jsDocEndSeqExists: boolean = TypeScriptHelpers.jsDocEndRegEx.test(jsDocLines[jsDocLines.length - 1]);
-      if (!(jsDocStartSeqExists && jsDocEndSeqExists)) {
-        errorLogger('JsDoc comment must begin with \"/**\" sequence and end with \"*/\" sequence.');
+      const jsDocStartSeqExists: boolean = TypeScriptHelpers.jsDocStartRegEx.test(jsDocLines[0].toString());
+      if (!jsDocStartSeqExists) {
+        errorLogger('JsDoc comment must begin with a \"/**\" sequence.');
+        return '';
+      }
+      const jsDocEndSeqExists: boolean = TypeScriptHelpers.jsDocEndRegEx.test(
+        jsDocLines[jsDocLines.length - 1].toString()
+      );
+      if (!jsDocEndSeqExists) {
+        errorLogger('JsDoc comment must end with a \"*/\" sequence.');
         return '';
       }
 

--- a/api-extractor/src/definitions/ApiDocumentation.ts
+++ b/api-extractor/src/definitions/ApiDocumentation.ts
@@ -250,7 +250,7 @@ export default class ApiDocumentation {
 
   protected _getJsDocs(apiItem: ApiItem): string {
     const sourceFile: ts.SourceFile = apiItem.getDeclaration().getSourceFile();
-    let jsDoc: string = TypeScriptHelpers.getJsDocComments(apiItem.getDeclaration(), this.reportError);
+    const jsDoc: string = TypeScriptHelpers.getJsDocComments(apiItem.getDeclaration(), this.reportError);
 
     // Eliminate tags and then count the English letters.  Are there at least 10 letters of text?
     // If not, we consider the definition to be "missingDocumentation".

--- a/api-extractor/testInputs/example2/example2-output.json
+++ b/api-extractor/testInputs/example2/example2-output.json
@@ -327,6 +327,19 @@
           "isBeta": false
         }
       }
+    },
+    "TestMissingCommentStar": {
+      "kind": "enum",
+      "values": {},
+      "deprecatedMessage": [],
+      "summary": [
+        {
+          "kind": "textDocElement",
+          "value": "Degenerate comment star missing here end of comment"
+        }
+      ],
+      "remarks": [],
+      "isBeta": false
     }
   }
 }

--- a/api-extractor/testInputs/example2/index.ts
+++ b/api-extractor/testInputs/example2/index.ts
@@ -1,4 +1,5 @@
 export {
+    TestMissingCommentStar,
     inheritDisplayMode,
     inheritCorrectlyButNotFound,
     inheritDisplayModeError,


### PR DESCRIPTION
-one liner jsDoc comments where being checked for an ending sequence of '*/' at the start of the last time. However the JsDoc comment can all be one line. 