### PR TITLE
Switch warning message type to verbose on CSS module generation 

### DIFF
--- a/common/changes/suppressWarning_2017-04-05-06-42.json
+++ b/common/changes/suppressWarning_2017-04-05-06-42.json
@@ -1,10 +1,8 @@
 {
-  "changes": [
-    {
-      "packageName": "@microsoft/gulp-core-build-sass",
-      "comment": "Add verboseCSSModuleWarning switch to output CSS module generation warning from type warning to verbose",
-      "type": "minor"
-    }
-  ],
+  "changes": [{
+    "packageName": "@microsoft/gulp-core-build-sass",
+    "comment": "Add task config property: warnOnCssTypeSafety to gulp-core-build-sass. if set to true, CSS module compile warning message will changed to verbose message",
+    "type": "minor"
+  }],
   "email": "timto@microsoft.com"
 }

--- a/common/changes/suppressWarning_2017-04-05-06-42.json
+++ b/common/changes/suppressWarning_2017-04-05-06-42.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/gulp-core-build-sass",
+      "comment": "Add verboseCSSModuleWarning switch to output CSS module generation warning from type warning to verbose",
+      "type": "minor"
+    }
+  ],
+  "email": "timto@microsoft.com"
+}

--- a/common/changes/suppressWarning_2017-04-05-06-42.json
+++ b/common/changes/suppressWarning_2017-04-05-06-42.json
@@ -1,7 +1,7 @@
 {
   "changes": [{
     "packageName": "@microsoft/gulp-core-build-sass",
-    "comment": "Add task config property: warnOnCssTypeSafety to gulp-core-build-sass. if set to true, CSS module compile warning message will changed to verbose message",
+    "comment": "Add task config property: warnOnCssInvalidPropertyName to gulp-core-build-sass. if set to false, CSS module compile warning message will changed to verbose message",
     "type": "minor"
   }],
   "email": "timto@microsoft.com"

--- a/gulp-core-build-sass/src/SassTask.ts
+++ b/gulp-core-build-sass/src/SassTask.ts
@@ -59,7 +59,7 @@ export class SassTask extends GulpTask<ISassTaskConfig> {
       'src/**/*.scss'
     ],
     useCSSModules: false,
-    warnOnCssTypeSafety: false,
+    warnOnCssTypeSafety: true,
     dropCssFiles: false,
     warnOnNonCSSModules: false
   };

--- a/gulp-core-build-sass/src/SassTask.ts
+++ b/gulp-core-build-sass/src/SassTask.ts
@@ -29,7 +29,7 @@ export interface ISassTaskConfig {
    * If true, we will set the CSS property naming warning to verbose message while the module is generating
    * to prevent task exit with exitcode: 1.
    */
-  verboseCSSModuleWarning?: boolean;
+  warnOnCssTypeSafety?: boolean;
   /**
    * If true, we will generate a CSS in the lib folder. If false, the CSS is directly embedded
    * into the TypeScript file
@@ -59,7 +59,7 @@ export class SassTask extends GulpTask<ISassTaskConfig> {
       'src/**/*.scss'
     ],
     useCSSModules: false,
-    verboseCSSModuleWarning: false,
+    warnOnCssTypeSafety: false,
     dropCssFiles: false,
     warnOnNonCSSModules: false
   };
@@ -193,7 +193,7 @@ export class SassTask extends GulpTask<ISassTaskConfig> {
               let line: string = '';
               if (key.indexOf('-') !== -1) {
                 let message: string = `The local CSS class '${key}' is not camelCase and will not be type-safe.`;
-                this.taskConfig.verboseCSSModuleWarning ?
+                this.taskConfig.warnOnCssTypeSafety ?
                   this.logVerbose(message) :
                   this.logWarning(message);
                 line = `  '${key}': '${value}'`;

--- a/gulp-core-build-sass/src/SassTask.ts
+++ b/gulp-core-build-sass/src/SassTask.ts
@@ -193,7 +193,7 @@ export class SassTask extends GulpTask<ISassTaskConfig> {
               const value: string = classNames[key];
               let line: string = '';
               if (key.indexOf('-') !== -1) {
-                let message: string = `The local CSS class '${key}' is not camelCase and will not be type-safe.`;
+                const message: string = `The local CSS class '${key}' is not camelCase and will not be type-safe.`;
                 this.taskConfig.warnOnCssInvalidPropertyName ?
                   this.logWarning(message) :
                   this.logVerbose(message);

--- a/gulp-core-build-sass/src/SassTask.ts
+++ b/gulp-core-build-sass/src/SassTask.ts
@@ -26,10 +26,11 @@ export interface ISassTaskConfig {
    */
   useCSSModules?: boolean;
   /**
-   * If true, we will set the CSS property naming warning to verbose message while the module is generating
+   * If false, we will set the CSS property naming warning to verbose message while the module is generating
    * to prevent task exit with exitcode: 1.
+   * Default value is true
    */
-  warnOnCssTypeSafety?: boolean;
+  warnOnCssInvalidPropertyName?: boolean;
   /**
    * If true, we will generate a CSS in the lib folder. If false, the CSS is directly embedded
    * into the TypeScript file
@@ -59,7 +60,7 @@ export class SassTask extends GulpTask<ISassTaskConfig> {
       'src/**/*.scss'
     ],
     useCSSModules: false,
-    warnOnCssTypeSafety: true,
+    warnOnCssInvalidPropertyName: true,
     dropCssFiles: false,
     warnOnNonCSSModules: false
   };
@@ -193,9 +194,9 @@ export class SassTask extends GulpTask<ISassTaskConfig> {
               let line: string = '';
               if (key.indexOf('-') !== -1) {
                 let message: string = `The local CSS class '${key}' is not camelCase and will not be type-safe.`;
-                this.taskConfig.warnOnCssTypeSafety ?
-                  this.logVerbose(message) :
-                  this.logWarning(message);
+                this.taskConfig.warnOnCssInvalidPropertyName ?
+                  this.logWarning(message) :
+                  this.logVerbose(message);
                 line = `  '${key}': '${value}'`;
               } else {
                 line = `  ${key}: '${value}'`;

--- a/gulp-core-build-sass/src/sass.schema.json
+++ b/gulp-core-build-sass/src/sass.schema.json
@@ -29,6 +29,12 @@
       "type": "boolean"
     },
 
+    "verboseCSSModuleWarning": {
+      "title": "Set CSS module warning message to verbose",
+      "description": "If true, we will generate a CSS in the lib folder. If false, the CSS is directly embedded into the TypeScript file",
+      "type": "boolean"
+    },
+
     "moduleExportName": {
       "title": "Defines the export name for the styles",
       "description": "If this option is specified, module css will be exported using the name provided. If an empty value is specified, the styles will be exported using 'export =', rather than a named export. By default we use the 'default' export name.",

--- a/gulp-core-build-sass/src/sass.schema.json
+++ b/gulp-core-build-sass/src/sass.schema.json
@@ -29,9 +29,9 @@
       "type": "boolean"
     },
 
-    "warnOnCssTypeSafety ": {
+    "warnOnCssInvalidPropertyName ": {
       "title": "Safety delver the CSS module compile warning",
-      "description": "If true, CSS module compile warning will be change verbose type to avoid build task exit with exitcode:1",
+      "description": "If false, CSS module compile warning will be change verbose type to avoid build task exit with exitcode:1",
       "type": "boolean"
     },
 

--- a/gulp-core-build-sass/src/sass.schema.json
+++ b/gulp-core-build-sass/src/sass.schema.json
@@ -29,9 +29,9 @@
       "type": "boolean"
     },
 
-    "verboseCSSModuleWarning": {
-      "title": "Set CSS module warning message to verbose",
-      "description": "If true, we will generate a CSS in the lib folder. If false, the CSS is directly embedded into the TypeScript file",
+    "warnOnCssTypeSafety ": {
+      "title": "Safety delver the CSS module compile warning",
+      "description": "If true, CSS module compile warning will be change verbose type to avoid build task exit with exitcode:1",
       "type": "boolean"
     },
 


### PR DESCRIPTION
Add a switch on SASS task config to be able to change CSS module generation warning message type to verbose to avoid exitcode:1 on the end of the build task.