### PR TITLE
Added ApiItemKind enum to ApiItem and refactored child classes

### DIFF
--- a/api-extractor/src/definitions/ApiEnum.ts
+++ b/api-extractor/src/definitions/ApiEnum.ts
@@ -12,7 +12,7 @@ import TypeScriptHelpers from '../TypeScriptHelpers';
 export default class ApiEnum extends ApiItemContainer {
   constructor(options: IApiItemOptions) {
     super(options);
-    this.kind = ApiItemKind.enum;
+    this.kind = ApiItemKind.Enum;
 
     for (const memberDeclaration of (options.declaration as ts.EnumDeclaration).members) {
       const memberSymbol: ts.Symbol = TypeScriptHelpers.getSymbolForDeclaration(memberDeclaration);

--- a/api-extractor/src/definitions/ApiEnum.ts
+++ b/api-extractor/src/definitions/ApiEnum.ts
@@ -1,4 +1,5 @@
 import * as ts from 'typescript';
+import { ApiItemKind } from './ApiItem';
 import ApiItemContainer from './ApiItemContainer';
 import { IApiItemOptions } from './ApiItem';
 import ApiEnumValue from './ApiEnumValue';
@@ -11,6 +12,8 @@ import TypeScriptHelpers from '../TypeScriptHelpers';
 export default class ApiEnum extends ApiItemContainer {
   constructor(options: IApiItemOptions) {
     super(options);
+    this.kind = ApiItemKind.enum;
+
     for (const memberDeclaration of (options.declaration as ts.EnumDeclaration).members) {
       const memberSymbol: ts.Symbol = TypeScriptHelpers.getSymbolForDeclaration(memberDeclaration);
 

--- a/api-extractor/src/definitions/ApiEnumValue.ts
+++ b/api-extractor/src/definitions/ApiEnumValue.ts
@@ -8,7 +8,7 @@ import PrettyPrinter from '../PrettyPrinter';
 export default class ApiEnumValue extends ApiItem {
   constructor(options: IApiItemOptions) {
     super(options);
-    this.kind = ApiItemKind.enumValue;
+    this.kind = ApiItemKind.EnumValue;
   }
 
   /**

--- a/api-extractor/src/definitions/ApiEnumValue.ts
+++ b/api-extractor/src/definitions/ApiEnumValue.ts
@@ -1,4 +1,4 @@
-import ApiItem, { IApiItemOptions } from './ApiItem';
+import ApiItem, { ApiItemKind, IApiItemOptions } from './ApiItem';
 import PrettyPrinter from '../PrettyPrinter';
 
 /**
@@ -8,6 +8,7 @@ import PrettyPrinter from '../PrettyPrinter';
 export default class ApiEnumValue extends ApiItem {
   constructor(options: IApiItemOptions) {
     super(options);
+    this.kind = ApiItemKind.enumValue;
   }
 
   /**

--- a/api-extractor/src/definitions/ApiFunction.ts
+++ b/api-extractor/src/definitions/ApiFunction.ts
@@ -16,7 +16,7 @@ class ApiFunction extends ApiItem {
 
   constructor(options: IApiItemOptions) {
     super(options);
-    this.kind = ApiItemKind.function;
+    this.kind = ApiItemKind.Function;
 
     const methodDeclaration: ts.FunctionDeclaration = options.declaration as ts.FunctionDeclaration;
 

--- a/api-extractor/src/definitions/ApiFunction.ts
+++ b/api-extractor/src/definitions/ApiFunction.ts
@@ -1,5 +1,5 @@
 import * as ts from 'typescript';
-import ApiItem, { IApiItemOptions } from './ApiItem';
+import ApiItem, { ApiItemKind, IApiItemOptions } from './ApiItem';
 import ApiParameter from './ApiParameter';
 import TypeScriptHelpers from '../TypeScriptHelpers';
 import PrettyPrinter from '../PrettyPrinter';
@@ -16,6 +16,7 @@ class ApiFunction extends ApiItem {
 
   constructor(options: IApiItemOptions) {
     super(options);
+    this.kind = ApiItemKind.function;
 
     const methodDeclaration: ts.FunctionDeclaration = options.declaration as ts.FunctionDeclaration;
 

--- a/api-extractor/src/definitions/ApiItem.ts
+++ b/api-extractor/src/definitions/ApiItem.ts
@@ -12,43 +12,43 @@ export enum ApiItemKind {
   /**
     * A TypeScript class.
     */
-  class = 0,
+  Class = 0,
   /**
     * A TypeScript enum.
     */
-  enum = 1,
+  Enum = 1,
   /**
     * A TypeScript value on an enum.
     */
-  enumValue = 2,
+  EnumValue = 2,
   /**
     * A TypeScript function.
     */
-  function = 3,
+  Function = 3,
   /**
     * A TypeScript interface.
     */
-  interface = 4,
+  Interface = 4,
   /**
     * A TypeScript method.
     */
-  method = 5,
+  Method = 5,
   /**
     * A TypeScript package.
     */
-  package = 6,
+  Package = 6,
   /**
     * A TypeScript parameter.
     */
-  parameter = 7,
+  Parameter = 7,
   /**
     * A TypeScript property.
     */
-  property = 8,
+  Property = 8,
   /**
     * A TypeScript type literal expression, i.e. which defines an anonymous interface.
     */
-  typeLiteral = 9
+  TypeLiteral = 9
 }
 
 /**

--- a/api-extractor/src/definitions/ApiItem.ts
+++ b/api-extractor/src/definitions/ApiItem.ts
@@ -6,6 +6,52 @@ import Extractor from '../Extractor';
 import ApiDocumentation from './ApiDocumentation';
 
 /**
+ * Indicates the type of definition represented by a ApiItem object.
+ */
+export enum ApiItemKind {
+  /**
+    * A TypeScript class.
+    */
+  class = 0,
+  /**
+    * A TypeScript enum.
+    */
+  enum = 1,
+  /**
+    * A TypeScript value on an enum.
+    */
+  enumValue = 2,
+  /**
+    * A TypeScript function.
+    */
+  function = 3,
+  /**
+    * A TypeScript interface.
+    */
+  interface = 4,
+  /**
+    * A TypeScript method.
+    */
+  method = 5,
+  /**
+    * A TypeScript package.
+    */
+  package = 6,
+  /**
+    * A TypeScript parameter.
+    */
+  parameter = 7,
+  /**
+    * A TypeScript property.
+    */
+  property = 8,
+  /**
+    * A TypeScript type literal expression, i.e. which defines an anonymous interface.
+    */
+  typeLiteral = 9
+}
+
+/**
   * This interface is used to pass options between constructors for ApiItem child classes.
   */
 export interface IApiItemOptions {
@@ -51,6 +97,11 @@ abstract class ApiItem {
    * from the top-level ApiPackage, not "MyClass" from the original definition.
    */
   public name: string;
+
+  /**
+   * Indicates the type of definition represented by this ApiItem instance.
+   */
+  public kind: ApiItemKind;
 
   /**
    * A list of extractor warnings that were reported using ApiItem.reportWarning().

--- a/api-extractor/src/definitions/ApiMethod.ts
+++ b/api-extractor/src/definitions/ApiMethod.ts
@@ -1,5 +1,5 @@
 import * as ts from 'typescript';
-import { IApiItemOptions } from './ApiItem';
+import { ApiItemKind, IApiItemOptions } from './ApiItem';
 import ApiMember from './ApiMember';
 import ApiParameter from './ApiParameter';
 import TypeScriptHelpers from '../TypeScriptHelpers';
@@ -17,6 +17,7 @@ export default class ApiMethod extends ApiMember {
 
   constructor(options: IApiItemOptions) {
     super(options);
+    this.kind = ApiItemKind.method;
 
     const methodDeclaration: ts.MethodDeclaration = options.declaration as ts.MethodDeclaration;
 

--- a/api-extractor/src/definitions/ApiMethod.ts
+++ b/api-extractor/src/definitions/ApiMethod.ts
@@ -17,7 +17,7 @@ export default class ApiMethod extends ApiMember {
 
   constructor(options: IApiItemOptions) {
     super(options);
-    this.kind = ApiItemKind.method;
+    this.kind = ApiItemKind.Method;
 
     const methodDeclaration: ts.MethodDeclaration = options.declaration as ts.MethodDeclaration;
 

--- a/api-extractor/src/definitions/ApiPackage.ts
+++ b/api-extractor/src/definitions/ApiPackage.ts
@@ -5,7 +5,7 @@ import Extractor from '../Extractor';
 import ApiStructuredType from './ApiStructuredType';
 import ApiEnum from './ApiEnum';
 import ApiFunction from './ApiFunction';
-import { IApiItemOptions } from './ApiItem';
+import { ApiItemKind, IApiItemOptions } from './ApiItem';
 import ApiItemContainer from './ApiItemContainer';
 import TypeScriptHelpers from '../TypeScriptHelpers';
 
@@ -39,6 +39,7 @@ export default class ApiPackage extends ApiItemContainer {
   }
   constructor(extractor: Extractor, rootFile: ts.SourceFile) {
     super(ApiPackage._getOptions(extractor, rootFile));
+    this.kind = ApiItemKind.package;
 
     const exportSymbols: ts.Symbol[] = this.typeChecker.getExportsOfModule(this.declarationSymbol);
     if (exportSymbols) {

--- a/api-extractor/src/definitions/ApiPackage.ts
+++ b/api-extractor/src/definitions/ApiPackage.ts
@@ -39,7 +39,7 @@ export default class ApiPackage extends ApiItemContainer {
   }
   constructor(extractor: Extractor, rootFile: ts.SourceFile) {
     super(ApiPackage._getOptions(extractor, rootFile));
-    this.kind = ApiItemKind.package;
+    this.kind = ApiItemKind.Package;
 
     const exportSymbols: ts.Symbol[] = this.typeChecker.getExportsOfModule(this.declarationSymbol);
     if (exportSymbols) {

--- a/api-extractor/src/definitions/ApiParameter.ts
+++ b/api-extractor/src/definitions/ApiParameter.ts
@@ -16,7 +16,7 @@ class ApiParameter extends ApiItem {
 
   constructor(options: IApiItemOptions, docComment?: string) {
     super(options);
-    this.kind = ApiItemKind.parameter;
+    this.kind = ApiItemKind.Parameter;
 
     this.documentation.docComment = docComment;
 

--- a/api-extractor/src/definitions/ApiParameter.ts
+++ b/api-extractor/src/definitions/ApiParameter.ts
@@ -1,5 +1,5 @@
 import * as ts from 'typescript';
-import ApiItem, { IApiItemOptions } from './ApiItem';
+import ApiItem, { ApiItemKind, IApiItemOptions } from './ApiItem';
 
 /**
  * This class is part of the ApiItem abstract syntax tree. It represents parameters of a function declaration
@@ -16,6 +16,7 @@ class ApiParameter extends ApiItem {
 
   constructor(options: IApiItemOptions, docComment?: string) {
     super(options);
+    this.kind = ApiItemKind.parameter;
 
     this.documentation.docComment = docComment;
 

--- a/api-extractor/src/definitions/ApiProperty.ts
+++ b/api-extractor/src/definitions/ApiProperty.ts
@@ -1,4 +1,4 @@
-import { IApiItemOptions } from './ApiItem';
+import { ApiItemKind, IApiItemOptions } from './ApiItem';
 import ApiMember from './ApiMember';
 
 /**
@@ -12,6 +12,7 @@ class ApiProperty extends ApiMember {
 
   constructor(options: IApiItemOptions) {
     super(options);
+    this.kind = ApiItemKind.property;
 
     this.isReadOnly = this.documentation.readonly ? this.documentation.readonly : false;
 

--- a/api-extractor/src/definitions/ApiProperty.ts
+++ b/api-extractor/src/definitions/ApiProperty.ts
@@ -12,7 +12,7 @@ class ApiProperty extends ApiMember {
 
   constructor(options: IApiItemOptions) {
     super(options);
-    this.kind = ApiItemKind.property;
+    this.kind = ApiItemKind.Property;
 
     this.isReadOnly = this.documentation.readonly ? this.documentation.readonly : false;
 

--- a/api-extractor/src/definitions/ApiStructuredType.ts
+++ b/api-extractor/src/definitions/ApiStructuredType.ts
@@ -39,11 +39,11 @@ export default class ApiStructuredType extends ApiItemContainer {
     this.type = this.typeChecker.getDeclaredTypeOfSymbol(this.declarationSymbol);
 
     if (this.declarationSymbol.flags & ts.SymbolFlags.Interface) {
-      this.kind = ApiItemKind.interface;
+      this.kind = ApiItemKind.Interface;
     } else if (this.declarationSymbol.flags & ts.SymbolFlags.TypeLiteral) {
-      this.kind = ApiItemKind.typeLiteral;
+      this.kind = ApiItemKind.TypeLiteral;
     } else {
-      this.kind = ApiItemKind.class;
+      this.kind = ApiItemKind.Class;
     }
 
     for (const memberDeclaration of this._classLikeDeclaration.members) {
@@ -111,7 +111,7 @@ export default class ApiStructuredType extends ApiItemContainer {
   public getDeclarationLine(): string {
     let result: string = '';
 
-    if (this.kind !== ApiItemKind.typeLiteral) {
+    if (this.kind !== ApiItemKind.TypeLiteral) {
       result += (this.declarationSymbol.flags & ts.SymbolFlags.Interface)
         ? 'interface ' : 'class ';
 

--- a/api-extractor/src/definitions/ApiStructuredType.ts
+++ b/api-extractor/src/definitions/ApiStructuredType.ts
@@ -3,35 +3,16 @@
 import * as ts from 'typescript';
 import ApiMethod from './ApiMethod';
 import ApiProperty from './ApiProperty';
-import ApiItem, { IApiItemOptions } from './ApiItem';
+import ApiItem, { ApiItemKind, IApiItemOptions } from './ApiItem';
 import ApiItemContainer from './ApiItemContainer';
 import TypeScriptHelpers from '../TypeScriptHelpers';
 import PrettyPrinter from '../PrettyPrinter';
-
-/**
-  * Indicates the type of definition represented by a ApiStructuredType object.
-  */
-export enum ApiStructuredTypeKind {
-  /**
-    * A TypeScript class.
-    */
-  Class,
-  /**
-    * A TypeScript interface.
-    */
-  Interface,
-  /**
-    * A TypeScript type literal expression, i.e. which defines an anonymous interface.
-    */
-  TypeLiteral
-}
 
 /**
   * This class is part of the ApiItem abstract syntax tree.  It represents a class,
   * interface, or type literal expression.
   */
 export default class ApiStructuredType extends ApiItemContainer {
-  public kind: ApiStructuredTypeKind;
   public implements?: string;
   public extends?: string;
 
@@ -58,11 +39,11 @@ export default class ApiStructuredType extends ApiItemContainer {
     this.type = this.typeChecker.getDeclaredTypeOfSymbol(this.declarationSymbol);
 
     if (this.declarationSymbol.flags & ts.SymbolFlags.Interface) {
-      this.kind = ApiStructuredTypeKind.Interface;
+      this.kind = ApiItemKind.interface;
     } else if (this.declarationSymbol.flags & ts.SymbolFlags.TypeLiteral) {
-      this.kind = ApiStructuredTypeKind.TypeLiteral;
+      this.kind = ApiItemKind.typeLiteral;
     } else {
-      this.kind = ApiStructuredTypeKind.Class;
+      this.kind = ApiItemKind.class;
     }
 
     for (const memberDeclaration of this._classLikeDeclaration.members) {
@@ -130,7 +111,7 @@ export default class ApiStructuredType extends ApiItemContainer {
   public getDeclarationLine(): string {
     let result: string = '';
 
-    if (this.kind !== ApiStructuredTypeKind.TypeLiteral) {
+    if (this.kind !== ApiItemKind.typeLiteral) {
       result += (this.declarationSymbol.flags & ts.SymbolFlags.Interface)
         ? 'interface ' : 'class ';
 

--- a/api-extractor/src/generators/ApiFileGenerator.ts
+++ b/api-extractor/src/generators/ApiFileGenerator.ts
@@ -1,10 +1,10 @@
 import * as fs from 'fs';
 import Extractor from '../Extractor';
-import ApiStructuredType, { ApiStructuredTypeKind } from '../definitions/ApiStructuredType';
+import ApiStructuredType from '../definitions/ApiStructuredType';
 import ApiEnum from '../definitions/ApiEnum';
 import ApiEnumValue from '../definitions/ApiEnumValue';
 import ApiFunction from '../definitions/ApiFunction';
-import ApiItem from '../definitions/ApiItem';
+import ApiItem, { ApiItemKind } from '../definitions/ApiItem';
 import ApiItemVisitor from '../ApiItemVisitor';
 import ApiPackage from '../definitions/ApiPackage';
 import ApiParameter from '../definitions/ApiParameter';
@@ -66,7 +66,7 @@ export default class ApiFileGenerator extends ApiItemVisitor {
       return;
     }
 
-    if (apiStructuredType.kind !== ApiStructuredTypeKind.TypeLiteral) {
+    if (apiStructuredType.kind !== ApiItemKind.typeLiteral) {
       this._writeJsdocSynopsis(apiStructuredType);
     }
 

--- a/api-extractor/src/generators/ApiFileGenerator.ts
+++ b/api-extractor/src/generators/ApiFileGenerator.ts
@@ -66,7 +66,7 @@ export default class ApiFileGenerator extends ApiItemVisitor {
       return;
     }
 
-    if (apiStructuredType.kind !== ApiItemKind.typeLiteral) {
+    if (apiStructuredType.kind !== ApiItemKind.TypeLiteral) {
       this._writeJsdocSynopsis(apiStructuredType);
     }
 

--- a/api-extractor/src/generators/ApiJsonGenerator.ts
+++ b/api-extractor/src/generators/ApiJsonGenerator.ts
@@ -73,8 +73,8 @@ export default class ApiJsonGenerator extends ApiItemVisitor {
 
   protected visitApiStructuredType(apiStructuredType: ApiStructuredType, refObject?: Object): void {
     const kind: string =
-      apiStructuredType.kind === ApiItemKind.class ? ApiJsonGenerator._KIND_CLASS :
-      apiStructuredType.kind === ApiItemKind.interface ? ApiJsonGenerator._KIND_INTERFACE :
+      apiStructuredType.kind === ApiItemKind.Class ? ApiJsonGenerator._KIND_CLASS :
+      apiStructuredType.kind === ApiItemKind.Interface ? ApiJsonGenerator._KIND_INTERFACE :
       '';
 
     const structureNode: Object = {

--- a/api-extractor/src/generators/ApiJsonGenerator.ts
+++ b/api-extractor/src/generators/ApiJsonGenerator.ts
@@ -3,11 +3,11 @@ import * as path from 'path';
 import * as ts from 'typescript';
 
 import Extractor from '../Extractor';
-import ApiStructuredType, { ApiStructuredTypeKind } from '../definitions/ApiStructuredType';
+import ApiStructuredType from '../definitions/ApiStructuredType';
 import ApiEnum from '../definitions/ApiEnum';
 import ApiEnumValue from '../definitions/ApiEnumValue';
 import ApiFunction from '../definitions/ApiFunction';
-import ApiItem from '../definitions/ApiItem';
+import ApiItem, { ApiItemKind } from '../definitions/ApiItem';
 import ApiItemVisitor from '../ApiItemVisitor';
 import ApiPackage from '../definitions/ApiPackage';
 import ApiParameter from '../definitions/ApiParameter';
@@ -73,8 +73,8 @@ export default class ApiJsonGenerator extends ApiItemVisitor {
 
   protected visitApiStructuredType(apiStructuredType: ApiStructuredType, refObject?: Object): void {
     const kind: string =
-      apiStructuredType.kind === ApiStructuredTypeKind.Class ? ApiJsonGenerator._KIND_CLASS :
-      apiStructuredType.kind === ApiStructuredTypeKind.Interface ? ApiJsonGenerator._KIND_INTERFACE :
+      apiStructuredType.kind === ApiItemKind.class ? ApiJsonGenerator._KIND_CLASS :
+      apiStructuredType.kind === ApiItemKind.interface ? ApiJsonGenerator._KIND_INTERFACE :
       '';
 
     const structureNode: Object = {

--- a/common/changes/dagaeta-ApiItemKind_2017-02-01-01-12.json
+++ b/common/changes/dagaeta-ApiItemKind_2017-02-01-01-12.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor",
+      "comment": "Added ApiItemKind enum and refactored child classes.",
+      "type": "patch"
+    }
+  ],
+  "email": "dagaeta@users.noreply.github.com"
+}

--- a/common/reviews/api/gulp-core-build-webpack.api.ts
+++ b/common/reviews/api/gulp-core-build-webpack.api.ts
@@ -13,7 +13,7 @@ class WebpackTask extends GulpTask<IWebpackTaskConfig> {
   // (undocumented)
   public isEnabled(buildConfig: IBuildConfig): boolean;
   // (undocumented)
-  protected loadSchema(): Object;
+  public loadSchema(): Object;
   // (undocumented)
   public name: string;
   // (undocumented)

--- a/common/reviews/api/node-library-build.api.ts
+++ b/common/reviews/api/node-library-build.api.ts
@@ -190,7 +190,7 @@ class TypeScriptTask extends GulpTask<ITypeScriptTaskConfig> {
   // (undocumented)
   getCleanMatch(buildConfig: IBuildConfig, taskConfig?: ITypeScriptTaskConfig): string[];
   // (undocumented)
-  protected loadSchema(): Object;
+  loadSchema(): Object;
   mergeConfig(config: ITypeScriptTaskConfig): void;
   // (undocumented)
   name: string;

--- a/common/reviews/api/web-library-build.api.ts
+++ b/common/reviews/api/web-library-build.api.ts
@@ -198,7 +198,7 @@ class TypeScriptTask extends GulpTask<ITypeScriptTaskConfig> {
   // (undocumented)
   getCleanMatch(buildConfig: IBuildConfig, taskConfig?: ITypeScriptTaskConfig): string[];
   // (undocumented)
-  protected loadSchema(): Object;
+  loadSchema(): Object;
   mergeConfig(config: ITypeScriptTaskConfig): void;
   // (undocumented)
   name: string;
@@ -224,7 +224,7 @@ class WebpackTask extends GulpTask<IWebpackTaskConfig> {
   // (undocumented)
   isEnabled(buildConfig: IBuildConfig): boolean;
   // (undocumented)
-  protected loadSchema(): Object;
+  loadSchema(): Object;
   // (undocumented)
   name: string;
   // (undocumented)


### PR DESCRIPTION
ApiItemKind enum is a refactoring needed for implementing local API reference resolution