### PR TITLE
SASS: module css hash should be changed when css content changes.

### DIFF
--- a/common/changes/dzearing-sass-fix_2017-02-14-08-11.json
+++ b/common/changes/dzearing-sass-fix_2017-02-14-08-11.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/gulp-core-build-sass",
+      "comment": "Updating SASS hash generation for css modules to consider css content in addition to filename.",
+      "type": "patch"
+    }
+  ],
+  "email": "dzearing@users.noreply.github.com"
+}

--- a/gulp-core-build-sass/src/SassTask.ts
+++ b/gulp-core-build-sass/src/SassTask.ts
@@ -241,12 +241,12 @@ export class SassTask extends GulpTask<ISassTaskConfig> {
     _classMaps[cssFileName] = json;
   }
 
-  private generateScopedName(name: string, fileName: string): string {
+  private generateScopedName(name: string, fileName: string, css: string): string {
     /* tslint:disable:typedef */
     const crypto = require('crypto');
     /* tslint:enable:typedef */
 
-    return name + '_' + crypto.createHmac('sha1', fileName).update(name).digest('hex').substring(0, 8);
+    return name + '_' + crypto.createHmac('sha1', fileName).update(css).digest('hex').substring(0, 8);
   }
 }
 


### PR DESCRIPTION
Between 2 versions, the hashes are not regenerating. This makes it so that any modifications to the css content of the file will re-eval the hash.