### PR TITLE
Support manual version update

### DIFF
--- a/rush/rush-lib/src/data/RushConfigurationProject.ts
+++ b/rush/rush-lib/src/data/RushConfigurationProject.ts
@@ -15,6 +15,7 @@ export interface IRushConfigurationProjectJson {
   reviewCategory?: string;
   cyclicDependencyProjects: string[];
   shouldPublish?: boolean;
+  manualVersionUpdate?: boolean;
 }
 
 /**
@@ -31,6 +32,7 @@ export default class RushConfigurationProject {
   private _cyclicDependencyProjects: Set<string>;
   private _shouldPublish: boolean;
   private _downstreamDependencyProjects: string[];
+  private _manualVersionUpdate: boolean;
 
   constructor(projectJson: IRushConfigurationProjectJson,
               rushConfiguration: RushConfiguration,
@@ -94,6 +96,7 @@ export default class RushConfigurationProject {
     }
     this._downstreamDependencyProjects = [];
     this._shouldPublish = !!projectJson.shouldPublish;
+    this._manualVersionUpdate = !!projectJson.manualVersionUpdate;
   }
 
   /**
@@ -167,5 +170,17 @@ export default class RushConfigurationProject {
    */
   public get shouldPublish(): boolean {
     return this._shouldPublish;
+  }
+
+  /**
+   * A flag which indicates whether changes to this project should cause version bump during
+   * `rush publish`.
+   * When manualVersionUpdate is true, this project won't get version bumped during `rush publish` and
+   * won't get published.
+   * When manualVersionUpdate is false (which is the default value), this project will get version bumped
+   * during `rush publish` if the project has changes. And as such, this project will get published.
+   */
+  public get manualVersionUpdate(): boolean {
+    return this._manualVersionUpdate;
   }
 }

--- a/rush/rush-lib/src/rush-schema.json
+++ b/rush/rush-lib/src/rush-schema.json
@@ -95,6 +95,10 @@
           "shouldPublish": {
             "description": "A flag indicating that changes to this project will be published to npm, which affects the Rush change and publish workflows.",
             "type": "boolean"
+          },
+          "manualVersionUpdate": {
+            "description": "A flag indicating that changes to this project will not cause version bump. It is used when the project version needs to be updated manually.",
+            "type": "boolean"
           }
         },
         "additionalProperties": false,

--- a/rush/rush/src/utilities/test/ChangelogGenerator.test.ts
+++ b/rush/rush/src/utilities/test/ChangelogGenerator.test.ts
@@ -109,7 +109,7 @@ describe('updateIndividualChangelog', () => {
     expect(actualResult).eql(expectedResult);
   });
 
-  it('can avoid adding duplicate entries', () => {
+  it('can merge duplicate entries', () => {
     const actualResult: IChangelog = ChangelogGenerator.updateIndividualChangelog(
       {
         packageName: 'a',
@@ -119,7 +119,7 @@ describe('updateIndividualChangelog', () => {
           packageName: 'a',
           type: 'patch',
           changeType: ChangeType.patch,
-          comment: 'Patching a'
+          comment: 'Patching a again'
         }]
       },
       path.resolve(__dirname, 'exampleChangelog'),
@@ -137,12 +137,19 @@ describe('updateIndividualChangelog', () => {
             patch: [
               {
                 comment: 'Patching a'
+              },
+              {
+                author: undefined,
+                comment: 'Patching a again',
+                commit: undefined
               }
             ]
           }
         }
       ]
     };
+    // Ignore comparing date.
+    expectedResult.entries[0].date = actualResult.entries[0].date;
 
     expect(actualResult).eql(expectedResult);
   });

--- a/rush/rush/src/utilities/test/PublishUtilities.test.ts
+++ b/rush/rush/src/utilities/test/PublishUtilities.test.ts
@@ -379,6 +379,21 @@ describe('updatePackages', () => {
       '1.0.0-' + suffix,
       'the "cyclic-dep-1" dependency in "cyclic-dep-2" should be updated');
   });
+
+  it('does not update version for project that needs manual version update.', () => {
+    const allPackages: Map<string, RushConfigurationProject> =
+      RushConfiguration.loadFromConfigurationFile(path.resolve(__dirname, 'packages', 'rush.json')).projectsByName;
+    const allChanges: IChangeInfoHash = PublishUtilities.findChangeRequests(
+      allPackages,
+      path.join(__dirname, 'manualVersionUpdate'),
+      false);
+    PublishUtilities.updatePackages(allChanges, allPackages, false);
+    expect(allPackages.get('mv1').packageJson.version).equals('1.1.0', 'mv1 version should be updated.');
+    expect(allPackages.get('mv2').packageJson.version).equals('1.0.0', 'mv2 version not be updated');
+    expect(allPackages.get('mv2').packageJson.dependencies['mv1']).equals('~1.1.0',
+      'mv2 dependency version should be updated.');
+    expect(allPackages.get('mv3').packageJson.version).equals('1.0.0', 'mv3 version should not be updated');
+  });
 });
 
 describe('isRangeDependency', () => {

--- a/rush/rush/src/utilities/test/manualVersionUpdate/change1.json
+++ b/rush/rush/src/utilities/test/manualVersionUpdate/change1.json
@@ -1,0 +1,7 @@
+{
+  "changes": [{
+    "packageName": "mv1",
+    "type": "minor",
+    "comment": "Minor version update for mv1"
+  }]
+}

--- a/rush/rush/src/utilities/test/manualVersionUpdate/change2.json
+++ b/rush/rush/src/utilities/test/manualVersionUpdate/change2.json
@@ -1,0 +1,7 @@
+{
+  "changes": [{
+    "packageName": "mv2",
+    "type": "patch",
+    "comment": "Patch version update for mv2"
+  }]
+}

--- a/rush/rush/src/utilities/test/packages/mv1/package.json
+++ b/rush/rush/src/utilities/test/packages/mv1/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "mv1",
+  "version": "1.0.0",
+  "description": "Test package mv1"
+}

--- a/rush/rush/src/utilities/test/packages/mv2/package.json
+++ b/rush/rush/src/utilities/test/packages/mv2/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "mv2",
+  "version": "1.0.0",
+  "description": "Test package mv2",
+  "dependencies": {
+    "mv1": "~1.0.0"
+  }
+}

--- a/rush/rush/src/utilities/test/packages/mv3/package.json
+++ b/rush/rush/src/utilities/test/packages/mv3/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "mv3",
+  "version": "1.0.0",
+  "description": "Test package mv3",
+  "dependencies": {
+    "mv2": "1.0.0"
+  }
+}

--- a/rush/rush/src/utilities/test/packages/rush.json
+++ b/rush/rush/src/utilities/test/packages/rush.json
@@ -27,6 +27,22 @@
       "reviewCategory": "third-party"
     },
     {
+      "packageName": "mv1",
+      "projectFolder": "mv1",
+      "reviewCategory": "third-party"
+    },
+    {
+      "packageName": "mv2",
+      "projectFolder": "mv2",
+      "reviewCategory": "third-party",
+      "manualVersionUpdate": true
+    },
+    {
+      "packageName": "mv3",
+      "projectFolder": "mv3",
+      "reviewCategory": "third-party"
+    },
+    {
       "packageName": "cyclic-dep-1",
       "projectFolder": "cyclic-dep-1",
       "reviewCategory": "third-party"


### PR DESCRIPTION
A project with manualVersionUpdate=true will not get version updated when changes get applied, therefore won't get published. Its change log gets merged onto existing version's change log. Its version has to be manually updated before it can be published. Changelog has to be manually fixed to the new version then. 

This flag is useful when there are special requirements on the package version.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/web-build-tools/148)
<!-- Reviewable:end -->
