### PR TITLE
Eliminate workarounds for @types/z-schema

### DIFF
--- a/common/npm-shrinkwrap.json
+++ b/common/npm-shrinkwrap.json
@@ -3,14 +3,14 @@
   "version": "0.0.0",
   "dependencies": {
     "@microsoft/api-extractor": {
-      "version": "1.1.1",
+      "version": "1.1.2",
       "from": "@microsoft/api-extractor@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-1.1.1.tgz"
+      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-1.1.2.tgz"
     },
     "@microsoft/gulp-core-build": {
-      "version": "2.2.0",
-      "from": "@microsoft/gulp-core-build@>=2.0.1 <3.0.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/gulp-core-build/-/gulp-core-build-2.2.0.tgz"
+      "version": "2.1.1",
+      "from": "@microsoft/gulp-core-build@>=2.1.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/gulp-core-build/-/gulp-core-build-2.1.1.tgz"
     },
     "@microsoft/gulp-core-build-mocha": {
       "version": "2.0.1",
@@ -19,7 +19,7 @@
     },
     "@microsoft/gulp-core-build-typescript": {
       "version": "2.2.1",
-      "from": "@microsoft/gulp-core-build-typescript@>=2.1.0 <3.0.0",
+      "from": "@microsoft/gulp-core-build-typescript@>=2.2.1 <3.0.0",
       "resolved": "https://registry.npmjs.org/@microsoft/gulp-core-build-typescript/-/gulp-core-build-typescript-2.2.1.tgz",
       "dependencies": {
         "lodash": {
@@ -35,9 +35,9 @@
       "resolved": "https://registry.npmjs.org/@microsoft/load-themed-styles/-/load-themed-styles-1.2.2.tgz"
     },
     "@microsoft/node-library-build": {
-      "version": "2.1.0",
-      "from": "@microsoft/node-library-build@>=2.1.0 <2.2.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/node-library-build/-/node-library-build-2.1.0.tgz"
+      "version": "2.2.0",
+      "from": "@microsoft/node-library-build@>=2.2.0 <2.3.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/node-library-build/-/node-library-build-2.2.0.tgz"
     },
     "@types/assertion-error": {
       "version": "1.0.30",

--- a/common/temp_modules/rush-api-extractor/package.json
+++ b/common/temp_modules/rush-api-extractor/package.json
@@ -8,7 +8,7 @@
     "chai": "~3.5.0",
     "gulp": "~3.9.1",
     "mocha": "~2.5.3",
-    "@microsoft/node-library-build": "~2.1.0",
+    "@microsoft/node-library-build": "~2.2.0",
     "@types/es6-collections": "^0.5.29",
     "@types/fs-extra": "~0.0.34",
     "@types/node": ">=6.0.51 <6.9.1",

--- a/common/temp_modules/rush-gulp-core-build-karma/package.json
+++ b/common/temp_modules/rush-gulp-core-build-karma/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "dependencies": {
-    "@microsoft/node-library-build": ">=2.1.0 <3.0.0",
+    "@microsoft/node-library-build": ">=2.2.0 <3.0.0",
     "@types/chalk": "^0.4.31",
     "@types/es6-promise": "0.0.32",
     "@types/gulp": "^3.8.32",

--- a/common/temp_modules/rush-gulp-core-build-mocha/package.json
+++ b/common/temp_modules/rush-gulp-core-build-mocha/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "dependencies": {
-    "@microsoft/node-library-build": ">=2.1.0 <3.0.0",
+    "@microsoft/node-library-build": ">=2.2.0 <3.0.0",
     "@types/chalk": "^0.4.31",
     "@types/gulp": "^3.8.32",
     "@types/gulp-istanbul": "^0.9.30",

--- a/common/temp_modules/rush-gulp-core-build-sass/package.json
+++ b/common/temp_modules/rush-gulp-core-build-sass/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "dependencies": {
-    "@microsoft/node-library-build": ">=2.1.0 <3.0.0",
+    "@microsoft/node-library-build": ">=2.2.0 <3.0.0",
     "@types/chalk": "^0.4.31",
     "@types/express": "^4.0.33",
     "@types/express-serve-static-core": "^4.0.38",

--- a/common/temp_modules/rush-gulp-core-build-serve/package.json
+++ b/common/temp_modules/rush-gulp-core-build-serve/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "dependencies": {
-    "@microsoft/node-library-build": ">=2.1.0 <3.0.0",
+    "@microsoft/node-library-build": ">=2.2.0 <3.0.0",
     "@types/chalk": "^0.4.31",
     "@types/express": "^4.0.33",
     "@types/express-serve-static-core": "^4.0.38",

--- a/common/temp_modules/rush-gulp-core-build-typescript/package.json
+++ b/common/temp_modules/rush-gulp-core-build-typescript/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "dependencies": {
-    "@microsoft/node-library-build": ">=2.1.0 <3.0.0",
+    "@microsoft/node-library-build": ">=2.2.0 <3.0.0",
     "@types/chalk": "^0.4.31",
     "@types/gulp-util": "^3.0.29",
     "@types/orchestrator": "0.0.30",
@@ -37,6 +37,6 @@
   },
   "rushDependencies": {
     "@microsoft/gulp-core-build": ">=2.1.0 <3.0.0",
-    "@microsoft/api-extractor": ">=1.1.1 <2.0.0"
+    "@microsoft/api-extractor": ">=1.1.2 <2.0.0"
   }
 }

--- a/common/temp_modules/rush-gulp-core-build-webpack/package.json
+++ b/common/temp_modules/rush-gulp-core-build-webpack/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "dependencies": {
-    "@microsoft/node-library-build": ">=2.1.0 <3.0.0",
+    "@microsoft/node-library-build": ">=2.2.0 <3.0.0",
     "@types/chalk": "^0.4.31",
     "@types/orchestrator": "0.0.30",
     "@types/q": "0.0.32",

--- a/common/temp_modules/rush-gulp-core-build/package.json
+++ b/common/temp_modules/rush-gulp-core-build/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "dependencies": {
-    "@microsoft/node-library-build": ">=2.1.0 <3.0.0",
+    "@microsoft/node-library-build": ">=2.2.0 <3.0.0",
     "chai": "~3.5.0",
     "typescript": "~2.1.4",
     "@types/assertion-error": "^1.0.30",

--- a/common/temp_modules/rush-package-deps-hash/package.json
+++ b/common/temp_modules/rush-package-deps-hash/package.json
@@ -12,6 +12,6 @@
     "@types/node": "^6.0.46"
   },
   "rushDependencies": {
-    "@microsoft/node-library-build": ">=2.1.0 <3.0.0"
+    "@microsoft/node-library-build": ">=2.2.0 <3.0.0"
   }
 }

--- a/common/temp_modules/rush-web-library-build/package.json
+++ b/common/temp_modules/rush-web-library-build/package.json
@@ -16,7 +16,7 @@
   },
   "rushDependencies": {
     "@microsoft/gulp-core-build": ">=2.1.0 <3.0.0",
-    "@microsoft/gulp-core-build-karma": ">=2.0.0 <3.0.0",
+    "@microsoft/gulp-core-build-karma": ">=2.0.2 <3.0.0",
     "@microsoft/gulp-core-build-sass": ">=2.0.0 <3.0.0",
     "@microsoft/gulp-core-build-serve": ">=2.0.0 <3.0.0",
     "@microsoft/gulp-core-build-typescript": ">=2.2.1 <3.0.0",


### PR DESCRIPTION
I already submitted an [upstream fix](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/14005) to DefinitelyTyped that adds the definitions that we rely on for schema validation.  This PR updates **web-build-tools** to use it.