### PR TITLE
Allow for local commands (other than gulp)

### DIFF
--- a/apps/rush/src/taskRunner/ProjectBuildTask.ts
+++ b/apps/rush/src/taskRunner/ProjectBuildTask.ts
@@ -244,8 +244,10 @@ export default class ProjectBuildTask implements ITaskDefinition {
     const command: string[] = rawCommand.split(' ');
     const commandArgs: string[] = command.splice(1);
 
-    if (command[0] === 'gulp') {
-      command[0] = path.join(this._rushConfiguration.commonTempFolder, 'node_modules', '.bin', command[0]);
+    const localCommandPath: string =
+      path.join(this._rushConfiguration.commonTempFolder, 'node_modules', '.bin', command[0]);
+    if (fsx.existsSync(localCommandPath)) {
+      command[0] = localCommandPath;
     }
 
     return {


### PR DESCRIPTION
Look for a file in the local .bin folder. If found, use it.

#161 
#162 