### PR TITLE
Added support that was missing for detecting readonly on documentation

### DIFF
--- a/api-extractor/src/definitions/ApiProperty.ts
+++ b/api-extractor/src/definitions/ApiProperty.ts
@@ -23,7 +23,7 @@ class ApiProperty extends ApiMember {
   public getDeclarationLine(): string {
     return super.getDeclarationLine({
       type: this.type,
-      readonly: this.isReadOnly
+      readonly: this.isReadOnly || this.documentation.readonly
     });
   }
 }

--- a/common/changes/dagaeta-readonly-support-ApiProperty_2017-02-02-01-37.json
+++ b/common/changes/dagaeta-readonly-support-ApiProperty_2017-02-02-01-37.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor",
+      "comment": "Added support for ApiProperty to detect readonly from documentation object.",
+      "type": "patch"
+    }
+  ],
+  "email": "dagaeta@users.noreply.github.com"
+}


### PR DESCRIPTION
This check was removed during a refactor #81 