### PR TITLE
Temporarily revert PR #102

### DIFF
--- a/common/changes/pgonzal-revert-pr102_2017-02-15-08-44.json
+++ b/common/changes/pgonzal-revert-pr102_2017-02-15-08-44.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Temporarily reverting the new temp_modules validation feature, because it is incompatible with some usage scenarios",
+      "type": "patch"
+    }
+  ],
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/rush/rush/src/actions/InstallAction.ts
+++ b/rush/rush/src/actions/InstallAction.ts
@@ -150,7 +150,8 @@ export default class InstallAction extends CommandLineAction {
     const globPattern: string = `${globEscape(normalizedPath)}/rush-*/package.json`;
     this._tempModulesFiles = glob.sync(globPattern, { nodir: true });
 
-    this._checkThatTempModulesMatch();
+    // TEMPORARILY DISABLED DUE TO REGRESSION (VSO 313164)
+    // this._checkThatTempModulesMatch();
 
     InstallAction.ensureLocalNpmTool(this._rushConfiguration, this._cleanInstallFull.value);
     this._installCommonModules();


### PR DESCRIPTION
The office-ui-fabric-react Travis builds were broken because the evergreen bot is bumping package.json without running "rush generate", which causes _checkThatTempModulesMatch() to fail.  This is a regression caused by PR #102.  Technically the bot *should* run "rush generate" after bumping the version, but insisting on that would be unreasonable because it would break the scenario.

I'm temporarily reverting this feature until we can sort it out.