### PR TITLE
Require commits to use GitHub scrubbed addresses

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ script:
   - node node_modules/@microsoft/rush/lib/rush.js change -v
   - echo -en 'travis_fold:end:check\\r'
   - echo 'Installing...' && echo -en 'travis_fold:start:install\\r'
-  - node node_modules/@microsoft/rush/lib/rush.js install
+  - node node_modules/@microsoft/rush/lib/rush.js install --bypass-policy
   - echo -en 'travis_fold:end:install\\r'
   - echo 'Linking...' && echo -en 'travis_fold:start:link\\r'
   - node node_modules/@microsoft/rush/lib/rush.js link

--- a/package.json
+++ b/package.json
@@ -4,6 +4,6 @@
   "description": "Web build tools",
 
   "devDependencies": {
-    "@microsoft/rush": "~1.4.0"
+    "@microsoft/rush": "~1.5.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,6 @@
   "description": "Web build tools",
 
   "devDependencies": {
-    "@microsoft/rush": "~1.5.0"
+    "@microsoft/rush": "~1.5.1"
   }
 }

--- a/rush.json
+++ b/rush.json
@@ -1,6 +1,6 @@
 {
   "npmVersion": "3.10.9",
-  "rushMinimumVersion": "1.5.0",
+  "rushMinimumVersion": "1.5.1",
   "nodeSupportedVersionRange": ">=4.3.0",
   "commonFolder": "common",
   "projectFolderMinDepth": 1,

--- a/rush.json
+++ b/rush.json
@@ -1,11 +1,18 @@
 {
   "npmVersion": "3.10.9",
-  "rushMinimumVersion": "1.4.0",
+  "rushMinimumVersion": "1.5.0",
   "nodeSupportedVersionRange": ">=4.3.0",
   "commonFolder": "common",
   "projectFolderMinDepth": 1,
   "reviewCategories": [ "libraries", "other" ],
   "packageReviewFile": "common/reviews/PackageDependencies.json",
+  "gitPolicy": {
+    // Require GitHub scrubbed e-mails
+    "allowedEmailRegExps": [
+      "[^@]+@users\.noreply\.github\.com"
+    ],
+    "sampleEmail": "mrexample@users.noreply.github.com"
+  },
   "projects": [
     {
       "packageName": "@microsoft/gulp-core-build",


### PR DESCRIPTION
Upgrade to Rush 1.5.0 and enable the "allowedEmailRegExps" setting in rush.json.