### PR TITLE
Fix an issue with `del` package during rush clean

### DIFF
--- a/common/changes/nickpape-fix-clean_2017-03-16-00-07.json
+++ b/common/changes/nickpape-fix-clean_2017-03-16-00-07.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/gulp-core-build",
+      "comment": "Fixes an issue with the clean command, which causes builds to spuriously fail.",
+      "type": "patch"
+    }
+  ],
+  "email": "nickpape@users.noreply.github.com"
+}

--- a/common/npm-shrinkwrap.json
+++ b/common/npm-shrinkwrap.json
@@ -3,24 +3,24 @@
   "version": "0.0.0",
   "dependencies": {
     "@microsoft/api-extractor": {
-      "version": "1.1.14",
-      "from": "@microsoft/api-extractor@>=1.1.4 <2.0.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-1.1.14.tgz"
+      "version": "1.1.15",
+      "from": "@microsoft/api-extractor@>=1.1.14 <2.0.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-1.1.15.tgz"
     },
     "@microsoft/gulp-core-build": {
-      "version": "2.4.0",
-      "from": "@microsoft/gulp-core-build@>=2.3.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/gulp-core-build/-/gulp-core-build-2.4.0.tgz"
+      "version": "2.4.1",
+      "from": "@microsoft/gulp-core-build@>=2.4.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/gulp-core-build/-/gulp-core-build-2.4.1.tgz"
     },
     "@microsoft/gulp-core-build-mocha": {
-      "version": "2.0.1",
-      "from": "@microsoft/gulp-core-build-mocha@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/gulp-core-build-mocha/-/gulp-core-build-mocha-2.0.1.tgz"
+      "version": "2.0.2",
+      "from": "@microsoft/gulp-core-build-mocha@>=2.0.1 <3.0.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/gulp-core-build-mocha/-/gulp-core-build-mocha-2.0.2.tgz"
     },
     "@microsoft/gulp-core-build-typescript": {
-      "version": "2.2.5",
+      "version": "2.2.6",
       "from": "@microsoft/gulp-core-build-typescript@>=2.2.5 <3.0.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/gulp-core-build-typescript/-/gulp-core-build-typescript-2.2.5.tgz",
+      "resolved": "https://registry.npmjs.org/@microsoft/gulp-core-build-typescript/-/gulp-core-build-typescript-2.2.6.tgz",
       "dependencies": {
         "lodash": {
           "version": "4.15.0",
@@ -35,14 +35,9 @@
       "resolved": "https://registry.npmjs.org/@microsoft/load-themed-styles/-/load-themed-styles-1.2.2.tgz"
     },
     "@microsoft/node-library-build": {
-      "version": "2.3.0",
+      "version": "2.3.1",
       "from": "@microsoft/node-library-build@>=2.3.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/node-library-build/-/node-library-build-2.3.0.tgz"
-    },
-    "@microsoft/package-deps-hash": {
-      "version": "0.0.4",
-      "from": "@microsoft/package-deps-hash@>=0.0.4 <0.1.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/package-deps-hash/-/package-deps-hash-0.0.4.tgz"
+      "resolved": "https://registry.npmjs.org/@microsoft/node-library-build/-/node-library-build-2.3.1.tgz"
     },
     "@microsoft/stream-collator": {
       "version": "1.0.2",
@@ -56,7 +51,7 @@
     },
     "@types/assertion-error": {
       "version": "1.0.30",
-      "from": "@types/assertion-error@>=1.0.30 <2.0.0",
+      "from": "@types/assertion-error@1.0.30",
       "resolved": "https://registry.npmjs.org/@types/assertion-error/-/assertion-error-1.0.30.tgz"
     },
     "@types/bluebird": {
@@ -71,7 +66,7 @@
     },
     "@types/chalk": {
       "version": "0.4.31",
-      "from": "@types/chalk@>=0.4.31 <0.5.0",
+      "from": "@types/chalk@0.4.31",
       "resolved": "https://registry.npmjs.org/@types/chalk/-/chalk-0.4.31.tgz"
     },
     "@types/es6-collections": {
@@ -106,7 +101,7 @@
     },
     "@types/gulp": {
       "version": "3.8.32",
-      "from": "@types/gulp@>=3.8.32 <4.0.0",
+      "from": "@types/gulp@3.8.32",
       "resolved": "https://registry.npmjs.org/@types/gulp/-/gulp-3.8.32.tgz"
     },
     "@types/gulp-istanbul": {
@@ -121,7 +116,7 @@
     },
     "@types/gulp-util": {
       "version": "3.0.30",
-      "from": "@types/gulp-util@>=3.0.29 <4.0.0",
+      "from": "@types/gulp-util@3.0.30",
       "resolved": "https://registry.npmjs.org/@types/gulp-util/-/gulp-util-3.0.30.tgz"
     },
     "@types/karma": {
@@ -151,7 +146,7 @@
     },
     "@types/mkdirp": {
       "version": "0.3.29",
-      "from": "@types/mkdirp@>=0.3.29 <0.6.0",
+      "from": "@types/mkdirp@0.3.29",
       "resolved": "https://registry.npmjs.org/@types/mkdirp/-/mkdirp-0.3.29.tgz"
     },
     "@types/mocha": {
@@ -190,9 +185,9 @@
       "resolved": "https://registry.npmjs.org/@types/rimraf/-/rimraf-0.0.28.tgz"
     },
     "@types/semver": {
-      "version": "5.3.31",
-      "from": "@types/semver@>=5.3.30 <6.0.0",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-5.3.31.tgz"
+      "version": "5.3.30",
+      "from": "@types/semver@5.3.30",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-5.3.30.tgz"
     },
     "@types/serve-static": {
       "version": "1.7.31",
@@ -206,7 +201,7 @@
     },
     "@types/through2": {
       "version": "2.0.32",
-      "from": "@types/through2@>=2.0.31 <3.0.0",
+      "from": "@types/through2@2.0.32",
       "resolved": "https://registry.npmjs.org/@types/through2/-/through2-2.0.32.tgz"
     },
     "@types/uglify-js": {
@@ -216,7 +211,7 @@
     },
     "@types/vinyl": {
       "version": "1.2.30",
-      "from": "@types/vinyl@>=1.2.30 <2.0.0",
+      "from": "@types/vinyl@1.2.30",
       "resolved": "https://registry.npmjs.org/@types/vinyl/-/vinyl-1.2.30.tgz"
     },
     "@types/webpack": {
@@ -455,9 +450,9 @@
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.0.tgz"
     },
     "base64-url": {
-      "version": "1.3.3",
-      "from": "base64-url@1.3.3",
-      "resolved": "https://registry.npmjs.org/base64-url/-/base64-url-1.3.3.tgz"
+      "version": "1.2.1",
+      "from": "base64-url@1.2.1",
+      "resolved": "https://registry.npmjs.org/base64-url/-/base64-url-1.2.1.tgz"
     },
     "base64id": {
       "version": "1.0.0",
@@ -635,9 +630,9 @@
       "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz"
     },
     "caniuse-db": {
-      "version": "1.0.30000634",
+      "version": "1.0.30000635",
       "from": "caniuse-db@>=1.0.30000488 <2.0.0",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000634.tgz"
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000635.tgz"
     },
     "capture-stack-trace": {
       "version": "1.0.0",
@@ -961,9 +956,9 @@
       "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.2.8.tgz"
     },
     "csrf": {
-      "version": "3.0.5",
+      "version": "3.0.6",
       "from": "csrf@>=3.0.0 <3.1.0",
-      "resolved": "https://registry.npmjs.org/csrf/-/csrf-3.0.5.tgz"
+      "resolved": "https://registry.npmjs.org/csrf/-/csrf-3.0.6.tgz"
     },
     "css-modules-loader-core": {
       "version": "1.0.1",
@@ -1201,9 +1196,9 @@
           "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz"
         },
         "readable-stream": {
-          "version": "2.2.3",
+          "version": "2.2.5",
           "from": "readable-stream@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.3.tgz"
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.5.tgz"
         }
       }
     },
@@ -1440,11 +1435,6 @@
       "from": "express-session@>=1.11.3 <1.12.0",
       "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.11.3.tgz",
       "dependencies": {
-        "base64-url": {
-          "version": "1.2.1",
-          "from": "base64-url@1.2.1",
-          "resolved": "https://registry.npmjs.org/base64-url/-/base64-url-1.2.1.tgz"
-        },
         "cookie": {
           "version": "0.1.3",
           "from": "cookie@0.1.3",
@@ -1862,9 +1852,9 @@
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
         },
         "readable-stream": {
-          "version": "2.2.3",
+          "version": "2.2.5",
           "from": "readable-stream@>=2.0.5 <3.0.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.3.tgz"
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.5.tgz"
         }
       }
     },
@@ -1911,9 +1901,9 @@
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
         },
         "readable-stream": {
-          "version": "2.2.3",
+          "version": "2.2.5",
           "from": "readable-stream@>=2.0.4 <3.0.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.3.tgz"
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.5.tgz"
         },
         "vinyl": {
           "version": "1.2.0",
@@ -1938,9 +1928,9 @@
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
         },
         "readable-stream": {
-          "version": "2.2.3",
+          "version": "2.2.5",
           "from": "readable-stream@>=2.1.5 <3.0.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.3.tgz"
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.5.tgz"
         }
       }
     },
@@ -2355,9 +2345,9 @@
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
         },
         "readable-stream": {
-          "version": "2.2.3",
+          "version": "2.2.5",
           "from": "readable-stream@>=2.0.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.3.tgz"
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.5.tgz"
         }
       }
     },
@@ -2468,9 +2458,9 @@
           "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz"
         },
         "readable-stream": {
-          "version": "2.2.3",
+          "version": "2.2.5",
           "from": "readable-stream@>=2.0.4 <3.0.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.3.tgz"
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.5.tgz"
         },
         "source-map": {
           "version": "0.5.6",
@@ -3192,9 +3182,9 @@
       }
     },
     "karma-webpack": {
-      "version": "2.0.2",
+      "version": "2.0.3",
       "from": "karma-webpack@>=2.0.1 <2.1.0",
-      "resolved": "https://registry.npmjs.org/karma-webpack/-/karma-webpack-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/karma-webpack/-/karma-webpack-2.0.3.tgz",
       "dependencies": {
         "async": {
           "version": "0.9.2",
@@ -3254,9 +3244,9 @@
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
         },
         "readable-stream": {
-          "version": "2.2.3",
+          "version": "2.2.5",
           "from": "readable-stream@>=2.0.5 <3.0.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.3.tgz"
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.5.tgz"
         }
       }
     },
@@ -3611,9 +3601,9 @@
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
         },
         "readable-stream": {
-          "version": "2.2.3",
+          "version": "2.2.5",
           "from": "readable-stream@>=2.0.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.3.tgz"
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.5.tgz"
         }
       }
     },
@@ -3638,9 +3628,9 @@
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
         },
         "readable-stream": {
-          "version": "2.2.3",
+          "version": "2.2.5",
           "from": "readable-stream@>=2.0.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.3.tgz"
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.5.tgz"
         }
       }
     },
@@ -3803,9 +3793,9 @@
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.49.tgz"
     },
     "node-gyp": {
-      "version": "3.5.0",
+      "version": "3.6.0",
       "from": "node-gyp@>=3.3.1 <4.0.0",
-      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.5.0.tgz"
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.6.0.tgz"
     },
     "node-libs-browser": {
       "version": "0.6.0",
@@ -4378,9 +4368,9 @@
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
         },
         "readable-stream": {
-          "version": "2.2.3",
+          "version": "2.2.5",
           "from": "readable-stream@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.3.tgz"
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.5.tgz"
         }
       }
     },
@@ -4425,9 +4415,9 @@
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
         },
         "readable-stream": {
-          "version": "2.2.3",
+          "version": "2.2.5",
           "from": "readable-stream@>=2.0.2 <3.0.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.3.tgz"
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.5.tgz"
         }
       }
     },
@@ -4507,9 +4497,9 @@
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
         },
         "readable-stream": {
-          "version": "2.2.3",
+          "version": "2.2.5",
           "from": "readable-stream@>=2.0.2 <3.0.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.3.tgz"
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.5.tgz"
         }
       }
     },
@@ -4596,14 +4586,7 @@
     "rush-gulp-core-build": {
       "version": "0.0.0",
       "from": "temp_modules\\rush-gulp-core-build",
-      "resolved": "file:temp_modules\\rush-gulp-core-build",
-      "dependencies": {
-        "@types/semver": {
-          "version": "5.3.30",
-          "from": "@types/semver@5.3.30",
-          "resolved": "https://registry.npmjs.org/@types/semver/-/semver-5.3.30.tgz"
-        }
-      }
+      "resolved": "file:temp_modules\\rush-gulp-core-build"
     },
     "rush-gulp-core-build-karma": {
       "version": "0.0.0",
@@ -5128,9 +5111,9 @@
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
         },
         "readable-stream": {
-          "version": "2.2.3",
+          "version": "2.2.5",
           "from": "readable-stream@>=2.1.5 <3.0.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.3.tgz"
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.5.tgz"
         }
       }
     },
@@ -5612,9 +5595,9 @@
           "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.3.0.tgz"
         },
         "readable-stream": {
-          "version": "2.2.3",
+          "version": "2.2.5",
           "from": "readable-stream@>=2.0.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.3.tgz"
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.5.tgz"
         },
         "source-map": {
           "version": "0.5.6",

--- a/common/reviews/PackageDependencies.json
+++ b/common/reviews/PackageDependencies.json
@@ -132,6 +132,10 @@
       "allowedCategories": [ "libraries" ]
     },
     {
+      "name": "globby",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
       "name": "gulp",
       "allowedCategories": [ "libraries", "other" ]
     },

--- a/common/temp_modules/rush-gulp-core-build/package.json
+++ b/common/temp_modules/rush-gulp-core-build/package.json
@@ -25,6 +25,8 @@
     "end-of-stream": "~1.1.0",
     "es6-promise": "~3.1.2",
     "fs-extra": "~0.26.7",
+    "globby": "~5.0.0",
+    "glob-escape": "~0.0.1",
     "gulp": "~3.9.1",
     "gulp-flatten": "~0.2.0",
     "gulp-if": "^2.0.1",

--- a/common/temp_modules/rush-node-library-build/package.json
+++ b/common/temp_modules/rush-node-library-build/package.json
@@ -10,7 +10,7 @@
   },
   "rushDependencies": {
     "@microsoft/gulp-core-build": ">=2.4.0 <3.0.0",
-    "@microsoft/gulp-core-build-mocha": ">=2.0.0 <3.0.0",
+    "@microsoft/gulp-core-build-mocha": ">=2.0.1 <3.0.0",
     "@microsoft/gulp-core-build-typescript": ">=2.2.5 <3.0.0"
   }
 }

--- a/common/temp_modules/rush-rush-lib/package.json
+++ b/common/temp_modules/rush-rush-lib/package.json
@@ -20,6 +20,6 @@
     "z-schema": "~3.17.0"
   },
   "rushDependencies": {
-    "@microsoft/node-library-build": ">=2.3.0 <3.0.0"
+    "@microsoft/node-library-build": ">=2.3.1 <3.0.0"
   }
 }

--- a/common/temp_modules/rush-rush/package.json
+++ b/common/temp_modules/rush-rush/package.json
@@ -14,7 +14,6 @@
     "@types/node": "6.0.62",
     "chai": "~3.5.0",
     "gulp": "~3.9.1",
-    "@microsoft/package-deps-hash": "~0.0.4",
     "@microsoft/stream-collator": "~1.0.2",
     "@microsoft/ts-command-line": "~1.1.1",
     "builtins": "~1.0.3",
@@ -32,7 +31,8 @@
     "wordwrap": "~1.0.0"
   },
   "rushDependencies": {
-    "@microsoft/node-library-build": ">=2.3.0 <3.0.0",
+    "@microsoft/node-library-build": ">=2.3.1 <3.0.0",
+    "@microsoft/package-deps-hash": "~2.0.1",
     "@microsoft/rush-lib": "2.3.1"
   }
 }

--- a/common/temp_modules/rush-test-web-library-build/package.json
+++ b/common/temp_modules/rush-test-web-library-build/package.json
@@ -10,6 +10,6 @@
     "gulp": "~3.9.1"
   },
   "rushDependencies": {
-    "@microsoft/web-library-build": ">=2.3.1 <3.0.0"
+    "@microsoft/web-library-build": ">=2.3.2 <3.0.0"
   }
 }

--- a/gulp-core-build/package.json
+++ b/gulp-core-build/package.json
@@ -34,6 +34,8 @@
     "end-of-stream": "~1.1.0",
     "es6-promise": "~3.1.2",
     "fs-extra": "~0.26.7",
+    "globby": "~5.0.0",
+    "glob-escape": "~0.0.1",
     "gulp": "~3.9.1",
     "gulp-flatten": "~0.2.0",
     "gulp-if": "^2.0.1",

--- a/gulp-core-build/src/tasks/CleanTask.ts
+++ b/gulp-core-build/src/tasks/CleanTask.ts
@@ -62,7 +62,7 @@ export class CleanTask extends GulpTask<void> {
       }
     }
 
-    // Apparently there is a wonderful bug with del whereby
+    // Appears to be a known issue with `del` whereby
     // if you ask to delete both a folder, and something in the folder,
     // it randomly chooses which one to delete first, which can cause
     // the function to fail sporadically. The fix for this is simple:

--- a/gulp-core-build/src/tasks/CleanTask.ts
+++ b/gulp-core-build/src/tasks/CleanTask.ts
@@ -1,8 +1,8 @@
 import { GulpTask } from './GulpTask';
 import gulp = require('gulp');
-import globby = require('globby');
 import * as path from 'path';
-import * as globEscape from 'glob-escape';
+
+import { FileDeletionUtility } from '../utilities/FileDeletionUtility';
 
 /**
  * The clean task is a special task which iterates through all registered
@@ -25,10 +25,8 @@ export class CleanTask extends GulpTask<void> {
     gulp: gulp.Gulp,
     completeCallback: (result?: Object) => void
   ): void {
-    /* tslint:disable:typedef */
-    const del = require('del');
-    /* tslint:disable:typedef */
 
+    // tslint:disable:typedef
     const { distFolder, libFolder, libAMDFolder, tempFolder } = this.buildConfig;
     let cleanPaths = [
       distFolder,
@@ -62,61 +60,11 @@ export class CleanTask extends GulpTask<void> {
       }
     }
 
-    // Appears to be a known issue with `del` whereby
-    // if you ask to delete both a folder, and something in the folder,
-    // it randomly chooses which one to delete first, which can cause
-    // the function to fail sporadically. The fix for this is simple:
-    // we need to remove any cleanPaths which exist under a folder we
-    // are attempting to delete
-    const fileMatches: string[] = globby.sync(cleanPaths);
-
-    // First we sort the list of files. We know that if something is a file,
-    // if matched, the parent folder should appear earlier in the list
-    fileMatches.sort();
-
-    if (fileMatches.length > 0) {
-      // We need to determine which paths exist under other paths, and remove them from the
-      // list of files to delete
-      const filesToDelete: string[] = [];
-
-      // current working directory
-      let curDir = undefined;
-
-      for (let i: number = 0; i < fileMatches.length; i++) {
-        const curFile: string = fileMatches[i];
-        if (this.isParentDirectory(curDir, curFile)) {
-          continue;
-        } else {
-          filesToDelete.push(globEscape(curFile));
-          curDir = curFile;
-        }
-      }
-
-      del(filesToDelete)
-        .then(() => completeCallback())
-        .catch((error) => completeCallback(error));
-    } else {
+    try {
+      FileDeletionUtility.deletePatterns(cleanPaths);
       completeCallback();
+    } catch (e) {
+      completeCallback(e);
     }
-  }
-
-  private isParentDirectory(directory: string, filepath: string): boolean {
-    if (!directory || !filepath) {
-      return false;
-    }
-
-    const directoryParts: string[] = path.resolve(directory).split(path.sep);
-    const fileParts: string[] = path.resolve(filepath).split(path.sep);
-
-    if (directoryParts.length >= fileParts.length) {
-      return false;
-    }
-
-    for (let i: number = 0; i < directoryParts.length; i++) {
-      if (directoryParts[i] !== fileParts[i]) {
-        return false;
-      }
-    }
-    return true;
   }
 }

--- a/gulp-core-build/src/tasks/CleanTask.ts
+++ b/gulp-core-build/src/tasks/CleanTask.ts
@@ -1,5 +1,8 @@
 import { GulpTask } from './GulpTask';
 import gulp = require('gulp');
+import globby = require('globby');
+import * as path from 'path';
+import * as globEscape from 'glob-escape';
 
 /**
  * The clean task is a special task which iterates through all registered
@@ -59,8 +62,61 @@ export class CleanTask extends GulpTask<void> {
       }
     }
 
-    del(cleanPaths)
-      .then(() => completeCallback())
-      .catch((error) => completeCallback(error));
+    // Apparently there is a wonderful bug with del whereby
+    // if you ask to delete both a folder, and something in the folder,
+    // it randomly chooses which one to delete first, which can cause
+    // the function to fail sporadically. The fix for this is simple:
+    // we need to remove any cleanPaths which exist under a folder we
+    // are attempting to delete
+    const fileMatches: string[] = globby.sync(cleanPaths);
+
+    // First we sort the list of files. We know that if something is a file,
+    // if matched, the parent folder should appear earlier in the list
+    fileMatches.sort();
+
+    if (fileMatches.length > 0) {
+      // We need to determine which paths exist under other paths, and remove them from the
+      // list of files to delete
+      const filesToDelete: string[] = [];
+
+      // current working directory
+      let curDir = undefined;
+
+      for (let i: number = 0; i < fileMatches.length; i++) {
+        const curFile: string = fileMatches[i];
+        if (this.isParentDirectory(curDir, curFile)) {
+          continue;
+        } else {
+          filesToDelete.push(globEscape(curFile));
+          curDir = curFile;
+        }
+      }
+
+      del(filesToDelete)
+        .then(() => completeCallback())
+        .catch((error) => completeCallback(error));
+    } else {
+      completeCallback();
+    }
   }
-}
+
+  private isParentDirectory(directory: string, filepath: string): boolean {
+    if (!directory || !filepath) {
+      return false;
+    }
+
+    const directoryParts: string[] = path.resolve(directory).split(path.sep);
+    const fileParts: string[] = path.resolve(filepath).split(path.sep);
+
+    if (directoryParts.length >= fileParts.length) {
+      return false;
+    }
+
+    for (let i: number = 0; i < directoryParts.length; i++) {
+      if (directoryParts[i] !== fileParts[i]) {
+        return false;
+      }
+    }
+    return true;
+  }
+};

--- a/gulp-core-build/src/tasks/CleanTask.ts
+++ b/gulp-core-build/src/tasks/CleanTask.ts
@@ -119,4 +119,4 @@ export class CleanTask extends GulpTask<void> {
     }
     return true;
   }
-};
+}

--- a/gulp-core-build/src/utilities/FileDeletionUtility.test.ts
+++ b/gulp-core-build/src/utilities/FileDeletionUtility.test.ts
@@ -1,0 +1,138 @@
+import { assert } from 'chai';
+import { FileDeletionUtility } from './FileDeletionUtility';
+
+describe('FileDeletionUtility', () => {
+  describe('constructor', () => {
+    it('can be constructed', () => {
+      const test: FileDeletionUtility = new FileDeletionUtility();
+    });
+  });
+  describe('isParentDirectory', () => {
+    it('can detect an immediate child', () => {
+      assert.isTrue(
+        FileDeletionUtility.isParentDirectory('/a', '/a/b.txt')
+      );
+    });
+    it('can detect a deep child', () => {
+      assert.isTrue(
+        FileDeletionUtility.isParentDirectory('/a', '/a/b/c/d.txt')
+      );
+    });
+    it('can detect if base path is longer', () => {
+      assert.isTrue(
+        FileDeletionUtility.isParentDirectory('/a/b/c/d', '/a/b/c/d/g.txt')
+      );
+    });
+    it('can detect siblings', () => {
+      assert.isFalse(
+        FileDeletionUtility.isParentDirectory('/a/b', '/a/c')
+      );
+    });
+    it('can detect siblings with file extensions', () => {
+      assert.isFalse(
+        FileDeletionUtility.isParentDirectory('/a/b/c.txt', '/a/b/d.txt')
+      );
+    });
+    it('can detect when not a parent', () => {
+      assert.isFalse(
+        FileDeletionUtility.isParentDirectory('/a/b/c', '/a')
+      );
+      assert.isFalse(
+        FileDeletionUtility.isParentDirectory('/a/b/c', '/a/b.txt')
+      );
+    });
+    it('accepts anything under the root', () => {
+      assert.isTrue(
+        FileDeletionUtility.isParentDirectory('/', '/a.txt')
+      );
+      assert.isTrue(
+        FileDeletionUtility.isParentDirectory('/', '/a/b/c/d.txt')
+      );
+    });
+    it('it is case sensitive', () => {
+      assert.isFalse(
+        FileDeletionUtility.isParentDirectory('/a', '/A/b.txt')
+      );
+      assert.isTrue(
+        FileDeletionUtility.isParentDirectory('/a', '/a/b.txt')
+      );
+      assert.isFalse(
+        FileDeletionUtility.isParentDirectory('/a/B/c', '/a/b/c/d.txt')
+      );
+    });
+    it('it does not accept null or undefined', () => {
+      /* tslint:disable:no-null-keyword */
+      assert.isFalse(
+        FileDeletionUtility.isParentDirectory('', '/A/b.txt')
+      );
+      assert.isFalse(
+        FileDeletionUtility.isParentDirectory(undefined, '/a/b.txt')
+      );
+      assert.isFalse(
+        FileDeletionUtility.isParentDirectory(null, '/a/b/c/d.txt')
+      );
+      assert.isFalse(
+        FileDeletionUtility.isParentDirectory('/A/b.txt', '')
+      );
+      assert.isFalse(
+        FileDeletionUtility.isParentDirectory('/a/b.txt', undefined)
+      );
+      assert.isFalse(
+        FileDeletionUtility.isParentDirectory('/a/b/c/d.txt', null)
+      );
+      /* tslint:enable:no-null-keyword */
+    });
+  });
+  describe('removeChildren', () => {
+    it('removes children of a parent', () => {
+      const files: string[] = [
+        '/a',
+        '/a/b',
+        '/a/b/c.txt',
+        '/a/b/d.txt',
+        '/a/z',
+        '/b/f/g',
+        '/b/f/ggg',
+        '/b/f/ggg/foo.txt',
+        '/c',
+        '/c/a.txt',
+        '/c/f/g/h/j/k/l/q',
+        '/d'
+      ];
+      const expected: string[] = [
+        '/a',
+        '/b/f/g',
+        '/b/f/ggg',
+        '/c',
+        '/d'
+      ];
+      const actual: string[] = FileDeletionUtility.removeChildren(files);
+
+      assert.equal(actual.length, expected.length);
+      assert.includeMembers(expected, actual);
+    });
+    it('removes everything under the root', () => {
+      const files: string[] = [
+        '/',
+        '/a/b',
+        '/a/b/c.txt',
+        '/a/b/d.txt',
+        '/a/z',
+        '/b/f/g',
+        '/b/f/ggg',
+        '/b/f/ggg/foo.txt',
+        '/c',
+        '/c/a.txt',
+        '/c/f/g/h/j/k/l/q',
+        '/d'
+      ];
+      const expected: string[] = [
+        '/'
+      ];
+      const actual: string[] = FileDeletionUtility.removeChildren(files);
+
+      assert.equal(actual.length, expected.length);
+      assert.includeMembers(expected, actual);
+    });
+  });
+});

--- a/gulp-core-build/src/utilities/FileDeletionUtility.ts
+++ b/gulp-core-build/src/utilities/FileDeletionUtility.ts
@@ -1,0 +1,80 @@
+import * as path from 'path';
+import * as globEscape from 'glob-escape';
+import globby = require('globby');
+
+/* tslint:disable:typedef */
+const del = require('del');
+/* tslint:disable:typedef */
+
+export class FileDeletionUtility {
+  public static deletePatterns(patterns: string[]) {
+    const files: string[] = globby.sync(patterns);
+    this.deleteFiles(files);
+  }
+
+  public static deleteFiles(files: string[]) {
+    del.sync(this.escapeFilepaths(this.removeChildren(files)));
+  }
+
+  public static escapeFilepaths(files: string[]): string[] {
+    return files.map((file: string) => {
+      return globEscape(file);
+    });
+  }
+
+  public static removeChildren(filenames: string[]): string[] {
+    // Appears to be a known issue with `del` whereby
+    // if you ask to delete both a folder, and something in the folder,
+    // it randomly chooses which one to delete first, which can cause
+    // the function to fail sporadically. The fix for this is simple:
+    // we need to remove any cleanPaths which exist under a folder we
+    // are attempting to delete
+
+    // First we sort the list of files. We know that if something is a file,
+    // if matched, the parent folder should appear earlier in the list
+    filenames.sort();
+
+    // We need to determine which paths exist under other paths, and remove them from the
+    // list of files to delete
+    const filesToDelete: string[] = [];
+
+    // current working directory
+    let currentParent = undefined;
+
+    for (let i: number = 0; i < filenames.length; i++) {
+      const curFile: string = filenames[i];
+      if (this.isParentDirectory(currentParent, curFile)) {
+        continue;
+      } else {
+        filesToDelete.push(curFile);
+        currentParent = curFile;
+      }
+    }
+    return filesToDelete;
+  }
+
+  public static isParentDirectory(directory: string, filepath: string): boolean {
+    if (!directory || !filepath) {
+      return false;
+    }
+
+    const directoryParts: string[] = path.resolve(directory).split(path.sep);
+    const fileParts: string[] = path.resolve(filepath).split(path.sep);
+
+    if (directoryParts[directoryParts.length - 1] === '') {
+      // this is to fix an issue with windows roots
+      directoryParts.pop();
+    }
+
+    if (directoryParts.length >= fileParts.length) {
+      return false;
+    }
+
+    for (let i: number = 0; i < directoryParts.length; i++) {
+      if (directoryParts[i] !== fileParts[i]) {
+        return false;
+      }
+    }
+    return true;
+  }
+}

--- a/gulp-core-build/typings-custom/glob-escape/index.d.ts
+++ b/gulp-core-build/typings-custom/glob-escape/index.d.ts
@@ -1,0 +1,10 @@
+// Type definitions for glob-escape 0.0.1
+// Definitions by: pgonzal
+
+declare module "glob-escape" {
+
+  function escapeGlob(glob: string): string;
+  function escapeGlob(glob: string[]): string[];
+
+  export = escapeGlob;
+}

--- a/rush/rush/src/taskRunner/ProjectBuildTask.ts
+++ b/rush/rush/src/taskRunner/ProjectBuildTask.ts
@@ -64,10 +64,12 @@ export default class ProjectBuildTask implements ITaskDefinition {
 
   public execute(writer: ITaskWriter): Promise<TaskStatus> {
     return new Promise<TaskStatus>((resolve: (status: TaskStatus) => void, reject: (errors: TaskError[]) => void) => {
-      getPackageDeps(this._rushProject.projectFolder, [PACKAGE_DEPS_FILENAME]).then(
-        (deps: IPackageDeps) => { this._executeTask(writer, deps, resolve, reject); },
-        (error: Error) => { this._executeTask(writer, undefined, resolve, reject); }
-      );
+      try {
+        const deps: IPackageDeps = getPackageDeps(this._rushProject.projectFolder, [PACKAGE_DEPS_FILENAME]);
+        this._executeTask(writer, deps, resolve, reject);
+      } catch (error) {
+        this._executeTask(writer, undefined, resolve, reject);
+      }
     });
   }
 

--- a/test-web-library-build/src/.gitignore
+++ b/test-web-library-build/src/.gitignore
@@ -1,0 +1,1 @@
+preCopyTest.ts

--- a/test-web-library-build/src/preCopyTest.ts
+++ b/test-web-library-build/src/preCopyTest.ts
@@ -1,3 +1,0 @@
-export default function preCopyTest(): void {
-  /* no-op */
-}


### PR DESCRIPTION
There is a problem with the `del` package where you cannot specify both a folder, and an item in the folder, else builds will spuriously fail.

Example:

```js
del(['/foo', '/foo/bar.txt'])  // sometimes this will cause an exception, as it tries to delete /foo/bar.txt
```

The fix is to pre-expand the glob matches, and remove any entry if a containing folder for that entry is already specified.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/web-build-tools/135)
<!-- Reviewable:end -->
