### PR TITLE
Improve watch()

### DIFF
--- a/common/changes/@microsoft/gulp-core-build/nickpape-test_2017-06-27-23-14.json
+++ b/common/changes/@microsoft/gulp-core-build/nickpape-test_2017-06-27-23-14.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/gulp-core-build",
+      "comment": "Improve watch() so that it will automatically begin excecuting and it will not exit if there is a failure on the initial build.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/gulp-core-build",
+  "email": "nickpape@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/gulp-core-build/nickpape-test_2017-06-27-23-16.json
+++ b/common/changes/@microsoft/gulp-core-build/nickpape-test_2017-06-27-23-16.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/gulp-core-build",
-      "comment": "Improve watch() so that it will automatically begin excecuting and it will not exit if there is a failure on the initial build.",
+      "comment": "Improve watch() so that it will automatically begin excecuting and it will not exit if there is a failure on the initial build",
       "type": "patch"
     }
   ],

--- a/common/changes/@microsoft/web-library-build/nickpape-test_2017-06-27-23-16.json
+++ b/common/changes/@microsoft/web-library-build/nickpape-test_2017-06-27-23-16.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/web-library-build",
+      "comment": "Fix an issue with 'gulp serve' where an initial build error would stop  watch from continuing",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/web-library-build",
+  "email": "nickpape@users.noreply.github.com"
+}

--- a/core-build/gulp-core-build/src/index.ts
+++ b/core-build/gulp-core-build/src/index.ts
@@ -194,7 +194,7 @@ export function watch(watchMatch: string | string[], task: IExecutable): IExecut
 
   return {
     execute: (buildConfig: IBuildConfig): Promise<void> => {
-      return new Promise<void>((resolve: () => void, reject: () => void) => {
+      return new Promise<void>(() => {
 
         function _runWatch(): Promise<void> {
           if (isWatchRunning) {

--- a/core-build/gulp-core-build/src/index.ts
+++ b/core-build/gulp-core-build/src/index.ts
@@ -189,6 +189,9 @@ export function watch(watchMatch: string | string[], task: IExecutable): IExecut
   let shouldRerunWatch: boolean = false;
   let lastError: boolean = undefined;
 
+  const successMessage: string = 'Build succeeded';
+  const failureMessage: string = 'Build failed';
+
   return {
     execute: (buildConfig: IBuildConfig): Promise<void> => {
       return new Promise<void>((resolve: () => void, reject: () => void) => {
@@ -196,7 +199,6 @@ export function watch(watchMatch: string | string[], task: IExecutable): IExecut
         function _runWatch(): Promise<void> {
           if (isWatchRunning) {
             shouldRerunWatch = true;
-            console.log('Watch is already running!');
           } else {
             isWatchRunning = true;
 
@@ -207,12 +209,12 @@ export function watch(watchMatch: string | string[], task: IExecutable): IExecut
 
                   if (buildConfig.showToast) {
                     notifier.notify({
-                      title: 'Build succeeded',
+                      title: successMessage,
                       message: packageJSON.name,
                       icon: buildConfig.buildSuccessIconPath
                     });
                   } else {
-                    log('Build succeeded');
+                    log(successMessage);
                   }
                 }
                 return _finalizeWatch();
@@ -223,12 +225,12 @@ export function watch(watchMatch: string | string[], task: IExecutable): IExecut
 
                   if (buildConfig.showToast) {
                     notifier.notify({
-                      title: 'Build failed',
+                      title: failureMessage,
                       message: error,
                       icon: buildConfig.buildErrorIconPath
                     });
                   } else {
-                    log('Build failure!');
+                    log(failureMessage);
                   }
                 }
 

--- a/core-build/gulp-core-build/src/index.ts
+++ b/core-build/gulp-core-build/src/index.ts
@@ -246,6 +246,7 @@ export function watch(watchMatch: string | string[], task: IExecutable): IExecut
             shouldRerunWatch = false;
             return _runWatch();
           }
+          return Promise.resolve();
         }
 
         setWatchMode();

--- a/core-build/test-web-library-build/config/pre-copy.json
+++ b/core-build/test-web-library-build/config/pre-copy.json
@@ -1,7 +1,7 @@
 {
   "copyTo": {
-    "src": [
-      "preCopyTest.ts"
+    "lib": [
+      "preCopyTest.js"
     ]
   }
 }

--- a/core-build/test-web-library-build/src/preCopyTest.d.ts
+++ b/core-build/test-web-library-build/src/preCopyTest.d.ts
@@ -1,0 +1,1 @@
+export default function preCopyTest(): void;

--- a/core-build/test-web-library-build/src/preCopyTest.js
+++ b/core-build/test-web-library-build/src/preCopyTest.js
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-export default function preCopyTest(): void {
+export default function preCopyTest() {
   /* no-op */
 }

--- a/core-build/web-library-build/src/index.ts
+++ b/core-build/web-library-build/src/index.ts
@@ -39,7 +39,7 @@ const sourceMatch: string[] = [
   '!src/**/*.scss.ts'
 ];
 
-const PRODUCTION = !!getConfig().args['--production'] || !!getConfig().args['--ship'];
+const PRODUCTION = !!getConfig().args['production'] || !!getConfig().args['ship'];
 setConfig({
   production: PRODUCTION,
   shouldWarningsFailBuild: PRODUCTION

--- a/core-build/web-library-build/src/index.ts
+++ b/core-build/web-library-build/src/index.ts
@@ -11,7 +11,7 @@ import {
   task,
   watch,
   setConfig,
-
+  getConfig
 } from '@microsoft/gulp-core-build';
 import { apiExtractor, typescript, tslint, text } from '@microsoft/gulp-core-build-typescript';
 import { sass } from '@microsoft/gulp-core-build-sass';
@@ -39,7 +39,7 @@ const sourceMatch: string[] = [
   '!src/**/*.scss.ts'
 ];
 
-const PRODUCTION = process.argv.indexOf('--production') !== -1 || process.argv.indexOf('--ship') !== -1;
+const PRODUCTION = !!getConfig().args['--production'] || !!getConfig().args['--ship'];
 setConfig({
   production: PRODUCTION,
   shouldWarningsFailBuild: PRODUCTION
@@ -65,14 +65,9 @@ task('test-watch', watch(sourceMatch, testTasks));
 
 // For watch scenarios like serve, make sure to exclude generated files from src (like *.scss.ts.)
 task('serve',
-  serial(
-    bundleTasks,
-    serve,
-    postProcessSourceMapsTask,
-    watch(
-      sourceMatch, serial(preCopy, sass, compileTsTasks,
-        postCopy, webpack, postProcessSourceMapsTask, reload)
-    )
+  watch(
+    sourceMatch, serial(preCopy, sass, compileTsTasks,
+      postCopy, webpack, postProcessSourceMapsTask, reload)
   )
 );
 


### PR DESCRIPTION
* We were experiencing an issue where, if there was a build error, "gulp serve" was ending instead of continuing to watch files for changes.
* This was because we had defined the build tasks twice, once in the watch() block, but again in a serial() block enveloping the two.
* After removing the duplicate build steps, I noticed the issue was that watch() was not kicked off unless there was a file change. Therefore, watch() was changed so that it would always initially invoke itself. 
* While doing that I noticed some issues with the promises (e.g. watch was reporting to gcb that it was completing before it actually was), so I fixed that issue by removing the `return Promise.resolve()` and replacing it with a Promise block that never returns.