### PR TITLE
Improve confusing error messages from api-extractor

### DIFF
--- a/api-extractor/src/DebugRun.ts
+++ b/api-extractor/src/DebugRun.ts
@@ -36,3 +36,5 @@ apiFileGenerator.writeApiFile('./lib/DebugRun.api.ts', analyzer);
 
 const apiJsonGenerator: ApiJsonGenerator = new ApiJsonGenerator();
 apiJsonGenerator.writeJsonFile('./lib/DebugRun.json', analyzer);
+
+console.log('DebugRun completed.');

--- a/api-extractor/src/DebugRun.ts
+++ b/api-extractor/src/DebugRun.ts
@@ -9,7 +9,7 @@ import ApiJsonGenerator from './generators/ApiJsonGenerator';
 
 const analyzer: Analyzer = new Analyzer(
   (message: string, fileName: string, lineNumber: number): void => {
-    console.log(`TypeScript error: ${message}` + os.EOL
+    console.log(`ErrorHandler: ${message}` + os.EOL
       + `  ${fileName}#${lineNumber}`);
   }
 );
@@ -25,9 +25,9 @@ analyzer.analyze({
     moduleResolution: ts.ModuleResolutionKind.NodeJs,
     experimentalDecorators: true,
     jsx: ts.JsxEmit.React,
-    rootDir: ''
+    rootDir: 'D:/GitRepos/sp-client/spfx-core/sp-codepart-base'
   },
-  entryPointFile: '',
+  entryPointFile: 'D:/GitRepos/sp-client/spfx-core/sp-codepart-base/src/index.ts',
   otherFiles: []
 });
 

--- a/api-extractor/src/DocElementParser.ts
+++ b/api-extractor/src/DocElementParser.ts
@@ -1,7 +1,7 @@
 import { ITextElement, IDocElement, IHrefLinkElement, ICodeLinkElement, ISeeDocElement } from './IDocElement';
 import { IApiDefinitionReference } from './IApiDefinitionReference';
 import ApiDocumentation from './definitions/ApiDocumentation';
-import Token from './Token';
+import Token, { TokenType } from './Token';
 import Tokenizer from './Tokenizer';
 
 export default class DocElementParser {
@@ -47,7 +47,7 @@ export default class DocElementParser {
         break;
       }
 
-      if (token.type === 'Tag') {
+      if (token.type === TokenType.Tag) {
         switch (token.tag) {
           case '@see':
             tokenizer.getToken();
@@ -60,7 +60,7 @@ export default class DocElementParser {
             parsing = false; // end of summary tokens
             break;
         }
-      } else if (token.type === 'Inline') {
+      } else if (token.type === TokenType.Inline) {
         switch (token.tag) {
           case '@link' :
             const linkDocElement: ICodeLinkElement | IHrefLinkElement = this.parseLinkTag(token, reportError);
@@ -73,7 +73,7 @@ export default class DocElementParser {
             parsing = false;
             break;
         }
-      } else if (token.type === 'Text') {
+      } else if (token.type === TokenType.Text) {
         docElements.push({kind: 'textDocElement', value: token.text} as ITextElement);
           tokenizer.getToken();
       } else {

--- a/api-extractor/src/Token.ts
+++ b/api-extractor/src/Token.ts
@@ -1,7 +1,7 @@
 /**
  * Allowed Token types.
  */
-export enum TokenTypes {
+export enum TokenType {
   /**
    * A Token that contains only text.
    */
@@ -14,10 +14,10 @@ export enum TokenTypes {
   Tag,
 
   /**
-   * This is a specific kind of Tag that is important to 
+   * This is a specific kind of Tag that is important to
    * distinguish because it contains additional parameters.
-   * 
-   * Example: 
+   *
+   * Example:
    * \{@link http://microosft.com | microsoft home \}
    * \{@inheritdoc  @ microsoft/sp-core-library:Guid.newGuid \}
    */
@@ -30,10 +30,9 @@ export enum TokenTypes {
 export default class Token {
 
   /**
-   * The type of the token. 
-   * Possible options: Text, Tag, Inline.
+   * The type of the token.
    */
-  private _type: string;
+  private _type: TokenType;
 
   /**
    * This is not used for Text.
@@ -46,7 +45,7 @@ export default class Token {
    */
   private _text: string;
 
-  constructor(type: string, tag?: string, text?: string) {
+  constructor(type: TokenType, tag?: string, text?: string) {
     this._type = type;
     this._tag = tag ? tag : '';
     this._text = text ? this._unescape(text) : '';
@@ -56,13 +55,13 @@ export default class Token {
   /**
    * Determines if the type is not what we expect.
    */
-  public requireType(type: string): void {
+  public requireType(type: TokenType): void {
     if (this._type !== type) {
-      throw new Error('Token of type \"${this._type}\" is not of required type \"${type}\"');
+      throw new Error(`Encountered a token of type \"${this._type}\" when expecting \"${type}\"`);
     }
   }
 
-  public get type(): string {
+  public get type(): TokenType {
     return this._type;
   }
 

--- a/api-extractor/src/Tokenizer.ts
+++ b/api-extractor/src/Tokenizer.ts
@@ -1,4 +1,4 @@
-import Token from './Token';
+import Token, { TokenType } from './Token';
 import TypeScriptHelpers from './TypeScriptHelpers';
 
 /**
@@ -29,7 +29,7 @@ export default class Tokenizer {
    * can be processed more strictly.
    * Example: "This is a JsDoc description with a {@link URL} and more text. \@summary example \@public"
    * => [
-   *  {tokenType: 'text', parameter: 'This is a JsDoc description with a'}, 
+   *  {tokenType: 'text', parameter: 'This is a JsDoc description with a'},
    *  {tokenType: '@link', parameter: 'URL'},
    *  {tokenType: '\@summary', parameter: ''},
    *  {tokenType: 'text', parameter: 'example'},
@@ -41,7 +41,7 @@ export default class Tokenizer {
       return;
     }
     const docEntries: string[] = TypeScriptHelpers.splitStringWithRegEx(docs, Tokenizer._jsdocTagsRegex);
-    const sanitizedTokens: string[] =  this._sanitizeDocEntries(docEntries); // remove white space and empty entries 
+    const sanitizedTokens: string[] =  this._sanitizeDocEntries(docEntries); // remove white space and empty entries
 
     // process each sanitized doc string to a Token object
     const tokens: Token[] = [];
@@ -50,11 +50,11 @@ export default class Tokenizer {
       let token: Token;
       value = sanitizedTokens[i];
       if (value.charAt(0) === '@') {
-       token = new Token('Tag', value);
+       token = new Token(TokenType.Tag, value);
       } else if (value.charAt(0) === '{' && value.charAt(value.length - 1) === '}') {
         token = this._tokenizeInline(value); // Can return undefined if invalid inline tag
       } else {
-        token = new Token('Text', '', value);
+        token = new Token(TokenType.Text, '', value);
       }
 
       if (token) {
@@ -66,7 +66,7 @@ export default class Tokenizer {
   }
 
   /**
-   * Parse an inline tag and returns the Token for it if itis a valid inline tag. 
+   * Parse an inline tag and returns the Token for it if itis a valid inline tag.
    * Example '{@link https://bing.com | Bing}' => '{type: 'Inline', tag: '@link', text: 'https://bing.com  | Bing'}'
    */
   protected _tokenizeInline(docEntry: string): Token {
@@ -98,11 +98,11 @@ export default class Tokenizer {
       }
 
       tokenChunks.shift(); // Gets rid of '@link'
-      const token: Token = new Token('Inline', '@link', tokenChunks.join(' '));
+      const token: Token = new Token(TokenType.Inline, '@link', tokenChunks.join(' '));
       return token;
     } else if (tokenChunks[0] === '@inheritdoc') {
       tokenChunks.shift(); // Gets rid of '@inheritdoc'
-      const token: Token = new Token('Inline', '@inheritdoc', tokenChunks.join(' '));
+      const token: Token = new Token(TokenType.Inline, '@inheritdoc', tokenChunks.join(' '));
       return token;
     }
 
@@ -119,7 +119,7 @@ export default class Tokenizer {
   }
 
   /**
-   * Trims whitespaces on either end of the entry (which is just a string within the doc comments), 
+   * Trims whitespaces on either end of the entry (which is just a string within the doc comments),
    * replaces \r and \n's with single whitespace, and removes empty entries.
    *
    * @param docEntries - Array of doc strings to be santitized

--- a/api-extractor/src/definitions/ApiDocumentation.ts
+++ b/api-extractor/src/definitions/ApiDocumentation.ts
@@ -8,7 +8,7 @@ import { IDocElement, IParam, IHrefLinkElement, ICodeLinkElement, ITextElement }
 import { IDocItem, IDocFunction } from '../IDocItem';
 import DocItemLoader from '../DocItemLoader';
 import { IApiDefinitionReference } from '../IApiDefinitionReference';
-import Token from '../Token';
+import Token, { TokenType } from '../Token';
 import Tokenizer from '../Tokenizer';
 
 /**
@@ -291,7 +291,7 @@ export default class ApiDocumentation {
         break;
       }
 
-      if (token.type === 'Tag') {
+      if (token.type === TokenType.Tag) {
         switch (token.tag) {
           case '@remarks':
             tokenizer.getToken();
@@ -359,7 +359,7 @@ export default class ApiDocumentation {
             tokenizer.getToken();
             this._reportBadJSDocTag(token);
         }
-      } else if (token.type === 'Inline') {
+      } else if (token.type === TokenType.Inline) {
         switch (token.tag) {
           case '@inheritdoc':
             tokenizer.getToken();
@@ -382,7 +382,7 @@ export default class ApiDocumentation {
             this._reportBadJSDocTag(token);
             break;
         }
-      } else if (token.type === 'Text')  {
+      } else if (token.type === TokenType.Text)  {
         tokenizer.getToken();
         // Shorten "This is too long text" to "This is..."
         const MAX_LENGTH: number = 40;
@@ -517,11 +517,11 @@ export default class ApiDocumentation {
       return;
     }
 
-    if (token.type === 'Inline' && !supportsInline) {
+    if (token.type === TokenType.Inline && !supportsInline) {
       this.reportError(`The JSDoc tag \"${token.tag}\" must not use the non-inline syntax (no curly braces)`);
       return;
     }
-    if (token.type === 'Tag' && !supportsRegular) {
+    if (token.type === TokenType.Tag && !supportsRegular) {
       this.reportError(`The JSDoc tag \"${token.tag}\" must use the inline syntax (with curly braces)`);
       return;
     }

--- a/api-extractor/src/generators/test/ApiFileGenerator.test.ts
+++ b/api-extractor/src/generators/test/ApiFileGenerator.test.ts
@@ -59,10 +59,9 @@ describe('ApiFileGenerator tests', function (): void {
        * Errors can be found in testInputs/folder/MyClass
        */
       assert.equal(capturedErrors.length, 2);
-      assert.equal(capturedErrors[0].message, 'The JSDoc tag "@badjsdoctag" is not allowed');
-      assert.equal(capturedErrors[1].message, 'Unexpected text. Text must either be the first ' +
-        'sentences of the JSDoc, or if too long for the first 2-3 sentences the text must be ' +
-        'preceded by a @internalremarks tag.');
+      assert.equal(capturedErrors[0].message, 'Unknown JSDoc tag "@badjsdoctag"');
+      assert.equal(capturedErrors[1].message, 'Unexpected text in JSDoc comment: '
+        + '"(Error #1 is the bad tag) Text can no..."');
     });
   });
 });

--- a/api-extractor/src/test/Token.test.ts
+++ b/api-extractor/src/test/Token.test.ts
@@ -1,7 +1,7 @@
 /// <reference types="mocha" />
 
 import { assert } from 'chai';
-import Token from '../Token';
+import Token, { TokenType } from '../Token';
 
 /* tslint:disable:no-function-expression - Mocha uses a poorly scoped "this" pointer */
 
@@ -13,18 +13,18 @@ describe('Token tests', function (): void {
     it('constructor()', function (): void {
       let token: Token;
 
-      token =  new Token('Text', '', 'Some text');
-      assert.equal(token.type, 'Text');
+      token =  new Token(TokenType.Text, '', 'Some text');
+      assert.equal(token.type, TokenType.Text);
       assert.equal(token.tag, '');
       assert.equal(token.text, 'Some text');
 
-      token = new Token('Tag', '@tagA');
-      assert.equal(token.type, 'Tag');
+      token = new Token(TokenType.Tag, '@tagA');
+      assert.equal(token.type, TokenType.Tag);
       assert.equal(token.tag, '@tagA');
       assert.equal(token.text, '');
 
-      token = new Token('Inline', '@link', 'http://www.microsoft.com');
-      assert.equal(token.type, 'Inline');
+      token = new Token(TokenType.Inline, '@link', 'http://www.microsoft.com');
+      assert.equal(token.type, TokenType.Inline);
       assert.equal(token.tag, '@link');
       assert.equal(token.text, 'http://www.microsoft.com');
     });
@@ -32,17 +32,17 @@ describe('Token tests', function (): void {
   it('RequireType() should raise error', function (): void {
       let token: Token;
 
-      token =  new Token('Text', '', 'Some text');
+      token =  new Token(TokenType.Text, '', 'Some text');
       let errorThrown: boolean = false;
       try {
-        token.requireType('Text');
+        token.requireType(TokenType.Text);
       } catch (error) {
         errorThrown = true;
       }
       assert.equal(errorThrown, false);
 
       try {
-        token.requireType('Tag');
+        token.requireType(TokenType.Tag);
       } catch (error) {
         errorThrown = true;
       }

--- a/api-extractor/src/test/Tokenizer.test.ts
+++ b/api-extractor/src/test/Tokenizer.test.ts
@@ -3,7 +3,7 @@
 import { assert } from 'chai';
 import JsonFile from '../JsonFile';
 import TestFileComparer from '../TestFileComparer';
-import Token from '../Token';
+import Token, { TokenType } from '../Token';
 import Tokenizer from '../Tokenizer';
 
 /* tslint:disable:no-function-expression - Mocha uses a poorly scoped "this" pointer */
@@ -36,14 +36,14 @@ describe('Tokenizer tests', function (): void {
         @tagc this is {   @inlineTag param1  param2   } and this is {just curly braces}`;
 
       const expectedTokens: Token[] = [
-        new Token('Text', '', 'this is a mock documentation'),
-        new Token('Tag', '@taga'),
-        new Token('Text', '', 'hi'),
-        new Token('Tag', '@tagb'),
-        new Token('Text', '', 'hello @invalid@tag email@domain.com'),
-        new Token('Tag', '@tagc'),
-        new Token('Text', '', 'this is'),
-        new Token('Text', '', 'and this is {just curly braces}')
+        new Token(TokenType.Text, '', 'this is a mock documentation'),
+        new Token(TokenType.Tag, '@taga'),
+        new Token(TokenType.Text, '', 'hi'),
+        new Token(TokenType.Tag, '@tagb'),
+        new Token(TokenType.Text, '', 'hello @invalid@tag email@domain.com'),
+        new Token(TokenType.Tag, '@tagc'),
+        new Token(TokenType.Text, '', 'this is'),
+        new Token(TokenType.Text, '', 'and this is {just curly braces}')
       ];
 
       const actualTokens: Token[] = testTokenizer.tokenizeDocs(docs);
@@ -54,7 +54,7 @@ describe('Tokenizer tests', function (): void {
 
     it('tokenizeInline()', function (): void {
       const token: string = '{    @link   https://bing.com  |  Bing  }';
-      const expectedToken: Token = new Token('Inline', '@link', 'https://bing.com | Bing');
+      const expectedToken: Token = new Token(TokenType.Inline, '@link', 'https://bing.com | Bing');
       const actualToken: Token = testTokenizer.tokenizeInline(token);
       assert.equal(expectedToken.type, actualToken.type);
       assert.equal(expectedToken.tag, actualToken.tag);

--- a/common/changes/pgonzal-fix-errors_2017-01-19-19-29.json
+++ b/common/changes/pgonzal-fix-errors_2017-01-19-19-29.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor",
+      "comment": "Improved error messages",
+      "type": "patch"
+    }
+  ],
+  "email": "pgonzal"
+}

--- a/gulp-core-build-typescript/src/ApiExtractorTask.ts
+++ b/gulp-core-build-typescript/src/ApiExtractorTask.ts
@@ -99,7 +99,7 @@ export class ApiExtractorTask extends GulpTask<IApiExtractorTaskConfig>  {
 
     const analyzer: Analyzer = new Analyzer(
       (message: string, fileName: string, lineNumber: number): void => {
-        this.logWarning(`TypeScript error: ${message}` + os.EOL
+        this.logWarning(`${message}` + os.EOL
           + `  ${fileName}#${lineNumber}`);
       }
     );


### PR DESCRIPTION
I got this error, which was confusing:

```
Warning - [apiExtractor] TypeScript error: Error formatting token tag: @inheritd
oc
  /some/path/SomeFile.ts#37
Warning - [apiExtractor] TypeScript error: Unexpected text. Text must either be
the first sentences of the JSDoc, or if too long for the first 2-3 sentences the
 text must be preceded by a @internalremarks tag.
```

The actual problem was that @inheritdoc should have been specified as an inline tag, rather than a regular tag.  Also, it is certainly not a "TypeScript error".