### PR TITLE
Make quiet the default, add --verbose

### DIFF
--- a/common/changes/nickpape-verbose-flags_2017-02-16-20-38.json
+++ b/common/changes/nickpape-verbose-flags_2017-02-16-20-38.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Make --quiet builds the default. Remove the --quiet parameter. Add a --verbose parameter which displays the build logs. Add a --very-verbose parameter to dinvoke the build step with the --verbose flag for enhanced debugging.",
+      "type": "major"
+    }
+  ],
+  "email": "nickpape@users.noreply.github.com"
+}

--- a/rush/rush/src/actions/RebuildAction.ts
+++ b/rush/rush/src/actions/RebuildAction.ts
@@ -104,8 +104,8 @@ export default class RebuildAction extends CommandLineAction {
     this._minimalParameter = this.defineFlagParameter({
       parameterLongName: '--minimal',
       parameterShortName: '-m',
-      description: 'Invokes the build script with the "--minimal" option, which speeds up the build by running the minimal set ' +
-        'of tasks required to produce an executable output'
+      description: 'Invokes the build script with the "--minimal" option, which speeds up the build by running the ' +
+        'minimal set of tasks required to produce an executable output'
     });
     this._verboseParameter = this.defineFlagParameter({
       parameterLongName: '--verbose',
@@ -115,7 +115,8 @@ export default class RebuildAction extends CommandLineAction {
     this._veryVerboseParameter = this.defineFlagParameter({
       parameterLongName: '--very-verbose',
       parameterShortName: '-vv',
-      description: 'Invokes the build script with the "--verbose" parameter. This implicity enables the "--verbose" flag which displays the build logs.'
+      description: 'Invokes the build script with the "--verbose" parameter. This implicity enables the "--verbose" ' +
+        'flag which displays the build logs'
     });
   }
 

--- a/rush/rush/src/actions/RebuildAction.ts
+++ b/rush/rush/src/actions/RebuildAction.ts
@@ -126,7 +126,7 @@ export default class RebuildAction extends CommandLineAction {
     console.log(`Starting "rush ${this.options.actionVerb}"` + os.EOL);
     const stopwatch: Stopwatch = Stopwatch.start();
 
-    const isQuietmode: boolean = !(this._verboseParameter.value)
+    const isQuietmode: boolean = !(this._verboseParameter.value);
 
     const taskRunner: TaskRunner = new TaskRunner(isQuietmode, this._parallelismParameter.value);
 

--- a/rush/rush/src/actions/RebuildAction.ts
+++ b/rush/rush/src/actions/RebuildAction.ts
@@ -49,6 +49,8 @@ export default class RebuildAction extends CommandLineAction {
   private _toFlag: CommandLineStringListParameter;
   private _vsoParameter: CommandLineFlagParameter;
   private _minimalParameter: CommandLineFlagParameter;
+  private _verboseParameter: CommandLineFlagParameter;
+  private _veryVerboseParameter: CommandLineFlagParameter;
 
   constructor(parser: RushCommandLineParser, options?: ICommandLineActionOptions) {
     super(options || {
@@ -102,8 +104,18 @@ export default class RebuildAction extends CommandLineAction {
     this._minimalParameter = this.defineFlagParameter({
       parameterLongName: '--minimal',
       parameterShortName: '-m',
-      description: 'Invokes gulp with the "--minimal" option, which speeds up the build by running the minimal set ' +
+      description: 'Invokes the build script with the "--minimal" option, which speeds up the build by running the minimal set ' +
         'of tasks required to produce an executable output'
+    });
+    this._verboseParameter = this.defineFlagParameter({
+      parameterLongName: '--verbose',
+      parameterShortName: '-v',
+      description: 'Display the logs during the build, rather than just displaying the build status summary'
+    });
+    this._veryVerboseParameter = this.defineFlagParameter({
+      parameterLongName: '--very-verbose',
+      parameterShortName: '-vv',
+      description: 'Invokes the build script with the "--verbose" parameter. This implicity enables the "--verbose" flag which displays the build logs.'
     });
   }
 
@@ -119,7 +131,9 @@ export default class RebuildAction extends CommandLineAction {
     console.log(`Starting "rush ${this.options.actionVerb}"` + os.EOL);
     const stopwatch: Stopwatch = Stopwatch.start();
 
-    const taskRunner: TaskRunner = new TaskRunner(this._quietParameter.value, this._parallelismParameter.value);
+    const isQuietmode: boolean = !(this._verboseParameter.value || this._veryVerboseParameter.value);
+
+    const taskRunner: TaskRunner = new TaskRunner(isQuietmode, this._parallelismParameter.value);
 
     const toFlags: string[] = this._toFlag.value;
     const fromFlags: string[] = this._fromFlag.value;
@@ -257,7 +271,8 @@ export default class RebuildAction extends CommandLineAction {
       this._productionParameter.value,
       this._npmParameter.value,
       this._minimalParameter.value,
-      this._isIncrementalBuildAllowed);
+      this._isIncrementalBuildAllowed,
+      this._veryVerboseParameter.value);
 
     if (!taskRunner.hasTask(projectTask.name)) {
       taskRunner.addTask(projectTask);

--- a/rush/rush/src/actions/RebuildAction.ts
+++ b/rush/rush/src/actions/RebuildAction.ts
@@ -112,12 +112,6 @@ export default class RebuildAction extends CommandLineAction {
       parameterShortName: '-v',
       description: 'Display the logs during the build, rather than just displaying the build status summary'
     });
-    this._veryVerboseParameter = this.defineFlagParameter({
-      parameterLongName: '--very-verbose',
-      parameterShortName: '-vv',
-      description: 'Invokes the build script with the "--verbose" parameter. This implicity enables the "--verbose" ' +
-        'flag which displays the build logs'
-    });
   }
 
   protected onExecute(): void {
@@ -132,7 +126,7 @@ export default class RebuildAction extends CommandLineAction {
     console.log(`Starting "rush ${this.options.actionVerb}"` + os.EOL);
     const stopwatch: Stopwatch = Stopwatch.start();
 
-    const isQuietmode: boolean = !(this._verboseParameter.value || this._veryVerboseParameter.value);
+    const isQuietmode: boolean = !(this._verboseParameter.value)
 
     const taskRunner: TaskRunner = new TaskRunner(isQuietmode, this._parallelismParameter.value);
 
@@ -272,8 +266,7 @@ export default class RebuildAction extends CommandLineAction {
       this._productionParameter.value,
       this._npmParameter.value,
       this._minimalParameter.value,
-      this._isIncrementalBuildAllowed,
-      this._veryVerboseParameter.value);
+      this._isIncrementalBuildAllowed);
 
     if (!taskRunner.hasTask(projectTask.name)) {
       taskRunner.addTask(projectTask);

--- a/rush/rush/src/actions/RebuildAction.ts
+++ b/rush/rush/src/actions/RebuildAction.ts
@@ -45,12 +45,10 @@ export default class RebuildAction extends CommandLineAction {
   private _parallelismParameter: CommandLineIntegerParameter;
   private _parser: RushCommandLineParser;
   private _productionParameter: CommandLineFlagParameter;
-  private _quietParameter: CommandLineFlagParameter;
   private _toFlag: CommandLineStringListParameter;
   private _vsoParameter: CommandLineFlagParameter;
   private _minimalParameter: CommandLineFlagParameter;
   private _verboseParameter: CommandLineFlagParameter;
-  private _veryVerboseParameter: CommandLineFlagParameter;
 
   constructor(parser: RushCommandLineParser, options?: ICommandLineActionOptions) {
     super(options || {
@@ -68,11 +66,6 @@ export default class RebuildAction extends CommandLineAction {
   }
 
   protected onDefineParameters(): void {
-    this._quietParameter = this.defineFlagParameter({
-      parameterLongName: '--quiet',
-      parameterShortName: '-q',
-      description: 'Only show errors and overall build status'
-    });
     this._productionParameter = this.defineFlagParameter({
       parameterLongName: '--production',
       description: 'Perform a production build'

--- a/rush/rush/src/taskRunner/ProjectBuildTask.ts
+++ b/rush/rush/src/taskRunner/ProjectBuildTask.ts
@@ -38,6 +38,7 @@ export default class ProjectBuildTask implements ITaskDefinition {
   private _production: boolean;
   private _npmMode: boolean;
   private _minimalMode: boolean;
+  private _verbose: boolean;
 
   private _hasWarningOrError: boolean;
 
@@ -49,7 +50,8 @@ export default class ProjectBuildTask implements ITaskDefinition {
     production: boolean,
     npmMode: boolean,
     minimalMode: boolean,
-    isIncrementalBuildAllowed: boolean
+    isIncrementalBuildAllowed: boolean,
+    verbose: boolean
   ) {
     this.name = rushProject.packageName;
     this._errorDetector = errorDetector;
@@ -59,6 +61,7 @@ export default class ProjectBuildTask implements ITaskDefinition {
     this._rushProject = rushProject;
     this._rushConfiguration = rushConfiguration;
     this._minimalMode = minimalMode;
+    this._verbose = verbose;
     this.isIncrementalBuildAllowed = isIncrementalBuildAllowed;
   }
 
@@ -152,6 +155,9 @@ export default class ProjectBuildTask implements ITaskDefinition {
         }
         if (this._minimalMode) {
           build.args.push('--minimal');
+        }
+        if (this._verbose) {
+          build.args.push('--verbose');
         }
 
         const actualBuildCommand: string = `${build.command} ${build.args.join(' ')}`;

--- a/rush/rush/src/taskRunner/ProjectBuildTask.ts
+++ b/rush/rush/src/taskRunner/ProjectBuildTask.ts
@@ -38,7 +38,6 @@ export default class ProjectBuildTask implements ITaskDefinition {
   private _production: boolean;
   private _npmMode: boolean;
   private _minimalMode: boolean;
-  private _verbose: boolean;
 
   private _hasWarningOrError: boolean;
 
@@ -50,8 +49,7 @@ export default class ProjectBuildTask implements ITaskDefinition {
     production: boolean,
     npmMode: boolean,
     minimalMode: boolean,
-    isIncrementalBuildAllowed: boolean,
-    verbose: boolean
+    isIncrementalBuildAllowed: boolean
   ) {
     this.name = rushProject.packageName;
     this._errorDetector = errorDetector;
@@ -61,7 +59,6 @@ export default class ProjectBuildTask implements ITaskDefinition {
     this._rushProject = rushProject;
     this._rushConfiguration = rushConfiguration;
     this._minimalMode = minimalMode;
-    this._verbose = verbose;
     this.isIncrementalBuildAllowed = isIncrementalBuildAllowed;
   }
 
@@ -155,9 +152,6 @@ export default class ProjectBuildTask implements ITaskDefinition {
         }
         if (this._minimalMode) {
           build.args.push('--minimal');
-        }
-        if (this._verbose) {
-          build.args.push('--verbose');
         }
 
         const actualBuildCommand: string = `${build.command} ${build.args.join(' ')}`;


### PR DESCRIPTION
Some feedback people have given is that the quiet (summary) build should be the default, and they would rather have a `--verbose` flag to display the build logs.