### PR TITLE
Disallow @summary tag

### DIFF
--- a/common/changes/@microsoft/api-extractor/pgonzal-api-extractor-cleanups_2017-06-16-02-40.json
+++ b/common/changes/@microsoft/api-extractor/pgonzal-api-extractor-cleanups_2017-06-16-02-40.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor",
+      "comment": "The unsupported @summary tag is now reported as an error",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/libraries/api-extractor/src/ApiDefinitionReference.ts
+++ b/libraries/api-extractor/src/ApiDefinitionReference.ts
@@ -103,9 +103,7 @@ export default class ApiDefinitionReference {
   public static createFromString(apiReferenceExpr: string,
     reportError: (message: string) => void): ApiDefinitionReference {
     if (!apiReferenceExpr || apiReferenceExpr.split(' ').length > 1) {
-      reportError('API reference expression must be of the form: ' +
-        '\'scopeName/packageName:exportName.memberName | display text\'' +
-        'where the \'|\' is required if a display text is provided');
+      reportError('An API item reference must use the notation: "@scopeName/packageName:exportName.memberName"');
       return;
     }
 

--- a/libraries/api-extractor/src/Tokenizer.ts
+++ b/libraries/api-extractor/src/Tokenizer.ts
@@ -27,11 +27,11 @@ export default class Tokenizer {
   /**
    * Converts a doc comment string into an array of Tokens. This processing is done so that docs
    * can be processed more strictly.
-   * Example: "This is a JsDoc description with a {@link URL} and more text. \@summary example \@public"
+   * Example: "This is a JsDoc description with a {@link URL} and more text. \@remarks example \@public"
    * => [
    *  {tokenType: 'text', parameter: 'This is a JsDoc description with a'},
    *  {tokenType: '@link', parameter: 'URL'},
-   *  {tokenType: '\@summary', parameter: ''},
+   *  {tokenType: '\@remarks', parameter: ''},
    *  {tokenType: 'text', parameter: 'example'},
    *  {tokenType: '\@public', parameter: ''}
    * ]

--- a/libraries/api-extractor/src/definitions/ApiDocumentation.ts
+++ b/libraries/api-extractor/src/definitions/ApiDocumentation.ts
@@ -85,7 +85,6 @@ export default class ApiDocumentation {
     '@public',
     '@returns',
     '@see',
-    '@summary',
     '@deprecated',
     '@readonly',
     '@remarks'

--- a/libraries/api-extractor/src/definitions/test/ApiDocumentation.test.ts
+++ b/libraries/api-extractor/src/definitions/test/ApiDocumentation.test.ts
@@ -65,8 +65,6 @@ describe('ApiDocumentation tests', function (): void {
        * - testInputs/example2/folder/MyDocumentedClass (10  errors)
        */
 
-      console.log(JSON.stringify(capturedErrors));
-
       assert.equal(capturedErrors.length, 8);
       assert.equal(capturedErrors[0].message, 'Cannot provide summary in JsDoc if @inheritdoc tag is given');
       assert.equal(capturedErrors[1].message, 'Unknown JSDoc tag "@badJsDocTag"');

--- a/libraries/api-extractor/src/definitions/test/ApiDocumentation.test.ts
+++ b/libraries/api-extractor/src/definitions/test/ApiDocumentation.test.ts
@@ -65,24 +65,21 @@ describe('ApiDocumentation tests', function (): void {
        * - testInputs/example2/folder/MyDocumentedClass (10  errors)
        */
 
-      assert.equal(capturedErrors.length, 10);
+      console.log(JSON.stringify(capturedErrors));
+
+      assert.equal(capturedErrors.length, 8);
       assert.equal(capturedErrors[0].message, 'Cannot provide summary in JsDoc if @inheritdoc tag is given');
-      assert.equal(capturedErrors[1].message, 'The JSDoc tag "@summary" is not supported in this context');
+      assert.equal(capturedErrors[1].message, 'Unknown JSDoc tag "@badJsDocTag"');
+      assert.equal(capturedErrors[2].message, 'Unknown tag name for inline tag.');
+      assert.equal(capturedErrors[3].message, 'Too few parameters for @link inline tag.');
+      assert.equal(capturedErrors[4].message, 'Unexpected text in JSDoc comment: "can not contain a tag"');
+      assert.equal(capturedErrors[5].message, 'More than one API Tag was specified');
       assert.equal(
-        capturedErrors[2].message, 'Unexpected text in JSDoc comment: "Mock class for testing JsDoc parser"'
-      );
-      assert.equal(capturedErrors[3].message, 'Unknown JSDoc tag "@badJsDocTag"');
-      assert.equal(capturedErrors[4].message, 'Unknown tag name for inline tag.');
-      assert.equal(capturedErrors[5].message, 'Too few parameters for @link inline tag.');
-      assert.equal(capturedErrors[6].message, 'Unexpected text in JSDoc comment: "can not contain a tag"');
-      assert.equal(capturedErrors[7].message, 'More than one API Tag was specified');
-      assert.equal(
-        capturedErrors[8].message,
-        'API reference expression must be of the form: \'scopeName/packageName:exportName.memberName ' +
-        '| display text\'where the \'|\' is required if a display text is provided'
+        capturedErrors[6].message,
+        'An API item reference must use the notation: "@scopeName/packageName:exportName.memberName"'
       );
       assert.equal(
-        capturedErrors[9].message,
+        capturedErrors[7].message,
         'inheritdoc source item is deprecated. Must provide @deprecated message or remove @inheritdoc inline tag.');
   });
 

--- a/libraries/api-extractor/src/test/DocElementParser.test.ts
+++ b/libraries/api-extractor/src/test/DocElementParser.test.ts
@@ -12,7 +12,7 @@ import ApiDocumentation from '../definitions/ApiDocumentation';
 import Extractor from './../Extractor';
 import Tokenizer from './../Tokenizer';
 
-const capturedErrors: {
+let capturedErrors: {
   message: string;
   fileName: string;
   lineNumber: number;
@@ -20,6 +20,15 @@ const capturedErrors: {
 
 function testErrorHandler(message: string, fileName: string, lineNumber: number): void {
   capturedErrors.push({ message, fileName, lineNumber });
+}
+
+function clearCapturedErrors(): void {
+  capturedErrors = [];
+}
+
+function assertCapturedErrors(expectedMessages: string[]): void {
+  assert.deepEqual(capturedErrors.map(x => x.message), expectedMessages,
+    'The captured errors did not match the expected output.');
 }
 
 const inputFolder: string = './testInputs/example2';
@@ -74,6 +83,7 @@ describe('DocElementParser tests', function (): void {
 
   describe('Basic Tests', (): void => {
     it('Should parse basic doc comment stream', (): void => {
+      clearCapturedErrors();
       const apiDoc: TestApiDocumentation = new TestApiDocumentation();
 
       const docs: string = 'This function parses docTokens for the apiLint website ' +
@@ -129,9 +139,11 @@ describe('DocElementParser tests', function (): void {
       JsonFile.saveJsonFile('./lib/paramDocExpected.json', JSON.stringify(expectedParam));
       JsonFile.saveJsonFile('./lib/paramDocActual.json', JSON.stringify(actualParam));
       TestFileComparer.assertFileMatchesExpected('./lib/paramDocActual.json', './lib/paramDocExpected.json');
+      assertCapturedErrors([]);
     });
 
     it('Should parse @deprecated correctly', (): void => {
+      clearCapturedErrors();
       const docs: string = '@deprecated - description of the deprecation';
       const tokenizer: Tokenizer = new Tokenizer(docs, console.log);
 
@@ -144,9 +156,11 @@ describe('DocElementParser tests', function (): void {
       JsonFile.saveJsonFile('./lib/deprecatedDocExpected.json', JSON.stringify(expectedDeprecated));
       JsonFile.saveJsonFile('./lib/deprecatedDocActual.json', JSON.stringify(actualDeprecated));
       TestFileComparer.assertFileMatchesExpected('./lib/deprecatedDocActual.json', './lib/deprecatedDocExpected.json');
+      assertCapturedErrors([]);
     });
 
     it('Should parse @see with nested link and/or text', (): void => {
+      clearCapturedErrors();
       const docs: string = 'Text describing the function’s purpose/nuances/context. \n' +
       '@see {@link https://github.com/OfficeDev/office-ui-fabric-react | The link will provide context}';
       const tokenizer: Tokenizer = new Tokenizer(docs, console.log);
@@ -170,9 +184,11 @@ describe('DocElementParser tests', function (): void {
       JsonFile.saveJsonFile('./lib/seeDocExpected.json', JSON.stringify(expectedSummary));
       JsonFile.saveJsonFile('./lib/seeDocActual.json', JSON.stringify(actualSummary));
       TestFileComparer.assertFileMatchesExpected('./lib/seeDocExpected.json', './lib/seeDocActual.json');
+      assertCapturedErrors([]);
     });
 
     it('Should parse @param with nested link and/or text', (): void => {
+      clearCapturedErrors();
       const apiDoc: TestApiDocumentation = new TestApiDocumentation();
 
       // Don't include the "@param" in the doc string, parseParam() expects this to be processed in a
@@ -202,9 +218,11 @@ describe('DocElementParser tests', function (): void {
         './lib/nestedParamDocActual.json',
         './lib/nestedParamDocExpected.json'
       );
+      assertCapturedErrors([]);
     });
 
     it('Should parse @link with url', (): void => {
+      clearCapturedErrors();
       const docs: string = '{@link https://microsoft.com}';
       const tokenizer: Tokenizer = new Tokenizer(docs, console.log);
 
@@ -222,11 +240,13 @@ describe('DocElementParser tests', function (): void {
       assert.equal(linkDocElement.referenceType, 'href');
       assert.equal(linkDocElement.targetUrl, 'https://microsoft.com');
       assert.equal(linkDocElement.value, '');
+      assertCapturedErrors([]);
     });
 
     it('Should parse @link with url and text', (): void => {
-     const docs: string = '{@link https://microsoft.com | microsoft home}';
-     const tokenizer: Tokenizer = new Tokenizer(docs, console.log);
+      clearCapturedErrors();
+      const docs: string = '{@link https://microsoft.com | microsoft home}';
+      const tokenizer: Tokenizer = new Tokenizer(docs, console.log);
 
       let docElements: IDocElement[];
       /* tslint:disable-next-line:no-any */
@@ -242,9 +262,29 @@ describe('DocElementParser tests', function (): void {
       assert.equal(linkDocElement.referenceType, 'href');
       assert.equal(linkDocElement.targetUrl, 'https://microsoft.com');
       assert.equal(linkDocElement.value, 'microsoft home');
+      assertCapturedErrors([]);
+    });
+
+    it('Should reject @link with missing pipe', (): void => {
+      clearCapturedErrors();
+
+      const docs: string = '{@link https://microsoft.com microsoft home}';
+      const tokenizer: Tokenizer = new Tokenizer(docs, console.log);
+
+      let docElements: IDocElement[];
+      /* tslint:disable-next-line:no-any */
+      let errorMessage: any;
+      try {
+        docElements = DocElementParser.parse(myDocumentedClass.documentation, tokenizer);
+      } catch (error) {
+        errorMessage = error;
+      }
+      assert.isUndefined(errorMessage);
+      assertCapturedErrors(['Invalid @link parameter, url must be a single string.']);
     });
 
     it('Should parse @link with API defintion reference', (): void => {
+      clearCapturedErrors();
       const docs: string = '{@link @microsoft/sp-core-library:Guid.equals}';
       const tokenizer: Tokenizer = new Tokenizer(docs, console.log);
 
@@ -264,9 +304,11 @@ describe('DocElementParser tests', function (): void {
       assert.equal(linkDocElement.packageName, 'sp-core-library');
       assert.equal(linkDocElement.exportName, 'Guid');
       assert.equal(linkDocElement.memberName, 'equals');
+      assertCapturedErrors([]);
     });
 
     it('Should parse @link with API defintion reference and text', (): void => {
+      clearCapturedErrors();
       const docs: string = '{@link @microsoft/sp-core-library:Guid.equals | Guid equals}';
       const tokenizer: Tokenizer = new Tokenizer(docs, console.log);
 
@@ -287,9 +329,11 @@ describe('DocElementParser tests', function (): void {
       assert.equal(linkDocElement.exportName, 'Guid');
       assert.equal(linkDocElement.memberName, 'equals');
       assert.equal(linkDocElement.value, 'Guid equals');
+      assertCapturedErrors([]);
     });
 
     it('Should report errors @link', (): void => {
+      clearCapturedErrors();
       const docs: string = '{@link @microsoft/sp-core-library:Guid.equals | Guid equals | something}';
       const tokenizer: Tokenizer = new Tokenizer(docs, console.log);
 
@@ -302,6 +346,7 @@ describe('DocElementParser tests', function (): void {
         errorMessage = error;
       }
       assert.isNotNull(errorMessage);
+      assertCapturedErrors(['Invalid @link parameters, at most one pipe character allowed.']);
     });
   });
 });

--- a/libraries/api-extractor/testInputs/example2/example2-output.json
+++ b/libraries/api-extractor/testInputs/example2/example2-output.json
@@ -142,7 +142,12 @@
           "value": ". This block is entirely valid and a correct documentation object should be built for this ApiItem."
         }
       ],
-      "remarks": [],
+      "remarks": [
+        {
+          "kind": "textDocElement",
+          "value": "Mock class for testing JsDoc parser"
+        }
+      ],
       "isBeta": false,
       "members": {
         "__constructor": {

--- a/libraries/api-extractor/testInputs/example2/src/MyDocumentedClass.ts
+++ b/libraries/api-extractor/testInputs/example2/src/MyDocumentedClass.ts
@@ -78,13 +78,9 @@ export function functionWithIncompleteParameterType(param1, param2: string): boo
  * correctly. It can contain a {@link https://bing.com/ | bing home}. This block is entirely
  * valid and a correct documentation object should be built for this ApiItem.
  *
- * @summary Mock class for testing JsDoc parser
  * @public
+ * @remarks Mock class for testing JsDoc parser
  */
-// (Error #2)
-// Error: The JSDoc tag "@summary" is not supported in this context
-// (Error #4)
-// Error: Unexpected text in JSDoc comment: "Mock class for testing JsDoc parser"
 export default class MyDocumentedClass {
 
 


### PR DESCRIPTION
API Extractor does not support the @summary tag, but some old code parsed it.  This PR removes that code and improves some various unit test code.