### PR TITLE
Publish Rush 3.0.4

### DIFF
--- a/apps/rush-lib/CHANGELOG.json
+++ b/apps/rush-lib/CHANGELOG.json
@@ -2,6 +2,18 @@
   "name": "@microsoft/rush-lib",
   "entries": [
     {
+      "version": "3.0.4",
+      "tag": "@microsoft/rush_v3.0.4",
+      "date": "Tue, May 17, 2017 01:48:27 GMT",
+      "comments": {
+        "patch": [
+          {
+            "comment": "Rush 3.0.4 was released."
+          }
+        ]
+      }
+    },
+    {
       "version": "3.0.3",
       "tag": "@microsoft/rush_v3.0.3",
       "date": "Tue, May 16, 2017 00:43:27 GMT",

--- a/apps/rush-lib/CHANGELOG.md
+++ b/apps/rush-lib/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Change Log - @microsoft/rush-lib
 
-This log was last generated on Tue, 16 May 2017 00:45:31 GMT and should not be manually modified.
+This log was last generated on Wed, 17 May 2017 01:49:02 GMT and should not be manually modified.
+
+## 3.0.4
+Tue, May 17, 2017 01:48:27 GMT
+
+### Patches
+
+- Rush 3.0.4 was released.
 
 ## 3.0.3
 Tue, May 16, 2017 00:43:27 GMT

--- a/apps/rush-lib/package.json
+++ b/apps/rush-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/rush-lib",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "description": "A library for writing scripts that interact with the Rush tool",
   "repository": {
     "type": "git",

--- a/apps/rush/CHANGELOG.json
+++ b/apps/rush/CHANGELOG.json
@@ -2,6 +2,24 @@
   "name": "@microsoft/rush",
   "entries": [
     {
+      "version": "3.0.4",
+      "tag": "@microsoft/rush_v3.0.4",
+      "date": "Tue, May 16, 2017 00:43:27 GMT",
+      "comments": {
+        "patch": [
+          {
+            "comment": "Improved the \"rush build\" change detection: if any file outside a project folder has changed, rebuild all projects."
+          },
+          {
+            "comment": "The \"rush build\" command now stores the command-line options used during a build, and forces a full rebuild if the options have changed."
+          },
+          {
+            "comment": "Fix for a \"rush publish\" bug involving command line option quoting."
+          }
+        ]
+      }
+    },
+    {
       "version": "3.0.3",
       "tag": "@microsoft/rush_v3.0.3",
       "date": "Tue, May 16, 2017 00:43:27 GMT",
@@ -24,7 +42,7 @@
           }
         ]
       }
-    },  
+    },
     {
       "version": "3.0.1",
       "tag": "@microsoft/rush_v3.0.1",

--- a/apps/rush/CHANGELOG.md
+++ b/apps/rush/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Change Log - @microsoft/rush
 
-This log was last generated on Tue, 16 May 2017 00:45:31 GMT and should not be manually modified.
+This log was last generated on Wed, 17 May 2017 01:49:02 GMT and should not be manually modified.
+
+## 3.0.4
+Tue, May 16, 2017 00:43:27 GMT
+
+### Patches
+
+- Improved the "rush build" change detection: if any file outside a project folder has changed, rebuild all projects.
+- The "rush build" command now stores the command-line options used during a build, and forces a full rebuild if the options have changed.
+- Fix for a "rush publish" bug involving command line option quoting.
 
 ## 3.0.3
 Tue, May 16, 2017 00:43:27 GMT

--- a/apps/rush/package.json
+++ b/apps/rush/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/rush",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "description": "The professional solution for consolidating all your JavaScript projects in one Git repo",
   "keywords": [
     "install",
@@ -29,7 +29,7 @@
   "license": "MIT",
   "dependencies": {
     "@microsoft/package-deps-hash": "~2.0.2",
-    "@microsoft/rush-lib": "3.0.3",
+    "@microsoft/rush-lib": "3.0.4",
     "@microsoft/stream-collator": "~2.0.0",
     "@microsoft/ts-command-line": "~2.0.0",
     "builtins": "~1.0.3",


### PR DESCRIPTION
This is a bug fix release:

- Improved the "rush build" change detection: if any file outside a project folder has changed, rebuild all projects.
- The "rush build" command now stores the command-line options used during a build, and forces a full rebuild if the options have changed.
- Fix for a "rush publish" bug involving command line option quoting.
