### PR TITLE
Update to json schema to reflect API definition reference feature 

### DIFF
--- a/api-extractor/src/schemas/api-json-schema.json
+++ b/api-extractor/src/schemas/api-json-schema.json
@@ -28,7 +28,7 @@
     },
 
     //---------------------------------------------------------------------------------------------
-     "linkDocElement": {
+    "linkDocElement": {
       "description": "A documentation element representing a hyperlink",
       "type": "object",
 
@@ -70,7 +70,7 @@
       },
       "additionalProperties": false,
       "required": [ "kind", "referenceType" ]
-    }, 
+    },
 
     //---------------------------------------------------------------------------------------------
     "seeDocElement": {

--- a/api-extractor/src/schemas/api-json-schema.json
+++ b/api-extractor/src/schemas/api-json-schema.json
@@ -28,7 +28,7 @@
     },
 
     //---------------------------------------------------------------------------------------------
-    "linkDocElement": {
+     "linkDocElement": {
       "description": "A documentation element representing a hyperlink",
       "type": "object",
 
@@ -50,11 +50,27 @@
         "value": {
           "description": "An optional display name to show for a link",
           "type": "string"
+        },
+        "memberName": {
+          "description": "An optional name that specifies the export item",
+          "type": "string"
+        },
+        "exportName": {
+          "description": "A name that is required if the referenceType is code",
+          "type": "string"
+        },
+        "packageName": {
+          "description": "An optional name of the package where an export is located",
+          "type": "string"
+        },
+        "scopeName": {
+          "description": "An optional name that scopes the package name",
+          "type": "string"
         }
       },
       "additionalProperties": false,
-      "required": [ "kind", "referenceType", "targetUrl" ]
-    },
+      "required": [ "kind", "referenceType" ]
+    }, 
 
     //---------------------------------------------------------------------------------------------
     "seeDocElement": {

--- a/common/changes/dagaeta-update-to-json-schema_2017-01-23-23-18.json
+++ b/common/changes/dagaeta-update-to-json-schema_2017-01-23-23-18.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor",
+      "comment": "Json schema was updated to reflect feature additions to linkDocElement. The linkDocElement can now be of type 'code' which refers to an API definition reference.",
+      "type": "patch"
+    }
+  ],
+  "email": "dgaeta@users.noreply.github.com"
+}


### PR DESCRIPTION
Feature work has recently been added to allow a link JSDoc tag to link to an API definition that is internal and external (external in the works). 
The schema needed to be updated to include the members that of linkDocElement that will now be present if a linkDocElement is of reference type 'code' (API definition reference). 