### PR TITLE
Fixing the way the TSLint task is configured.

### DIFF
--- a/common/changes/ianc-fixing-tslint-config_2017-04-03-22-52.json
+++ b/common/changes/ianc-fixing-tslint-config_2017-04-03-22-52.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/gulp-core-build-typescript",
+      "comment": "Fixing the way the TSLint task is configured to allow removal of existing rules.",
+      "type": "patch"
+    }
+  ],
+  "email": "ianc@microsoft.com"
+}

--- a/common/changes/ianc-fixing-tslint-config_2017-04-03-22-52.json
+++ b/common/changes/ianc-fixing-tslint-config_2017-04-03-22-52.json
@@ -6,5 +6,5 @@
       "type": "patch"
     }
   ],
-  "email": "ianc@microsoft.com"
+  "email": "iclanton@users.noreply.github.com"
 }

--- a/gulp-core-build-typescript/src/TSLintTask.ts
+++ b/gulp-core-build-typescript/src/TSLintTask.ts
@@ -97,15 +97,13 @@ export class TSLintTask extends GulpTask<ITSLintTaskConfig> {
   /* tslint:enable:no-any */
 
   public mergeConfig(config: ITSLintTaskConfig): void {
-    // If the removeExistingRules flag is set, clear out any existing rules
-    if (config.removeExistingRules &&
-        this.taskConfig &&
-        this.taskConfig.lintConfig) {
-      delete this.taskConfig.lintConfig.rules;
-      delete config.removeExistingRules;
-    }
-
+    this._prepareUpdateConfig(config);
     super.mergeConfig(config);
+  }
+
+  public setConfig(config: ITSLintTaskConfig): void {
+    this._prepareUpdateConfig(config);
+    super.setConfig(config);
   }
 
   public loadSchema(): Object {
@@ -191,6 +189,16 @@ export class TSLintTask extends GulpTask<ITSLintTaskConfig> {
 
   public getCleanMatch(buildConfig: IBuildConfig, taskConfig: ITSLintTaskConfig = this.taskConfig): string[] {
     return [path.join(buildConfig.rootPath, buildConfig.tempFolder)];
+  }
+
+  private _prepareUpdateConfig(newConfig: ITSLintTaskConfig): void {
+    // If the removeExistingRules flag is set, clear out any existing rules
+    if (newConfig.removeExistingRules &&
+        this.taskConfig &&
+        this.taskConfig.lintConfig) {
+      delete this.taskConfig.lintConfig.rules;
+      delete newConfig.removeExistingRules;
+    }
   }
 
   private _getTsLintFilepath(): string {

--- a/gulp-core-build-typescript/src/TSLintTask.ts
+++ b/gulp-core-build-typescript/src/TSLintTask.ts
@@ -82,7 +82,7 @@ export class TSLintTask extends GulpTask<ITSLintTaskConfig> {
     rulesDirectory: ((): string[] => {
       const msCustomRulesMain: string = require.resolve('tslint-microsoft-contrib');
       const msCustomRulesDirectory: string = path.dirname(msCustomRulesMain);
-      return TSLint.Configuration.getRulesDirectories([ msCustomRulesDirectory ], __dirname);
+      return TSLint.Configuration.getRulesDirectories([msCustomRulesDirectory], __dirname);
     })(),
     sourceMatch: [
       'src/**/*.ts',
@@ -96,7 +96,7 @@ export class TSLintTask extends GulpTask<ITSLintTaskConfig> {
   private _defaultLintRules: any = undefined;
   /* tslint:enable:no-any */
 
-  public setConfig(config: ITSLintTaskConfig): void {
+  public mergeConfig(config: ITSLintTaskConfig): void {
     // If the removeExistingRules flag is set, clear out any existing rules
     if (config.removeExistingRules &&
         this.taskConfig &&
@@ -105,7 +105,7 @@ export class TSLintTask extends GulpTask<ITSLintTaskConfig> {
       delete config.removeExistingRules;
     }
 
-    super.setConfig(config);
+    super.mergeConfig(config);
   }
 
   public loadSchema(): Object {
@@ -127,7 +127,7 @@ export class TSLintTask extends GulpTask<ITSLintTaskConfig> {
 
     return gulp.src(this.taskConfig.sourceMatch)
       .pipe(cached(
-        through2.obj(function(
+        through2.obj(function (
           file: gutil.File,
           encoding: string,
           callback: (encoding?: string, file?: gutil.File) => void): void {
@@ -201,6 +201,7 @@ export class TSLintTask extends GulpTask<ITSLintTaskConfig> {
     if (!this._defaultLintRules) {
       this._defaultLintRules = require('./defaultTslint.json');
     }
+
     return merge(
       (this.taskConfig.useDefaultConfigAsBase ? this._defaultLintRules : {}),
       this.taskConfig.lintConfig || {});


### PR DESCRIPTION
The TSLint task currently doesn't respect the `removeExistingRules` option because the code that initializes the tasks calls `mergeConfig` instead of `setConfig`.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/web-build-tools/150)
<!-- Reviewable:end -->
