### PR TITLE
Fix how shell command is executed on mac.

### DIFF
--- a/apps/rush-lib/src/utilities/Utilities.ts
+++ b/apps/rush-lib/src/utilities/Utilities.ts
@@ -302,9 +302,11 @@ export default class Utilities {
   ): child_process.SpawnSyncReturns<Buffer> {
     let shellCommand: string = process.env.comspec || 'cmd';
     let commandFlags: string = '/d /s /c';
+    let useShell: boolean = true;
     if (process.platform !== 'win32') {
       shellCommand = 'sh';
       commandFlags = '-c';
+      useShell = false;
     }
 
     const result: child_process.SpawnSyncReturns<Buffer> = child_process.spawnSync(
@@ -312,7 +314,7 @@ export default class Utilities {
       [commandFlags, command],
       {
         cwd: workingDirectory,
-        shell: false,
+        shell: useShell,
         env: environmentVariables,
         stdio: captureOutput ? ['pipe', 'pipe', 'pipe'] : [0, 1, 2]
       });
@@ -336,9 +338,11 @@ export default class Utilities {
   ): child_process.ChildProcess {
     let shellCommand: string = process.env.comspec || 'cmd';
     let commandFlags: string = '/d /s /c';
+    let useShell: boolean = true;
     if (process.platform !== 'win32') {
       shellCommand = 'sh';
       commandFlags = '-c';
+      useShell = false;
     }
 
     return child_process.spawn(
@@ -346,7 +350,7 @@ export default class Utilities {
       [commandFlags, command],
       {
         cwd: workingDirectory,
-        shell: false,
+        shell: useShell,
         env: environmentVariables,
         stdio: captureOutput ? ['pipe', 'pipe', 'pipe'] : [0, 1, 2]
       });

--- a/apps/rush-lib/src/utilities/Utilities.ts
+++ b/apps/rush-lib/src/utilities/Utilities.ts
@@ -312,7 +312,7 @@ export default class Utilities {
       [commandFlags, command],
       {
         cwd: workingDirectory,
-        shell: true,
+        shell: false,
         env: environmentVariables,
         stdio: captureOutput ? ['pipe', 'pipe', 'pipe'] : [0, 1, 2]
       });
@@ -346,7 +346,7 @@ export default class Utilities {
       [commandFlags, command],
       {
         cwd: workingDirectory,
-        shell: true,
+        shell: false,
         env: environmentVariables,
         stdio: captureOutput ? ['pipe', 'pipe', 'pipe'] : [0, 1, 2]
       });


### PR DESCRIPTION
Processing script parameters is tricky and different on different os. Avoid running sh on top of sh on mac. But windows needs cmd to run on shell to run properly. 