### PR TITLE
Disable automatic publishing for Rush

### DIFF
--- a/rush.json
+++ b/rush.json
@@ -110,17 +110,23 @@
         "@microsoft/node-library-build"
       ]
     },
+
+    // Rush is published manually for two reasons:
+    // 1. We need to do proper validation before pushing out a new release
+    //    that potentially could screw up everyone's daily work.
+    // 2. The "rush" and "rush-lib" packages need to have identical versions,
+    //    which is currently not supported by the automatic publishing system.
     {
       "packageName": "@microsoft/rush",
       "projectFolder": "rush/rush",
       "reviewCategory": "libraries",
-      "shouldPublish": true
+      "shouldPublish": false
     },
     {
       "packageName": "@microsoft/rush-lib",
       "projectFolder": "rush/rush-lib",
       "reviewCategory": "libraries",
-      "shouldPublish": true
+      "shouldPublish": false
     }
   ]
 }

--- a/rush/rush-lib/package.json
+++ b/rush/rush-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/rush-lib",
-  "version": "1.8.0",
+  "version": "1.8.3",
   "description": "Library support for the Rush tool",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/rush/rush/package.json
+++ b/rush/rush/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/rush",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "description": "Manage building/installing of multiple NPM package folders",
   "scripts": {
     "build": "gulp",
@@ -13,7 +13,7 @@
   "license": "MIT",
   "dependencies": {
     "@microsoft/package-deps-hash": "~0.0.4",
-    "@microsoft/rush-lib": "1.8.0",
+    "@microsoft/rush-lib": "1.8.3",
     "@microsoft/stream-collator": "~1.0.2",
     "@microsoft/ts-command-line": "~1.1.1",
     "builtins": "~1.0.3",


### PR DESCRIPTION
This fixes the bug where you install Rush 1.8.2 and then it prints a banner saying that it's Rush 1.8.0.