### PR TITLE
Changed ApiDocumentation dependency to abstract away API reference resolving

### DIFF
--- a/api-extractor/src/DocItemLoader.ts
+++ b/api-extractor/src/DocItemLoader.ts
@@ -47,10 +47,7 @@ export default class DocItemLoader {
   }
 
   /**
-   * Attempts to resolve an API item from the provided apiDefinitionRef.
-   * First checks the cache for the package, if not in the cache then the method
-   * will attempt to the locate the associated json file to load the package and
-   * check there. If the API item can not be found the method will return undefined.
+   * {@inheritdoc ApiDocumentation.IReferenceResolver}
    */
   public resolve(apiDefinitionRef: IApiDefinitionReference, reportError: (message: string) => void): IDocItem {
     if (!apiDefinitionRef) {

--- a/api-extractor/src/DocItemLoader.ts
+++ b/api-extractor/src/DocItemLoader.ts
@@ -47,12 +47,12 @@ export default class DocItemLoader {
   }
 
   /**
-   * Attempts to retrieve an API item from the provided apiDefinitionRef.
+   * Attempts to resolve an API item from the provided apiDefinitionRef.
    * First checks the cache for the package, if not in the cache then the method
    * will attempt to the locate the associated json file to load the package and
    * check there. If the API item can not be found the method will return undefined.
    */
-  public getItem(apiDefinitionRef: IApiDefinitionReference, reportError: (message: string) => void): IDocItem {
+  public resolve(apiDefinitionRef: IApiDefinitionReference, reportError: (message: string) => void): IDocItem {
     if (!apiDefinitionRef) {
       reportError('Expected reference within {@inheritdoc} tag');
       return undefined;

--- a/api-extractor/src/definitions/ApiDocumentation.ts
+++ b/api-extractor/src/definitions/ApiDocumentation.ts
@@ -176,8 +176,8 @@ export default class ApiDocumentation {
    * assessible ApiItem properties. 
    * 
    * Ex: this is useful in the case of parsing inheritdoc expressions,
-   * in the sense that we do not know if we the IInherited documentation 
-   * is coming from an ApiItem or from an IDocItem.
+   * in the sense that we do not know if we the inherited documentation 
+   * is coming from an ApiItem or a IDocItem.
    */
   public referenceResolver: IReferenceResolver;
 

--- a/api-extractor/src/definitions/ApiDocumentation.ts
+++ b/api-extractor/src/definitions/ApiDocumentation.ts
@@ -61,6 +61,13 @@ export interface IScopePackageName {
 /**
  * A dependency for ApiDocumentation constructor that abstracts away the function 
  * of resolving an API definition reference.
+ * 
+ * @internalremarks reportError() will be called if the apiDefinitionRef is to a non local 
+ * item and the package of that non local item can not be found. 
+ * If there is no package given and an  item can not be found we will return undefined. 
+ * Once we support local references, we can be sure that reportError will only be 
+ * called once if the item can not be found (and undefined will be retured by the reference 
+ * function).
  */
 export interface IReferenceResolver {
   resolve(apiDefinitionRef: IApiDefinitionReference, reportError: (message: string) => void): IDocItem;

--- a/api-extractor/src/definitions/ApiDocumentation.ts
+++ b/api-extractor/src/definitions/ApiDocumentation.ts
@@ -4,7 +4,6 @@ import ApiItem from './ApiItem';
 import DocElementParser from '../DocElementParser';
 import { IDocElement, IParam, IHrefLinkElement, ICodeLinkElement, ITextElement } from '../IDocElement';
 import { IDocItem, IDocFunction } from '../IDocItem';
-import DocItemLoader from '../DocItemLoader';
 import { IApiDefinitionReference } from '../IApiDefinitionReference';
 import Token, { TokenType } from '../Token';
 import Tokenizer from '../Tokenizer';
@@ -57,6 +56,14 @@ export interface IScopePackageName {
    * The package name of an API reference expression.
    */
   package: string;
+}
+
+/**
+ * A dependency for ApiDocumentation constructor that abstracts away the function 
+ * of resolving an API definition reference.
+ */
+export interface IReferenceResolver {
+  resolve(apiDefinitionRef: IApiDefinitionReference, reportError: (message: string) => void): IDocItem;
 }
 
 export default class ApiDocumentation {
@@ -163,7 +170,16 @@ export default class ApiDocumentation {
   public isOverride?: boolean;
   public hasReadOnlyTag?: boolean;
 
-  public docItemLoader: DocItemLoader;
+  /**
+   * A function type interface that abstracts away resolving 
+   * an API definition reference to an item that has friendly 
+   * assessible ApiItem properties. 
+   * 
+   * Ex: this is useful in the case of parsing inheritdoc expressions,
+   * in the sense that we do not know if we the IInherited documentation 
+   * is coming from an ApiItem or from an IDocItem.
+   */
+  public referenceResolver: IReferenceResolver;
 
   /**
    * We need the extractor to access the package that this ApiItem
@@ -236,11 +252,11 @@ export default class ApiDocumentation {
   }
 
   constructor(docComment: string,
-    docItemLoader: DocItemLoader,
+    referenceResolver: IReferenceResolver,
     extractor: Extractor,
     errorLogger: (message: string) => void) {
     this.originalJsDoc = docComment;
-    this.docItemLoader = docItemLoader;
+    this.referenceResolver = referenceResolver;
     this.extractor = extractor;
     this.reportError = errorLogger;
     this.parameters = {};
@@ -419,7 +435,7 @@ export default class ApiDocumentation {
     }
 
     // Atempt to locate the apiDefinitionRef
-    const inheritedDoc: IDocItem = this.docItemLoader.getItem(apiDefinitionRef, this.reportError);
+    const inheritedDoc: IDocItem = this.referenceResolver.resolve(apiDefinitionRef, this.reportError);
 
     // If no IDocItem found then nothing to inherit
     // But for the time being set the summary to a text object

--- a/api-extractor/src/test/DocItemLoader.test.ts
+++ b/api-extractor/src/test/DocItemLoader.test.ts
@@ -20,7 +20,7 @@ describe('DocItemLoader tests', function (): void {
       };
       const docItemLoader: DocItemLoader = new DocItemLoader('./testInputs/example2');
       /* ts-lint:diasble:no-unused-variable */
-      const apiDocItem: IDocItem = docItemLoader.getItem(apiDefRef, console.log);
+      const apiDocItem: IDocItem = docItemLoader.resolve(apiDefRef, console.log);
 
       JsonFile.saveJsonFile('./lib/inheritedDoc-output.json', JSON.stringify(apiDocItem));
       TestFileComparer.assertFileMatchesExpected(

--- a/common/changes/dagaeta-api-extractor-reference-resolver_2017-02-10-20-21.json
+++ b/common/changes/dagaeta-api-extractor-reference-resolver_2017-02-10-20-21.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor",
+      "comment": "Changed dependency for ApiDocumentation to abstract the resolving of API definition references.",
+      "type": "patch"
+    }
+  ],
+  "email": "dgaeta@users.noreply.github.com"
+}


### PR DESCRIPTION
- Changed dependency from DocItemLoader to IReferenceResolver. 
- For now the IReferenceResolver is still pointing to the DocItemLoader, but this abstraction will be useful in later development of resolving local API definition references. (Where we don't know if the reference is coming from a JSON file or the extractor dictionary) 