### PR TITLE
Add a --temp-modules flag to the install step, which will look for out of date temp_modules

### DIFF
--- a/common/changes/nickpape-warn-option_2017-02-24-21-58.json
+++ b/common/changes/nickpape-warn-option_2017-02-24-21-58.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Added the --temp-modules flag, which controls if rush will treat out of date temp_modules as an error, a warning, or if it will ignore them entirely.",
+      "type": "minor"
+    }
+  ],
+  "email": "nickpape@users.noreply.github.com"
+}

--- a/common/npm-shrinkwrap.json
+++ b/common/npm-shrinkwrap.json
@@ -3,14 +3,14 @@
   "version": "0.0.0",
   "dependencies": {
     "@microsoft/api-extractor": {
-      "version": "1.1.11",
+      "version": "1.1.14",
       "from": "@microsoft/api-extractor@>=1.1.4 <2.0.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-1.1.11.tgz"
+      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-1.1.14.tgz"
     },
     "@microsoft/gulp-core-build": {
-      "version": "2.3.1",
+      "version": "2.4.0",
       "from": "@microsoft/gulp-core-build@>=2.3.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/gulp-core-build/-/gulp-core-build-2.3.1.tgz"
+      "resolved": "https://registry.npmjs.org/@microsoft/gulp-core-build/-/gulp-core-build-2.4.0.tgz"
     },
     "@microsoft/gulp-core-build-mocha": {
       "version": "2.0.1",
@@ -50,9 +50,16 @@
       "resolved": "https://registry.npmjs.org/@microsoft/stream-collator/-/stream-collator-1.0.2.tgz"
     },
     "@microsoft/ts-command-line": {
-      "version": "1.1.1",
-      "from": "@microsoft/ts-command-line@>=1.1.1 <1.2.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/ts-command-line/-/ts-command-line-1.1.1.tgz"
+      "version": "2.0.0",
+      "from": "@microsoft/ts-command-line@>=2.0.0 <2.1.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/ts-command-line/-/ts-command-line-2.0.0.tgz",
+      "dependencies": {
+        "@types/node": {
+          "version": "6.0.62",
+          "from": "@types/node@6.0.62",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.62.tgz"
+        }
+      }
     },
     "@types/assertion-error": {
       "version": "1.0.30",
@@ -65,9 +72,9 @@
       "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.0.37.tgz"
     },
     "@types/chai": {
-      "version": "3.4.34",
+      "version": "3.4.35",
       "from": "@types/chai@>=3.4.34 <3.6.0",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-3.4.34.tgz"
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-3.4.35.tgz"
     },
     "@types/chalk": {
       "version": "0.4.31",
@@ -635,9 +642,9 @@
       "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz"
     },
     "caniuse-db": {
-      "version": "1.0.30000623",
+      "version": "1.0.30000626",
       "from": "caniuse-db@>=1.0.30000488 <2.0.0",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000623.tgz"
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000626.tgz"
     },
     "capture-stack-trace": {
       "version": "1.0.0",
@@ -675,9 +682,9 @@
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.6.1.tgz"
     },
     "clean-css": {
-      "version": "3.4.24",
+      "version": "3.4.25",
       "from": "clean-css@>=3.4.20 <4.0.0",
-      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-3.4.24.tgz",
+      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-3.4.25.tgz",
       "dependencies": {
         "commander": {
           "version": "2.8.1",
@@ -823,9 +830,21 @@
       }
     },
     "connect": {
-      "version": "3.5.1",
+      "version": "3.6.0",
       "from": "connect@>=3.3.5 <4.0.0",
-      "resolved": "https://registry.npmjs.org/connect/-/connect-3.5.1.tgz"
+      "resolved": "https://registry.npmjs.org/connect/-/connect-3.6.0.tgz",
+      "dependencies": {
+        "debug": {
+          "version": "2.6.1",
+          "from": "debug@2.6.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.1.tgz"
+        },
+        "ms": {
+          "version": "0.7.2",
+          "from": "ms@0.7.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
+        }
+      }
     },
     "connect-livereload": {
       "version": "0.5.4",
@@ -1184,9 +1203,9 @@
           "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz"
         },
         "readable-stream": {
-          "version": "2.2.2",
+          "version": "2.2.3",
           "from": "readable-stream@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz"
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.3.tgz"
         }
       }
     },
@@ -1224,9 +1243,9 @@
       }
     },
     "engine.io": {
-      "version": "1.8.2",
-      "from": "engine.io@1.8.2",
-      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-1.8.2.tgz",
+      "version": "1.8.3",
+      "from": "engine.io@1.8.3",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-1.8.3.tgz",
       "dependencies": {
         "debug": {
           "version": "2.3.3",
@@ -1241,9 +1260,9 @@
       }
     },
     "engine.io-client": {
-      "version": "1.8.2",
-      "from": "engine.io-client@1.8.2",
-      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-1.8.2.tgz",
+      "version": "1.8.3",
+      "from": "engine.io-client@1.8.3",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-1.8.3.tgz",
       "dependencies": {
         "component-emitter": {
           "version": "1.2.1",
@@ -1406,6 +1425,11 @@
       "from": "express@>=4.14.0 <4.15.0",
       "resolved": "https://registry.npmjs.org/express/-/express-4.14.1.tgz",
       "dependencies": {
+        "finalhandler": {
+          "version": "0.5.1",
+          "from": "finalhandler@0.5.1",
+          "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.5.1.tgz"
+        },
         "qs": {
           "version": "6.2.0",
           "from": "qs@6.2.0",
@@ -1557,9 +1581,21 @@
       "resolved": "https://registry.npmjs.org/filled-array/-/filled-array-1.1.0.tgz"
     },
     "finalhandler": {
-      "version": "0.5.1",
-      "from": "finalhandler@0.5.1",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.5.1.tgz"
+      "version": "1.0.0",
+      "from": "finalhandler@1.0.0",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.0.tgz",
+      "dependencies": {
+        "debug": {
+          "version": "2.6.1",
+          "from": "debug@2.6.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.1.tgz"
+        },
+        "ms": {
+          "version": "0.7.2",
+          "from": "ms@0.7.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
+        }
+      }
     },
     "find-index": {
       "version": "0.1.1",
@@ -1828,9 +1864,9 @@
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
         },
         "readable-stream": {
-          "version": "2.2.2",
+          "version": "2.2.3",
           "from": "readable-stream@>=2.0.5 <3.0.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz"
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.3.tgz"
         }
       }
     },
@@ -1877,9 +1913,9 @@
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
         },
         "readable-stream": {
-          "version": "2.2.2",
+          "version": "2.2.3",
           "from": "readable-stream@>=2.0.4 <3.0.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz"
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.3.tgz"
         },
         "vinyl": {
           "version": "1.2.0",
@@ -1904,9 +1940,9 @@
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
         },
         "readable-stream": {
-          "version": "2.2.2",
+          "version": "2.2.3",
           "from": "readable-stream@>=2.1.5 <3.0.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz"
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.3.tgz"
         }
       }
     },
@@ -2321,9 +2357,9 @@
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
         },
         "readable-stream": {
-          "version": "2.2.2",
+          "version": "2.2.3",
           "from": "readable-stream@>=2.0.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz"
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.3.tgz"
         }
       }
     },
@@ -2377,9 +2413,9 @@
       }
     },
     "gulp-typescript": {
-      "version": "3.1.4",
+      "version": "3.1.5",
       "from": "gulp-typescript@>=3.1.3 <3.2.0",
-      "resolved": "https://registry.npmjs.org/gulp-typescript/-/gulp-typescript-3.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/gulp-typescript/-/gulp-typescript-3.1.5.tgz",
       "dependencies": {
         "glob": {
           "version": "5.0.15",
@@ -2434,9 +2470,9 @@
           "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz"
         },
         "readable-stream": {
-          "version": "2.2.2",
+          "version": "2.2.3",
           "from": "readable-stream@>=2.0.4 <3.0.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz"
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.3.tgz"
         },
         "source-map": {
           "version": "0.5.6",
@@ -3208,9 +3244,9 @@
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
         },
         "readable-stream": {
-          "version": "2.2.2",
+          "version": "2.2.3",
           "from": "readable-stream@>=2.0.5 <3.0.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz"
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.3.tgz"
         }
       }
     },
@@ -3247,9 +3283,9 @@
       }
     },
     "loader-utils": {
-      "version": "0.2.16",
+      "version": "0.2.17",
       "from": "loader-utils@>=0.0.0 <1.0.0",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.16.tgz"
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz"
     },
     "lodash": {
       "version": "1.0.2",
@@ -3565,9 +3601,9 @@
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
         },
         "readable-stream": {
-          "version": "2.2.2",
+          "version": "2.2.3",
           "from": "readable-stream@>=2.0.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz"
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.3.tgz"
         }
       }
     },
@@ -3592,9 +3628,9 @@
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
         },
         "readable-stream": {
-          "version": "2.2.2",
+          "version": "2.2.3",
           "from": "readable-stream@>=2.0.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz"
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.3.tgz"
         }
       }
     },
@@ -4047,6 +4083,11 @@
       "from": "path-is-inside@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz"
     },
+    "path-parse": {
+      "version": "1.0.5",
+      "from": "path-parse@>=1.0.5 <2.0.0",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz"
+    },
     "path-root": {
       "version": "0.1.1",
       "from": "path-root@>=0.1.1 <0.2.0",
@@ -4140,9 +4181,9 @@
       "resolved": "https://registry.npmjs.org/plur/-/plur-2.1.2.tgz"
     },
     "postcss": {
-      "version": "5.2.13",
+      "version": "5.2.15",
       "from": "postcss@>=5.0.21 <6.0.0",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.13.tgz",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.15.tgz",
       "dependencies": {
         "source-map": {
           "version": "0.5.6",
@@ -4242,9 +4283,9 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
     },
     "qs": {
-      "version": "6.3.0",
+      "version": "6.3.1",
       "from": "qs@>=6.3.0 <6.4.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.0.tgz"
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.1.tgz"
     },
     "querystring": {
       "version": "0.2.0",
@@ -4277,9 +4318,9 @@
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.2.0.tgz"
     },
     "rc": {
-      "version": "1.1.6",
+      "version": "1.1.7",
       "from": "rc@>=1.1.6 <2.0.0",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.6.tgz"
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.7.tgz"
     },
     "read": {
       "version": "1.0.7",
@@ -4297,9 +4338,9 @@
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
         },
         "readable-stream": {
-          "version": "2.2.2",
+          "version": "2.2.3",
           "from": "readable-stream@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz"
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.3.tgz"
         }
       }
     },
@@ -4351,9 +4392,9 @@
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
         },
         "readable-stream": {
-          "version": "2.2.2",
+          "version": "2.2.3",
           "from": "readable-stream@>=2.0.2 <3.0.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz"
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.3.tgz"
         }
       }
     },
@@ -4433,9 +4474,9 @@
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
         },
         "readable-stream": {
-          "version": "2.2.2",
+          "version": "2.2.3",
           "from": "readable-stream@>=2.0.2 <3.0.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz"
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.3.tgz"
         }
       }
     },
@@ -4465,9 +4506,9 @@
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz"
     },
     "resolve": {
-      "version": "1.2.0",
+      "version": "1.3.1",
       "from": "resolve@>=1.1.7 <2.0.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.2.0.tgz"
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.3.1.tgz"
     },
     "resolve-dir": {
       "version": "0.1.1",
@@ -4576,6 +4617,11 @@
       "from": "temp_modules\\rush-rush",
       "resolved": "file:temp_modules\\rush-rush",
       "dependencies": {
+        "@types/chai": {
+          "version": "3.4.34",
+          "from": "@types/chai@3.4.34",
+          "resolved": "https://registry.npmjs.org/@types/chai/-/chai-3.4.34.tgz"
+        },
         "@types/mocha": {
           "version": "2.2.38",
           "from": "@types/mocha@2.2.38",
@@ -4608,6 +4654,11 @@
       "from": "temp_modules\\rush-rush-lib",
       "resolved": "file:temp_modules\\rush-rush-lib",
       "dependencies": {
+        "@types/chai": {
+          "version": "3.4.34",
+          "from": "@types/chai@3.4.34",
+          "resolved": "https://registry.npmjs.org/@types/chai/-/chai-3.4.34.tgz"
+        },
         "@types/fs-extra": {
           "version": "0.0.34",
           "from": "@types/fs-extra@0.0.34",
@@ -4796,9 +4847,9 @@
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
     },
     "socket.io": {
-      "version": "1.7.2",
+      "version": "1.7.3",
       "from": "socket.io@>=1.4.5 <2.0.0",
-      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-1.7.2.tgz",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-1.7.3.tgz",
       "dependencies": {
         "debug": {
           "version": "2.3.3",
@@ -4835,9 +4886,9 @@
       }
     },
     "socket.io-client": {
-      "version": "1.7.2",
-      "from": "socket.io-client@1.7.2",
-      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-1.7.2.tgz",
+      "version": "1.7.3",
+      "from": "socket.io-client@1.7.3",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-1.7.3.tgz",
       "dependencies": {
         "component-emitter": {
           "version": "1.2.1",
@@ -4997,9 +5048,9 @@
       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz"
     },
     "strip-json-comments": {
-      "version": "1.0.4",
-      "from": "strip-json-comments@>=1.0.4 <1.1.0",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
+      "version": "2.0.1",
+      "from": "strip-json-comments@>=2.0.1 <2.1.0",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz"
     },
     "sudo": {
       "version": "1.0.3",
@@ -5069,9 +5120,9 @@
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
         },
         "readable-stream": {
-          "version": "2.2.2",
+          "version": "2.2.3",
           "from": "readable-stream@>=2.1.5 <3.0.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz"
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.3.tgz"
         }
       }
     },
@@ -5541,9 +5592,9 @@
           "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.3.0.tgz"
         },
         "readable-stream": {
-          "version": "2.2.2",
+          "version": "2.2.3",
           "from": "readable-stream@>=2.0.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz"
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.3.tgz"
         },
         "supports-color": {
           "version": "3.2.3",
@@ -5565,9 +5616,9 @@
       }
     },
     "webpack-dev-middleware": {
-      "version": "1.10.0",
+      "version": "1.10.1",
       "from": "webpack-dev-middleware@>=1.0.11 <2.0.0",
-      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.10.0.tgz"
+      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.10.1.tgz"
     },
     "websocket-driver": {
       "version": "0.6.5",
@@ -5625,9 +5676,9 @@
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.1.tgz"
     },
     "ws": {
-      "version": "1.1.1",
-      "from": "ws@1.1.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.1.tgz"
+      "version": "1.1.2",
+      "from": "ws@1.1.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.2.tgz"
     },
     "wtf-8": {
       "version": "1.0.0",

--- a/common/temp_modules/rush-gulp-core-build-karma/package.json
+++ b/common/temp_modules/rush-gulp-core-build-karma/package.json
@@ -28,6 +28,6 @@
     "webpack": "~1.13.0"
   },
   "rushDependencies": {
-    "@microsoft/gulp-core-build": ">=2.3.1 <3.0.0"
+    "@microsoft/gulp-core-build": ">=2.4.0 <3.0.0"
   }
 }

--- a/common/temp_modules/rush-gulp-core-build-mocha/package.json
+++ b/common/temp_modules/rush-gulp-core-build-mocha/package.json
@@ -18,6 +18,6 @@
     "gulp-mocha": "~2.2.0"
   },
   "rushDependencies": {
-    "@microsoft/gulp-core-build": ">=2.3.1 <3.0.0"
+    "@microsoft/gulp-core-build": ">=2.4.0 <3.0.0"
   }
 }

--- a/common/temp_modules/rush-gulp-core-build-sass/package.json
+++ b/common/temp_modules/rush-gulp-core-build-sass/package.json
@@ -32,6 +32,6 @@
     "postcss-modules": "~0.5.0"
   },
   "rushDependencies": {
-    "@microsoft/gulp-core-build": ">=2.3.1 <3.0.0"
+    "@microsoft/gulp-core-build": ">=2.4.0 <3.0.0"
   }
 }

--- a/common/temp_modules/rush-gulp-core-build-serve/package.json
+++ b/common/temp_modules/rush-gulp-core-build-serve/package.json
@@ -28,6 +28,6 @@
     "sudo": "~1.0.3"
   },
   "rushDependencies": {
-    "@microsoft/gulp-core-build": ">=2.3.1 <3.0.0"
+    "@microsoft/gulp-core-build": ">=2.4.0 <3.0.0"
   }
 }

--- a/common/temp_modules/rush-gulp-core-build-typescript/package.json
+++ b/common/temp_modules/rush-gulp-core-build-typescript/package.json
@@ -36,7 +36,7 @@
     "typescript": "~2.1.4"
   },
   "rushDependencies": {
-    "@microsoft/gulp-core-build": ">=2.3.1 <3.0.0",
-    "@microsoft/api-extractor": ">=1.1.11 <2.0.0"
+    "@microsoft/gulp-core-build": ">=2.4.0 <3.0.0",
+    "@microsoft/api-extractor": ">=1.1.14 <2.0.0"
   }
 }

--- a/common/temp_modules/rush-gulp-core-build-webpack/package.json
+++ b/common/temp_modules/rush-gulp-core-build-webpack/package.json
@@ -21,6 +21,6 @@
     "fsevents": "*"
   },
   "rushDependencies": {
-    "@microsoft/gulp-core-build": ">=2.3.1 <3.0.0"
+    "@microsoft/gulp-core-build": ">=2.4.0 <3.0.0"
   }
 }

--- a/common/temp_modules/rush-node-library-build/package.json
+++ b/common/temp_modules/rush-node-library-build/package.json
@@ -9,7 +9,7 @@
     "gulp": "~3.9.1"
   },
   "rushDependencies": {
-    "@microsoft/gulp-core-build": ">=2.3.1 <3.0.0",
+    "@microsoft/gulp-core-build": ">=2.4.0 <3.0.0",
     "@microsoft/gulp-core-build-mocha": ">=2.0.0 <3.0.0",
     "@microsoft/gulp-core-build-typescript": ">=2.2.5 <3.0.0"
   }

--- a/common/temp_modules/rush-rush/package.json
+++ b/common/temp_modules/rush-rush/package.json
@@ -16,7 +16,7 @@
     "gulp": "~3.9.1",
     "@microsoft/package-deps-hash": "~0.0.4",
     "@microsoft/stream-collator": "~1.0.2",
-    "@microsoft/ts-command-line": "~1.1.1",
+    "@microsoft/ts-command-line": "~2.0.0",
     "builtins": "~1.0.3",
     "colors": "~1.1.2",
     "fs-extra": "~0.26.0",
@@ -33,6 +33,6 @@
   },
   "rushDependencies": {
     "@microsoft/node-library-build": "~2.3.0",
-    "@microsoft/rush-lib": "1.8.0"
+    "@microsoft/rush-lib": "1.9.0"
   }
 }

--- a/common/temp_modules/rush-web-library-build/package.json
+++ b/common/temp_modules/rush-web-library-build/package.json
@@ -13,8 +13,8 @@
     "fsevents": "*"
   },
   "rushDependencies": {
-    "@microsoft/gulp-core-build": ">=2.3.1 <3.0.0",
-    "@microsoft/gulp-core-build-karma": ">=2.1.3 <3.0.0",
+    "@microsoft/gulp-core-build": ">=2.4.0 <3.0.0",
+    "@microsoft/gulp-core-build-karma": ">=2.2.0 <3.0.0",
     "@microsoft/gulp-core-build-sass": ">=2.0.5 <3.0.0",
     "@microsoft/gulp-core-build-serve": ">=2.0.3 <3.0.0",
     "@microsoft/gulp-core-build-typescript": ">=2.2.5 <3.0.0",

--- a/rush/rush/package.json
+++ b/rush/rush/package.json
@@ -20,7 +20,7 @@
     "@microsoft/package-deps-hash": "~0.0.4",
     "@microsoft/rush-lib": "1.9.0",
     "@microsoft/stream-collator": "~1.0.2",
-    "@microsoft/ts-command-line": "~1.1.1",
+    "@microsoft/ts-command-line": "~2.0.0",
     "builtins": "~1.0.3",
     "colors": "~1.1.2",
     "fs-extra": "~0.26.0",

--- a/rush/rush/src/actions/InstallAction.ts
+++ b/rush/rush/src/actions/InstallAction.ts
@@ -136,6 +136,7 @@ export default class InstallAction extends CommandLineAction {
     });
     this._checkTempModules = this.defineOptionParameter({
       parameterLongName: '--temp-modules',
+      parameterShortName: '-t',
       description: 'A flag controlling whether Rush should check that the temp_modules are up to date or not' +
       '. Defaults to "warn"',
       options: ['none', 'warn', 'err']
@@ -254,9 +255,11 @@ export default class InstallAction extends CommandLineAction {
           const errorMsg: string = `The project ${project.packageName}'s temp_module is outdated`;
           const rerunGenerate: string = '\nDid you forget to run rush generate?';
 
-          console.log(colors.red(`${errorMsg}:\n`));
-          console.log(colors.red(`EXPECTED:\n${JSON.stringify(expectedTempModule, undefined, 2)}\n`));
-          console.log(colors.red(`ACTUAL: \n${JSON.stringify(tempModule.packageJson, undefined, 2)}`));
+          const color: (msg: string) => string = shouldWarn ? colors.yellow : colors.red;
+
+          console.log(color(`${errorMsg}:\n`));
+          console.log(color(`EXPECTED:\n${JSON.stringify(expectedTempModule, undefined, 2)}\n`));
+          console.log(color(`ACTUAL: \n${JSON.stringify(tempModule.packageJson, undefined, 2)}`));
 
           const message: string = errorMsg + '\n' + rerunGenerate;
           if (shouldWarn) {


### PR DESCRIPTION
If someone edits a package.json without running generate, their temp_modules will become out of date with the project's package.json.  Initially, I introduced code which checked this, and threw an exception if they were out of date. Unfortunately, this doesn't play very nicely with the auto-publishing feature.

Therefore, I propose to control the behavior with a command line flag. There will be 3 modes: `none`, `err`, `warn`. If no flag is specified, we default to `warn`.

This should allow us to slowly integrate this into the CI.