### PR TITLE
Export JsonSchemaValidator

### DIFF
--- a/apps/rush-lib/src/index.ts
+++ b/apps/rush-lib/src/index.ts
@@ -67,7 +67,7 @@ export {
 export {
   default as Utilities
 } from './utilities/Utilities';
-  
+
 export {
   default as JsonSchemaValidator
 } from './utilities/JsonSchemaValidator';

--- a/apps/rush-lib/src/index.ts
+++ b/apps/rush-lib/src/index.ts
@@ -69,7 +69,7 @@ export {
 } from './utilities/Utilities';
   
 export {
-  JsonSchemaValidator
+  default as JsonSchemaValidator
 } from './utilities/JsonSchemaValidator';
 
 export {

--- a/apps/rush-lib/src/index.ts
+++ b/apps/rush-lib/src/index.ts
@@ -67,6 +67,10 @@ export {
 export {
   default as Utilities
 } from './utilities/Utilities';
+  
+export {
+  JsonSchemaValidator
+} from './utilities/JsonSchemaValidator';
 
 export {
   Stopwatch,

--- a/common/reviews/api/rush-lib.api.ts
+++ b/common/reviews/api/rush-lib.api.ts
@@ -177,6 +177,15 @@ class JsonFile {
   public static saveJsonFile(jsonData: any, jsonFilename: string, options: ISaveJsonFileOptions = {}): boolean;
 }
 
+// (undocumented)
+class JsonSchemaValidator {
+  // (undocumented)
+  public static loadFromFile(schemaFilename: string): JsonSchemaValidator;
+  // WARNING: The type "ValidateErrorCallback" needs to be exported by the package (e.g. added to index.ts)
+  // (undocumented)
+  public validateObject(jsonObject: Object, errorCallback: ValidateErrorCallback): void;
+}
+
 // @public (undocumented)
 class Npm {
   // (undocumented)


### PR DESCRIPTION
Exporting the implementation of the JsonSchemaValidator. It is a useful utility that can be reused in many places. We should consider moving this to a more core package and doing an API review.