### PR TITLE
Rush: Deprecate the "--quiet" flag rather than completely removing it 

### DIFF
--- a/common/changes/common.json
+++ b/common/changes/common.json
@@ -1,0 +1,15 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush-lib",
+      "comment": "Rush will automatically create the common folder.",
+      "type": "patch"
+    },
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Rush install checks to ensure that generate has been run.",
+      "type": "patch"
+    }
+  ],
+  "email": "nickpape@users.noreply.github.com"
+}

--- a/common/changes/pinned.json
+++ b/common/changes/pinned.json
@@ -1,0 +1,15 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush-lib",
+      "comment": "Add a \"pinnedVersions\" option to rush.json, which will add dependencies to the common package.json. Since these dependencies are installed first, this mechanism can be used to control versions of unconstrained second-level dependencies.",
+      "type": "minor"
+    },
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Add a \"pinnedVersions\" option to rush.json, which will add dependencies to the common package.json. Since these dependencies are installed first, this mechanism can be used to control versions of unconstrained second-level dependencies.",
+      "type": "minor"
+    }
+  ],
+  "email": "nickpape@users.noreply.github.com"
+}

--- a/common/changes/verbose.json
+++ b/common/changes/verbose.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Make --quiet builds the default. Deprecate the --quiet parameter. Add a --verbose parameter which displays the build logs.",
+      "type": "minor"
+    }
+  ],
+  "email": "nickpape@users.noreply.github.com"
+}

--- a/rush/rush/src/actions/RebuildAction.ts
+++ b/rush/rush/src/actions/RebuildAction.ts
@@ -45,6 +45,7 @@ export default class RebuildAction extends CommandLineAction {
   private _parallelismParameter: CommandLineIntegerParameter;
   private _parser: RushCommandLineParser;
   private _productionParameter: CommandLineFlagParameter;
+  private _quietParameter: CommandLineFlagParameter;
   private _toFlag: CommandLineStringListParameter;
   private _vsoParameter: CommandLineFlagParameter;
   private _minimalParameter: CommandLineFlagParameter;
@@ -105,6 +106,11 @@ export default class RebuildAction extends CommandLineAction {
       parameterShortName: '-v',
       description: 'Display the logs during the build, rather than just displaying the build status summary'
     });
+    this._quietParameter = this.defineFlagParameter({
+      parameterLongName: '--quiet',
+      parameterShortName: '-q',
+      description: 'Only show errors and overall build status'
+    });
   }
 
   protected onExecute(): void {
@@ -115,6 +121,10 @@ export default class RebuildAction extends CommandLineAction {
         + os.EOL + 'Did you run "rush link"?');
     }
     this._rushLinkJson = JsonFile.loadJsonFile(this._rushConfiguration.rushLinkJsonFilename);
+
+    if (this._quietParameter.value) {
+      console.log(colors.yellow(`DEPRECATED: the --quiet parameter is deprecated, as builds are quiet by default`));
+    }
 
     console.log(`Starting "rush ${this.options.actionVerb}"` + os.EOL);
     const stopwatch: Stopwatch = Stopwatch.start();

--- a/rush/rush/src/actions/RebuildAction.ts
+++ b/rush/rush/src/actions/RebuildAction.ts
@@ -123,7 +123,7 @@ export default class RebuildAction extends CommandLineAction {
     this._rushLinkJson = JsonFile.loadJsonFile(this._rushConfiguration.rushLinkJsonFilename);
 
     if (this._quietParameter.value) {
-      console.log(colors.yellow(`DEPRECATED: the --quiet parameter is deprecated, as builds are quiet by default`));
+      console.log(colors.yellow(`DEPRECATED: The --quiet parameter will be removed soon, because builds are now quiet by default`));
     }
 
     console.log(`Starting "rush ${this.options.actionVerb}"` + os.EOL);

--- a/rush/rush/src/actions/RebuildAction.ts
+++ b/rush/rush/src/actions/RebuildAction.ts
@@ -123,7 +123,8 @@ export default class RebuildAction extends CommandLineAction {
     this._rushLinkJson = JsonFile.loadJsonFile(this._rushConfiguration.rushLinkJsonFilename);
 
     if (this._quietParameter.value) {
-      console.log(colors.yellow(`DEPRECATED: The --quiet parameter will be removed soon, because builds are now quiet by default`));
+      console.log(colors.yellow(`DEPRECATED: The --quiet parameter will be removed soon, ` +
+        `because builds are now quiet by default`));
     }
 
     console.log(`Starting "rush ${this.options.actionVerb}"` + os.EOL);


### PR DESCRIPTION
Many CI scripts will have to be updated. We should let the new flags bake for a while before removing anything.