### PR TITLE
Rush-lib: Move the pinnedVersions into it's own file

### DIFF
--- a/rush/rush-lib/src/data/PackageReviewConfiguration.ts
+++ b/rush/rush-lib/src/data/PackageReviewConfiguration.ts
@@ -54,7 +54,7 @@ export default class PackageReviewConfiguration {
 
   /**
    * Loads the configuration data from PackageDependencies.json and returns
-   * an PackageReviewFile object.
+   * an PackageReviewConfiguration object.
    */
   public static loadFromFile(jsonFilename: string): PackageReviewConfiguration {
     const packageReviewJson: IPackageReviewJson = JsonFile.loadJsonFile(jsonFilename);
@@ -88,7 +88,7 @@ export default class PackageReviewConfiguration {
   }
 
   /**
-   * DO NOT CALL -- Use PackageReviewFile.loadFromFile() instead.
+   * DO NOT CALL -- Use PackageReviewConfiguration.loadFromFile() instead.
    */
   constructor(packageReviewJson: IPackageReviewJson, jsonFilename: string) {
     this._loadedJson = packageReviewJson;

--- a/rush/rush-lib/src/data/PinnedVersionsConfiguration.ts
+++ b/rush/rush-lib/src/data/PinnedVersionsConfiguration.ts
@@ -34,8 +34,7 @@ export class PinnedVersionsConfiguration {
 
   public set(dependency: string, version: string): this {
     if (!semver.valid(version)) {
-      throw new Error(`In rush.json, the pinned version "${version}" for "${dependency}"` +
-        ` project is not a valid semantic version`);
+      throw new Error(`The pinned version "${version}" for "${dependency}" project is not a valid semantic version.`);
     }
     this._data.set(dependency, version);
     return this;

--- a/rush/rush-lib/src/data/PinnedVersionsConfiguration.ts
+++ b/rush/rush-lib/src/data/PinnedVersionsConfiguration.ts
@@ -1,0 +1,70 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import * as semver from 'semver';
+
+import JsonFile from '../utilities/JsonFile';
+
+export interface IPinnedVersionsJson {
+  [dependency: string]: string;
+}
+
+export class PinnedVersionsConfiguration extends Map<string, string> {
+  private _filename: string;
+
+  public static tryLoadFromFile(jsonFilename: string): PinnedVersionsConfiguration {
+    let pinnedVersionJson: IPinnedVersionsJson = undefined;
+    try {
+      pinnedVersionJson = JsonFile.loadJsonFile(jsonFilename);
+    } catch (e) {
+      /* no-op */
+    }
+
+    return PinnedVersionsConfiguration.create(pinnedVersionJson, jsonFilename);
+  }
+
+  public static create(pinnedVersionJson: IPinnedVersionsJson, filename: string): PinnedVersionsConfiguration {
+    // This is a workaround for extending a Map in es5, although technically
+    // __proto__ was standardized in es6, this should work anyhow since people only
+    // run this tool via node anyway, which is es6
+
+    const inst: Map<string, string> = new Map<string, string>();
+    // tslint:disable-next-line:no-string-literal
+    inst['__proto__'] = PinnedVersionsConfiguration.prototype;
+    const newInst: PinnedVersionsConfiguration = inst as PinnedVersionsConfiguration;
+
+    newInst._filename = filename;
+
+    return newInst;
+  }
+
+  /**
+   * DO NOT CALL -- Use PinnedVersionsConfiguration.loadFromFile() instead.
+   */
+  constructor() {
+    super();
+    throw new Error(`Do not directly instantiate PinnedVersionsConfiguration`);
+  }
+
+  public set(dependency: string, version: string): this {
+    if (!semver.valid(version)) {
+      throw new Error(`In rush.json, the pinned version "${version}" for "${dependency}"` +
+        ` project is not a valid semantic version`);
+    }
+    super.set(dependency, version);
+    return this;
+  }
+
+  public save(): this {
+    JsonFile.saveJsonFile(this._serialize(), this._filename);
+    return this;
+  }
+
+  private _serialize(): IPinnedVersionsJson {
+    const rawJson: IPinnedVersionsJson = {};
+    this.forEach((version: string, dependency: string) => {
+      rawJson[dependency] = version;
+    });
+    return rawJson;
+  }
+}

--- a/rush/rush-lib/src/data/PinnedVersionsConfiguration.ts
+++ b/rush/rush-lib/src/data/PinnedVersionsConfiguration.ts
@@ -44,6 +44,10 @@ export class PinnedVersionsConfiguration {
     return this._data.get(dependency);
   }
 
+  public has(dependency: string): boolean {
+    return this._data.has(dependency);
+  }
+
   public forEach(cb: (version: string, dependency: string) => void): this {
     this._data.forEach(cb);
     return this;
@@ -52,6 +56,19 @@ export class PinnedVersionsConfiguration {
   public save(): this {
     JsonFile.saveJsonFile(this._serialize(), this._filename);
     return this;
+  }
+
+  public delete(dependency: string): boolean {
+    return this._data.delete(dependency);
+  }
+
+  public clear(): this {
+    this._data.clear();
+    return this;
+  }
+
+  public get size(): number {
+    return this._data.size;
   }
 
   private _serialize(): IPinnedVersionsJson {

--- a/rush/rush-lib/src/index.ts
+++ b/rush/rush-lib/src/index.ts
@@ -18,6 +18,11 @@ export {
 } from './data/PackageReviewConfiguration';
 
 export {
+  IPinnedVersionsJson,
+  PinnedVersionsConfiguration
+} from './data/PinnedVersionsConfiguration';
+
+export {
   PackageDependencyKind,
   IPackageDependency,
   IPackageJson,


### PR DESCRIPTION
It is difficult to programatically update pinnedVersions, which is a feature that is needed for some internal tooling.