### PR TITLE
Write the TSLint configuration file to the temp directory during build.

### DIFF
--- a/common/changes/write-config_2017-03-12-14-57.json
+++ b/common/changes/write-config_2017-03-12-14-57.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/gulp-core-build-typescript",
+      "comment": "Write the TSLint configuration file when execute.",
+      "type": "minor"
+    }
+  ],
+  "email": "lijunle@users.noreply.github.com"
+}

--- a/gulp-core-build-typescript/src/TSLintTask.ts
+++ b/gulp-core-build-typescript/src/TSLintTask.ts
@@ -1,4 +1,4 @@
-import { GulpTask } from '@microsoft/gulp-core-build';
+import { GulpTask, IBuildConfig } from '@microsoft/gulp-core-build';
 import gulpType = require('gulp');
 /* tslint:disable:typedef */
 const md5 = require('md5');
@@ -6,7 +6,6 @@ const merge = require('lodash').merge;
 /* tslint:enable:typedef */
 import through2 = require('through2');
 import gutil = require('gulp-util');
-import { Readable } from 'stream';
 import * as fs from 'fs';
 import * as TSLint from 'tslint';
 import * as path from 'path';
@@ -119,6 +118,9 @@ export class TSLintTask extends GulpTask<ITSLintTaskConfig> {
     const activeLintRules: any = taskScope._loadLintRules(); // tslint:disable-line:no-any
 
     // Write out the active lint rules for easier debugging
+    if (!fs.existsSync(path.dirname(this._getTsLintFilepath()))) {
+      fs.mkdirSync(path.dirname(this._getTsLintFilepath()));
+    }
     fs.writeFileSync(this._getTsLintFilepath(), JSON.stringify(activeLintRules, undefined, 2));
 
     const cached = require('gulp-cache'); // tslint:disable-line
@@ -187,8 +189,12 @@ export class TSLintTask extends GulpTask<ITSLintTaskConfig> {
       ));
   }
 
+  public getCleanMatch(buildConfig: IBuildConfig, taskConfig: ITSLintTaskConfig = this.taskConfig): string[] {
+    return [path.join(buildConfig.rootPath, buildConfig.tempFolder)];
+  }
+
   private _getTsLintFilepath(): string {
-    return path.resolve(this.buildConfig.rootPath, this.buildConfig.tempFolder, 'tslint.json');
+    return path.join(this.buildConfig.rootPath, this.buildConfig.tempFolder, 'tslint.json');
   }
 
   private _loadLintRules(): any { // tslint:disable-line:no-any

--- a/gulp-core-build-typescript/src/TSLintTask.ts
+++ b/gulp-core-build-typescript/src/TSLintTask.ts
@@ -118,8 +118,8 @@ export class TSLintTask extends GulpTask<ITSLintTaskConfig> {
 
     const activeLintRules: any = taskScope._loadLintRules(); // tslint:disable-line:no-any
 
-    // @todo This stream is not piped to returned value. Find a way to block the execute flow.
-    this._writeLintRules(activeLintRules);
+    // Write out the active lint rules for easier debugging
+    fs.writeFileSync(this._getTsLintFilepath(), JSON.stringify(activeLintRules, undefined, 2));
 
     const cached = require('gulp-cache'); // tslint:disable-line
 
@@ -187,6 +187,10 @@ export class TSLintTask extends GulpTask<ITSLintTaskConfig> {
       ));
   }
 
+  private _getTsLintFilepath(): string {
+    return path.resolve(this.buildConfig.rootPath, this.buildConfig.tempFolder, 'tslint.json');
+  }
+
   private _loadLintRules(): any { // tslint:disable-line:no-any
     if (!this._defaultLintRules) {
       this._defaultLintRules = require('./defaultTslint.json');
@@ -194,18 +198,5 @@ export class TSLintTask extends GulpTask<ITSLintTaskConfig> {
     return merge(
       (this.taskConfig.useDefaultConfigAsBase ? this._defaultLintRules : {}),
       this.taskConfig.lintConfig || {});
-  }
-
-  private _writeLintRules(lintRules: any): fs.WriteStream { // tslint:disable-line:no-any
-    const tslintFilePath: string = path.resolve(this.buildConfig.rootPath, this.buildConfig.tempFolder, 'tslint.json');
-    const tslintFileStream: fs.WriteStream = fs.createWriteStream(tslintFilePath);
-
-    const readable: Readable = new Readable();
-    const pipe: fs.WriteStream = readable.pipe(tslintFileStream);
-
-    readable.push(JSON.stringify(lintRules, undefined, 2));
-    readable.push(null); // tslint:disable-line:no-null-keyword
-
-    return pipe;
   }
 }


### PR DESCRIPTION
- The TSLint configuration file can be used for [VSCode TSLint plugin](https://marketplace.visualstudio.com/items?itemName=eg2.tslint).
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/Microsoft/web-build-tools/pull/129%23discussion_r105621243%22%2C%20%22https%3A//github.com/Microsoft/web-build-tools/pull/129%23discussion_r105621439%22%2C%20%22https%3A//github.com/Microsoft/web-build-tools/pull/129%23discussion_r105710804%22%2C%20%22https%3A//github.com/Microsoft/web-build-tools/pull/129%23discussion_r105712938%22%2C%20%22https%3A//github.com/Microsoft/web-build-tools/pull/129%23discussion_r105746332%22%2C%20%22https%3A//github.com/Microsoft/web-build-tools/pull/129%23discussion_r105746908%22%2C%20%22https%3A//github.com/Microsoft/web-build-tools/pull/129%23discussion_r105747588%22%5D%2C%20%22comments%22%3A%20%7B%22Pull%20fe933c0899d20881f06508df30250a50fa8aa445%20common/changes/write-config_2017-03-12-14-57.json%205%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/Microsoft/web-build-tools/pull/129%23discussion_r105746332%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%5C%22%2Aafter%20executing%5C%22%5Cr%5Cn%5Cr%5Cn--%20Remember%20that%20this%20string%20ends%20up%20in%20the%20changelog%22%2C%20%22created_at%22%3A%20%222017-03-13T19%3A10%3A11Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars3.githubusercontent.com/u/17131271%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/nickpape-msft%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20common/changes/write-config_2017-03-12-14-57.json%3AL1-11%22%7D%2C%20%22Pull%20b769efe01e62b990905b5e52bdebbba60105edab%20gulp-core-build-typescript/src/TSLintTask.ts%2015%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/Microsoft/web-build-tools/pull/129%23discussion_r105621243%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22You%20should%20be%20able%20to%20do%20this%20with%20Gulp.%22%2C%20%22created_at%22%3A%20%222017-03-13T09%3A46%3A33Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/5010588%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/iclanton%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20can%20do%20it%20as%20%2Agulp-like%2A%20pattern%20like%20%5Bthis%5D%28http%3A//stackoverflow.com/a/23398200/1436671%29.%20Do%20you%20think%20it%20is%20OK%3F%22%2C%20%22created_at%22%3A%20%222017-03-13T16%3A57%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/1296500%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lijunle%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20gulp-core-build-typescript/src/TSLintTask.ts%3AL117-127%22%7D%2C%20%22Pull%20b769efe01e62b990905b5e52bdebbba60105edab%20gulp-core-build-typescript/src/TSLintTask.ts%2026%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/Microsoft/web-build-tools/pull/129%23discussion_r105621439%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Is%20the%20%60tslint.json%60%20file%20location%20configurable%20in%20the%20TSLint%20plugin%3F%22%2C%20%22created_at%22%3A%20%222017-03-13T09%3A47%3A30Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/5010588%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/iclanton%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yes.%20There%20is%20an%20option%20-%20%60tslint.configFile%60%20to%20config%20the%20%60tslint.config%60%20file.%5Cr%5Cn%5Cr%5Cn%3E%20https%3A//marketplace.visualstudio.com/items%3FitemName%3Deg2.tslint%22%2C%20%22created_at%22%3A%20%222017-03-13T16%3A49%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/1296500%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lijunle%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20gulp-core-build-typescript/src/TSLintTask.ts%3AL195-212%22%7D%2C%20%22Pull%20fe933c0899d20881f06508df30250a50fa8aa445%20gulp-core-build-typescript/src/TSLintTask.ts%2015%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/Microsoft/web-build-tools/pull/129%23discussion_r105746908%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22If%20you%20want%20to%20block%20behind%20this%20stream%2C%20I%20would%20advice%20using%20merge%20plugin%20to%20merge%20this%20and%20the%20below%20streams.%5Cr%5Cn%5Cr%5CnHowever%2C%20I%20still%20think%20using%20gulp%20to%20write%20a%20single%20file%20is%20complete%20overkill.%20fs.writeFileSync%28%29%20will%20be%2010%25%20the%20%23%20of%20lines.%22%2C%20%22created_at%22%3A%20%222017-03-13T19%3A12%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars3.githubusercontent.com/u/17131271%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/nickpape-msft%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20gulp-core-build-typescript/src/TSLintTask.ts%3AL117-127%22%7D%2C%20%22Pull%20fe933c0899d20881f06508df30250a50fa8aa445%20gulp-core-build-typescript/src/TSLintTask.ts%2035%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/Microsoft/web-build-tools/pull/129%23discussion_r105747588%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Also%2C%20it%20looks%20like%20this%20is%20the%20wrong%20type%20of%20stream.%20Gulp/Vinyl%20is%20using%20a%20Stream%20of%20GulpUtil.Files%20objects.%20A%20better%20way%20to%20accomplish%20what%20this%20function%20is%20doing%20would%20be%20to%20adopt%20some%20code%20from%20%60FileUtils.ts%60%20in%20%60%40microsoft/sp-build-core-tasks%60.%20IMO%2C%20we%20should%20migrate%20some%20of%20those%20utilities%20into%20directly%20into%20GCB.%22%2C%20%22created_at%22%3A%20%222017-03-13T19%3A15%3A38Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars3.githubusercontent.com/u/17131271%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/nickpape-msft%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20gulp-core-build-typescript/src/TSLintTask.ts%3AL195-212%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [x] <a href='#crh-comment-Pull b769efe01e62b990905b5e52bdebbba60105edab gulp-core-build-typescript/src/TSLintTask.ts 15'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/Microsoft/web-build-tools/pull/129#discussion_r105621243'>File: gulp-core-build-typescript/src/TSLintTask.ts:L117-127</a></b>
- <a href='https://github.com/iclanton'><img border=0 src='https://avatars2.githubusercontent.com/u/5010588?v=3' height=16 width=16></a> You should be able to do this with Gulp.
- <a href='https://github.com/lijunle'><img border=0 src='https://avatars2.githubusercontent.com/u/1296500?v=3' height=16 width=16></a> I can do it as *gulp-like* pattern like [this](http://stackoverflow.com/a/23398200/1436671). Do you think it is OK?
- [x] <a href='#crh-comment-Pull b769efe01e62b990905b5e52bdebbba60105edab gulp-core-build-typescript/src/TSLintTask.ts 26'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/Microsoft/web-build-tools/pull/129#discussion_r105621439'>File: gulp-core-build-typescript/src/TSLintTask.ts:L195-212</a></b>
- <a href='https://github.com/iclanton'><img border=0 src='https://avatars2.githubusercontent.com/u/5010588?v=3' height=16 width=16></a> Is the `tslint.json` file location configurable in the TSLint plugin?
- <a href='https://github.com/lijunle'><img border=0 src='https://avatars2.githubusercontent.com/u/1296500?v=3' height=16 width=16></a> Yes. There is an option - `tslint.configFile` to config the `tslint.config` file.
> https://marketplace.visualstudio.com/items?itemName=eg2.tslint
- [x] <a href='#crh-comment-Pull fe933c0899d20881f06508df30250a50fa8aa445 common/changes/write-config_2017-03-12-14-57.json 5'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/Microsoft/web-build-tools/pull/129#discussion_r105746332'>File: common/changes/write-config_2017-03-12-14-57.json:L1-11</a></b>
- <a href='https://github.com/nickpape-msft'><img border=0 src='https://avatars3.githubusercontent.com/u/17131271?v=3' height=16 width=16></a> "*after executing"
-- Remember that this string ends up in the changelog
- [x] <a href='#crh-comment-Pull fe933c0899d20881f06508df30250a50fa8aa445 gulp-core-build-typescript/src/TSLintTask.ts 15'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/Microsoft/web-build-tools/pull/129#discussion_r105746908'>File: gulp-core-build-typescript/src/TSLintTask.ts:L117-127</a></b>
- <a href='https://github.com/nickpape-msft'><img border=0 src='https://avatars3.githubusercontent.com/u/17131271?v=3' height=16 width=16></a> If you want to block behind this stream, I would advice using merge plugin to merge this and the below streams.
However, I still think using gulp to write a single file is complete overkill. fs.writeFileSync() will be 10% the # of lines.
- [x] <a href='#crh-comment-Pull fe933c0899d20881f06508df30250a50fa8aa445 gulp-core-build-typescript/src/TSLintTask.ts 35'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/Microsoft/web-build-tools/pull/129#discussion_r105747588'>File: gulp-core-build-typescript/src/TSLintTask.ts:L195-212</a></b>
- <a href='https://github.com/nickpape-msft'><img border=0 src='https://avatars3.githubusercontent.com/u/17131271?v=3' height=16 width=16></a> Also, it looks like this is the wrong type of stream. Gulp/Vinyl is using a Stream of GulpUtil.Files objects. A better way to accomplish what this function is doing would be to adopt some code from `FileUtils.ts` in `@microsoft/sp-build-core-tasks`. IMO, we should migrate some of those utilities into directly into GCB.


<a href='https://www.codereviewhub.com/Microsoft/web-build-tools/pull/129?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/Microsoft/web-build-tools/pull/129?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/Microsoft/web-build-tools/pull/129'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/web-build-tools/129)
<!-- Reviewable:end -->
