### PR TITLE
Fix a bug with handling of @link tags for API Extractor

### DIFF
--- a/common/changes/@microsoft/api-extractor/pgonzal-ae-pipe-bug_2017-06-19-19-29.json
+++ b/common/changes/@microsoft/api-extractor/pgonzal-ae-pipe-bug_2017-06-19-19-29.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor",
+      "comment": "Fix a bug with parsing of @link tags",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/libraries/api-extractor/src/DocElementParser.ts
+++ b/libraries/api-extractor/src/DocElementParser.ts
@@ -9,7 +9,7 @@ import ResolvedApiItem from './ResolvedApiItem';
 export default class DocElementParser {
   /**
    * Used to validate the display text for an \@link tag.  The display text can contain any
-   * characters except for certain reserved AEDoc delimiters: "@", "|", "{", "}".
+   * characters except for certain AEDoc delimiters: "@", "|", "{", "}".
    * This RegExp matches the first bad character.
    * Example: "Microsoft's {spec}" --> "{"
    */
@@ -152,7 +152,7 @@ export default class DocElementParser {
       return undefined;
     }
 
-    const addressPart: string = pipeSplitContent.length > 0 ? pipeSplitContent[0] : '';
+    const addressPart: string = pipeSplitContent[0];
     const displayTextPart: string = pipeSplitContent.length > 1 ? pipeSplitContent[1] : '';
 
     // Try to guess if the tokenContent is a link or API definition reference

--- a/libraries/api-extractor/src/DocElementParser.ts
+++ b/libraries/api-extractor/src/DocElementParser.ts
@@ -199,7 +199,7 @@ export default class DocElementParser {
     if (displayTextPart) {
       const match: RegExpExecArray | undefined = this._displayTextBadCharacterRegEx.exec(displayTextPart);
       if (match) {
-        documentation.reportError(`The {@link} tag\'s display text contains an unsupported `
+        documentation.reportError(`The {@link} tag\'s display text contains an unsupported`
           + ` character: "${match[0]}"`);
         return undefined;
       }

--- a/libraries/api-extractor/src/test/DocElementParser.test.ts
+++ b/libraries/api-extractor/src/test/DocElementParser.test.ts
@@ -101,7 +101,7 @@ describe('DocElementParser tests', function (): void {
               kind: 'linkDocElement',
               referenceType: 'href',
               targetUrl: 'https://github.com/OfficeDev/office-ui-fabric-react',
-              value: ''
+              value: 'https://github.com/OfficeDev/office-ui-fabric-react'
         } as IHrefLinkElement
       ];
       const actualSummary: IDocElement[] = DocElementParser.parse(myDocumentedClass.documentation, tokenizer);
@@ -203,7 +203,7 @@ describe('DocElementParser tests', function (): void {
               kind: 'linkDocElement',
               referenceType: 'href',
               targetUrl: 'http://wikipedia.org/pixel_units',
-              value: ''
+              value: 'http://wikipedia.org/pixel_units'
           } as IHrefLinkElement
       ];
       const expectedParam: IParam = {
@@ -239,7 +239,7 @@ describe('DocElementParser tests', function (): void {
       const linkDocElement: IHrefLinkElement = (docElements[0] as IHrefLinkElement);
       assert.equal(linkDocElement.referenceType, 'href');
       assert.equal(linkDocElement.targetUrl, 'https://microsoft.com');
-      assert.equal(linkDocElement.value, '');
+      assert.equal(linkDocElement.value, 'https://microsoft.com');
       assertCapturedErrors([]);
     });
 

--- a/libraries/api-extractor/src/test/DocElementParser.test.ts
+++ b/libraries/api-extractor/src/test/DocElementParser.test.ts
@@ -284,7 +284,25 @@ describe('DocElementParser tests', function (): void {
         +  ' contains spaces, encode them using %20; for display text, use a pipe delimiter ("|")']);
     });
 
-    it('Should parse @link with API defintion reference', (): void => {
+    it('Should reject @link with bad display text character', (): void => {
+      clearCapturedErrors();
+
+      const docs: string = '{@link https://example.com | Ex@ample}';
+      const tokenizer: Tokenizer = new Tokenizer(docs, console.log);
+
+      let docElements: IDocElement[];
+      /* tslint:disable-next-line:no-any */
+      let errorMessage: any;
+      try {
+        docElements = DocElementParser.parse(myDocumentedClass.documentation, tokenizer);
+      } catch (error) {
+        errorMessage = error;
+      }
+      assert.isUndefined(errorMessage);
+      assertCapturedErrors(['The {@link} tag\'s display text contains an unsupported character: "@"']);
+    });
+
+    it('Should parse @link with API definition reference', (): void => {
       clearCapturedErrors();
       const docs: string = '{@link @microsoft/sp-core-library:Guid.equals}';
       const tokenizer: Tokenizer = new Tokenizer(docs, console.log);

--- a/libraries/api-extractor/testInputs/example3/example3-output.json
+++ b/libraries/api-extractor/testInputs/example3/example3-output.json
@@ -344,7 +344,8 @@
           "scopeName": "",
           "packageName": "",
           "exportName": "publicEnum",
-          "memberName": ""
+          "memberName": "",
+          "value": "publicEnum"
         },
         {
           "kind": "linkDocElement",
@@ -352,7 +353,8 @@
           "scopeName": "",
           "packageName": "",
           "exportName": "internalEnum",
-          "memberName": ""
+          "memberName": "",
+          "value": "internalEnum"
         }
       ],
       "remarks": [],


### PR DESCRIPTION
API Extractor `@link` tags can include optional display text.  For example, "widgets" and "draw() function" in this sample code:

```javascript
/**
 * The base class for all {@link https://en.wikipedia.org/wiki/Widget | widgets}.
 * @remarks
 * Implements the {@link @microsoft/widget-lib:IWidget} interface.  To draw the widget,
 * call the {@link BaseWidget.draw | draw() function}.
 * @public
 */
```

This PR fixes a bug where certain characters (e.g. an apostrophe) were not allowed in the display text.

It also changes the API JSON semantics slightly:  Before, if display text was omitted, the `value` field would be an empty string, leaving the documentation generator to determine the display text based on the address.  After this PR, API Extractor always provides the display text.