### PR TITLE
Audit API Extractor error strings

### DIFF
--- a/common/changes/@microsoft/api-extractor/pgonzal-ae-error-strings_2017-06-19-18-55.json
+++ b/common/changes/@microsoft/api-extractor/pgonzal-ae-error-strings_2017-06-19-18-55.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor",
+      "comment": "Improved the wording of many error messages",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/libraries/api-extractor/src/ApiDefinitionReference.ts
+++ b/libraries/api-extractor/src/ApiDefinitionReference.ts
@@ -136,7 +136,7 @@ export default class ApiDefinitionReference {
     }
 
     if (!apiReferenceExpr.match(ApiDefinitionReference._exportRegEx)) {
-      throw reportError(`API item reference contains invalid characters: "${apiReferenceExpr}"`);
+      throw reportError(`The API item reference contains invalid characters: "${apiReferenceExpr}"`);
     }
 
     return ApiDefinitionReference.createFromParts(apiDefRefParts);

--- a/libraries/api-extractor/src/ApiDefinitionReference.ts
+++ b/libraries/api-extractor/src/ApiDefinitionReference.ts
@@ -131,11 +131,12 @@ export default class ApiDefinitionReference {
       apiDefRefParts.memberName = parts[2] ? parts[2] : ''; // e.g. equals
     } else {
       // the export name is required
-       throw reportError(`Api reference expression contains invalid characters: ${apiReferenceExpr}`);
+       throw reportError(`The API item reference contains an invalid "exportName.memberName"`
+        + ` expression: "${apiReferenceExpr}"`);
     }
 
     if (!apiReferenceExpr.match(ApiDefinitionReference._exportRegEx)) {
-      throw reportError(`Api reference expression contains invalid characters: ${apiReferenceExpr}`);
+      throw reportError(`API item reference contains invalid characters: "${apiReferenceExpr}"`);
     }
 
     return ApiDefinitionReference.createFromParts(apiDefRefParts);

--- a/libraries/api-extractor/src/DocElementParser.ts
+++ b/libraries/api-extractor/src/DocElementParser.ts
@@ -126,7 +126,7 @@ export default class DocElementParser {
    * linkDocElement with the corresponding information. If the corresponding inline tag \@link is
    * not formatted correctly an error will be reported.
    *
-   * The format for the \@link tag is {\@link url or API defintion reference | display text}, where
+   * The format for the \@link tag is {\@link URL or API defintion reference | display text}, where
    * the '|' is only needed if the optional display text is given.
    *
    * Examples:
@@ -137,7 +137,7 @@ export default class DocElementParser {
    */
   public static parseLinkTag(documentation: ApiDocumentation, tokenItem: Token): IHrefLinkElement | ICodeLinkElement {
     if (!tokenItem.text) {
-      documentation.reportError('The {@link} tag must include a url or API item reference');
+      documentation.reportError('The {@link} tag must include a URL or API item reference');
        return;
     }
 
@@ -158,7 +158,7 @@ export default class DocElementParser {
     if (tokenItem.text.match(this._hrefRegEx)) {
       const urlContent: string[] = pipeSplitContent[0].split(' ');
 
-      // Make sure only a single url is given
+      // Make sure only a single URL is given
       if (urlContent.length > 1 && urlContent[1] !== '' ) {
         documentation.reportError('The {@link} tag contains additional spaces after the URL;'
           + ' if the URL contains spaces, encode them using %20; for display text, use a pipe delimiter ("|")');

--- a/libraries/api-extractor/src/IDocElement.ts
+++ b/libraries/api-extractor/src/IDocElement.ts
@@ -33,7 +33,7 @@ export interface IHrefLinkElement extends IBaseDocElement {
   referenceType: 'href';
 
   /**
-   * The url that this link element references.
+   * The URL that this link element references.
    */
   targetUrl: string;
 
@@ -74,7 +74,7 @@ export interface ICodeLinkElement extends IBaseDocElement {
   memberName?: string;
 
   /**
-   * Optional text to display in place of the API reference string url that is
+   * Optional text to display in place of the API reference string URL that is
    * constructed from the ts-spec tool.
    */
   value?: string;

--- a/libraries/api-extractor/src/Token.ts
+++ b/libraries/api-extractor/src/Token.ts
@@ -8,20 +8,20 @@ export enum TokenType {
   Text,
 
   /**
-   * A Token that specifies a tag.
-   * Example: \@link, \@internal, etc.
+   * A Token representing an AEDoc block tag.
+   * Example: \@public, \@remarks, etc.
    */
-  Tag,
+  BlockTag,
 
   /**
-   * This is a specific kind of Tag that is important to
-   * distinguish because it contains additional parameters.
+   * A Token representing an AEDoc inline tag.  Inline tags must be enclosed in
+   * curly braces, which may include parameters.
    *
    * Example:
    * \{@link http://microosft.com | microsoft home \}
    * \{@inheritdoc  @ microsoft/sp-core-library:Guid.newGuid \}
    */
-  Inline
+  InlineTag
 }
 
 /**

--- a/libraries/api-extractor/src/Tokenizer.ts
+++ b/libraries/api-extractor/src/Tokenizer.ts
@@ -50,7 +50,7 @@ export default class Tokenizer {
       let token: Token;
       value = sanitizedTokens[i];
       if (value.charAt(0) === '@') {
-       token = new Token(TokenType.Tag, value);
+       token = new Token(TokenType.BlockTag, value);
       } else if (value.charAt(0) === '{' && value.charAt(value.length - 1) === '}') {
         token = this._tokenizeInline(value); // Can return undefined if invalid inline tag
       } else {
@@ -71,20 +71,21 @@ export default class Tokenizer {
    */
   protected _tokenizeInline(docEntry: string): Token {
     if (docEntry.charAt(0) !== '{' || docEntry.charAt(docEntry.length - 1) !== '}') {
-      this._reportError('All inline tags should be wrapped inside curly braces.');
-      return;
+      // This is a program bug, since _tokenizeDocs() checks this condition before calling
+      this._reportError('The AEDoc tag is not enclosed in "{" and "}"');
     }
     const tokenContent: string = docEntry.slice(1, docEntry.length - 1).trim();
 
     if (tokenContent.charAt(0) !== '@') {
-      this._reportError('Content of inline tags should start with a leading \'@\'.');
+      // This is a program bug, since it should have already been validated by the Tokenizer
+      this._reportError('The AEDoc tag does not start with "@".');
       return;
     }
 
     const unescapedCurlyBraces: RegExp = /([^\\])({|}[^$])/gi;
     if (unescapedCurlyBraces.test(tokenContent)) {
-      this._reportError(`Unescaped '{' or '}' detected inside an inline tag. ` +
-        'Use \\ to escape curly braces inside inline tags.');
+      this._reportError(`An unescaped "{" or "}" character was found inside an inline tag. ` +
+        'Use a backslash ("\\") to escape curly braces.');
       return;
     }
 
@@ -93,20 +94,21 @@ export default class Tokenizer {
     const tokenChunks: string[] = tokenContent.split(/\s+/gi);
     if (tokenChunks[0] === '@link') {
       if (tokenChunks.length < 2) {
-        this._reportError('Too few parameters for @link inline tag.');
+        this._reportError('The {@link} tag must include a URL or API item reference');
         return;
       }
 
       tokenChunks.shift(); // Gets rid of '@link'
-      const token: Token = new Token(TokenType.Inline, '@link', tokenChunks.join(' '));
+      const token: Token = new Token(TokenType.InlineTag, '@link', tokenChunks.join(' '));
       return token;
     } else if (tokenChunks[0] === '@inheritdoc') {
       tokenChunks.shift(); // Gets rid of '@inheritdoc'
-      const token: Token = new Token(TokenType.Inline, '@inheritdoc', tokenChunks.join(' '));
+      const token: Token = new Token(TokenType.InlineTag, '@inheritdoc', tokenChunks.join(' '));
       return token;
     }
 
-    this._reportError('Unknown tag name for inline tag.');
+    // This is a program bug
+    this._reportError('Invalid call to _tokenizeInline()');
     return;
   }
 

--- a/libraries/api-extractor/src/definitions/ApiDocumentation.ts
+++ b/libraries/api-extractor/src/definitions/ApiDocumentation.ts
@@ -339,7 +339,7 @@ export default class ApiDocumentation {
     }
 
     if (releaseTagCount > 1) {
-      this.reportError('More than one one release tag (@alpha, @beta, etc) was specified');
+      this.reportError('More than one release tag (@alpha, @beta, etc) was specified');
     }
 
     if (this.preapproved && this.releaseTag !== ReleaseTag.Internal) {

--- a/libraries/api-extractor/src/definitions/ApiItem.ts
+++ b/libraries/api-extractor/src/definitions/ApiItem.ts
@@ -379,7 +379,7 @@ abstract class ApiItem {
     if (this.kind === ApiItemKind.Package) {
       if (this.documentation.releaseTag !== ReleaseTag.None) {
         const tag: string = '@' + ReleaseTag[this.documentation.releaseTag].toLowerCase();
-        this.reportError(`The ${tag} tag is not allowed on the package, which is always public`);
+        this.reportError(`The ${tag} tag is not allowed on the package, which is always considered to be @public`);
       }
     }
 
@@ -391,8 +391,8 @@ abstract class ApiItem {
     }
 
     if (this.documentation.isDocInheritedDeprecated && this.documentation.deprecatedMessage.length === 0) {
-      this.reportError('inheritdoc source item is deprecated. ' +
-        'Must provide @deprecated message or remove @inheritdoc inline tag.');
+      this.reportError('The @inheritdoc target has been marked as @deprecated.  ' +
+        'Add a @deprecated message here, or else remove the @inheritdoc relationship.');
     }
   }
 

--- a/libraries/api-extractor/src/definitions/ApiNamespace.ts
+++ b/libraries/api-extractor/src/definitions/ApiNamespace.ts
@@ -34,7 +34,10 @@ export default class ApiNamespace extends ApiItemContainer {
         const followedSymbol: ts.Symbol = this.followAliases(exportSymbol);
 
         if (!followedSymbol.declarations) {
-          this.reportWarning(`Definition with no declarations: ${exportSymbol.name}`);
+          // This is an API Extractor bug, but it could happen e.g. if we upgrade to a new
+          // version of the TypeScript compiler that introduces new AST variations that we
+          // haven't tested before.
+          this.reportWarning(`The definition "${exportSymbol.name}" has no declarations`);
           continue;
         }
 
@@ -68,16 +71,16 @@ export default class ApiNamespace extends ApiItemContainer {
           continue;
         }
 
-        // Typescript VariableDeclaration exist within a VariableDeclarationList,
-        // the VariableDeclarationList exists within a VariableStatement and
-        // this is where the JSDoc comment Node exists.
+        // Typescript's VariableDeclaration AST nodes have an VariableDeclarationList parent,
+        // and the VariableDeclarationList exists within a VariableStatement, which is where
+        // the JSDoc comment Node can be found.
         // If there is no parent or grandparent of this VariableDeclartion then
         // we do not know how to obtain the JSDoc comment.
         let jsdocNode: ts.Node;
         if (!declaration.parent || !declaration.parent.parent ||
           declaration.parent.parent.kind !== ts.SyntaxKind.VariableStatement) {
-          this.reportWarning(`Export "${exportSymbol.name}" expected to have a 'grand' parent ` +
-            '"VariableStatement" in order to obtain JSDoc comment');
+          this.reportWarning(`Unable to locate the documentation node for "${exportSymbol.name}"; `
+            + `this may be an API Extractor bug`);
         } else {
           jsdocNode = declaration.parent.parent;
         }

--- a/libraries/api-extractor/src/definitions/ApiPackage.ts
+++ b/libraries/api-extractor/src/definitions/ApiPackage.ts
@@ -53,6 +53,9 @@ export default class ApiPackage extends ApiItemContainer {
         const followedSymbol: ts.Symbol = this.followAliases(exportSymbol);
 
         if (!followedSymbol.declarations) {
+          // This is an API Extractor bug, but it could happen e.g. if we upgrade to a new
+          // version of the TypeScript compiler that introduces new AST variations that we
+          // haven't tested before.
           this.reportWarning(`Definition with no declarations: ${exportSymbol.name}`);
           continue;
         }

--- a/libraries/api-extractor/src/definitions/ApiStructuredType.ts
+++ b/libraries/api-extractor/src/definitions/ApiStructuredType.ts
@@ -96,8 +96,10 @@ export default class ApiStructuredType extends ApiItemContainer {
     // Throw errors for setters that don't have a corresponding getter
     this._setterNames.forEach((setterName: string) => {
       if (!this.getMemberItem(setterName)) {
-        this.reportError(`Found setter named ${setterName} with no corresponding getter. \
-          WriteOnly properties are prohibited.`);
+        // Normally we treat API design changes as warnings rather than errors.  However,
+        // a missing getter is bizarre enough that it's reasonable to assume it's a mistake,
+        // not a conscious design choice.
+        this.reportError(`The "${setterName}" property has a setter, but no a getter`);
       }
     });
   }

--- a/libraries/api-extractor/src/definitions/test/ApiDocumentation.test.ts
+++ b/libraries/api-extractor/src/definitions/test/ApiDocumentation.test.ts
@@ -66,20 +66,19 @@ describe('ApiDocumentation tests', function (): void {
        */
 
       assert.equal(capturedErrors.length, 8);
-      assert.equal(capturedErrors[0].message, 'Cannot provide summary in AEDoc if @inheritdoc tag is given');
-      assert.equal(capturedErrors[1].message, 'Unknown AEDoc tag "@badAedocTag"');
-      assert.equal(capturedErrors[2].message, 'Unknown tag name for inline tag.');
-      assert.equal(capturedErrors[3].message, 'Too few parameters for @link inline tag.');
+      assert.equal(capturedErrors[0].message, 'A summary block is not allowed here, because the @inheritdoc'
+        + ' target provides the summary');
+      assert.equal(capturedErrors[1].message, 'The JSDoc tag "@badAedocTag" is not supported by AEDoc');
+      assert.equal(capturedErrors[2].message, 'Invalid call to _tokenizeInline()');
+      assert.equal(capturedErrors[3].message, 'The {@link} tag must include a URL or API item reference');
       assert.equal(capturedErrors[4].message, 'Unexpected text in AEDoc comment: "can not contain a tag"');
-      assert.equal(capturedErrors[5].message, 'More than one release tag was specified');
-      assert.equal(
-        capturedErrors[6].message,
-        'An API item reference must use the notation: "@scopeName/packageName:exportName.memberName"'
+      assert.equal(capturedErrors[5].message, 'More than one release tag (@alpha, @beta, etc) was specified');
+      assert.equal(capturedErrors[6].message, 'An API item reference must use the notation:'
+        + ' "@scopeName/packageName:exportName.memberName"'
       );
-      assert.equal(
-        capturedErrors[7].message,
-        'inheritdoc source item is deprecated. Must provide @deprecated message or remove @inheritdoc inline tag.');
-  });
+      assert.equal(capturedErrors[7].message, 'The @inheritdoc target has been marked as @deprecated.  '
+        + 'Add a @deprecated message here, or else remove the @inheritdoc relationship.');
+    });
 
     it('Should parse release tag', function (): void {
       const expectedReleaseTag: ReleaseTag = ReleaseTag.Public;

--- a/libraries/api-extractor/src/generators/test/ApiFileGenerator.test.ts
+++ b/libraries/api-extractor/src/generators/test/ApiFileGenerator.test.ts
@@ -63,7 +63,7 @@ describe('ApiFileGenerator tests', function (): void {
        * Errors can be found in testInputs/folder/MyClass
        */
       assert.equal(capturedErrors.length, 2);
-      assert.equal(capturedErrors[0].message, 'Unknown AEDoc tag "@badAedocTag"');
+      assert.equal(capturedErrors[0].message, 'The JSDoc tag "@badAedocTag" is not supported by AEDoc');
       assert.equal(capturedErrors[1].message, 'Unexpected text in AEDoc comment: '
         + '"(Error #1 is the bad tag) Text can no..."');
     });

--- a/libraries/api-extractor/src/test/DocElementParser.test.ts
+++ b/libraries/api-extractor/src/test/DocElementParser.test.ts
@@ -280,7 +280,8 @@ describe('DocElementParser tests', function (): void {
         errorMessage = error;
       }
       assert.isUndefined(errorMessage);
-      assertCapturedErrors(['Invalid @link parameter, URL must be a single string.']);
+      assertCapturedErrors(['The {@link} tag contains additional spaces after the URL; if the URL'
+        +  ' contains spaces, encode them using %20; for display text, use a pipe delimiter ("|")']);
     });
 
     it('Should parse @link with API defintion reference', (): void => {
@@ -346,7 +347,7 @@ describe('DocElementParser tests', function (): void {
         errorMessage = error;
       }
       assert.isNotNull(errorMessage);
-      assertCapturedErrors(['Invalid @link parameters, at most one pipe character allowed.']);
+      assertCapturedErrors(['The {@link} tag contains more than one pipe character ("|")']);
     });
   });
 });

--- a/libraries/api-extractor/src/test/DocElementParser.test.ts
+++ b/libraries/api-extractor/src/test/DocElementParser.test.ts
@@ -221,7 +221,7 @@ describe('DocElementParser tests', function (): void {
       assertCapturedErrors([]);
     });
 
-    it('Should parse @link with url', (): void => {
+    it('Should parse @link with URL', (): void => {
       clearCapturedErrors();
       const docs: string = '{@link https://microsoft.com}';
       const tokenizer: Tokenizer = new Tokenizer(docs, console.log);
@@ -243,7 +243,7 @@ describe('DocElementParser tests', function (): void {
       assertCapturedErrors([]);
     });
 
-    it('Should parse @link with url and text', (): void => {
+    it('Should parse @link with URL and text', (): void => {
       clearCapturedErrors();
       const docs: string = '{@link https://microsoft.com | microsoft home}';
       const tokenizer: Tokenizer = new Tokenizer(docs, console.log);
@@ -280,7 +280,7 @@ describe('DocElementParser tests', function (): void {
         errorMessage = error;
       }
       assert.isUndefined(errorMessage);
-      assertCapturedErrors(['Invalid @link parameter, url must be a single string.']);
+      assertCapturedErrors(['Invalid @link parameter, URL must be a single string.']);
     });
 
     it('Should parse @link with API defintion reference', (): void => {

--- a/libraries/api-extractor/src/test/DocItemLoader.test.ts
+++ b/libraries/api-extractor/src/test/DocItemLoader.test.ts
@@ -63,7 +63,8 @@ describe('DocItemLoader tests', function (): void {
 
       assert.equal(capturedErrors.length, 2);
       assert.equal(capturedErrors[0].message, 'circular reference');
-      assert.equal(capturedErrors[1].message, 'Unable to link to "Internal" API item');
+      assert.equal(capturedErrors[1].message, 'The {@link} tag references an @internal or @alpha API item,'
+        + ' which will not appear in the generated documentation');
       TestFileComparer.assertFileMatchesExpected(outputJsonFile, expectedJsonFile);
       TestFileComparer.assertFileMatchesExpected(outputApiFile, expectedApiFile);
     });

--- a/libraries/api-extractor/src/test/Token.test.ts
+++ b/libraries/api-extractor/src/test/Token.test.ts
@@ -18,13 +18,13 @@ describe('Token tests', function (): void {
       assert.equal(token.tag, '');
       assert.equal(token.text, 'Some text');
 
-      token = new Token(TokenType.Tag, '@tagA');
-      assert.equal(token.type, TokenType.Tag);
+      token = new Token(TokenType.BlockTag, '@tagA');
+      assert.equal(token.type, TokenType.BlockTag);
       assert.equal(token.tag, '@tagA');
       assert.equal(token.text, '');
 
-      token = new Token(TokenType.Inline, '@link', 'http://www.microsoft.com');
-      assert.equal(token.type, TokenType.Inline);
+      token = new Token(TokenType.InlineTag, '@link', 'http://www.microsoft.com');
+      assert.equal(token.type, TokenType.InlineTag);
       assert.equal(token.tag, '@link');
       assert.equal(token.text, 'http://www.microsoft.com');
     });
@@ -42,7 +42,7 @@ describe('Token tests', function (): void {
       assert.equal(errorThrown, false);
 
       try {
-        token.requireType(TokenType.Tag);
+        token.requireType(TokenType.BlockTag);
       } catch (error) {
         errorThrown = true;
       }

--- a/libraries/api-extractor/src/test/Tokenizer.test.ts
+++ b/libraries/api-extractor/src/test/Tokenizer.test.ts
@@ -37,11 +37,11 @@ describe('Tokenizer tests', function (): void {
 
       const expectedTokens: Token[] = [
         new Token(TokenType.Text, '', 'this is a mock documentation'),
-        new Token(TokenType.Tag, '@taga'),
+        new Token(TokenType.BlockTag, '@taga'),
         new Token(TokenType.Text, '', 'hi'),
-        new Token(TokenType.Tag, '@tagb'),
+        new Token(TokenType.BlockTag, '@tagb'),
         new Token(TokenType.Text, '', 'hello @invalid@tag email@domain.com'),
-        new Token(TokenType.Tag, '@tagc'),
+        new Token(TokenType.BlockTag, '@tagc'),
         new Token(TokenType.Text, '', 'this is'),
         new Token(TokenType.Text, '', 'and this is {just curly braces}')
       ];
@@ -54,7 +54,7 @@ describe('Tokenizer tests', function (): void {
 
     it('tokenizeInline()', function (): void {
       const token: string = '{    @link   https://bing.com  |  Bing  }';
-      const expectedToken: Token = new Token(TokenType.Inline, '@link', 'https://bing.com | Bing');
+      const expectedToken: Token = new Token(TokenType.InlineTag, '@link', 'https://bing.com | Bing');
       const actualToken: Token = testTokenizer.tokenizeInline(token);
       assert.equal(expectedToken.type, actualToken.type);
       assert.equal(expectedToken.tag, actualToken.tag);

--- a/libraries/api-extractor/testInputs/example2/example2-output.json
+++ b/libraries/api-extractor/testInputs/example2/example2-output.json
@@ -216,7 +216,7 @@
           "summary": [
             {
               "kind": "textDocElement",
-              "value": "This doc has {curly braces} which is valid but the inline @link token is missing a pipe between the url and the display text"
+              "value": "This doc has {curly braces} which is valid but the inline @link token is missing a pipe between the URL and the display text"
             },
             {
               "kind": "textDocElement",

--- a/libraries/api-extractor/testInputs/example2/src/MyDocumentedClass.ts
+++ b/libraries/api-extractor/testInputs/example2/src/MyDocumentedClass.ts
@@ -131,7 +131,7 @@ export default class MyDocumentedClass {
 
   /**
    * This doc has {curly braces} which is valid but the inline \@link token is missing a
-   * pipe between the url and the display text {@link validURL \{text\}}
+   * pipe between the URL and the display text {@link validURL \{text\}}
    * The displayName is not allowed to have non word characters.
    */
   // (Error #9)


### PR DESCRIPTION
I reviewed all the `reportWarning()` and `reportError()` calls, and cleaned up the error messages.