### PR TITLE
Prevent "rush publish" from corrupting Git

### DIFF
--- a/rush/rush/src/actions/PublishAction.ts
+++ b/rush/rush/src/actions/PublishAction.ts
@@ -23,6 +23,7 @@ import PublishUtilities, {
   IChangeInfoHash
 } from '../utilities/PublishUtilities';
 import ChangelogGenerator from '../utilities/ChangelogGenerator';
+import GitPolicy from '../utilities/GitPolicy';
 import PrereleaseToken from '../utilities/PrereleaseToken';
 
 export default class PublishAction extends CommandLineAction {
@@ -121,6 +122,11 @@ export default class PublishAction extends CommandLineAction {
    * Executes the publish action, which will read change request files, apply changes to package.jsons,
    */
   protected onExecute(): void {
+    if (!GitPolicy.check(this._rushConfiguration)) {
+      process.exit(1);
+      return;
+    }
+
     console.log(`Starting "rush publish" ${EOL}`);
 
     this._rushConfiguration = RushConfiguration.loadFromDefaultLocation();


### PR DESCRIPTION
The "rush publish" command bumps versions and creates Git tags by comitting changes to the repo.  Because our CI system isn't configured properly, it's been introducing malformed e-mail addresses like this:

```
Local Admin by Powershell <Local Admin by Powershell> 
```

Spaces are not formally allowed in an e-mail address, and certain commands such as `git filter branch` actually crash when they fail to parse these strings.  We will fix our CI system, but to prevent this in the future, I'm updating "rush publish" to enforce Rush's Git policy (if there is one).

We don't need a `--bypass-policy` option for this command, since it's intended to be run by an automation system.  If you really want a bad e-mail, you can simply add it to the Rush policy.