### PR TITLE
Added description for packages implementation

### DIFF
--- a/api-extractor/src/Analyzer.ts
+++ b/api-extractor/src/Analyzer.ts
@@ -83,9 +83,6 @@ export default class Analyzer {
     if (!rootFile) {
       throw new Error('Unable to load file: ' + options.entryPointFile);
     }
-    // const rootFileSymbol: ts.Symbol = TypeScriptHelpers.getSymbolForDeclaration(rootFile);
-
-    // this.package = new ApiPackage(this, rootFileSymbol);
 
     this.package = new ApiPackage(this, rootFile);
   }

--- a/api-extractor/src/Analyzer.ts
+++ b/api-extractor/src/Analyzer.ts
@@ -83,9 +83,11 @@ export default class Analyzer {
     if (!rootFile) {
       throw new Error('Unable to load file: ' + options.entryPointFile);
     }
-    const rootFileSymbol: ts.Symbol = TypeScriptHelpers.getSymbolForDeclaration(rootFile);
+    // const rootFileSymbol: ts.Symbol = TypeScriptHelpers.getSymbolForDeclaration(rootFile);
 
-    this.package = new ApiPackage(this, rootFileSymbol);
+    // this.package = new ApiPackage(this, rootFileSymbol);
+
+    this.package = new ApiPackage(this, rootFile);
   }
 
   /**

--- a/api-extractor/src/Analyzer.ts
+++ b/api-extractor/src/Analyzer.ts
@@ -1,6 +1,5 @@
 import * as ts from 'typescript';
 import ApiPackage from './definitions/ApiPackage';
-import TypeScriptHelpers from './TypeScriptHelpers';
 import DocItemLoader from './DocItemLoader';
 
 export type ApiErrorHandler = (message: string, fileName: string, lineNumber: number) => void;

--- a/api-extractor/src/DebugRun.ts
+++ b/api-extractor/src/DebugRun.ts
@@ -25,7 +25,7 @@ analyzer.analyze({
     moduleResolution: ts.ModuleResolutionKind.NodeJs,
     experimentalDecorators: true,
     jsx: ts.JsxEmit.React,
-    rootDir: './testInputs/example2' //'D:/GitRepos/sp-client/spfx-core/sp-codepart-base'
+    rootDir: './testInputs/example2' // 'D:/GitRepos/sp-client/spfx-core/sp-codepart-base'
   },
   entryPointFile: './testInputs/example2/index.ts', // 'D:/GitRepos/sp-client/spfx-core/sp-codepart-base/src/index.ts',
   otherFiles: []

--- a/api-extractor/src/DebugRun.ts
+++ b/api-extractor/src/DebugRun.ts
@@ -25,9 +25,9 @@ analyzer.analyze({
     moduleResolution: ts.ModuleResolutionKind.NodeJs,
     experimentalDecorators: true,
     jsx: ts.JsxEmit.React,
-    rootDir: 'D:/GitRepos/sp-client/spfx-core/sp-codepart-base'
+    rootDir: './testInputs/example2' //'D:/GitRepos/sp-client/spfx-core/sp-codepart-base'
   },
-  entryPointFile: 'D:/GitRepos/sp-client/spfx-core/sp-codepart-base/src/index.ts',
+  entryPointFile: './testInputs/example2/index.ts', // 'D:/GitRepos/sp-client/spfx-core/sp-codepart-base/src/index.ts',
   otherFiles: []
 });
 

--- a/api-extractor/src/DebugRun.ts
+++ b/api-extractor/src/DebugRun.ts
@@ -25,9 +25,9 @@ analyzer.analyze({
     moduleResolution: ts.ModuleResolutionKind.NodeJs,
     experimentalDecorators: true,
     jsx: ts.JsxEmit.React,
-    rootDir: './testInputs/example2' // 'D:/GitRepos/sp-client/spfx-core/sp-codepart-base'
+    rootDir: './testInputs/example2'
   },
-  entryPointFile: './testInputs/example2/index.ts', // 'D:/GitRepos/sp-client/spfx-core/sp-codepart-base/src/index.ts',
+  entryPointFile: './testInputs/example2/index.ts',
   otherFiles: []
 });
 

--- a/api-extractor/src/PrettyPrinter.ts
+++ b/api-extractor/src/PrettyPrinter.ts
@@ -1,7 +1,7 @@
 /* tslint:disable:no-bitwise */
 
 import * as ts from 'typescript';
-
+import TypeScriptHelpers from './TypeScriptHelpers';
 /**
   * Some helper functions for formatting certain TypeScript Compiler API expressions.
   */
@@ -10,23 +10,36 @@ export default class PrettyPrinter {
     * Used for debugging only.  This dumps the TypeScript Compiler's abstract syntax tree.
     */
   public static dumpTree(node: ts.Node, indent: string = ''): void {
-    if (node.kind === ts.SyntaxKind.FromKeyword) {
-      console.log('**');
-    }
+    try {
+      const jsdoc: string = TypeScriptHelpers.getJsDocComments(node, console.log);
+      if (jsdoc && jsdoc.trim()) {
+        console.log('COMMENT=' + jsdoc);
+      }
+    } catch (e) {} /* tslint:disable-line:no-empty */
 
     const kindName: string = ts.SyntaxKind[node.kind];
-    let trimmedText: string = node.getText()
-      .replace(/[\r\n]/g, ' ')
-      .replace(/\s+/g, ' ')
-      .trim();
+    let trimmedText: string;
 
-    if (trimmedText.length > 100) {
-      trimmedText = trimmedText.substr(0, 97) + '...';
+    try {
+      trimmedText = node.getText()
+        .replace(/[\r\n]/g, ' ')
+        .replace(/\s+/g, ' ')
+        .trim();
+
+      if (trimmedText.length > 100) {
+        trimmedText = trimmedText.substr(0, 97) + '...';
+      }
+    } catch (e) {
+      trimmedText = '(error getting text)';
     }
 
     console.log(`${indent}${kindName}: [${trimmedText}]`);
-    for (const childNode of node.getChildren()) {
-      PrettyPrinter.dumpTree(childNode, indent + '  ');
+    try {
+      for (const childNode of node.getChildren()) {
+        PrettyPrinter.dumpTree(childNode, indent + '  ');
+      }
+    } catch (e) {
+      // sometimes getChildren() throws an exception
     }
   }
 

--- a/api-extractor/src/PrettyPrinter.ts
+++ b/api-extractor/src/PrettyPrinter.ts
@@ -1,7 +1,6 @@
 /* tslint:disable:no-bitwise */
 
 import * as ts from 'typescript';
-import TypeScriptHelpers from './TypeScriptHelpers';
 /**
   * Some helper functions for formatting certain TypeScript Compiler API expressions.
   */

--- a/api-extractor/src/PrettyPrinter.ts
+++ b/api-extractor/src/PrettyPrinter.ts
@@ -12,9 +12,6 @@ export default class PrettyPrinter {
   public static dumpTree(node: ts.Node, indent: string = ''): void {
     try {
       const jsdoc: string = TypeScriptHelpers.getJsDocComments(node, console.log);
-      if (jsdoc && jsdoc.trim()) {
-        console.log('COMMENT=' + jsdoc);
-      }
     } catch (e) {} /* tslint:disable-line:no-empty */
 
     const kindName: string = ts.SyntaxKind[node.kind];
@@ -33,7 +30,6 @@ export default class PrettyPrinter {
       trimmedText = '(error getting text)';
     }
 
-    console.log(`${indent}${kindName}: [${trimmedText}]`);
     try {
       for (const childNode of node.getChildren()) {
         PrettyPrinter.dumpTree(childNode, indent + '  ');

--- a/api-extractor/src/PrettyPrinter.ts
+++ b/api-extractor/src/PrettyPrinter.ts
@@ -10,10 +10,6 @@ export default class PrettyPrinter {
     * Used for debugging only.  This dumps the TypeScript Compiler's abstract syntax tree.
     */
   public static dumpTree(node: ts.Node, indent: string = ''): void {
-    try {
-      const jsdoc: string = TypeScriptHelpers.getJsDocComments(node, console.log);
-    } catch (e) {} /* tslint:disable-line:no-empty */
-
     const kindName: string = ts.SyntaxKind[node.kind];
     let trimmedText: string;
 

--- a/api-extractor/src/definitions/ApiDocumentation.ts
+++ b/api-extractor/src/definitions/ApiDocumentation.ts
@@ -10,6 +10,7 @@ import DocItemLoader from '../DocItemLoader';
 import { IApiDefinitionReference } from '../IApiDefinitionReference';
 import Token, { TokenType } from '../Token';
 import Tokenizer from '../Tokenizer';
+import ApiPackage from './ApiPackage';
 
 /**
   * An "API Tag" is a custom JSDoc tag which indicates whether an ApiItem definition
@@ -22,27 +23,27 @@ export enum ApiTag {
   /**
    * No API Tag was specified in the JSDoc summary.
    */
-  None,
+  None = 0,
   /**
    * The API was documented as internal, i.e. not callable by third party developers.
    */
-  Internal,
+  Internal = 1,
   /**
    * The API was documented as "alpha."  This status is not generally used.  See the
    * ApiPrinciplesAndProcess.md for details.
    */
-  Alpha,
+  Alpha = 2,
   /**
    * The API was documented as callable by third party developers, but at their own risk.
    * Web parts that call beta APIs should only be used for experimentation, because the Web Part
    * will break if Microsoft changes the API signature later.
    */
-  Beta,
+  Beta = 3,
   /**
    * The API was documented as callable by third party developers, with a guarantee that Microsoft will
    * never make any breaking changes once the API is published.
    */
-  Public
+  Public = 4
 }
 
 /**
@@ -253,8 +254,10 @@ export default class ApiDocumentation {
   }
 
   protected _getJsDocs(apiItem: ApiItem): string {
-    const sourceFile: ts.SourceFile = apiItem.getDeclaration().getSourceFile();
-    const jsDoc: string = TypeScriptHelpers.getJsDocComments(apiItem.getDeclaration(), this.reportError);
+    if (!apiItem.jsdocNode) {
+      return '';
+    }
+    const jsDoc: string = TypeScriptHelpers.getJsDocComments(apiItem.jsdocNode, this.reportError);
 
     // Eliminate tags and then count the English letters.  Are there at least 10 letters of text?
     // If not, we consider the definition to be "missingDocumentation".
@@ -400,6 +403,14 @@ export default class ApiDocumentation {
 
     if (apiTagCount > 1) {
       this.reportError('More than one API Tag was specified');
+    }
+
+    if (this.apiItem instanceof ApiPackage) {
+      if (apiTagCount > 0) {
+        const tag: string = '@' + ApiTag[this.apiTag].toLowerCase();
+        this.reportError(`The ${tag} tag is not allowed on the package`);
+      }
+      this.apiTag = ApiTag.Public;
     }
 
     if (this.preapproved) {

--- a/api-extractor/src/definitions/ApiDocumentation.ts
+++ b/api-extractor/src/definitions/ApiDocumentation.ts
@@ -408,7 +408,7 @@ export default class ApiDocumentation {
     if (this.apiItem instanceof ApiPackage) {
       if (apiTagCount > 0) {
         const tag: string = '@' + ApiTag[this.apiTag].toLowerCase();
-        this.reportError(`The ${tag} tag is not allowed on the package`);
+        this.reportError(`The ${tag} tag is not allowed on the package, which is always public`);
       }
       this.apiTag = ApiTag.Public;
     }

--- a/api-extractor/src/definitions/ApiEnum.ts
+++ b/api-extractor/src/definitions/ApiEnum.ts
@@ -17,7 +17,8 @@ export default class ApiEnum extends ApiItemContainer {
       const memberOptions: IApiItemOptions = {
         analyzer: this.analyzer,
         declaration: memberDeclaration,
-        declarationSymbol: memberSymbol
+        declarationSymbol: memberSymbol,
+        jsdocNode: memberDeclaration
       };
 
       this.addMemberItem(new ApiEnumValue(memberOptions));

--- a/api-extractor/src/definitions/ApiFunction.ts
+++ b/api-extractor/src/definitions/ApiFunction.ts
@@ -29,7 +29,8 @@ class ApiFunction extends ApiItem {
         this.params.push(new ApiParameter({
           analyzer: this.analyzer,
           declaration: param,
-          declarationSymbol: declarationSymbol
+          declarationSymbol: declarationSymbol,
+          jsdocNode: param
         }, docComment));
       }
     }

--- a/api-extractor/src/definitions/ApiItem.ts
+++ b/api-extractor/src/definitions/ApiItem.ts
@@ -9,9 +9,27 @@ import ApiDocumentation from './ApiDocumentation';
   * This interface is used to pass options between constructors for ApiItem child classes.
   */
 export interface IApiItemOptions {
+  /**
+   * The associated Analyzer object for this ApiItem
+   */
   analyzer: Analyzer;
+  /**
+   * The declaration node for the main syntax item that this ApiItem is associated with. 
+   */
   declaration: ts.Declaration;
+  /**
+   * The semantic information for the declaration.
+   */
   declarationSymbol: ts.Symbol;
+  /**
+   * The declaration node that contains the JSDoc comments for this ApiItem.
+   * In most cases this is the same as `declaration`, but for ApiPackage it will be
+   * a separate node under the root.
+   */
+  jsdocNode: ts.Node;
+  /**
+   * The symbol used to export this ApiItem from the ApiPackage.
+   */
   exportSymbol?: ts.Symbol;
 }
 
@@ -40,6 +58,13 @@ abstract class ApiItem {
    * the API file produced by ApiFileGenerator.
    */
   public warnings: string[];
+
+  /**
+   * The declaration node that contains the JSDoc comments for this ApiItem.
+   * In most cases this is the same as `declaration`, but for ApiPackage it will be
+   * a separate node under the root.
+   */
+  public jsdocNode: ts.Node;
 
   public documentation: ApiDocumentation;
 
@@ -79,6 +104,7 @@ abstract class ApiItem {
     this.reportError = this.reportError.bind(this);
 
     this.declaration = options.declaration;
+    this.jsdocNode = options.jsdocNode;
     this._errorNode = options.declaration;
     this.warnings = [];
 

--- a/api-extractor/src/definitions/ApiMember.ts
+++ b/api-extractor/src/definitions/ApiMember.ts
@@ -66,7 +66,8 @@ export default class ApiMember extends ApiItem {
       const typeLiteralOptions: IApiItemOptions = {
         analyzer: this.analyzer,
         declaration: propertyTypeDeclaration,
-        declarationSymbol: propertyTypeSymbol
+        declarationSymbol: propertyTypeSymbol,
+        jsdocNode: propertyTypeDeclaration
       };
 
       this.typeLiteral = new ApiStructuredType(typeLiteralOptions);

--- a/api-extractor/src/definitions/ApiMethod.ts
+++ b/api-extractor/src/definitions/ApiMethod.ts
@@ -30,7 +30,8 @@ export default class ApiMethod extends ApiMember {
         this.params.push(new ApiParameter({
           analyzer: this.analyzer,
           declaration: param,
-          declarationSymbol: declarationSymbol
+          declarationSymbol: declarationSymbol,
+          jsdocNode: param
         }, docComment));
       }
     }

--- a/api-extractor/src/definitions/ApiPackage.ts
+++ b/api-extractor/src/definitions/ApiPackage.ts
@@ -14,16 +14,16 @@ import TypeScriptHelpers from '../TypeScriptHelpers';
   * exports for an Rush package.  This object acts as the root of the Analyzer's tree.
   */
 export default class ApiPackage extends ApiItemContainer {
-  private static _getOptions(analyzer: Analyzer, rootFileSymbol: ts.Symbol): IApiItemOptions {
+  private static _getOptions(analyzer: Analyzer, rootFile: ts.SourceFile): IApiItemOptions {
+    const rootFileSymbol: ts.Symbol = TypeScriptHelpers.getSymbolForDeclaration(rootFile);
     let statement: ts.VariableStatement;
     let foundDescription: ts.Node = undefined;
-    for (const statementNode of (rootFileSymbol.declarations[0] as ts.SourceFile).statements) {
+
+    for (const statementNode of rootFile.statements) {
       if (statementNode.kind === ts.SyntaxKind.VariableStatement) {
         statement = statementNode as ts.VariableStatement;
         for (const statementDeclaration of statement.declarationList.declarations) {
           if (statementDeclaration.name.getText() === 'packageDescription') {
-            // The following line is useful for debugging
-            // console.log('FOUND: ' + TypeScriptHelpers.getJsDocComments(statement, console.log));
             foundDescription = statement;
           }
         }
@@ -37,10 +37,10 @@ export default class ApiPackage extends ApiItemContainer {
       jsdocNode: foundDescription
     };
   }
-  constructor(analyzer: Analyzer, rootFileSymbol: ts.Symbol) {
-    super(ApiPackage._getOptions(analyzer, rootFileSymbol));
+  constructor(analyzer: Analyzer, rootFile: ts.SourceFile) {
+    super(ApiPackage._getOptions(analyzer, rootFile));
 
-    const exportSymbols: ts.Symbol[] = this.typeChecker.getExportsOfModule(rootFileSymbol);
+    const exportSymbols: ts.Symbol[] = this.typeChecker.getExportsOfModule(this.declarationSymbol);
     if (exportSymbols) {
       for (const exportSymbol of exportSymbols) {
         const followedSymbol: ts.Symbol = this.followAliases(exportSymbol);

--- a/api-extractor/src/definitions/ApiStructuredType.ts
+++ b/api-extractor/src/definitions/ApiStructuredType.ts
@@ -182,7 +182,8 @@ export default class ApiStructuredType extends ApiItemContainer {
     const memberOptions: IApiItemOptions = {
       analyzer: this.analyzer,
       declaration: memberDeclaration,
-      declarationSymbol: memberSymbol
+      declarationSymbol: memberSymbol,
+      jsdocNode: memberDeclaration
     };
 
     if (memberSymbol.flags & (

--- a/api-extractor/src/generators/ApiFileGenerator.ts
+++ b/api-extractor/src/generators/ApiFileGenerator.ts
@@ -138,6 +138,9 @@ export default class ApiFileGenerator extends ApiItemVisitor {
    * by the Analzer.
    */
   private _writeJsdocSynopsis(apiItem: ApiItem): void {
+    if (apiItem instanceof ApiPackage) {
+      return;
+    }
     const lines: string[] = apiItem.warnings.map((x: string) => 'WARNING: ' + x);
 
     let footer: string = '';

--- a/api-extractor/src/generators/ApiFileGenerator.ts
+++ b/api-extractor/src/generators/ApiFileGenerator.ts
@@ -138,45 +138,46 @@ export default class ApiFileGenerator extends ApiItemVisitor {
    * by the Analzer.
    */
   private _writeJsdocSynopsis(apiItem: ApiItem): void {
-    if (apiItem instanceof ApiPackage) {
-      return;
-    }
     const lines: string[] = apiItem.warnings.map((x: string) => 'WARNING: ' + x);
 
-    let footer: string = '';
-    switch (apiItem.documentation.apiTag) {
-      case ApiTag.Internal:
-        footer += '@internal';
-        break;
-      case ApiTag.Alpha:
-        footer += '@alpha';
-        break;
-      case ApiTag.Beta:
-        footer += '@beta';
-        break;
-      case ApiTag.Public:
-        footer += '@public';
-        break;
-    }
-
-    // deprecatedMessage is initialized by default,
-    // this ensures it has contents before adding '@deprecated'
-    if (apiItem.documentation.deprecatedMessage.length > 0) {
-      if (footer) {
-        footer += ' ';
+    if (apiItem instanceof ApiPackage && !apiItem.documentation.summary.length) {
+      lines.push('(No packageDescription for this package)');
+    } else {
+      let footer: string = '';
+      switch (apiItem.documentation.apiTag) {
+        case ApiTag.Internal:
+          footer += '@internal';
+          break;
+        case ApiTag.Alpha:
+          footer += '@alpha';
+          break;
+        case ApiTag.Beta:
+          footer += '@beta';
+          break;
+        case ApiTag.Public:
+          footer += '@public';
+          break;
       }
-      footer += '@deprecated';
-    }
 
-    if (apiItem.documentation.isMissing) {
-      if (footer) {
-        footer += ' ';
+      // deprecatedMessage is initialized by default,
+      // this ensures it has contents before adding '@deprecated'
+      if (apiItem.documentation.deprecatedMessage.length > 0) {
+        if (footer) {
+          footer += ' ';
+        }
+        footer += '@deprecated';
       }
-      footer += '(undocumented)';
-    }
 
-    if (footer) {
-      lines.push(footer);
+      if (apiItem.documentation.isMissing) {
+        if (footer) {
+          footer += ' ';
+        }
+        footer += '(undocumented)';
+      }
+
+      if (footer) {
+        lines.push(footer);
+      }
     }
 
     if (lines.length) {

--- a/api-extractor/src/generators/ApiJsonGenerator.ts
+++ b/api-extractor/src/generators/ApiJsonGenerator.ts
@@ -161,6 +161,7 @@ export default class ApiJsonGenerator extends ApiItemVisitor {
   protected visitApiPackage(apiPackage: ApiPackage, refObject?: Object): void {
     refObject['kind'] = ApiJsonGenerator._KIND_PACKAGE; /* tslint:disable-line:no-string-literal */
     refObject['summary'] = apiPackage.documentation.summary; /* tslint:disable-line:no-string-literal */
+    refObject['remarks'] = apiPackage.documentation.remarks; /* tslint:disable-line:no-string-literal */
 
     const membersNode: Object = {};
     refObject[ApiJsonGenerator._EXPORTS_KEY] = membersNode;

--- a/api-extractor/src/generators/ApiJsonGenerator.ts
+++ b/api-extractor/src/generators/ApiJsonGenerator.ts
@@ -160,6 +160,7 @@ export default class ApiJsonGenerator extends ApiItemVisitor {
 
   protected visitApiPackage(apiPackage: ApiPackage, refObject?: Object): void {
     refObject['kind'] = ApiJsonGenerator._KIND_PACKAGE; /* tslint:disable-line:no-string-literal */
+    refObject['summary'] = apiPackage.documentation.summary; /* tslint:disable-line:no-string-literal */
 
     const membersNode: Object = {};
     refObject[ApiJsonGenerator._EXPORTS_KEY] = membersNode;

--- a/api-extractor/src/index.ts
+++ b/api-extractor/src/index.ts
@@ -1,3 +1,10 @@
+
+/**
+ * A utility that analyzes a project, detects common JSDoc problems , and generates
+ * a report of the exported Public API.
+ */
+declare const packageDescription: void;
+
 export { default as Analyzer, IApiAnalyzerOptions, ApiErrorHandler } from './Analyzer';
 export { default as ApiFileGenerator  } from './generators/ApiFileGenerator';
 export { default as ApiJsonGenerator  } from './generators/ApiJsonGenerator';

--- a/api-extractor/src/schemas/api-json-schema.json
+++ b/api-extractor/src/schemas/api-json-schema.json
@@ -522,6 +522,9 @@
       "type": "string",
       "enum": [ "package" ]
     },
+    "summary": {
+          "$ref": "#/definitions/docElementCollection"
+    },
     "exports": {
       "description": "The exported definitions for this API package",
       "type": "object",

--- a/api-extractor/src/schemas/api-json-schema.json
+++ b/api-extractor/src/schemas/api-json-schema.json
@@ -525,6 +525,9 @@
     "summary": {
           "$ref": "#/definitions/docElementCollection"
     },
+    "remarks": {
+          "$ref": "#/definitions/docElementCollection"
+    },
     "exports": {
       "description": "The exported definitions for this API package",
       "type": "object",

--- a/api-extractor/testInputs/example1/example1-output.ts
+++ b/api-extractor/testInputs/example1/example1-output.ts
@@ -31,3 +31,4 @@ class PreapprovedInternalClass {
 // (undocumented)
 export function publicFunction(param: number): string;
 
+// (No packageDescription for this package)

--- a/api-extractor/testInputs/example2/example2-output.json
+++ b/api-extractor/testInputs/example2/example2-output.json
@@ -1,5 +1,11 @@
 {
   "kind": "package",
+  "summary": [
+    {
+      "kind": "textDocElement",
+      "value": "Here is some documentation for example2."
+    }
+  ],
   "exports": {
     "inheritCorrectlyButNotFound": {
       "kind": "enum",

--- a/api-extractor/testInputs/example2/example2-output.json
+++ b/api-extractor/testInputs/example2/example2-output.json
@@ -6,6 +6,12 @@
       "value": "Here is some documentation for example2."
     }
   ],
+  "remarks": [
+    {
+      "kind": "textDocElement",
+      "value": "These are additional remarks that may be too long for the summary. They should appear in the remarks of the json generated file for this package."
+    }
+  ],
   "exports": {
     "inheritCorrectlyButNotFound": {
       "kind": "enum",

--- a/api-extractor/testInputs/example2/index.ts
+++ b/api-extractor/testInputs/example2/index.ts
@@ -1,5 +1,7 @@
 /**
  * Here is some documentation for example2.
+ * @remarks These are additional remarks that may be too long for the summary.
+ * They should appear in the remarks of the json generated file for this package.
  */
 declare const packageDescription: void;
 

--- a/api-extractor/testInputs/example2/index.ts
+++ b/api-extractor/testInputs/example2/index.ts
@@ -1,3 +1,8 @@
+/**
+ * Here is some documentation for example2.
+ */
+declare const packageDescription: void;
+
 export {
     TestMissingCommentStar,
     inheritDisplayMode,

--- a/common/changes/dagaeta-package-comments_2017-01-25-02-39.json
+++ b/common/changes/dagaeta-package-comments_2017-01-25-02-39.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor",
+      "comment": "Added description for packages implementation.",
+      "type": "patch"
+    }
+  ],
+  "email": "dgaeta@users.noreply.github.com"
+}


### PR DESCRIPTION
- package descriptions are created at the top of the their index.ts file:
```typscript 
/**
 * A utility that analyzes a project, detects common JSDoc problems , and generates
 * a report of the exported Public API.
 */
declare const packageDescription: void;
```

- if their is no package description no error is reported. We can see this is working by observing that testInput/example2 has a description and testInput/example1 has no package description (with no change in their reported errors count)