### PR TITLE
removed hard coding of @public API tag on ApiPackage documentation

### DIFF
--- a/api-extractor/src/definitions/ApiItem.ts
+++ b/api-extractor/src/definitions/ApiItem.ts
@@ -334,7 +334,6 @@ abstract class ApiItem {
         const tag: string = '@' + ApiTag[this.documentation.apiTag].toLowerCase();
         this.reportError(`The ${tag} tag is not allowed on the package, which is always public`);
       }
-      this.documentation.apiTag = ApiTag.Public;
     }
 
     if (this.documentation.preapproved) {

--- a/api-extractor/testInputs/example2/example2-output.ts
+++ b/api-extractor/testInputs/example2/example2-output.ts
@@ -52,4 +52,3 @@ enum TestMissingCommentStar {
 
 // WARNING: functionWithIncompleteReturnType has incomplete type information
 // WARNING: functionWithIncompleteParameterType has incomplete type information
-// @public

--- a/common/changes/dagaeta-remove-public-api-tag-apipackage_2017-04-05-16-08.json
+++ b/common/changes/dagaeta-remove-public-api-tag-apipackage_2017-04-05-16-08.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor",
+      "comment": "Removed hard coding of @public for ApiPackage",
+      "type": "patch"
+    }
+  ],
+  "email": "dagaeta@users.noreply.github.com"
+}


### PR DESCRIPTION
-We were setting the API tag on ApiPackages to @public by default, this PR removes that line and leaves the API tag unset. 