### PR TITLE
API Extractor now warns when an @internal definition is missing the underscore prefix

### DIFF
--- a/common/changes/@microsoft/api-extractor/pgonzal-ae-underscore-prefix_2017-06-19-20-20.json
+++ b/common/changes/@microsoft/api-extractor/pgonzal-ae-underscore-prefix_2017-06-19-20-20.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor",
+      "comment": "API Extractor now issues warnings for @internal definitions that are not prefixed with an underscore",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/libraries/api-extractor/src/definitions/ApiDocumentation.ts
+++ b/libraries/api-extractor/src/definitions/ApiDocumentation.ts
@@ -404,10 +404,13 @@ export default class ApiDocumentation {
 
       // If the apiDefinitionRef can not be found the resolvedApiItem will be
       // undefined and an error will have been reported via this.reportError
-      if (resolvedApiItem && resolvedApiItem.releaseTag === ReleaseTag.Internal
-        || resolvedApiItem.releaseTag === ReleaseTag.Alpha) {
-        this.reportError('The {@link} tag references an @internal or @alpha API item, '
-          + 'which will not appear in the generated documentation');
+      if (resolvedApiItem) {
+        if (resolvedApiItem.releaseTag === ReleaseTag.Internal
+          || resolvedApiItem.releaseTag === ReleaseTag.Alpha) {
+
+          this.reportError('The {@link} tag references an @internal or @alpha API item, '
+            + 'which will not appear in the generated documentation');
+        }
       }
     }
   }

--- a/libraries/api-extractor/src/definitions/ApiItem.ts
+++ b/libraries/api-extractor/src/definitions/ApiItem.ts
@@ -403,8 +403,8 @@ abstract class ApiItem {
       }
     } else {
       if (this.documentation.releaseTag === ReleaseTag.Internal) {
-        this.reportWarning('Because this definition is marked as @internal, an underscore prefix ("_") should'
-          + ' be added to its name');
+        this.reportWarning('Because this definition is explicitly marked as @internal, an underscore prefix ("_")'
+          + ' should be added to its name');
       }
     }
   }

--- a/libraries/api-extractor/src/definitions/ApiItem.ts
+++ b/libraries/api-extractor/src/definitions/ApiItem.ts
@@ -394,6 +394,19 @@ abstract class ApiItem {
       this.reportError('The @inheritdoc target has been marked as @deprecated.  ' +
         'Add a @deprecated message here, or else remove the @inheritdoc relationship.');
     }
+
+    if (this.name.substr(0, 1) === '_') {
+      if (this.documentation.releaseTag !== ReleaseTag.Internal
+        && this.documentation.releaseTag !== ReleaseTag.None) {
+        this.reportWarning('The underscore prefix ("_") should only be used with definitions'
+          + ' that are explicitly marked as @internal');
+      }
+    } else {
+      if (this.documentation.releaseTag === ReleaseTag.Internal) {
+        this.reportWarning('Because this definition is marked as @internal, an underscore prefix ("_") should'
+          + ' be added to its name');
+      }
+    }
   }
 
   /**

--- a/libraries/api-extractor/src/test/DocItemLoader.test.ts
+++ b/libraries/api-extractor/src/test/DocItemLoader.test.ts
@@ -19,6 +19,11 @@ function testErrorHandler(message: string, fileName: string, lineNumber: number)
   capturedErrors.push({ message, fileName, lineNumber });
 }
 
+function assertCapturedErrors(expectedMessages: string[]): void {
+  assert.deepEqual(capturedErrors.map(x => x.message), expectedMessages,
+    'The captured errors did not match the expected output.');
+}
+
 // These warnings would normally be printed at the bottom
 // of the source package's '*.api.ts' file.
 const warnings: string[] = [];
@@ -61,10 +66,11 @@ describe('DocItemLoader tests', function (): void {
       const apiFileGenerator: ApiFileGenerator = new ApiFileGenerator();
       apiFileGenerator.writeApiFile(outputApiFile, extractor);
 
-      assert.equal(capturedErrors.length, 2);
-      assert.equal(capturedErrors[0].message, 'circular reference');
-      assert.equal(capturedErrors[1].message, 'The {@link} tag references an @internal or @alpha API item,'
-        + ' which will not appear in the generated documentation');
+      assertCapturedErrors([
+        'circular reference',
+        'The {@link} tag references an @internal or @alpha API item,'
+          + ' which will not appear in the generated documentation'
+      ]);
       TestFileComparer.assertFileMatchesExpected(outputJsonFile, expectedJsonFile);
       TestFileComparer.assertFileMatchesExpected(outputApiFile, expectedApiFile);
     });

--- a/libraries/api-extractor/testInputs/example1/example1-output.api.ts
+++ b/libraries/api-extractor/testInputs/example1/example1-output.api.ts
@@ -3,6 +3,18 @@ class ___proto__ {
   public propertyIsEnumerable: string;
 }
 
+// WARNING: propertyWithNoType has incomplete type information
+// @internal
+class _InternalClass {
+  // (undocumented)
+  public test(): void;
+}
+
+// @internal (preapproved)
+class _PreapprovedInternalClass {
+}
+
+
 // (undocumented)
 class A extends __proto__, implements hasOwnProperty {
   // (undocumented)
@@ -13,10 +25,10 @@ class A extends __proto__, implements hasOwnProperty {
 
 // @public
 class AliasClass4 {
+  // @internal
+  public _aliasFunc(): void;
   // (undocumented)
   public aliasField: number;
-  // @internal
-  public aliasFunc(): void;
   // (undocumented)
   public readonly shouldBeReadOnly: number;
 }
@@ -43,13 +55,6 @@ interface hasOwnProperty {
   ___lookupSetter__: __proto__;
 }
 
-// WARNING: propertyWithNoType has incomplete type information
-// @internal
-class InternalClass {
-  // (undocumented)
-  public test(): void;
-}
-
 // (undocumented)
 class MyClass {
   // (undocumented)
@@ -59,11 +64,6 @@ class MyClass {
   // (undocumented)
   public test(): void;
 }
-
-// @internal (preapproved)
-class PreapprovedInternalClass {
-}
-
 
 // (undocumented)
 export function publicFunction(param: number): string;

--- a/libraries/api-extractor/testInputs/example1/example1-output.api.ts
+++ b/libraries/api-extractor/testInputs/example1/example1-output.api.ts
@@ -6,6 +6,7 @@ class ___proto__ {
 // WARNING: propertyWithNoType has incomplete type information
 // @internal
 class _InternalClass {
+  public _internalMethodWithRedundantUnderscore(): void;
   // (undocumented)
   public test(): void;
 }
@@ -42,10 +43,16 @@ class AlphaTaggedClass {
 
 // @beta
 class BetaTaggedClass {
+  // WARNING: The underscore prefix ("_") should only be used with definitions that are explicitly marked as @internal
+  // @alpha
+  public _alphaMethodWithBadUnderscore(): void;
   // @internal
   public _internalMethod(): void;
   // @alpha
   public alphaMethod(): void;
+  // WARNING: Because this definition is explicitly marked as @internal, an underscore prefix ("_") should be added to its name
+  // @internal
+  public internalMethodMissingUnderscore(): void;
   public plainMethod(): void;
 }
 

--- a/libraries/api-extractor/testInputs/example1/folder/AliasClass.ts
+++ b/libraries/api-extractor/testInputs/example1/folder/AliasClass.ts
@@ -10,12 +10,11 @@ export class AliasClass {
    * AEDoc for aliasFunc()
    * @internal
    */
-  public aliasFunc(): void {
-    console.log('this is a public API');
+  public _aliasFunc(): void {
+    console.log('this is an internal API');
   }
+
   public aliasField: number;
-
-
 
   public get shouldBeReadOnly(): number {
     return this.readOnlyNumber;

--- a/libraries/api-extractor/testInputs/example1/folder/MyClass.ts
+++ b/libraries/api-extractor/testInputs/example1/folder/MyClass.ts
@@ -44,6 +44,13 @@ export class InternalClass {
   public test(): void {
     console.log('this is a public API');
   }
+
+  /**
+   * This *implicitly* internal method should NOT have an underscore.
+   * API Extractor currently does NOT issue a warning for this case.
+   */
+  public _internalMethodWithRedundantUnderscore(): void {
+  }
 }
 
 /**

--- a/libraries/api-extractor/testInputs/example1/folder/ReleaseTagTests.ts
+++ b/libraries/api-extractor/testInputs/example1/folder/ReleaseTagTests.ts
@@ -42,6 +42,20 @@ export class BetaTaggedClass {
    */
   public alphaMethod(): void {
   }
+
+  /**
+   * This internal method should have an underscore.
+   * @internal
+   */
+  public internalMethodMissingUnderscore(): void {
+  }
+
+  /**
+   * This alpha method should have an underscore.
+   * @alpha
+   */
+  public _alphaMethodWithBadUnderscore(): void {
+  }
 }
 
 /**

--- a/libraries/api-extractor/testInputs/example1/index.ts
+++ b/libraries/api-extractor/testInputs/example1/index.ts
@@ -1,6 +1,13 @@
 import OtherName from './folder/AliasClass2';
 
-export { default as MyClass, InternalClass, PreapprovedInternalClass, __proto__, hasOwnProperty, A } from './folder/MyClass';
+export {
+  default as MyClass, InternalClass as _InternalClass,
+  PreapprovedInternalClass as _PreapprovedInternalClass,
+  __proto__,
+  hasOwnProperty,
+  A
+} from './folder/MyClass';
+
 export { AliasClass3 as AliasClass4 } from './folder/AliasClass3';
 
 function privateFunction(): number {

--- a/libraries/api-extractor/testInputs/example3/example3-output.api.ts
+++ b/libraries/api-extractor/testInputs/example3/example3-output.api.ts
@@ -1,3 +1,7 @@
+// @internal
+enum _internalEnum {
+}
+
 enum inheritEnumValues {
   index_one = 1,
   index_zero = 0
@@ -16,10 +20,6 @@ enum inheritLocalOptionOne {
 
 // WARNING: Unable to find referenced member "MyClass.methodWithTwoParams"
 export function inheritLocalOptionTwoFunction(): void;
-
-// @internal
-enum internalEnum {
-}
 
 interface IStructuredTypeInherit {
   thisIsTypeLiteral: [{name: string, age: number}];

--- a/libraries/api-extractor/testInputs/example3/example3-output.json
+++ b/libraries/api-extractor/testInputs/example3/example3-output.json
@@ -351,7 +351,7 @@
           "referenceType": "code",
           "scopeName": "",
           "packageName": "",
-          "exportName": "internalEnum",
+          "exportName": "_internalEnum",
           "memberName": ""
         }
       ],

--- a/libraries/api-extractor/testInputs/example3/src/MyClass.ts
+++ b/libraries/api-extractor/testInputs/example3/src/MyClass.ts
@@ -4,7 +4,7 @@
 export enum inheritLocalOptionOne {
 }
 
-/** 
+/**
  * {@inheritdoc MyClass.methodWithTwoParams }
  */
 // (Error #1) methodWithTwoParams not a member of MyClass
@@ -27,7 +27,7 @@ export enum inheritEnumValues {
 }
 
 /**
- * We will try to inheritdoc the documentation for 
+ * We will try to inheritdoc the documentation for
  * one of the enum value's documentation.
  */
 export enum sourceEnumValuesDoc{
@@ -36,7 +36,7 @@ export enum sourceEnumValuesDoc{
    */
   zero = 0,
   /**
-   * We will also try to inherit this. 
+   * We will also try to inherit this.
    */
   one = 1
 }
@@ -114,10 +114,10 @@ export interface IStructuredTypeSource {
 }
 
 /**
- * Here we test that an error is reported when attempting to link to an 
+ * Here we test that an error is reported when attempting to link to an
  * internal API item.
  * {@link publicEnum}
- * {@link internalEnum}
+ * {@link _internalEnum}
  */
 export enum testingLinks {
 }
@@ -125,16 +125,16 @@ export enum testingLinks {
 /**
  * This enum is public and any API items can safely inherit documentation
  * or link to this item.
- * 
+ *
  * @public
  */
 export enum publicEnum {
 }
 
 /**
- * This enum is internal and an error should be reported 
+ * This enum is internal and an error should be reported
  * if any API items inherit or link to this item.
- * 
+ *
  * @internal
  */
 export enum internalEnum {

--- a/libraries/api-extractor/testInputs/example3/src/index.ts
+++ b/libraries/api-extractor/testInputs/example3/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * This example folder is used to test the functionality of DocItemLoader and API reference resolution. 
+ * This example folder is used to test the functionality of DocItemLoader and API reference resolution.
  */
 declare const packageDescription: void;
 
@@ -16,6 +16,6 @@ export {
     IStructuredTypeSource,
     testingLinks,
     publicEnum,
-    internalEnum
+    internalEnum as _internalEnum
 } from './MyClass';
 export { default as MyClass } from './MyClass';


### PR DESCRIPTION
When a definition is *explicitly* marked as `@internal`, an underscore prefix should be added to its *exported* name.  Some examples:

```typescript
/** @internal */
// The underscore is optional here, because an underscore is being
// applied separately where MyClass is exported.
class MyClass {
  // The myMethod() member is implicitly internal because
  // it's part of an internal class
  public myMethod(): void { // <-- MUST NOT have underscore
  }
}

/** @public */
class MyPublicClass { // <-- MUST NOT have underscore 
  /** @internal */
  public _myInternalMethod(): void { // <-- MUST have underscore  
  }
}

let _MyClass = MyClass;
export default _MyClass;
```