### PR TITLE
Trim Rush config, introduce a "common/config/rush" folder

### DIFF
--- a/common/reviews/api/rush-lib.api.ts
+++ b/common/reviews/api/rush-lib.api.ts
@@ -226,12 +226,19 @@ class RushConfigurationProject {
 }
 
 // @public
-class RushConstants {
-  public static nodeModulesFolderName: string;
-  public static npmShrinkwrapFilename: string;
-  public static rushTempFolderName: string;
-  public static rushTempNpmScope: string;
-  public static rushTempProjectsFolderName: string;
+module RushConstants {
+  commonFolderName: string = 'common';
+
+  nodeModulesFolderName: string = 'node_modules';
+
+  npmShrinkwrapFilename: string = 'npm-shrinkwrap.json';
+
+  rushTempFolderName: string = 'temp';
+
+  rushTempNpmScope: string = '@rush-temp';
+
+  rushTempProjectsFolderName: string = 'projects';
+
 }
 
 // @public

--- a/common/reviews/api/rush-lib.api.ts
+++ b/common/reviews/api/rush-lib.api.ts
@@ -178,6 +178,7 @@ export function RegexErrorDetector(regex: RegExp,
 class RushConfiguration {
   public readonly committedShrinkwrapFilename: string;
   public readonly commonFolder: string;
+  public readonly commonRushConfigFolder: string;
   public readonly commonTempFolder: string;
   public findProjectByShorthandName(shorthandProjectName: string): RushConfigurationProject;
   public findProjectByTempName(tempProjectName: string): RushConfigurationProject | undefined;
@@ -193,7 +194,6 @@ class RushConfiguration {
   public readonly npmToolFilename: string;
   public readonly npmToolVersion: string;
   public readonly packageReviewFile: string;
-  // (undocumented)
   public readonly pinnedVersions: PinnedVersionsConfiguration;
   public readonly projectFolderMaxDepth: number;
   public readonly projectFolderMinDepth: number;
@@ -232,6 +232,8 @@ module RushConstants {
   nodeModulesFolderName: string = 'node_modules';
 
   npmShrinkwrapFilename: string = 'npm-shrinkwrap.json';
+
+  pinnedVersionsFilename: string = 'pinnedVersions.json';
 
   rushTempFolderName: string = 'temp';
 

--- a/rush/rush-lib/src/RushConstants.ts
+++ b/rush/rush-lib/src/RushConstants.ts
@@ -6,32 +6,37 @@
  *
  * @public
  */
-export class RushConstants {
+export namespace RushConstants {
+  /**
+   * The folder name ("common") where Rush's common data will be stored.
+   */
+  export const commonFolderName: string = 'common';
+
   /**
    * The NPM scope ("@rush-temp") that is used for Rush's temporary projects.
    */
-  public static readonly rushTempNpmScope: string = '@rush-temp';
+  export const rushTempNpmScope: string = '@rush-temp';
 
   /**
    * The folder name ("temp") under the common folder where temporary files will be stored.
    * Example: "C:\MyRepo\common\temp"
    */
-  public static readonly rushTempFolderName: string = 'temp';
+  export const rushTempFolderName: string = 'temp';
 
   /**
    * The folder name ("projects") where temporary projects will be stored.
    * Example: "C:\MyRepo\common\temp\projects"
    */
-  public static readonly rushTempProjectsFolderName: string = 'projects';
+  export const rushTempProjectsFolderName: string = 'projects';
 
   /**
    * The filename ("npm-shrinkwrap.json") used to store state for the "npm shrinkwrap"
    * command.
    */
-  public static readonly npmShrinkwrapFilename: string = 'npm-shrinkwrap.json';
+  export const npmShrinkwrapFilename: string = 'npm-shrinkwrap.json';
 
   /**
    * The filename ("node_modules") where NPM installs its packages.
    */
-  public static readonly nodeModulesFolderName: string = 'node_modules';
+  export const nodeModulesFolderName: string = 'node_modules';
 }

--- a/rush/rush-lib/src/RushConstants.ts
+++ b/rush/rush-lib/src/RushConstants.ts
@@ -39,4 +39,12 @@ export namespace RushConstants {
    * The filename ("node_modules") where NPM installs its packages.
    */
   export const nodeModulesFolderName: string = 'node_modules';
+
+  /**
+   * The filename ("pinnedVersions.json") for an optional configuration file
+   * that stores a table of dependencies that should be pinned to a specific
+   * version for all projects.  This configuration file should go in the
+   * "common/config/rush" folder.
+   */
+  export const pinnedVersionsFilename: string = 'pinnedVersions.json';
 }

--- a/rush/rush-lib/src/data/PinnedVersionsConfiguration.ts
+++ b/rush/rush-lib/src/data/PinnedVersionsConfiguration.ts
@@ -11,7 +11,7 @@ interface IPinnedVersionsJson {
 }
 
 /**
- * Pinned Versions is a rush feature designed to mimic the behavior of NPM
+ * Pinned Versions is a Rush feature designed to mimic the behavior of NPM
  * when performing an install. Essentially, for a project, NPM installs all of
  * the first level dependencies before starting any second-level dependencies.
  * This means that you can control the specific version of a second-level dependency

--- a/rush/rush-lib/src/data/RushConfiguration.ts
+++ b/rush/rush-lib/src/data/RushConfiguration.ts
@@ -37,7 +37,6 @@ export interface IRushConfigurationJson {
   reviewCategories?: string[];
   gitPolicy?: IRushGitPolicyJson;
   projects: IRushConfigurationProjectJson[];
-  pinnedVersions: { [dependency: string]: string }; // deprecated
 }
 
 /**
@@ -545,31 +544,5 @@ export default class RushConfiguration {
 
     const pinnedVersionsFile: string = path.join(this.commonFolder, 'pinnedVersions.json');
     this._pinnedVersions = PinnedVersionsConfiguration.tryLoadFromFile(pinnedVersionsFile);
-
-    if (rushConfigurationJson.pinnedVersions) {
-      console.log(`DEPRECATED: the "pinnedVersions" field in "rush.json" is deprecated.${os.EOL}` +
-        `Please move the contents of this field to the following file:${os.EOL}  "${pinnedVersionsFile}"`);
-      console.log();
-
-      Object.keys(rushConfigurationJson.pinnedVersions).forEach((dependency: string) => {
-        const pinnedVersion: string = rushConfigurationJson.pinnedVersions[dependency];
-
-        if (this._projectsByName.has(dependency)) {
-          throw new Error(`In rush.json, cannot add a pinned version ` +
-            `for local project: "${dependency}"`);
-        }
-
-        if (this._pinnedVersions.has(dependency)) {
-          const preferredVersion: string = this._pinnedVersions.get(dependency);
-          if (preferredVersion !== pinnedVersion) {
-            console.log(`Pinned version "${dependency}@${pinnedVersion}" defined in "rush.json" ` +
-              `is conflicting with pinned version "${dependency}@${preferredVersion}" in "pinnedVersions.json".` +
-              `${os.EOL}  Using ${dependency}@${preferredVersion}!${os.EOL}`);
-          }
-        } else {
-          this._pinnedVersions.set(dependency, pinnedVersion);
-        }
-      });
-    }
   }
 }

--- a/rush/rush-lib/src/data/RushConfiguration.ts
+++ b/rush/rush-lib/src/data/RushConfiguration.ts
@@ -440,11 +440,8 @@ export default class RushConfiguration {
     this._rushJsonFolder = path.dirname(rushJsonFilename);
     this._commonFolder = path.resolve(path.join(this._rushJsonFolder, RushConstants.commonFolderName));
     if (!fsx.existsSync(this._commonFolder)) {
-      console.log(`No common folder was detected.`);
       console.log(`Creating folder: ${this._commonFolder}`);
       fsx.mkdirsSync(this._commonFolder);
-      console.log(`Next, you should probably run "rush generate"`);
-      process.exit(1);
     }
     this._commonTempFolder = path.join(this._commonFolder, RushConstants.rushTempFolderName);
 

--- a/rush/rush-lib/src/data/RushConfiguration.ts
+++ b/rush/rush-lib/src/data/RushConfiguration.ts
@@ -35,7 +35,6 @@ export interface IRushConfigurationJson {
   projectFolderMaxDepth?: number;
   packageReviewFile?: string;
   reviewCategories?: string[];
-  useLocalNpmCache?: boolean;
   gitPolicy?: IRushGitPolicyJson;
   projects: IRushConfigurationProjectJson[];
   pinnedVersions: { [dependency: string]: string }; // deprecated
@@ -206,8 +205,10 @@ export default class RushConfiguration {
   }
 
   /**
-   * If rush.json requested useLocalNpmCache=true, then this will specify a local folder
-   * for the NPM cache; otherwise, the value is undefined.
+   * The local folder that will store the NPM package cache.  Rush does not rely on the
+   * NPM's default global cache folder, because NPM's caching implementation does not
+   * reliably handle multiple processes.  (For example, if a build box is running
+   * "rush install" simultaneoulsy for two different working folders, it may fail randomly.)
    *
    * Example: "C:\MyRepo\common\temp\npm-cache"
    */
@@ -216,8 +217,9 @@ export default class RushConfiguration {
   }
 
   /**
-   * If rush.json requested useLocalNpmCache=true, then this will specify a local folder
-   * for the NPM temporary storage; otherwise, the value is undefined.
+   * The local folder where NPM's temporary files will be written during installation.
+   * Rush does not rely on the global default folder, because it may be on a different
+   * hard disk.
    *
    * Example: "C:\MyRepo\common\temp\npm-tmp"
    */
@@ -447,10 +449,8 @@ export default class RushConfiguration {
     }
     this._commonTempFolder = path.join(this._commonFolder, RushConstants.rushTempFolderName);
 
-    if (rushConfigurationJson.useLocalNpmCache) {
-      this._npmCacheFolder = path.resolve(path.join(this._commonTempFolder, 'npm-cache'));
-      this._npmTmpFolder = path.resolve(path.join(this._commonTempFolder, 'npm-tmp'));
-    }
+    this._npmCacheFolder = path.resolve(path.join(this._commonTempFolder, 'npm-cache'));
+    this._npmTmpFolder = path.resolve(path.join(this._commonTempFolder, 'npm-tmp'));
 
     this._committedShrinkwrapFilename = path.join(this._commonFolder, RushConstants.npmShrinkwrapFilename);
     this._tempShrinkwrapFilename = path.join(this._commonTempFolder, RushConstants.npmShrinkwrapFilename);

--- a/rush/rush-lib/src/data/RushConfiguration.ts
+++ b/rush/rush-lib/src/data/RushConfiguration.ts
@@ -28,7 +28,6 @@ export interface IRushGitPolicyJson {
  */
 export interface IRushConfigurationJson {
   $schema: string;
-  commonFolder: string;
   npmVersion: string;
   rushMinimumVersion: string;
   nodeSupportedVersionRange?: string;
@@ -189,8 +188,8 @@ export default class RushConfiguration {
   }
 
   /**
-   * The common folder specified in rush.json.  By default, this is the fully
-   * resolved path for a subfolder of rushJsonFolder whose name is "common".
+   * The fully resolved path for the "common" folder where Rush will store settings that
+   * affect all Rush projects.  This is always a subfolder of the folder containing "rush.json".
    * Example: "C:\MyRepo\common"
    */
   public get commonFolder(): string {
@@ -438,7 +437,7 @@ export default class RushConfiguration {
     }
 
     this._rushJsonFolder = path.dirname(rushJsonFilename);
-    this._commonFolder = path.resolve(path.join(this._rushJsonFolder, rushConfigurationJson.commonFolder));
+    this._commonFolder = path.resolve(path.join(this._rushJsonFolder, RushConstants.commonFolderName));
     if (!fsx.existsSync(this._commonFolder)) {
       console.log(`No common folder was detected.`);
       console.log(`Creating folder: ${this._commonFolder}`);

--- a/rush/rush-lib/src/data/RushConfiguration.ts
+++ b/rush/rush-lib/src/data/RushConfiguration.ts
@@ -15,7 +15,7 @@ import Utilities from '../utilities/Utilities';
 import { RushConstants } from '../RushConstants';
 
 /**
- * A list of known config filenames that are expected to appear in the "./common/rush/config" folder.
+ * A list of known config filenames that are expected to appear in the "./common/config/rush" folder.
  * To avoid confusion/mistakes, any extra files will be reported as an error.
  */
 const knownRushConfigFilenames: string[] = [
@@ -189,6 +189,13 @@ export default class RushConfiguration {
     return tempNamesByProject;
   }
 
+  /**
+   * If someone adds a config file in the "common/rush/config" folder, it would be a bad
+   * experience for Rush to silently ignore their file simply because they mispelled the
+   * filename, or maybe it's an old format that's no longer supported.  The
+   * _validateCommonRushConfigFolder() function makes sure that this folder only contains
+   * recognized config files.
+   */
   private static _validateCommonRushConfigFolder(commonRushConfigFolder: string): void {
     if (!fsx.existsSync(commonRushConfigFolder)) {
       console.log(`Creating folder: ${commonRushConfigFolder}`);
@@ -208,13 +215,13 @@ export default class RushConfiguration {
 
       // Ignore harmless file extensions
       const fileExtension: string = path.extname(filename);
-      if (['.bak', '.md', '.old', '.disabled'].indexOf(fileExtension) >= 0) {
+      if (['.bak', '.disabled', '.md', '.old', '.orig'].indexOf(fileExtension) >= 0) {
         continue;
       }
 
       const knownSet: Set<string> = new Set<string>(knownRushConfigFilenames.map(x => x.toUpperCase()));
 
-      // Is the filename something we know?
+      // Is the filename something we know?  If not, report an error.
       if (!knownSet.has(filename.toUpperCase())) {
         throw new Error(`An unrecognized file "${filename}" was found in the Rush config folder:`
           + ` ${commonRushConfigFolder}`);
@@ -502,7 +509,7 @@ export default class RushConfiguration {
 
     this._commonFolder = path.resolve(path.join(this._rushJsonFolder, RushConstants.commonFolderName));
 
-    this._commonRushConfigFolder = path.join(this._commonFolder, 'config/rush');
+    this._commonRushConfigFolder = path.join(this._commonFolder, 'config', 'rush');
     RushConfiguration._validateCommonRushConfigFolder(this._commonRushConfigFolder);
 
     this._commonTempFolder = path.join(this._commonFolder, RushConstants.rushTempFolderName);

--- a/rush/rush-lib/src/data/test/RushConfiguration.test.ts
+++ b/rush/rush-lib/src/data/test/RushConfiguration.test.ts
@@ -1,0 +1,59 @@
+/// <reference types='mocha' />
+
+import { assert } from 'chai';
+import RushConfiguration from '../RushConfiguration';
+import RushConfigurationProject from '../RushConfigurationProject';
+import * as path from 'path';
+import Utilities from '../../utilities/Utilities';
+
+function normalizePathForComparison(path: string): string {
+  return Utilities.getAllReplaced(path, '\\', '/').toUpperCase();
+}
+
+function assertPathProperty(validatedPropertyName: string, absolutePath: string, relativePath: string): void {
+  const resolvedRelativePath: string = path.resolve(__dirname, relativePath);
+  assert.equal(normalizePathForComparison(absolutePath), normalizePathForComparison(resolvedRelativePath),
+    `Failed to validate ${validatedPropertyName}`);
+}
+
+describe('RushConfiguration', () => {
+
+  it('can load repo/rush.json', (done: MochaDone) => {
+    const rushFilename: string = path.resolve(__dirname, 'repo', 'rush.json');
+    const rushConfiguration: RushConfiguration = RushConfiguration.loadFromConfigurationFile(rushFilename);
+
+    assertPathProperty('committedShrinkwrapFilename',
+      rushConfiguration.committedShrinkwrapFilename, './repo/common/npm-shrinkwrap.json');
+    assertPathProperty('commonFolder',
+      rushConfiguration.commonFolder, './repo/common');
+    assertPathProperty('commonTempFolder',
+      rushConfiguration.commonTempFolder, './repo/common/temp');
+    assertPathProperty('npmCacheFolder',
+      rushConfiguration.npmCacheFolder, './repo/common/temp/npm-cache');
+    assertPathProperty('npmTmpFolder',
+      rushConfiguration.npmTmpFolder, './repo/common/temp/npm-tmp');
+    assertPathProperty('npmToolFilename',
+      rushConfiguration.npmToolFilename, './repo/common/temp/npm-local/node_modules/.bin/npm');
+    assertPathProperty('rushJsonFolder',
+      rushConfiguration.rushJsonFolder, './repo');
+    assertPathProperty('rushLinkJsonFilename',
+      rushConfiguration.rushLinkJsonFilename, './repo/common/temp/rush-link.json');
+
+    assert.equal(rushConfiguration.npmToolVersion, '4.5.0', 'Failed to validate npmToolVersion');
+
+    assert.equal(rushConfiguration.projectFolderMaxDepth, 2, 'Failed to validate projectFolderMaxDepth');
+    assert.equal(rushConfiguration.projectFolderMinDepth, 1, 'Failed to validate projectFolderMinDepth');
+
+    assert.equal(rushConfiguration.projects.length, 3);
+
+    // Validate project1 settings
+    const project1: RushConfigurationProject = rushConfiguration.getProjectByName('project1');
+    assert.ok(project1, 'Failed to find project1');
+
+    assert.equal(project1.packageName, 'project1', 'Failed to validate project1.packageName');
+    assertPathProperty('project1.projectFolder', project1.projectFolder, './repo/project1');
+    assert.equal(project1.tempProjectName, '@rush-temp/project1', 'Failed to validate project1.tempProjectName');
+
+    done();
+  });
+});

--- a/rush/rush-lib/src/data/test/RushConfiguration.test.ts
+++ b/rush/rush-lib/src/data/test/RushConfiguration.test.ts
@@ -26,6 +26,8 @@ describe('RushConfiguration', () => {
       rushConfiguration.committedShrinkwrapFilename, './repo/common/npm-shrinkwrap.json');
     assertPathProperty('commonFolder',
       rushConfiguration.commonFolder, './repo/common');
+    assertPathProperty('commonRushConfigFolder',
+      rushConfiguration.commonRushConfigFolder, './repo/common/config/rush');
     assertPathProperty('commonTempFolder',
       rushConfiguration.commonTempFolder, './repo/common/temp');
     assertPathProperty('npmCacheFolder',

--- a/rush/rush-lib/src/data/test/RushConfiguration.test.ts
+++ b/rush/rush-lib/src/data/test/RushConfiguration.test.ts
@@ -23,7 +23,7 @@ describe('RushConfiguration', () => {
     const rushConfiguration: RushConfiguration = RushConfiguration.loadFromConfigurationFile(rushFilename);
 
     assertPathProperty('committedShrinkwrapFilename',
-      rushConfiguration.committedShrinkwrapFilename, './repo/common/npm-shrinkwrap.json');
+      rushConfiguration.committedShrinkwrapFilename, './repo/common/config/rush/npm-shrinkwrap.json');
     assertPathProperty('commonFolder',
       rushConfiguration.commonFolder, './repo/common');
     assertPathProperty('commonRushConfigFolder',

--- a/rush/rush-lib/src/data/test/repo/project1/package.json
+++ b/rush/rush-lib/src/data/test/repo/project1/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "project1",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "jquery": "^3.2.1",
+    "react": "^0.14.9"
+  }
+}

--- a/rush/rush-lib/src/data/test/repo/project2/package.json
+++ b/rush/rush-lib/src/data/test/repo/project2/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "project2",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "jquery": "^2.2.4",
+    "react": "^15.5.4"
+  }
+}

--- a/rush/rush-lib/src/data/test/repo/project3/package.json
+++ b/rush/rush-lib/src/data/test/repo/project3/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "project3",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "react": "^0.14.9",
+    "project2": "1.x"
+  }
+}

--- a/rush/rush-lib/src/data/test/repo/rush.json
+++ b/rush/rush-lib/src/data/test/repo/rush.json
@@ -1,0 +1,21 @@
+{
+  "rushMinimumVersion": "2.5.0",
+  "npmVersion": "4.5.0",
+  "projects": [
+
+    {
+      "packageName": "project1",
+      "projectFolder": "project1"
+    },
+
+    {
+      "packageName": "project2",
+      "projectFolder": "project2"
+    },
+
+    {
+      "packageName": "project3",
+      "projectFolder": "project3"
+    }
+  ]
+}

--- a/rush/rush-lib/src/rush-schema.json
+++ b/rush/rush-lib/src/rush-schema.json
@@ -92,16 +92,6 @@
         "additionalProperties": false,
         "required": [ "packageName", "projectFolder" ]
       }
-    },
-    "pinnedVersions": {
-      "description": "A mapping of dependency package names to a semantic version. These are included in the common package.json and are used to control versions of second-level dependencies.",
-      "type": "object",
-      "patternProperties": {
-        "^\\S+$": {
-          "type": "string",
-          "description": "A semantic version specifier"
-        }
-      }
     }
   },
   "additionalProperties": false,

--- a/rush/rush-lib/src/rush-schema.json
+++ b/rush/rush-lib/src/rush-schema.json
@@ -41,10 +41,6 @@
         "type": "string"
       }
     },
-    "useLocalNpmCache": {
-      "description": "If true, use repository-scoped NPM cache and tmp folders",
-      "type": "boolean"
-    },
     "gitPolicy": {
       "description": "If the project is stored in a Git repository, additional settings related to Git",
       "type": "object",

--- a/rush/rush-lib/src/rush-schema.json
+++ b/rush/rush-lib/src/rush-schema.json
@@ -8,10 +8,6 @@
       "description": "The metadata to indicate the JSON schema, required by some editors such as VS2015",
       "type": "string"
     },
-    "commonFolder": {
-      "description": "Specifies the name of a top-level global folder containing a package.json file with a superset of all dependencies for all projects in the repository.  Example: \"common\"",
-      "type": "string"
-    },
     "npmVersion": {
       "description": "The version of the NPM tool to install.",
       "type": "string",
@@ -113,5 +109,5 @@
     }
   },
   "additionalProperties": false,
-  "required": [ "commonFolder", "npmVersion", "rushMinimumVersion", "projects" ]
+  "required": [ "npmVersion", "rushMinimumVersion", "projects" ]
 }

--- a/rush/rush/src/utilities/InstallManager.ts
+++ b/rush/rush/src/utilities/InstallManager.ts
@@ -465,26 +465,12 @@ export default class InstallManager {
         return;
       }
     } else {
-      // Since cleanInstall=true, we need to start by cleaning the cache
-      if (this._rushConfiguration.npmCacheFolder) {
-        console.log(`Deleting the NPM cache folder`);
-        // This is faster and more thorough than "npm cache clean"
-        this._asyncRecycler.moveFolder(this._rushConfiguration.npmCacheFolder);
-      } else if (installType === InstallType.UnsafePurge) {
-        console.log(os.EOL + `Running "npm cache clean" to clean the global cache`);
-        const npmArgs: string[] = ['cache', 'clean'];
-        this.pushConfigurationNpmArgs(npmArgs);
-        Utilities.executeCommand(npmToolFilename, npmArgs, this._rushConfiguration.commonTempFolder);
-      } else {
-        // The global NPM cache is (inexplicably) not threadsafe, so if there are any
-        // concurrent "npm install" processes running this would cause them to crash.
-        console.log(os.EOL + 'Skipping "npm cache clean" because the cache is global.');
-      }
+      console.log(`Deleting the NPM cache folder`);
+      // This is faster and more thorough than "npm cache clean"
+      this._asyncRecycler.moveFolder(this._rushConfiguration.npmCacheFolder);
 
-      if (this._rushConfiguration.npmTmpFolder) {
-        console.log(`Deleting the "npm-tmp" folder`);
-        this._asyncRecycler.moveFolder(this._rushConfiguration.npmTmpFolder);
-      }
+      console.log(`Deleting the "npm-tmp" folder`);
+      this._asyncRecycler.moveFolder(this._rushConfiguration.npmTmpFolder);
     }
 
     if (markerFileExistedAtStart) {
@@ -569,13 +555,8 @@ export default class InstallManager {
    * to the command-line.
    */
   public pushConfigurationNpmArgs(npmArgs: string[]): void {
-    if (this._rushConfiguration.npmCacheFolder) {
-      npmArgs.push('--cache', this._rushConfiguration.npmCacheFolder);
-    }
-
-    if (this._rushConfiguration.npmTmpFolder) {
-      npmArgs.push('--tmp', this._rushConfiguration.npmTmpFolder);
-    }
+    npmArgs.push('--cache', this._rushConfiguration.npmCacheFolder);
+    npmArgs.push('--tmp', this._rushConfiguration.npmTmpFolder);
   }
 
   /**

--- a/rush/rush/src/utilities/InstallManager.ts
+++ b/rush/rush/src/utilities/InstallManager.ts
@@ -289,7 +289,7 @@ export default class InstallManager {
 
     // Also copy down the committed .npmrc file, if there is one
     // "common\.npmrc" --> "common\temp\.npmrc"
-    const committedNpmrcPath: string = path.join(this._rushConfiguration.commonFolder, '.npmrc');
+    const committedNpmrcPath: string = path.join(this._rushConfiguration.commonRushConfigFolder, '.npmrc');
     const tempNpmrcPath: string = path.join(this._rushConfiguration.commonTempFolder, '.npmrc');
     this.syncFile(committedNpmrcPath, tempNpmrcPath);
 

--- a/rush/rush/src/utilities/test/packages/rush.json
+++ b/rush/rush/src/utilities/test/packages/rush.json
@@ -1,5 +1,4 @@
 {
-  "commonFolder": "common",
   "npmVersion": "3.10.8",
   "rushMinimumVersion": "1.0.5",
   "nodeSupportedVersionRange": ">=4.3.0 <7.0.0",


### PR DESCRIPTION
This PR includes the following updates for the rush configuration, based on our design discussion:

- remove the "commonFolder" setting from rush.json
- remove the "useLocalNpmCache" setting from rush.json; it is now "always on"
- remove the deprecated "pinnedVersions" setting from rush.json
- Move ancillary config files into the "common/config/rush" folder; an error will be reported if any unrecognized files are found here
- Add unit tests for RushConfiguration

NOTE:  We also discussed some changes for the "packageReviewFile"/PackageDependencies.json feature; I will handle that in a separate PR.