### PR TITLE
Updates node-notifier dependency to v5.0.1

### DIFF
--- a/gulp-core-build/package.json
+++ b/gulp-core-build/package.json
@@ -42,7 +42,7 @@
     "jju": "~1.3.0",
     "lodash.merge": "~4.3.2",
     "merge2": "~1.0.2",
-    "node-notifier": "~4.5.0",
+    "node-notifier": "~5.0.1",
     "object-assign": "~4.1.0",
     "pretty-hrtime": "~1.0.2",
     "rimraf": "~2.5.4",


### PR DESCRIPTION
Updates the dependency of `node-notifier` to the latest [newly released `v5.0.1`](https://github.com/mikaelbr/node-notifier/blob/master/CHANGELOG.md#v500).

With this change there are a lot fewer dependencies as the built in CLI is removed, and other dependencies are trimmed. 

No change in the way it's used in this package.
