### PR TITLE
Add enabled toggle to both GulpTask and IExecutable

### DIFF
--- a/common/changes/nickpape-add-is-enabled-toggle-instead-of-override_2017-02-16-23-48.json
+++ b/common/changes/nickpape-add-is-enabled-toggle-instead-of-override_2017-02-16-23-48.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/gulp-core-build",
+      "comment": "Add an enabled toggle to IExecutable and GulpTask. Using this toggle is now preferred to overriding the isEnabled function.",
+      "type": "minor"
+    }
+  ],
+  "email": "nickpape@users.noreply.github.com"
+}

--- a/common/reviews/api/gulp-core-build.api.ts
+++ b/common/reviews/api/gulp-core-build.api.ts
@@ -42,13 +42,14 @@ class GulpTask<TASK_CONFIG> implements IExecutable {
   public buildConfig: IBuildConfig;
   public cleanMatch: string[];
   public copyFile(localSourcePath: string, localDestPath?: string): void;
+  public enabled: boolean;
   public execute(config: IBuildConfig): Promise<void>;
   public abstract executeTask(gulp: gulp.Gulp | GulpProxy, completeCallback?: (result?: Object) => void): Promise<Object> | NodeJS.ReadWriteStream | void;
   public fileError(filePath: string, line: number, column: number, errorCode: string, message: string): void;
   public fileExists(localPath: string): boolean;
   public fileWarning(filePath: string, line: number, column: number, warningCode: string, message: string): void;
   public getCleanMatch(buildConfig: IBuildConfig, taskConfig: TASK_CONFIG = this.taskConfig): string[];
-  public isEnabled(buildConfig: IBuildConfig): boolean;
+  public isEnabled(config?: IBuildConfig): boolean;
   protected loadSchema(): Object;
   public log(message: string): void;
   public logError(message: string): void;
@@ -108,6 +109,8 @@ interface ICustomGulpTask {
 
 // (undocumented)
 interface IExecutable {
+  // (undocumented)
+  enabled?: boolean;
   execute: (config: IBuildConfig) => Promise<void>;
   getCleanMatch?: (config: IBuildConfig, taskConfig?: any) => string[];
   isEnabled?: (config?: IBuildConfig) => boolean;

--- a/gulp-core-build/src/IExecutable.ts
+++ b/gulp-core-build/src/IExecutable.ts
@@ -10,6 +10,8 @@ export interface IExecutable {
   /** Optional name to give the task. If no name is provided, the "Running subtask" logging will be silent. */
   name?: string;
 
+  enabled?: boolean;
+
   /** Optional callback to indicate if the task is enabled or not. */
   isEnabled?: (config?: IBuildConfig) => boolean;
 

--- a/gulp-core-build/src/tasks/GulpTask.ts
+++ b/gulp-core-build/src/tasks/GulpTask.ts
@@ -2,6 +2,7 @@
 import * as path from 'path';
 import * as fs from 'fs';
 
+import { getConfig } from '../index';
 import { GulpProxy } from '../GulpProxy';
 import { IExecutable } from '../IExecutable';
 import { IBuildConfig } from '../IBuildConfig';
@@ -36,11 +37,26 @@ export abstract class GulpTask<TASK_CONFIG> implements IExecutable {
    * will return this value.
    */
   public cleanMatch: string[];
+  /**
+   * Indicates whether this task should be executed or not. This toggle is used by isEnabled() to determine
+   * if the task should run. Since some tasks have more complex logic to determine if they should run or
+   * not, the isEnabled() function can be overriden.
+   */
+  public enabled: boolean = true;
 
   /**
    * The memoized schema for this task. Should not be utilized by child classes, use schema property instead.
    */
   private _schema: Object;
+
+  /**
+   * Overridable function which returns true if this task should be executed, or false if it should be skipped.
+   * @param buildConfig - the build configuration which should be used when determining if the task is enabled
+   * @returns true if the build is not redundant and the enabled toggle is true
+   */
+  public isEnabled(config?: IBuildConfig): boolean {
+    return (!config || !config.isRedundantBuild) && this.enabled;
+  };
 
   /**
    * A JSON Schema object which will be used to validate this task's configuration file.
@@ -108,15 +124,6 @@ export abstract class GulpTask<TASK_CONFIG> implements IExecutable {
     if (rawConfig) {
       this.mergeConfig(rawConfig);
     }
-  }
-
-  /**
-   * Overridable function which returns true if this task should be executed, or false if it should be skipped.
-   * @param buildConfig - the build configuration which should be used when determining if the task is enabled
-   * @returns true if the build is not redundant
-   */
-  public isEnabled(buildConfig: IBuildConfig): boolean {
-    return (!buildConfig || !buildConfig.isRedundantBuild);
   }
 
   /**

--- a/gulp-core-build/src/tasks/GulpTask.ts
+++ b/gulp-core-build/src/tasks/GulpTask.ts
@@ -2,7 +2,6 @@
 import * as path from 'path';
 import * as fs from 'fs';
 
-import { getConfig } from '../index';
 import { GulpProxy } from '../GulpProxy';
 import { IExecutable } from '../IExecutable';
 import { IBuildConfig } from '../IBuildConfig';


### PR DESCRIPTION
People have been overriding the isEnabled function to turn tasks off. This is weird. Now, there is a toggle which is read by the default isEnabled function. Consumers should use this toggle.

VSO 310452