### PR TITLE
Fix a minor bug where Rush complained about extra directories

### DIFF
--- a/apps/rush-lib/src/data/RushConfiguration.ts
+++ b/apps/rush-lib/src/data/RushConfiguration.ts
@@ -210,7 +210,7 @@ export default class RushConfiguration {
 
       // Ignore things that aren't actual files
       const stat: fsx.Stats = fsx.statSync(resolvedFilename);
-      if (!stat.isFile() && !stat.isSymbolicLink) {
+      if (!stat.isFile() && !stat.isSymbolicLink()) {
         continue;
       }
 

--- a/apps/rush-lib/src/data/RushConfiguration.ts
+++ b/apps/rush-lib/src/data/RushConfiguration.ts
@@ -209,7 +209,7 @@ export default class RushConfiguration {
       const resolvedFilename: string = path.resolve(commonRushConfigFolder, filename);
 
       // Ignore things that aren't actual files
-      const stat: fsx.Stats = fsx.statSync(resolvedFilename);
+      const stat: fsx.Stats = fsx.lstatSync(resolvedFilename);
       if (!stat.isFile() && !stat.isSymbolicLink()) {
         continue;
       }


### PR DESCRIPTION
A logic check didn't work correctly because of a typo.  As a result, Rush's check for unrecognized files was also complaining about subdirectories (which is unreasonably pedantic).