### PR TITLE
Adding ability to override the export method for sass css modules.

### DIFF
--- a/common/changes/dzearing-sass-module-export_2017-03-20-20-22.json
+++ b/common/changes/dzearing-sass-module-export_2017-03-20-20-22.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/gulp-core-build-sass",
+      "comment": "Adding moduleExportName option to sass task, so that we can optionally export to something other than \"default\".",
+      "type": "minor"
+    }
+  ],
+  "email": "dzearing@microsoft.com"
+}

--- a/gulp-core-build-sass/src/SassTask.ts
+++ b/gulp-core-build-sass/src/SassTask.ts
@@ -203,7 +203,7 @@ export class SassTask extends GulpTask<ISassTaskConfig> {
 
             if (this.taskConfig.moduleExportName === '') {
               exportString = 'export = styles;';
-            } else if (!!exportString) {
+            } else if (!!this.taskConfig.moduleExportName) {
               exportString = `export const ${ this.taskConfig.moduleExportName } = styles;`;
             }
 

--- a/gulp-core-build-sass/src/SassTask.ts
+++ b/gulp-core-build-sass/src/SassTask.ts
@@ -34,6 +34,12 @@ export interface ISassTaskConfig {
    * If files are matched by sassMatch which do not end in .module.scss, log a warning.
    */
   warnOnNonCSSModules?: boolean;
+  /**
+   * If this option is specified, module css will be exported using the name provided. If an
+   * empty value is specified, the styles will be exported using 'export =', rather than a
+   * named export. By default we use the 'default' export name.
+   */
+  moduleExportName?: string;
 }
 
 const _classMaps: { [file: string]: Object } = {};
@@ -193,10 +199,18 @@ export class SassTask extends GulpTask<ISassTaskConfig> {
               classNamesLines.push(line);
             });
 
+            let exportString: string = 'export default styles;';
+
+            if (this.taskConfig.moduleExportName === '') {
+              exportString = 'export = styles;';
+            } else if (!!exportString) {
+              exportString = `export const ${ this.taskConfig.moduleExportName } = styles;`;
+            }
+
             classNamesLines.push(
               '};',
               '',
-              'export default styles;'
+              exportString
             );
 
             exportClassNames = classNamesLines.join(EOL);

--- a/gulp-core-build-sass/src/sass.schema.json
+++ b/gulp-core-build-sass/src/sass.schema.json
@@ -29,6 +29,12 @@
       "type": "boolean"
     },
 
+    "moduleExportName": {
+      "title": "Defines the export name for the styles",
+      "description": "If this option is specified, module css will be exported using the name provided. If an empty value is specified, the styles will be exported using 'export =', rather than a named export. By default we use the 'default' export name.",
+      "type": "string"
+    },
+
     "dropCssFiles": {
       "title": "Create CSS Files",
       "description": "If true, we will generate a CSS in the lib folder. If false, the CSS is directly embedded into the TypeScript file",

--- a/gulp-core-build-sass/src/sass.schema.json
+++ b/gulp-core-build-sass/src/sass.schema.json
@@ -32,7 +32,8 @@
     "moduleExportName": {
       "title": "Defines the export name for the styles",
       "description": "If this option is specified, module css will be exported using the name provided. If an empty value is specified, the styles will be exported using 'export =', rather than a named export. By default we use the 'default' export name.",
-      "type": "string"
+      "type": "string",
+      "pattern": "^[a-zA-Z][a-zA-Z0-9]*$"
     },
 
     "dropCssFiles": {


### PR DESCRIPTION
This change should not change any default behavior, but adds a config setting `moduleExportName` which allows you to tweak how the styles are exported as a css module:

Without providing the config setting, we export as normal:
```ts
export default styles;
```

With a blank string, we export the object:
```ts
export = styles;
```

With a name provided, we export a const:
```ts
export const ${ name } = styles;
```

This helps with integration using the webpack loader stack, which doesn't export defaults and conflicts with the gcb stack.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/web-build-tools/142)
<!-- Reviewable:end -->
