### PR TITLE
Publish Rush 3.0.3 with fix for install issue

### DIFF
--- a/apps/rush-lib/CHANGELOG.json
+++ b/apps/rush-lib/CHANGELOG.json
@@ -2,6 +2,18 @@
   "name": "@microsoft/rush-lib",
   "entries": [
     {
+      "version": "3.0.3",
+      "tag": "@microsoft/rush_v3.0.3",
+      "date": "Tue, May 16, 2017 00:43:27 GMT",
+      "comments": {
+        "patch": [
+          {
+            "comment": "Rush 3.0.3 was released."
+          }
+        ]
+      }
+    },
+    {
       "version": "3.0.2",
       "tag": "@microsoft/rush-lib_v3.0.2",
       "date": "Sun, May 14, 2017 19:22:16 GMT",

--- a/apps/rush-lib/CHANGELOG.md
+++ b/apps/rush-lib/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Change Log - @microsoft/rush-lib
 
-This log was last generated on Sun, 14 May 2017 22:28:58 GMT and should not be manually modified.
+This log was last generated on Tue, 16 May 2017 00:45:31 GMT and should not be manually modified.
+
+## 3.0.3
+Tue, May 16, 2017 00:43:27 GMT
+
+### Patches
+
+- Rush 3.0.3 was released.
 
 ## 3.0.2
 Sun, May 14, 2017 19:22:16 GMT

--- a/apps/rush-lib/package.json
+++ b/apps/rush-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/rush-lib",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "A library for writing scripts that interact with the Rush tool",
   "repository": {
     "type": "git",

--- a/apps/rush/CHANGELOG.json
+++ b/apps/rush/CHANGELOG.json
@@ -2,6 +2,18 @@
   "name": "@microsoft/rush",
   "entries": [
     {
+      "version": "3.0.3",
+      "tag": "@microsoft/rush_v3.0.3",
+      "date": "Tue, May 16, 2017 00:43:27 GMT",
+      "comments": {
+        "patch": [
+          {
+            "comment": "Fix a regression where \"rush install\" sometimes failed to install the NPM tool"
+          }
+        ]
+      }
+    },
+    {
       "version": "3.0.2",
       "tag": "@microsoft/rush_v3.0.2",
       "date": "Sun, May 14, 2017 19:22:16 GMT",

--- a/apps/rush/CHANGELOG.md
+++ b/apps/rush/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Change Log - @microsoft/rush
 
-This log was last generated on Sun, 14 May 2017 22:28:58 GMT and should not be manually modified.
+This log was last generated on Tue, 16 May 2017 00:45:31 GMT and should not be manually modified.
+
+## 3.0.3
+Tue, May 16, 2017 00:43:27 GMT
+
+### Patches
+
+- Fix a regression where "rush install" sometimes failed to install the NPM tool
 
 ## 3.0.2
 Sun, May 14, 2017 19:22:16 GMT

--- a/apps/rush/package.json
+++ b/apps/rush/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/rush",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "The professional solution for consolidating all your JavaScript projects in one Git repo",
   "keywords": [
     "install",
@@ -29,7 +29,7 @@
   "license": "MIT",
   "dependencies": {
     "@microsoft/package-deps-hash": "~2.0.2",
-    "@microsoft/rush-lib": "3.0.2",
+    "@microsoft/rush-lib": "3.0.3",
     "@microsoft/stream-collator": "~2.0.0",
     "@microsoft/ts-command-line": "~2.0.0",
     "builtins": "~1.0.3",


### PR DESCRIPTION
This PR fixes a regression where "rush install" sometimes failed to install the local NPM tool (in the ~/.rush/npm-A.B.C" folder).