### PR TITLE
Nickpape/fix declaration

### DIFF
--- a/common/changes/nickpape-fix-declaration_2017-01-31-20-17.json
+++ b/common/changes/nickpape-fix-declaration_2017-01-31-20-17.json
@@ -1,0 +1,25 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/gulp-core-build-webpack",
+      "comment": "Make loadSchema public instead of protected.",
+      "type": "patch"
+    },
+    {
+      "packageName": "@microsoft/gulp-core-build-typescript",
+      "comment": "Make loadSchema public instead of protected.",
+      "type": "patch"
+    },
+    {
+      "packageName": "@microsoft/gulp-core-build-serve",
+      "comment": "Make loadSchema public instead of protected.",
+      "type": "patch"
+    },
+    {
+      "packageName": "@microsoft/gulp-core-build-sass",
+      "comment": "Make loadSchema public instead of protected.",
+      "type": "patch"
+    }
+  ],
+  "email": "nickpape-msft@users.noreply.github.com"
+}

--- a/gulp-core-build-sass/src/SassTask.ts
+++ b/gulp-core-build-sass/src/SassTask.ts
@@ -56,7 +56,7 @@ export class SassTask extends GulpTask<ISassTaskConfig> {
     'src/**/*.scss.ts'
   ];
 
-  protected loadSchema(): Object {
+  public loadSchema(): Object {
     return require('./sass.schema.json');
   }
 

--- a/gulp-core-build-serve/src/ServeTask.ts
+++ b/gulp-core-build-serve/src/ServeTask.ts
@@ -84,7 +84,7 @@ export class ServeTask extends GulpTask<IServeTaskConfig> {
     tryCreateDevCertificate: false
   };
 
-  protected loadSchema(): Object {
+  public loadSchema(): Object {
     return require('./serve.schema.json');
   }
 

--- a/gulp-core-build-typescript/src/TypeScriptTask.ts
+++ b/gulp-core-build-typescript/src/TypeScriptTask.ts
@@ -114,7 +114,7 @@ export class TypeScriptTask extends GulpTask<ITypeScriptTaskConfig> {
   private _tsProject: ts.Project;
   private _tsAMDProject: ts.Project;
 
-  protected loadSchema(): Object {
+  public loadSchema(): Object {
     return require('./schemas/typescript.schema.json');
   }
 

--- a/gulp-core-build-webpack/src/WebpackTask.ts
+++ b/gulp-core-build-webpack/src/WebpackTask.ts
@@ -52,7 +52,7 @@ export class WebpackTask extends GulpTask<IWebpackTaskConfig> {
     );
   }
 
-  protected loadSchema(): Object {
+  public loadSchema(): Object {
     return require('./webpack.schema.json');
   }
 


### PR DESCRIPTION
`loadSchema()` should be public, rather than private, as otherwise TypeScript complains that the task does not properly extend GulpTask.