### PR TITLE
Publish gulp-core-build-typescript

### DIFF
--- a/common/changes/@microsoft/gulp-core-build-typescript/pgonzal-publish-gcb-typescript_2017-06-16-00-57.json
+++ b/common/changes/@microsoft/gulp-core-build-typescript/pgonzal-publish-gcb-typescript_2017-06-16-00-57.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/gulp-core-build-typescript",
+      "comment": "Upgraded api-extractor dependency",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/gulp-core-build-typescript",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/core-build/gulp-core-build-typescript/README.md
+++ b/core-build/gulp-core-build-typescript/README.md
@@ -171,5 +171,3 @@ typescript.setConfig({
 # License
 
 [MIT](https://github.com/Microsoft/gulp-core-build-typescript/blob/master/LICENSE)
-
-EDITED

--- a/core-build/gulp-core-build-typescript/README.md
+++ b/core-build/gulp-core-build-typescript/README.md
@@ -171,3 +171,5 @@ typescript.setConfig({
 # License
 
 [MIT](https://github.com/Microsoft/gulp-core-build-typescript/blob/master/LICENSE)
+
+EDITED


### PR DESCRIPTION
The **gulp-core-build-typescript** package didn't get republished when **api-extractor** was changed.  (We're investigating whether this is due to a bug.)  This PR adds an empty change log record to force republishing.