### PR TITLE
Rush: add "pinnedVersions" option

### DIFF
--- a/common/changes/nickpape-rush-pinned-versions_2017-02-24-00-38.json
+++ b/common/changes/nickpape-rush-pinned-versions_2017-02-24-00-38.json
@@ -2,12 +2,12 @@
   "changes": [
     {
       "packageName": "@microsoft/rush-lib",
-      "comment": "Add a \"pinnedVersions\" option to rush.json, which will add dependencies to the top-level package.json. These dependencies are resolved first, and thus this mechanism can be used to control versions of second-level dependencies.",
+      "comment": "Add a \"pinnedVersions\" option to rush.json, which will add dependencies to the common package.json. Since these dependencies are installed first, this mechanism can be used to control versions of unconstrained second-level dependencies.",
       "type": "minor"
     },
     {
       "packageName": "@microsoft/rush",
-      "comment": "Add a \"pinnedVersions\" option to rush.json, which will add dependencies to the top-level package.json. These dependencies are resolved first, and thus this mechanism can be used to control versions of second-level dependencies.",
+      "comment": "Add a \"pinnedVersions\" option to rush.json, which will add dependencies to the common package.json. Since these dependencies are installed first, this mechanism can be used to control versions of unconstrained second-level dependencies.",
       "type": "minor"
     }
   ],

--- a/common/changes/nickpape-rush-pinned-versions_2017-02-24-00-38.json
+++ b/common/changes/nickpape-rush-pinned-versions_2017-02-24-00-38.json
@@ -1,0 +1,15 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush-lib",
+      "comment": "Add a \"pinnedVersions\" option to rush.json, which will add dependencies to the top-level package.json. These dependencies are resolved first, and thus this mechanism can be used to control versions of second-level dependencies.",
+      "type": "minor"
+    },
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Add a \"pinnedVersions\" option to rush.json, which will add dependencies to the top-level package.json. These dependencies are resolved first, and thus this mechanism can be used to control versions of second-level dependencies.",
+      "type": "minor"
+    }
+  ],
+  "email": "nickpape@users.noreply.github.com"
+}

--- a/rush/rush-lib/src/data/RushConfiguration.ts
+++ b/rush/rush-lib/src/data/RushConfiguration.ts
@@ -310,7 +310,7 @@ export default class RushConfiguration {
 
         if (this._projectsByName.has(dependency)) {
           throw new Error(`In rush.json, cannot add a pinned version ` +
-            `for a rush-ified project: "${dependency}"`);
+            `for local project: "${dependency}"`);
         }
 
         this._pinnedVersions.set(dependency, pinnedVersion);

--- a/rush/rush-lib/src/rush-schema.json
+++ b/rush/rush-lib/src/rush-schema.json
@@ -102,10 +102,10 @@
       }
     },
     "pinnedVersions": {
-      "description": "A mapping of dependency package names to a semantic version. These are included in the common package.json and is used to control versions of second-level dependencies.",
+      "description": "A mapping of dependency package names to a semantic version. These are included in the common package.json and are used to control versions of second-level dependencies.",
       "type": "object",
       "patternProperties": {
-        "^[a-zA-Z0-9_@/-]+$": {
+        "^\\S+$": {
           "type": "string",
           "description": "A semantic version specifier"
         }

--- a/rush/rush-lib/src/rush-schema.json
+++ b/rush/rush-lib/src/rush-schema.json
@@ -100,6 +100,16 @@
         "additionalProperties": false,
         "required": [ "packageName", "projectFolder" ]
       }
+    },
+    "pinnedVersions": {
+      "description": "A mapping of dependency package names to a semantic version. These are included in the common package.json and is used to control versions of second-level dependencies.",
+      "type": "object",
+      "patternProperties": {
+        "^[a-zA-Z0-9_@/-]+$": {
+          "type": "string",
+          "description": "A semantic version specifier"
+        }
+      }
     }
   },
   "additionalProperties": false,

--- a/rush/rush/src/actions/GenerateAction.ts
+++ b/rush/rush/src/actions/GenerateAction.ts
@@ -77,6 +77,11 @@ export default class GenerateAction extends CommandLineAction {
       version: '0.0.0'
     };
 
+    // Add any pinned versions to the top of the commonPackageJson
+    rushConfiguration.pinnedVersions.forEach((version: string, dependency: string) => {
+      commonPackageJson.dependencies[dependency] = version;
+    });
+
     console.log('Creating temp projects...');
 
     // To make the common/package.json file more readable, sort alphabetically


### PR DESCRIPTION
In certain cases, it is desirable to control which version of a second-level dependency NPM will resolve to.

For example, recently a patch version of `loader-utils` deprecated a function being called by `css-loader`. The version specifier for `loader-utils` was a range: `>=1.0.0 <2.0.0`. However, `loader-utils` is not a top-level dependency of the project, therefore, in order to control the version, we must add it to our package.json.

However, this is undesirable, as we have now added a package as a dependency even though we don't actually depend on it. Additionally, we would likely have to add this dependency to every package.json. Even if we do that, there are still cases where NPM will install side-by-side versions.

The solution: add a new field to rush.json called `pinnedVersions`. This field is a mapping of dependencies to version specifiers. During `rush generate`, when constructing the `common/package.json`, we inject these dependencies at the top of the file. This will instruct NPM to resolve those dependencies before resolving any others, thus bypassing the side-by-side versions issue.