### PR TITLE
Adds a 'check-versions' command which can be used to locate inconsistencies in dependency versions in a repo

### DIFF
--- a/common/changes/nickpape-check-versions-command_2017-02-13-21-56.json
+++ b/common/changes/nickpape-check-versions-command_2017-02-13-21-56.json
@@ -1,0 +1,15 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush-lib",
+      "comment": "Adds an extra utility (VersionMismatchFinder), which can locate inconsistencies in versions of dependencies across the repo.",
+      "type": "minor"
+    },
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Adds an extra command (rush check-versions), which can find inconsistencies in package.json dependency versions across a repository.",
+      "type": "minor"
+    }
+  ],
+  "email": "nickpape@users.noreply.github.com"
+}

--- a/rush.json
+++ b/rush.json
@@ -114,13 +114,13 @@
       "packageName": "@microsoft/rush",
       "projectFolder": "rush/rush",
       "reviewCategory": "libraries",
-      "shouldPublish": false
+      "shouldPublish": true
     },
     {
       "packageName": "@microsoft/rush-lib",
       "projectFolder": "rush/rush-lib",
       "reviewCategory": "libraries",
-      "shouldPublish": false
+      "shouldPublish": true
     }
   ]
 }

--- a/rush/rush-lib/src/data/VersionMismatchFinder.ts
+++ b/rush/rush-lib/src/data/VersionMismatchFinder.ts
@@ -46,8 +46,8 @@ export class VersionMismatchFinder {
       this._addDependenciesToList(project.packageName, project.packageJson.dependencies);
       this._addDependenciesToList(project.packageName, project.packageJson.devDependencies);
       // tslint:disable:no-any
-      this._addDependenciesToList(project.packageName, (project.packageJson as any).peerDependencies);
-      this._addDependenciesToList(project.packageName, (project.packageJson as any).optionalDependencies);
+      this._addDependenciesToList(project.packageName, project.packageJson.peerDependencies);
+      this._addDependenciesToList(project.packageName, project.packageJson.optionalDependencies);
       // tslint:enable:no-any
     });
 

--- a/rush/rush-lib/src/data/VersionMismatchFinder.ts
+++ b/rush/rush-lib/src/data/VersionMismatchFinder.ts
@@ -1,0 +1,71 @@
+import RushConfigurationProject from './RushConfigurationProject';
+export class VersionMismatchFinder {
+  private _projects: RushConfigurationProject[];
+ /* store it like this:
+  * {
+  *   "@types/node": {
+  *     "1.0.0": [ '@ms/rush' ]
+  *   }
+  * }
+  */
+  private _mismatches: Map<string, Map<string, string[]>>;
+  constructor(projects: RushConfigurationProject[]) {
+    this._projects = projects;
+    this._mismatches = new Map<string, Map<string, string[]>>();
+    this._analyze();
+  }
+  public get numberOfMismatches(): number {
+    return this._mismatches.size;
+  }
+  public getMismatches(): Array<string> {
+    return this._iterableToArray<string>(this._mismatches.keys());
+  }
+  public getVersionsOfMismatch(mismatch: string): Array<string> {
+    return this._mismatches.has(mismatch)
+      ? this._iterableToArray<string>(this._mismatches.get(mismatch).keys())
+      : undefined;
+  }
+  public getConsumersOfMismatch(mismatch: string, version: string): Array<string> {
+    const mismatchedPackage: Map<string, string[]> = this._mismatches.get(mismatch);
+    if (!mismatchedPackage) {
+      return undefined;
+    }
+    const mismatchedVersion: string[] = mismatchedPackage.get(version);
+    return mismatchedVersion;
+  }
+  private _analyze(): void {
+    this._projects.forEach((project: RushConfigurationProject) => {
+      this._addDependenciesToList(project.packageName, project.packageJson.dependencies);
+      this._addDependenciesToList(project.packageName, project.packageJson.devDependencies);
+      // tslint:disable:no-any
+      this._addDependenciesToList(project.packageName, (project.packageJson as any).peerDependencies);
+      this._addDependenciesToList(project.packageName, (project.packageJson as any).optionalDependencies);
+      // tslint:enable:no-any
+    });
+    this._mismatches.forEach((mismatches: Map<string, string[]>, project: string) => {
+      if (mismatches.size <= 1) {
+        this._mismatches.delete(project);
+      }
+    });
+  }
+  private _addDependenciesToList(project: string, depMap: { [dependency: string]: string }): void {
+    Object.keys(depMap || {}).forEach((dependency: string) => {
+      const version: string = depMap[dependency];
+      if (!this._mismatches.has(dependency)) {
+        this._mismatches.set(dependency, new Map<string, string[]>());
+      }
+      if (!this._mismatches.get(dependency).has(version)) {
+        this._mismatches.get(dependency).set(version, []);
+      }
+      this._mismatches.get(dependency).get(version).push(project);
+    });
+  }
+  private _iterableToArray<T>(iterable: Iterator<T>): T[] {
+    const b: T[] = [];
+    let a: IteratorResult<T>;
+    while ((a = iterable.next()) && !a.done) {
+      b.push(a.value);
+    }
+    return b;
+  }
+}

--- a/rush/rush-lib/src/data/VersionMismatchFinder.ts
+++ b/rush/rush-lib/src/data/VersionMismatchFinder.ts
@@ -1,4 +1,5 @@
 import RushConfigurationProject from './RushConfigurationProject';
+
 export class VersionMismatchFinder {
   private _projects: RushConfigurationProject[];
  /* store it like this:
@@ -9,30 +10,37 @@ export class VersionMismatchFinder {
   * }
   */
   private _mismatches: Map<string, Map<string, string[]>>;
+
   constructor(projects: RushConfigurationProject[]) {
     this._projects = projects;
     this._mismatches = new Map<string, Map<string, string[]>>();
     this._analyze();
   }
+
   public get numberOfMismatches(): number {
     return this._mismatches.size;
   }
+
   public getMismatches(): Array<string> {
     return this._iterableToArray<string>(this._mismatches.keys());
   }
+
   public getVersionsOfMismatch(mismatch: string): Array<string> {
     return this._mismatches.has(mismatch)
       ? this._iterableToArray<string>(this._mismatches.get(mismatch).keys())
       : undefined;
   }
+
   public getConsumersOfMismatch(mismatch: string, version: string): Array<string> {
     const mismatchedPackage: Map<string, string[]> = this._mismatches.get(mismatch);
     if (!mismatchedPackage) {
       return undefined;
     }
+
     const mismatchedVersion: string[] = mismatchedPackage.get(version);
     return mismatchedVersion;
   }
+
   private _analyze(): void {
     this._projects.forEach((project: RushConfigurationProject) => {
       this._addDependenciesToList(project.packageName, project.packageJson.dependencies);
@@ -42,12 +50,14 @@ export class VersionMismatchFinder {
       this._addDependenciesToList(project.packageName, (project.packageJson as any).optionalDependencies);
       // tslint:enable:no-any
     });
+
     this._mismatches.forEach((mismatches: Map<string, string[]>, project: string) => {
       if (mismatches.size <= 1) {
         this._mismatches.delete(project);
       }
     });
   }
+
   private _addDependenciesToList(project: string, depMap: { [dependency: string]: string }): void {
     Object.keys(depMap || {}).forEach((dependency: string) => {
       const version: string = depMap[dependency];
@@ -60,6 +70,7 @@ export class VersionMismatchFinder {
       this._mismatches.get(dependency).get(version).push(project);
     });
   }
+
   private _iterableToArray<T>(iterable: Iterator<T>): T[] {
     const b: T[] = [];
     let a: IteratorResult<T>;

--- a/rush/rush-lib/src/data/test/VersionMismatchFinder.test.ts
+++ b/rush/rush-lib/src/data/test/VersionMismatchFinder.test.ts
@@ -1,0 +1,278 @@
+/// <reference types='mocha' />
+import { assert } from 'chai';
+import RushConfigurationProject from '../RushConfigurationProject';
+import { VersionMismatchFinder } from '../VersionMismatchFinder';
+describe('VersionMismatchFinder', () => {
+  it('finds no mismatches if there are none', (done: MochaDone) => {
+    const projects: RushConfigurationProject[] = [
+      {
+        packageName: 'A',
+        packageJson: {
+          dependencies: {
+            '@types/foo': '1.2.3',
+            'karma': '0.0.1'
+          }
+        }
+      },
+      {
+        packageName: 'B',
+        packageJson: {
+          dependencies: {
+            '@types/foo': '1.2.3',
+            'karma': '0.0.1'
+          }
+        }
+      }
+    ] as any as RushConfigurationProject[]; // tslint:disable-line:no-any
+    const mismatchFinder: VersionMismatchFinder = new VersionMismatchFinder(projects);
+    console.log(mismatchFinder.getMismatches());
+    assert.isNumber(mismatchFinder.numberOfMismatches);
+    assert.equal(mismatchFinder.numberOfMismatches, 0);
+    assert.equal(mismatchFinder.getMismatches().length, 0);
+    done();
+  });
+  it('finds a mismatch in two packages', (done: MochaDone) => {
+    const projects: RushConfigurationProject[] = [
+      {
+        packageName: 'A',
+        packageJson: {
+          dependencies: {
+            '@types/foo': '1.2.3',
+            'karma': '0.0.1'
+          }
+        }
+      },
+      {
+        packageName: 'B',
+        packageJson: {
+          dependencies: {
+            '@types/foo': '2.0.0',
+            'karma': '0.0.1'
+          }
+        }
+      }
+    ] as any as RushConfigurationProject[]; // tslint:disable-line:no-any
+    const mismatchFinder: VersionMismatchFinder = new VersionMismatchFinder(projects);
+    assert.isNumber(mismatchFinder.numberOfMismatches);
+    assert.equal(mismatchFinder.numberOfMismatches, 1);
+    assert.equal(mismatchFinder.getMismatches().length, 1);
+    assert.equal(mismatchFinder.getMismatches()[0], '@types/foo');
+    assert.includeMembers(mismatchFinder.getVersionsOfMismatch('@types/foo'), ['2.0.0', '1.2.3']);
+    assert.equal(mismatchFinder.getConsumersOfMismatch('@types/foo', '2.0.0'), 'B');
+    assert.equal(mismatchFinder.getConsumersOfMismatch('@types/foo', '1.2.3'), 'A');
+    done();
+  });
+  it('won\'t let you access mismatches that don\t exist', (done: MochaDone) => {
+    const projects: RushConfigurationProject[] = [
+      {
+        packageName: 'A',
+        packageJson: {
+          dependencies: {
+            '@types/foo': '1.2.3',
+            'karma': '0.0.1'
+          }
+        }
+      },
+      {
+        packageName: 'B',
+        packageJson: {
+          dependencies: {
+            '@types/foo': '2.0.0',
+            'karma': '0.0.1'
+          }
+        }
+      }
+    ] as any as RushConfigurationProject[]; // tslint:disable-line:no-any
+    const mismatchFinder: VersionMismatchFinder = new VersionMismatchFinder(projects);
+    assert.equal(mismatchFinder.getVersionsOfMismatch('@types/foobar'), undefined);
+    assert.equal(mismatchFinder.getConsumersOfMismatch('@types/fobar', '2.0.0'), undefined);
+    assert.equal(mismatchFinder.getConsumersOfMismatch('@types/foo', '9.9.9'), undefined);
+    done();
+  });
+  it('finds two mismatches in two different pairs of projects', (done: MochaDone) => {
+    const projects: RushConfigurationProject[] = [
+      {
+        packageName: 'A',
+        packageJson: {
+          dependencies: {
+            '@types/foo': '1.2.3',
+            'karma': '0.0.1'
+          }
+        }
+      },
+      {
+        packageName: 'B',
+        packageJson: {
+          dependencies: {
+            '@types/foo': '2.0.0',
+            'karma': '0.0.1'
+          }
+        }
+      },
+      {
+        packageName: 'C',
+        packageJson: {
+          dependencies: {
+            'mocha': '1.2.3',
+            'karma': '0.0.1'
+          }
+        }
+      },
+      {
+        packageName: 'D',
+        packageJson: {
+          dependencies: {
+            'mocha': '2.0.0',
+            'karma': '0.0.1'
+          }
+        }
+      }
+    ] as any as RushConfigurationProject[]; // tslint:disable-line:no-any
+    const mismatchFinder: VersionMismatchFinder = new VersionMismatchFinder(projects);
+    assert.isNumber(mismatchFinder.numberOfMismatches);
+    assert.equal(mismatchFinder.numberOfMismatches, 2);
+    assert.equal(mismatchFinder.getMismatches().length, 2);
+    assert.includeMembers(mismatchFinder.getMismatches(), ['@types/foo', 'mocha']);
+    assert.includeMembers(mismatchFinder.getVersionsOfMismatch('@types/foo'), ['2.0.0', '1.2.3']);
+    assert.includeMembers(mismatchFinder.getVersionsOfMismatch('mocha'), ['2.0.0', '1.2.3']);
+    assert.equal(mismatchFinder.getConsumersOfMismatch('@types/foo', '1.2.3'), 'A');
+    assert.equal(mismatchFinder.getConsumersOfMismatch('@types/foo', '2.0.0'), 'B');
+    assert.equal(mismatchFinder.getConsumersOfMismatch('mocha', '1.2.3'), 'C');
+    assert.equal(mismatchFinder.getConsumersOfMismatch('mocha', '2.0.0'), 'D');
+    done();
+  });
+  it('finds three mismatches in three projects', (done: MochaDone) => {
+      const projects: RushConfigurationProject[] = [
+      {
+        packageName: 'A',
+        packageJson: {
+          dependencies: {
+            '@types/foo': '1.2.3',
+            'karma': '0.0.1'
+          }
+        }
+      },
+      {
+        packageName: 'B',
+        packageJson: {
+          dependencies: {
+            '@types/foo': '2.0.0',
+            'karma': '0.0.1'
+          }
+        }
+      },
+      {
+        packageName: 'C',
+        packageJson: {
+          dependencies: {
+            '@types/foo': '9.9.9',
+            'karma': '0.0.1'
+          }
+        }
+      }
+    ] as any as RushConfigurationProject[]; // tslint:disable-line:no-any
+    const mismatchFinder: VersionMismatchFinder = new VersionMismatchFinder(projects);
+    assert.isNumber(mismatchFinder.numberOfMismatches);
+    assert.equal(mismatchFinder.numberOfMismatches, 1);
+    assert.equal(mismatchFinder.getMismatches().length, 1);
+    assert.includeMembers(mismatchFinder.getMismatches(), ['@types/foo']);
+    assert.includeMembers(mismatchFinder.getVersionsOfMismatch('@types/foo'), ['2.0.0', '1.2.3', '9.9.9']);
+    assert.equal(mismatchFinder.getConsumersOfMismatch('@types/foo', '1.2.3'), 'A');
+    assert.equal(mismatchFinder.getConsumersOfMismatch('@types/foo', '2.0.0'), 'B');
+    assert.equal(mismatchFinder.getConsumersOfMismatch('@types/foo', '9.9.9'), 'C');
+    done();
+  });
+  it('checks dev dependencies', (done: MochaDone) => {
+    const projects: RushConfigurationProject[] = [
+      {
+        packageName: 'A',
+        packageJson: {
+          dependencies: {
+            '@types/foo': '1.2.3',
+            'karma': '0.0.1'
+          }
+        }
+      },
+      {
+        packageName: 'B',
+        packageJson: {
+          devDependencies: {
+            '@types/foo': '2.0.0',
+            'karma': '0.0.1'
+          }
+        }
+      }
+    ] as any as RushConfigurationProject[]; // tslint:disable-line:no-any
+    const mismatchFinder: VersionMismatchFinder = new VersionMismatchFinder(projects);
+    assert.isNumber(mismatchFinder.numberOfMismatches);
+    assert.equal(mismatchFinder.numberOfMismatches, 1);
+    assert.equal(mismatchFinder.getMismatches().length, 1);
+    assert.equal(mismatchFinder.getMismatches()[0], '@types/foo');
+    assert.includeMembers(mismatchFinder.getVersionsOfMismatch('@types/foo'), ['2.0.0', '1.2.3']);
+    assert.equal(mismatchFinder.getConsumersOfMismatch('@types/foo', '2.0.0'), 'B');
+    assert.equal(mismatchFinder.getConsumersOfMismatch('@types/foo', '1.2.3'), 'A');
+    done();
+  });
+  it('checks peer dependencies', (done: MochaDone) => {
+    const projects: RushConfigurationProject[] = [
+      {
+        packageName: 'A',
+        packageJson: {
+          dependencies: {
+            '@types/foo': '1.2.3',
+            'karma': '0.0.1'
+          }
+        }
+      },
+      {
+        packageName: 'B',
+        packageJson: {
+          peerDependencies: {
+            '@types/foo': '2.0.0',
+            'karma': '0.0.1'
+          }
+        }
+      }
+    ] as any as RushConfigurationProject[]; // tslint:disable-line:no-any
+    const mismatchFinder: VersionMismatchFinder = new VersionMismatchFinder(projects);
+    assert.isNumber(mismatchFinder.numberOfMismatches);
+    assert.equal(mismatchFinder.numberOfMismatches, 1);
+    assert.equal(mismatchFinder.getMismatches().length, 1);
+    assert.equal(mismatchFinder.getMismatches()[0], '@types/foo');
+    assert.includeMembers(mismatchFinder.getVersionsOfMismatch('@types/foo'), ['2.0.0', '1.2.3']);
+    assert.equal(mismatchFinder.getConsumersOfMismatch('@types/foo', '2.0.0'), 'B');
+    assert.equal(mismatchFinder.getConsumersOfMismatch('@types/foo', '1.2.3'), 'A');
+    done();
+  });
+  it('checks optional dependencies', (done: MochaDone) => {
+    const projects: RushConfigurationProject[] = [
+      {
+        packageName: 'A',
+        packageJson: {
+          dependencies: {
+            '@types/foo': '1.2.3',
+            'karma': '0.0.1'
+          }
+        }
+      },
+      {
+        packageName: 'B',
+        packageJson: {
+          optionalDependencies: {
+            '@types/foo': '2.0.0',
+            'karma': '0.0.1'
+          }
+        }
+      }
+    ] as any as RushConfigurationProject[]; // tslint:disable-line:no-any
+    const mismatchFinder: VersionMismatchFinder = new VersionMismatchFinder(projects);
+    assert.isNumber(mismatchFinder.numberOfMismatches);
+    assert.equal(mismatchFinder.numberOfMismatches, 1);
+    assert.equal(mismatchFinder.getMismatches().length, 1);
+    assert.equal(mismatchFinder.getMismatches()[0], '@types/foo');
+    assert.includeMembers(mismatchFinder.getVersionsOfMismatch('@types/foo'), ['2.0.0', '1.2.3']);
+    assert.equal(mismatchFinder.getConsumersOfMismatch('@types/foo', '2.0.0'), 'B');
+    assert.equal(mismatchFinder.getConsumersOfMismatch('@types/foo', '1.2.3'), 'A');
+    done();
+  });
+});

--- a/rush/rush-lib/src/data/test/VersionMismatchFinder.test.ts
+++ b/rush/rush-lib/src/data/test/VersionMismatchFinder.test.ts
@@ -1,8 +1,11 @@
 /// <reference types='mocha' />
+
 import { assert } from 'chai';
 import RushConfigurationProject from '../RushConfigurationProject';
 import { VersionMismatchFinder } from '../VersionMismatchFinder';
+
 describe('VersionMismatchFinder', () => {
+
   it('finds no mismatches if there are none', (done: MochaDone) => {
     const projects: RushConfigurationProject[] = [
       {
@@ -31,6 +34,7 @@ describe('VersionMismatchFinder', () => {
     assert.equal(mismatchFinder.getMismatches().length, 0);
     done();
   });
+
   it('finds a mismatch in two packages', (done: MochaDone) => {
     const projects: RushConfigurationProject[] = [
       {
@@ -62,6 +66,7 @@ describe('VersionMismatchFinder', () => {
     assert.equal(mismatchFinder.getConsumersOfMismatch('@types/foo', '1.2.3'), 'A');
     done();
   });
+
   it('won\'t let you access mismatches that don\t exist', (done: MochaDone) => {
     const projects: RushConfigurationProject[] = [
       {
@@ -89,6 +94,7 @@ describe('VersionMismatchFinder', () => {
     assert.equal(mismatchFinder.getConsumersOfMismatch('@types/foo', '9.9.9'), undefined);
     done();
   });
+
   it('finds two mismatches in two different pairs of projects', (done: MochaDone) => {
     const projects: RushConfigurationProject[] = [
       {
@@ -141,6 +147,7 @@ describe('VersionMismatchFinder', () => {
     assert.equal(mismatchFinder.getConsumersOfMismatch('mocha', '2.0.0'), 'D');
     done();
   });
+
   it('finds three mismatches in three projects', (done: MochaDone) => {
       const projects: RushConfigurationProject[] = [
       {
@@ -182,6 +189,7 @@ describe('VersionMismatchFinder', () => {
     assert.equal(mismatchFinder.getConsumersOfMismatch('@types/foo', '9.9.9'), 'C');
     done();
   });
+
   it('checks dev dependencies', (done: MochaDone) => {
     const projects: RushConfigurationProject[] = [
       {
@@ -213,6 +221,7 @@ describe('VersionMismatchFinder', () => {
     assert.equal(mismatchFinder.getConsumersOfMismatch('@types/foo', '1.2.3'), 'A');
     done();
   });
+
   it('checks peer dependencies', (done: MochaDone) => {
     const projects: RushConfigurationProject[] = [
       {
@@ -244,6 +253,7 @@ describe('VersionMismatchFinder', () => {
     assert.equal(mismatchFinder.getConsumersOfMismatch('@types/foo', '1.2.3'), 'A');
     done();
   });
+
   it('checks optional dependencies', (done: MochaDone) => {
     const projects: RushConfigurationProject[] = [
       {

--- a/rush/rush-lib/src/index.ts
+++ b/rush/rush-lib/src/index.ts
@@ -32,6 +32,10 @@ export {
 } from './data/ChangeManagement';
 
 export {
+  VersionMismatchFinder
+} from './data/VersionMismatchFinder'
+
+export {
   ErrorDetectionMode,
   IErrorDetectionRule,
   RegexErrorDetector,

--- a/rush/rush-lib/typings/read-package-tree/read-package-tree.d.ts
+++ b/rush/rush-lib/typings/read-package-tree/read-package-tree.d.ts
@@ -40,6 +40,7 @@ interface PackageJson {
   description?: string;
   devDependencies?: { [key: string]: string };
   optionalDependencies?: { [key: string]: string };
+  peerDependencies?: { [key: string]: string };
   private?: boolean;
   scripts?: { [key: string]: string };
 

--- a/rush/rush/src/actions/CheckVersionsAction.ts
+++ b/rush/rush/src/actions/CheckVersionsAction.ts
@@ -1,0 +1,60 @@
+/**
+ * @Copyright (c) Microsoft Corporation.  All rights reserved.
+ */
+
+import * as colors from 'colors';
+import * as os from 'os';
+import { CommandLineAction } from '@microsoft/ts-command-line';
+
+import RushCommandLineParser from './RushCommandLineParser';
+
+import {
+  RushConfiguration,
+  VersionMismatchFinder
+} from '@microsoft/rush-lib';
+
+export default class CheckVersionsAction extends CommandLineAction {
+  private _parser: RushCommandLineParser;
+
+  constructor(parser: RushCommandLineParser) {
+    super({
+      actionVerb: 'check-versions',
+      summary: 'Checks each project\'s package.json files and ensures that all dependencies are of the same ' +
+        'version throughout the repository.',
+      documentation: 'Checks each project\'s package.json files and ensures that all dependencies are of the ' +
+        'same version throughout the repository.'
+    });
+    this._parser = parser;
+  }
+
+  protected onDefineParameters(): void {
+    // abstract
+  }
+
+  protected onExecute(): void {
+    console.log(`Starting "rush check-versions"${os.EOL}`);
+
+    const config: RushConfiguration = RushConfiguration.loadFromDefaultLocation();
+
+    const mismatchFinder: VersionMismatchFinder = new VersionMismatchFinder(config.projects);
+
+    // Iterate over the list. For any dependency with mismatching versions, print the projects
+    mismatchFinder.getMismatches().forEach((dependency: string) => {
+      console.log(colors.yellow(dependency));
+      mismatchFinder.getVersionsOfMismatch(dependency).forEach((version: string) => {
+        console.log(`  ${version}`);
+        mismatchFinder.getConsumersOfMismatch(dependency, version).forEach((project: string) => {
+          console.log(`   - ${project}`);
+        });
+      });
+      console.log();
+    });
+
+    if (mismatchFinder.numberOfMismatches) {
+      console.log(colors.red(`Found ${mismatchFinder.numberOfMismatches} mis-matching dependencies!`));
+      process.exit(1);
+    } else {
+      console.log(colors.green(`Found no mis-matching dependencies!`));
+    }
+  }
+}

--- a/rush/rush/src/actions/RushCommandLineParser.ts
+++ b/rush/rush/src/actions/RushCommandLineParser.ts
@@ -19,6 +19,7 @@ import LinkAction from './LinkAction';
 import PublishAction from './PublishAction';
 import RebuildAction from './RebuildAction';
 import UnlinkAction from './UnlinkAction';
+import CheckVersionsAction from './CheckVersionsAction';
 
 export default class RushCommandLineParser extends CommandLineParser {
   public rushConfiguration: RushConfiguration;
@@ -45,6 +46,7 @@ export default class RushCommandLineParser extends CommandLineParser {
     this.addAction(new PublishAction(this));
     this.addAction(new RebuildAction(this));
     this.addAction(new UnlinkAction(this));
+    this.addAction(new CheckVersionsAction(this));
   }
 
   protected onDefineParameters(): void {


### PR DESCRIPTION
Sample output:

```
@types/es6-collections
  ^0.5.29
   - @microsoft/api-extractor
  0.5.29
   - @microsoft/rush
   - @microsoft/rush-lib

@types/fs-extra
  ~0.0.34
   - @microsoft/api-extractor
  >=0.0.34, <0.27.0
   - @microsoft/gulp-core-build-typescript
  0.0.37
   - @microsoft/rush
  0.0.34
   - @microsoft/rush-lib

@types/node
  >=6.0.51 <6.9.1
   - @microsoft/api-extractor
  ^6.0.46
   - @microsoft/gulp-core-build
   - @microsoft/gulp-core-build-mocha
   - @microsoft/gulp-core-build-sass
   - @microsoft/gulp-core-build-serve
   - @microsoft/gulp-core-build-typescript
   - @microsoft/gulp-core-build-webpack
   - @microsoft/node-library-build
   - @microsoft/package-deps-hash
   - @microsoft/web-library-build
  6.0.62
   - @microsoft/rush
   - @microsoft/rush-lib

@types/z-schema
  ~3.16.31
   - @microsoft/api-extractor
   - @microsoft/gulp-core-build
  3.16.31
   - @microsoft/rush-lib

fs-extra
  ~0.26.0
   - @microsoft/api-extractor
   - @microsoft/gulp-core-build-typescript
   - @microsoft/rush
   - @microsoft/rush-lib
  ~0.26.7
   - @microsoft/gulp-core-build

@types/chai
  >=3.4.34 <3.6.0
   - @microsoft/api-extractor
   - test-web-library-build
  ^3.4.34
   - @microsoft/gulp-core-build
   - @microsoft/package-deps-hash
  3.4.34
   - @microsoft/rush
   - @microsoft/rush-lib

@types/mocha
  >=2.2.33 <2.6.0
   - @microsoft/api-extractor
   - test-web-library-build
  ^2.2.32
   - @microsoft/gulp-core-build
   - @microsoft/gulp-core-build-mocha
   - @microsoft/package-deps-hash
  2.2.38
   - @microsoft/rush
   - @microsoft/rush-lib

@microsoft/node-library-build
  ~2.3.0
   - @microsoft/api-extractor
   - @microsoft/rush
   - @microsoft/rush-lib
  >=2.2.0 <3.0.0
   - @microsoft/gulp-core-build
   - @microsoft/package-deps-hash
  >=2.3.0 <3.0.0
   - @microsoft/gulp-core-build-karma
   - @microsoft/gulp-core-build-mocha
   - @microsoft/gulp-core-build-sass
   - @microsoft/gulp-core-build-serve
   - @microsoft/gulp-core-build-typescript
   - @microsoft/gulp-core-build-webpack

rimraf
  ~2.5.4
   - @microsoft/gulp-core-build
  ~2.5.2
   - @microsoft/rush-lib

semver
  ~5.3.0
   - @microsoft/gulp-core-build
  ~5.2.0
   - @microsoft/rush
   - @microsoft/rush-lib

gulp-changed
  ~1.3.0
   - @microsoft/gulp-core-build-sass
  ~1.3.2
   - @microsoft/gulp-core-build-typescript

Found 11 mis-matching dependencies!
```