### PR TITLE
The install and the generate actions should run link automatically

### DIFF
--- a/rush/rush/src/actions/GenerateAction.ts
+++ b/rush/rush/src/actions/GenerateAction.ts
@@ -29,6 +29,7 @@ export default class GenerateAction extends CommandLineAction {
   private _rushConfiguration: RushConfiguration;
   private _packageReviewChecker: PackageReviewChecker;
   private _lazyParameter: CommandLineFlagParameter;
+  private _noLinkParameter: CommandLineFlagParameter;
 
   private static _deleteCommonNodeModules(rushConfiguration: RushConfiguration, isLazy: boolean): void {
     const nodeModulesPath: string = path.join(rushConfiguration.commonFolder, 'node_modules');
@@ -163,6 +164,10 @@ export default class GenerateAction extends CommandLineAction {
       description: 'Do not clean the "node_modules" folder before running "npm install".'
         + ' This is faster, but less correct, so only use it for debugging.'
     });
+    this._noLinkParameter = this.defineFlagParameter({
+      parameterLongName: '--no-link',
+      description: 'Do not automatically run the Link action after completing Generate action'
+    });
   }
 
   protected onExecute(): void {
@@ -201,7 +206,11 @@ export default class GenerateAction extends CommandLineAction {
     stopwatch.stop();
     console.log(os.EOL + colors.green(`Rush generate finished successfully. (${stopwatch.toString()})`));
 
-    const linker: LinkAction = new LinkAction(this._parser);
-    linker.execute();
+    if (!this._noLinkParameter.value) {
+      const linkAction: LinkAction = new LinkAction(this._parser);
+      linkAction.execute();
+    } else {
+      console.log(os.EOL + 'Next you should probably run: "rush link"');
+    }
   }
 }

--- a/rush/rush/src/actions/GenerateAction.ts
+++ b/rush/rush/src/actions/GenerateAction.ts
@@ -18,6 +18,7 @@ import {
   Stopwatch
 } from '@microsoft/rush-lib';
 
+import LinkAction from './LinkAction';
 import InstallAction from './InstallAction';
 import RushCommandLineParser from './RushCommandLineParser';
 import PackageReviewChecker from '../utilities/PackageReviewChecker';
@@ -199,6 +200,8 @@ export default class GenerateAction extends CommandLineAction {
 
     stopwatch.stop();
     console.log(os.EOL + colors.green(`Rush generate finished successfully. (${stopwatch.toString()})`));
-    console.log(os.EOL + 'Next you should probably run: "rush link"');
+
+    const linker: LinkAction = new LinkAction(this._parser);
+    linker.execute();
   }
 }

--- a/rush/rush/src/actions/InstallAction.ts
+++ b/rush/rush/src/actions/InstallAction.ts
@@ -39,6 +39,7 @@ export default class InstallAction extends CommandLineAction {
   private _cleanInstall: CommandLineFlagParameter;
   private _cleanInstallFull: CommandLineFlagParameter;
   private _bypassPolicy: CommandLineFlagParameter;
+  private _noLinkParameter: CommandLineFlagParameter;
 
   private _tempModulesFiles: string[] = [];
 
@@ -130,6 +131,10 @@ export default class InstallAction extends CommandLineAction {
       parameterLongName: '--bypass-policy',
       description: 'Overrides gitPolicy enforcement (use honorably!)'
     });
+    this._noLinkParameter = this.defineFlagParameter({
+      parameterLongName: '--no-link',
+      description: 'Do not automatically run the Link action after completing Generate action'
+    });
   }
 
   protected onExecute(): void {
@@ -166,8 +171,12 @@ export default class InstallAction extends CommandLineAction {
     stopwatch.stop();
     console.log(colors.green(`The common NPM packages are up to date. (${stopwatch.toString()})`));
 
-    const linker: LinkAction = new LinkAction(this._parser);
-    linker.execute();
+    if (!this._noLinkParameter.value) {
+      const linkAction: LinkAction = new LinkAction(this._parser);
+      linkAction.execute();
+    } else {
+      console.log(os.EOL + 'Next you should probably run: "rush link"');
+    }
   }
 
   private _checkThatTempModulesMatch(): void {

--- a/rush/rush/src/actions/InstallAction.ts
+++ b/rush/rush/src/actions/InstallAction.ts
@@ -23,6 +23,7 @@ import {
 import RushCommandLineParser from './RushCommandLineParser';
 import GitPolicy from '../utilities/GitPolicy';
 import { TempModuleGenerator } from '../utilities/TempModuleGenerator';
+import LinkAction from './LinkAction';
 
 const MAX_INSTALL_ATTEMPTS: number = 5;
 
@@ -164,7 +165,9 @@ export default class InstallAction extends CommandLineAction {
 
     stopwatch.stop();
     console.log(colors.green(`The common NPM packages are up to date. (${stopwatch.toString()})`));
-    console.log(os.EOL + 'Next you should probably run: "rush link"');
+
+    const linker: LinkAction = new LinkAction(this._parser);
+    linker.execute();
   }
 
   private _checkThatTempModulesMatch(): void {


### PR DESCRIPTION
After running install or generate, we almost always want to run `rush link`. We should automatically do this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/web-build-tools/134)
<!-- Reviewable:end -->
