### PR TITLE
Fix Rush metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,6 @@
   "description": "Web build tools",
 
   "devDependencies": {
-    "@microsoft/rush": "~1.5.1"
+    "@microsoft/rush": "~1.8.2"
   }
 }

--- a/rush/rush-lib/package.json
+++ b/rush/rush-lib/package.json
@@ -2,6 +2,11 @@
   "name": "@microsoft/rush-lib",
   "version": "1.8.3",
   "description": "Library support for the Rush tool",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/microsoft/web-build-tools"
+  },
+  "homepage": "http://aka.ms/rush",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/rush/rush/package.json
+++ b/rush/rush/package.json
@@ -1,7 +1,12 @@
 {
   "name": "@microsoft/rush",
   "version": "1.8.3",
-  "description": "Manage building/installing of multiple NPM package folders",
+  "description": "A fast solution for building/publishing many NPM packages",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/microsoft/web-build-tools"
+  },
+  "homepage": "http://aka.ms/rush",
   "scripts": {
     "build": "gulp",
     "clean": "gulp clean",

--- a/rush/rush/src/actions/RushCommandLineParser.ts
+++ b/rush/rush/src/actions/RushCommandLineParser.ts
@@ -29,8 +29,7 @@ export default class RushCommandLineParser extends CommandLineParser {
     super({
       toolFilename: 'rush',
       toolDescription: 'Rush helps you to manage a collection of Node Package Manager'
-      + ' projects.  (For more details about NPM, see the www.npmjs.com web site.)'
-      + ' Rush collects the dependencies for all projects into a "common" folder,'
+      + ' projects.  Rush collects the dependencies for all projects into a "common" folder,'
       + ' detects which projects can be locally linked, and then performs a fast parallel'
       + ' build according to the detected dependency graph.  If you want to decompose'
       + ' your monolithic project into many small packages but are afraid of the dreaded'

--- a/rush/rush/src/rush.ts
+++ b/rush/rush/src/rush.ts
@@ -8,7 +8,7 @@ import { rushVersion } from '@microsoft/rush-lib';
 import RushCommandLineParser from './actions/RushCommandLineParser';
 
 console.log(os.EOL + colors.bold(`Rush Multi-Package Build Tool ${rushVersion}`)
-  + os.EOL);
+  + colors.cyan(' - http://aka.ms/rush') + os.EOL);
 
 const parser: RushCommandLineParser = new RushCommandLineParser();
 


### PR DESCRIPTION
Fix up the NPM package metadata for publishing.  Also bump web-build-tools to use the latest Rush.