### PR TITLE
Removes seemingly unused dependency

### DIFF
--- a/web-library-build/package.json
+++ b/web-library-build/package.json
@@ -27,8 +27,7 @@
     "@types/gulp": "^3.8.32",
     "@types/node": "^6.0.46",
     "gulp": "~3.9.1",
-    "gulp-replace": "^0.5.4",
-    "node-notifier": "~4.6.1"
+    "gulp-replace": "^0.5.4"
   },
   "devDependencies": {
     "typescript": "~2.1.4"


### PR DESCRIPTION
Looks to me as `node-notifier` isn't used in this sub-package. Maybe there is some build steps, automatic transformation or merging of other packages going on so I might be wrong. But it seems to me as node-notifier can be removed fromt this.