### PR TITLE
Add version policy configuration and a Rush action to enforce version policy

### DIFF
--- a/apps/rush-lib/package.json
+++ b/apps/rush-lib/package.json
@@ -23,6 +23,7 @@
     "@types/z-schema": "3.16.31",
     "fs-extra": "~0.26.7",
     "jju": "~1.3.0",
+    "lodash": "~4.15.0",
     "rimraf": "~2.5.4",
     "semver": "~5.3.0",
     "z-schema": "~3.17.0"
@@ -33,6 +34,7 @@
     "gulp": "~3.9.1",
     "mocha": "~2.5.3",
     "sinon": "~1.17.3",
+    "@types/lodash": "4.14.52",
     "@types/sinon": "1.16.34",
     "@types/mocha": "2.2.38",
     "@types/chai": "3.4.34",

--- a/apps/rush-lib/src/RushConstants.ts
+++ b/apps/rush-lib/src/RushConstants.ts
@@ -81,4 +81,9 @@ export namespace RushConstants {
    * command to determine if a particular project needs to be rebuilt.
    */
   export const packageDepsFilename: string = 'package-deps.json';
+
+  /**
+   * @alpha
+   */
+  export const versionPoliciesFileName: string = 'version-policies.json';
 }

--- a/apps/rush-lib/src/data/RushConfiguration.ts
+++ b/apps/rush-lib/src/data/RushConfiguration.ts
@@ -523,10 +523,24 @@ export default class RushConfiguration {
 
   /**
    * Gets the version policy by its name.
+   * Throws error if the version policy is not found.
    * @param policyName - Name of the version policy
+   * @alpha
    */
   public getVersionPolicy(policyName: string): VersionPolicy {
-    return this._versionPolicies.get(policyName);
+    const policy: VersionPolicy = this._versionPolicies.get(policyName);
+    if (!policy) {
+      throw new Error('Failed to find version policy by name \'${policyName}\'');
+    }
+    return policy;
+  }
+
+  /**
+   * Gets all the version policies
+   * @alpha
+   */
+  public get versionPolicies(): Map<string, VersionPolicy> {
+    return this._versionPolicies;
   }
 
   private _populateDownstreamDependencies(dependencies: { [key: string]: string }, packageName: string): void {

--- a/apps/rush-lib/src/data/RushConfiguration.ts
+++ b/apps/rush-lib/src/data/RushConfiguration.ts
@@ -26,7 +26,8 @@ const knownRushConfigFilenames: string[] = [
   RushConstants.npmShrinkwrapFilename,
   RushConstants.pinnedVersionsFilename,
   RushConstants.browserApprovedPackagesFilename,
-  RushConstants.nonbrowserApprovedPackagesFilename
+  RushConstants.nonbrowserApprovedPackagesFilename,
+  RushConstants.versionPoliciesFileName
 ];
 
 /**
@@ -596,7 +597,8 @@ export default class RushConfiguration {
       this._eventHooks = new EventHooks(rushConfigurationJson.eventHooks);
     }
 
-    const versionPolicyConfigFile: string = path.join(this._commonRushConfigFolder, 'version-policies.json');
+    const versionPolicyConfigFile: string = path.join(this._commonRushConfigFolder,
+      RushConstants.versionPoliciesFileName);
     this._versionPolicyConfiguration = new VersionPolicyConfiguration(versionPolicyConfigFile);
 
     this._projects = [];

--- a/apps/rush-lib/src/data/RushConfigurationProject.ts
+++ b/apps/rush-lib/src/data/RushConfigurationProject.ts
@@ -8,7 +8,6 @@ import JsonFile from '../utilities/JsonFile';
 import Utilities from '../utilities/Utilities';
 import RushConfiguration from '../data/RushConfiguration';
 import { RushConstants } from '../RushConstants';
-import { VersionPolicy } from './VersionPolicy';
 
 /**
  * This represents the JSON data object for a project entry in the rush.json configuration file.
@@ -36,7 +35,7 @@ export default class RushConfigurationProject {
   private _tempProjectName: string;
   private _tempPackageJsonFilename: string;
   private _cyclicDependencyProjects: Set<string>;
-  private _verionPolicy: VersionPolicy;
+  private _versionPolicyName: string;
   private _shouldPublish: boolean;
   private _downstreamDependencyProjects: string[];
 
@@ -109,9 +108,7 @@ export default class RushConfigurationProject {
     }
     this._downstreamDependencyProjects = [];
     this._shouldPublish = !!projectJson.shouldPublish;
-    if (projectJson.versionPolicyName) {
-      this._verionPolicy = rushConfiguration.getVersionPolicy(projectJson.versionPolicyName);
-    }
+    this._versionPolicyName = projectJson.versionPolicyName;
   }
 
   /**
@@ -201,14 +198,14 @@ export default class RushConfigurationProject {
    * should be published during `rush publish`.
    */
   public get shouldPublish(): boolean {
-    return this._shouldPublish || !!this._verionPolicy;
+    return this._shouldPublish || !!this._versionPolicyName;
   }
 
   /**
    * The version policy used by this project.
    * @alpha
    */
-  public get versionPolicy(): VersionPolicy {
-    return this._verionPolicy;
+  public get versionPolicyName(): string {
+    return this._versionPolicyName;
   }
 }

--- a/apps/rush-lib/src/data/RushConfigurationProject.ts
+++ b/apps/rush-lib/src/data/RushConfigurationProject.ts
@@ -8,6 +8,7 @@ import JsonFile from '../utilities/JsonFile';
 import Utilities from '../utilities/Utilities';
 import RushConfiguration from '../data/RushConfiguration';
 import { RushConstants } from '../RushConstants';
+import { VersionPolicy } from './VersionPolicy';
 
 /**
  * This represents the JSON data object for a project entry in the rush.json configuration file.
@@ -17,6 +18,7 @@ export interface IRushConfigurationProjectJson {
   projectFolder: string;
   reviewCategory?: string;
   cyclicDependencyProjects: string[];
+  versionPolicyName?: string;
   shouldPublish?: boolean;
 }
 
@@ -34,6 +36,7 @@ export default class RushConfigurationProject {
   private _tempProjectName: string;
   private _tempPackageJsonFilename: string;
   private _cyclicDependencyProjects: Set<string>;
+  private _verionPolicy: VersionPolicy;
   private _shouldPublish: boolean;
   private _downstreamDependencyProjects: string[];
 
@@ -106,6 +109,9 @@ export default class RushConfigurationProject {
     }
     this._downstreamDependencyProjects = [];
     this._shouldPublish = !!projectJson.shouldPublish;
+    if (projectJson.versionPolicyName) {
+      this._verionPolicy = rushConfiguration.getVersionPolicy(projectJson.versionPolicyName);
+    }
   }
 
   /**
@@ -195,6 +201,14 @@ export default class RushConfigurationProject {
    * should be published during `rush publish`.
    */
   public get shouldPublish(): boolean {
-    return this._shouldPublish;
+    return this._shouldPublish || !!this._verionPolicy;
+  }
+
+  /**
+   * The version policy used by this project.
+   * @alpha
+   */
+  public get versionPolicy(): VersionPolicy {
+    return this._verionPolicy;
   }
 }

--- a/apps/rush-lib/src/data/VersionPolicy.ts
+++ b/apps/rush-lib/src/data/VersionPolicy.ts
@@ -1,14 +1,22 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
+import { cloneDeep } from 'lodash';
+import { SemVer } from 'semver';
+
 import {
   IVersionPolicyJson,
   ILockStepVersionJson,
   IIndividualVersionJson
 } from './RushConfiguration';
 
+import IPackageJson from '../utilities/IPackageJson';
+
+import RushConfigurationProject from './RushConfigurationProject';
+
 /**
  * Type of version bumps
+ * @alpha
  */
 export enum BumpType {
   'prerelease',
@@ -20,6 +28,7 @@ export enum BumpType {
 
 /**
  * Version policy base type names
+ * @alpha
  */
 export enum BaseTypeName {
   'lockStepVersion',
@@ -28,8 +37,9 @@ export enum BaseTypeName {
 
 /**
  * This is the base class for version policy which controls how versions get bumped.
+ * @alpha
  */
-export class VersionPolicy {
+export abstract class VersionPolicy {
   private _policyName: string;
   private _baseType: BaseTypeName;
 
@@ -55,32 +65,47 @@ export class VersionPolicy {
   public get baseType(): BaseTypeName {
     return this._baseType;
   }
+
+  public abstract ensure(project: RushConfigurationProject): IPackageJson | undefined;
 }
 
 /**
  * This policy indicates all related projects should use the same version.
+ * @alpha
  */
 export class LockStepVersionPolicy extends VersionPolicy {
-  private _version: string;
+  private _version: SemVer;
   private _nextBump: BumpType;
 
   constructor(versionPolicyJson: ILockStepVersionJson) {
     super(versionPolicyJson);
-    this._version = versionPolicyJson.version;
+    this._version = new SemVer(versionPolicyJson.version);
     this._nextBump = BumpType[versionPolicyJson.nextBump];
   }
 
-  public get version(): string {
+  public get version(): SemVer {
     return this._version;
   }
 
   public get nextBump(): BumpType {
     return this._nextBump;
   }
+
+  public ensure(project: RushConfigurationProject): IPackageJson | undefined {
+    const packageVersion: SemVer = new SemVer(project.packageJson.version);
+    if (packageVersion.format() === this._version.format()) {
+      // No need to update the project
+      return undefined;
+    }
+    const updatedProject: IPackageJson = cloneDeep(project.packageJson);
+    updatedProject.version = this._version.format();
+    return updatedProject;
+  }
 }
 
 /**
  * This policy indicates all related projects get version bump driven by their own changes.
+ * @alpha
  */
 export class IndividualVersionPolicy extends VersionPolicy {
   private _lockedMajor: number | undefined;
@@ -92,5 +117,18 @@ export class IndividualVersionPolicy extends VersionPolicy {
 
   public get lockedMajor(): number | undefined {
     return this._lockedMajor;
+  }
+
+  public ensure(project: RushConfigurationProject): IPackageJson | undefined {
+    if (this.lockedMajor) {
+      const version: SemVer = new SemVer(project.packageJson.version);
+      if (version.major !== this._lockedMajor) {
+        const updatedProject: IPackageJson = cloneDeep(project.packageJson);
+        version.major = this._lockedMajor;
+        updatedProject.version = version.format();
+        return updatedProject;
+      }
+    }
+    return undefined;
   }
 }

--- a/apps/rush-lib/src/data/VersionPolicy.ts
+++ b/apps/rush-lib/src/data/VersionPolicy.ts
@@ -8,7 +8,7 @@ import {
   IVersionPolicyJson,
   ILockStepVersionJson,
   IIndividualVersionJson
-} from './RushConfiguration';
+} from './VersionPolicyConfiguration';
 
 import IPackageJson from '../utilities/IPackageJson';
 
@@ -28,7 +28,7 @@ export enum BumpType {
  * Version policy base type names
  * @alpha
  */
-export enum BaseTypeName {
+export enum VersionPolicyDefinitionName {
   'lockStepVersion',
   'individualVersion'
 }
@@ -39,13 +39,13 @@ export enum BaseTypeName {
  */
 export abstract class VersionPolicy {
   private _policyName: string;
-  private _baseType: BaseTypeName;
+  private _definitionName: VersionPolicyDefinitionName;
 
   public static load(versionPolicyJson: IVersionPolicyJson): VersionPolicy {
-    const baseTypeName: BaseTypeName = BaseTypeName[versionPolicyJson.baseType];
-    if (baseTypeName === BaseTypeName.lockStepVersion) {
+    const definition: VersionPolicyDefinitionName = VersionPolicyDefinitionName[versionPolicyJson.definitionName];
+    if (definition === VersionPolicyDefinitionName.lockStepVersion) {
       return new LockStepVersionPolicy(versionPolicyJson as ILockStepVersionJson);
-    } else if (baseTypeName === BaseTypeName.individualVersion) {
+    } else if (definition === VersionPolicyDefinitionName.individualVersion) {
       return new IndividualVersionPolicy(versionPolicyJson as IIndividualVersionJson);
     }
     return undefined;
@@ -53,15 +53,15 @@ export abstract class VersionPolicy {
 
   constructor(versionPolicyJson: IVersionPolicyJson) {
     this._policyName = versionPolicyJson.policyName;
-    this._baseType = BaseTypeName[versionPolicyJson.baseType];
+    this._definitionName = VersionPolicyDefinitionName[versionPolicyJson.definitionName];
   }
 
   public get policyName(): string {
     return this._policyName;
   }
 
-  public get baseType(): BaseTypeName {
-    return this._baseType;
+  public get definitionName(): VersionPolicyDefinitionName {
+    return this._definitionName;
   }
 
   public abstract ensure(project: IPackageJson): IPackageJson | undefined;

--- a/apps/rush-lib/src/data/VersionPolicy.ts
+++ b/apps/rush-lib/src/data/VersionPolicy.ts
@@ -1,0 +1,96 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import {
+  IVersionPolicyJson,
+  ILockStepVersionJson,
+  IIndividualVersionJson
+} from './RushConfiguration';
+
+/**
+ * Type of version bumps
+ */
+export enum BumpType {
+  'prerelease',
+  'release',
+  'patch',
+  'minor',
+  'major'
+}
+
+/**
+ * Version policy base type names
+ */
+export enum BaseTypeName {
+  'lockStepVersion',
+  'individualVersion'
+}
+
+/**
+ * This is the base class for version policy which controls how versions get bumped.
+ */
+export class VersionPolicy {
+  private _policyName: string;
+  private _baseType: BaseTypeName;
+
+  public static load(versionPolicyJson: IVersionPolicyJson): VersionPolicy {
+    const baseTypeName: BaseTypeName = BaseTypeName[versionPolicyJson.baseType];
+    if (baseTypeName === BaseTypeName.lockStepVersion) {
+      return new LockStepVersionPolicy(versionPolicyJson as ILockStepVersionJson);
+    } else if (baseTypeName === BaseTypeName.individualVersion) {
+      return new IndividualVersionPolicy(versionPolicyJson as IIndividualVersionJson);
+    }
+    return undefined;
+  }
+
+  constructor(versionPolicyJson: IVersionPolicyJson) {
+    this._policyName = versionPolicyJson.policyName;
+    this._baseType = BaseTypeName[versionPolicyJson.baseType];
+  }
+
+  public get policyName(): string {
+    return this._policyName;
+  }
+
+  public get baseType(): BaseTypeName {
+    return this._baseType;
+  }
+}
+
+/**
+ * This policy indicates all related projects should use the same version.
+ */
+export class LockStepVersionPolicy extends VersionPolicy {
+  private _version: string;
+  private _nextBump: BumpType;
+
+  constructor(versionPolicyJson: ILockStepVersionJson) {
+    super(versionPolicyJson);
+    this._version = versionPolicyJson.version;
+    this._nextBump = BumpType[versionPolicyJson.nextBump];
+  }
+
+  public get version(): string {
+    return this._version;
+  }
+
+  public get nextBump(): BumpType {
+    return this._nextBump;
+  }
+}
+
+/**
+ * This policy indicates all related projects get version bump driven by their own changes.
+ */
+export class IndividualVersionPolicy extends VersionPolicy {
+  private _lockedMajor: number | undefined;
+
+  constructor(versionPolicyJson: IIndividualVersionJson) {
+    super(versionPolicyJson);
+    this._lockedMajor = versionPolicyJson.lockedMajor;
+  }
+
+  public get lockedMajor(): number | undefined {
+    return this._lockedMajor;
+  }
+}

--- a/apps/rush-lib/src/data/VersionPolicyConfiguration.ts
+++ b/apps/rush-lib/src/data/VersionPolicyConfiguration.ts
@@ -8,16 +8,25 @@ import JsonFile from '../utilities/JsonFile';
 
 import { VersionPolicy } from './VersionPolicy';
 
+/**
+ * @alpha
+ */
 export interface IVersionPolicyJson {
   policyName: string;
   definitionName: string;
 }
 
+/**
+ * @alpha
+ */
 export interface ILockStepVersionJson extends IVersionPolicyJson {
   version: string;
   nextBump: string;
 }
 
+/**
+ * @alpha
+ */
 export interface IIndividualVersionJson extends IVersionPolicyJson {
   lockedMajor?: number;
 }

--- a/apps/rush-lib/src/data/VersionPolicyConfiguration.ts
+++ b/apps/rush-lib/src/data/VersionPolicyConfiguration.ts
@@ -1,0 +1,78 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import * as path from 'path';
+import * as fsx from 'fs-extra';
+import JsonSchemaValidator from '../utilities/JsonSchemaValidator';
+import JsonFile from '../utilities/JsonFile';
+
+import { VersionPolicy } from './VersionPolicy';
+
+export interface IVersionPolicyJson {
+  policyName: string;
+  definitionName: string;
+}
+
+export interface ILockStepVersionJson extends IVersionPolicyJson {
+  version: string;
+  nextBump: string;
+}
+
+export interface IIndividualVersionJson extends IVersionPolicyJson {
+  lockedMajor?: number;
+}
+
+/**
+ * @alpha
+ */
+export class VersionPolicyConfiguration {
+  private _versionPolicies: Map<string, VersionPolicy>;
+
+  public constructor(private _jsonFileName: string) {
+    this._versionPolicies = new Map<string, VersionPolicy>();
+    this._loadFile();
+  }
+
+  /**
+   * Gets the version policy by its name.
+   * Throws error if the version policy is not found.
+   * @param policyName - Name of the version policy
+   * @alpha
+   */
+  public getVersionPolicy(policyName: string): VersionPolicy {
+    const policy: VersionPolicy = this._versionPolicies.get(policyName);
+    if (!policy) {
+      throw new Error(`Failed to find version policy by name \'${policyName}\'`);
+    }
+    return policy;
+  }
+
+  /**
+   * Gets all the version policies
+   * @alpha
+   */
+  public get versionPolicies(): Map<string, VersionPolicy> {
+    return this._versionPolicies;
+  }
+
+  private _loadFile(): void {
+    if (!fsx.existsSync(this._jsonFileName)) {
+      return;
+    }
+    const versionPolicyJson: IVersionPolicyJson[] = JsonFile.loadJsonFile(this._jsonFileName);
+
+    const schemaPath: string = path.join(__dirname, '../version-policies.schema.json');
+    const validator: JsonSchemaValidator = JsonSchemaValidator.loadFromFile(schemaPath);
+    validator.validateObject(versionPolicyJson, (errorDescription: string) => {
+      throw new Error(`Error parsing file '${path.basename(this._jsonFileName)}':\n`
+        + errorDescription);
+    });
+
+    versionPolicyJson.forEach(policyJson => {
+      const policy: VersionPolicy = VersionPolicy.load(policyJson);
+      if (policy) {
+        this._versionPolicies.set(policy.policyName, policy);
+      }
+    });
+  }
+}

--- a/apps/rush-lib/src/data/test/VersionPolicy.test.ts
+++ b/apps/rush-lib/src/data/test/VersionPolicy.test.ts
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+/// <reference types='mocha' />
+
+import * as path from 'path';
+import { assert } from 'chai';
+import RushConfiguration from '../RushConfiguration';
+
+import {
+  VersionPolicy,
+  LockStepVersionPolicy,
+  IndividualVersionPolicy,
+  BumpType
+} from '../VersionPolicy';
+
+describe('VersionPolicy', () => {
+  it('can load lockStepVersion.', () => {
+    const rushFilename: string = path.resolve(__dirname, 'jsonFiles', 'rushWithLockVersion.json');
+    const rushConfiguration: RushConfiguration = RushConfiguration.loadFromConfigurationFile(rushFilename);
+    const versionPolicy: VersionPolicy = rushConfiguration.getVersionPolicy('testPolicy1');
+    assert.isTrue(versionPolicy instanceof LockStepVersionPolicy, 'versionPolicy is a LockStepVersionPolicy');
+    const lockStepVersionPolicy: LockStepVersionPolicy = versionPolicy as LockStepVersionPolicy;
+    assert.equal(lockStepVersionPolicy.version, '1.1.0');
+    assert.equal(lockStepVersionPolicy.nextBump, BumpType.patch);
+  });
+
+  it('can load lockStepVersion.', () => {
+    const rushFilename: string = path.resolve(__dirname, 'jsonFiles', 'rushWithIndividualVersion.json');
+    const rushConfiguration: RushConfiguration = RushConfiguration.loadFromConfigurationFile(rushFilename);
+    const versionPolicy: VersionPolicy = rushConfiguration.getVersionPolicy('testPolicy2');
+    assert.isTrue(versionPolicy instanceof IndividualVersionPolicy, 'versionPolicy is a IndividualVersionPolicy');
+    const individualVersionPolicy: IndividualVersionPolicy = versionPolicy as IndividualVersionPolicy;
+    assert.equal(individualVersionPolicy.lockedMajor, 2);
+  });
+});

--- a/apps/rush-lib/src/data/test/VersionPolicy.test.ts
+++ b/apps/rush-lib/src/data/test/VersionPolicy.test.ts
@@ -5,7 +5,7 @@
 
 import * as path from 'path';
 import { assert } from 'chai';
-import RushConfiguration from '../RushConfiguration';
+import { VersionPolicyConfiguration } from '../VersionPolicyConfiguration';
 import IPackageJson from '../../utilities/IPackageJson';
 
 import {
@@ -17,9 +17,9 @@ import {
 
 describe('VersionPolicy', () => {
   describe('LockStepVersion', () => {
-    const rushFilename: string = path.resolve(__dirname, 'jsonFiles', 'rushWithLockVersion.json');
-    const rushConfiguration: RushConfiguration = RushConfiguration.loadFromConfigurationFile(rushFilename);
-    const versionPolicy: VersionPolicy = rushConfiguration.getVersionPolicy('testPolicy1');
+    const filename: string = path.resolve(__dirname, 'jsonFiles', 'rushWithLockVersion.json');
+    const versionPolicyConfig: VersionPolicyConfiguration = new VersionPolicyConfiguration(filename);
+    const versionPolicy: VersionPolicy = versionPolicyConfig.getVersionPolicy('testPolicy1');
 
     it('loads configuration.', () => {
       assert.isTrue(versionPolicy instanceof LockStepVersionPolicy, 'versionPolicy is a LockStepVersionPolicy');
@@ -62,9 +62,9 @@ describe('VersionPolicy', () => {
   });
 
   describe('IndividualVersionPolicy', () => {
-    const rushFilename: string = path.resolve(__dirname, 'jsonFiles', 'rushWithIndividualVersion.json');
-    const rushConfiguration: RushConfiguration = RushConfiguration.loadFromConfigurationFile(rushFilename);
-    const versionPolicy: VersionPolicy = rushConfiguration.getVersionPolicy('testPolicy2');
+    const fileName: string = path.resolve(__dirname, 'jsonFiles', 'rushWithIndividualVersion.json');
+    const versionPolicyConfig: VersionPolicyConfiguration = new VersionPolicyConfiguration(fileName);
+    const versionPolicy: VersionPolicy = versionPolicyConfig.getVersionPolicy('testPolicy2');
 
     it('loads configuration', () => {
       assert.isTrue(versionPolicy instanceof IndividualVersionPolicy, 'versionPolicy is a IndividualVersionPolicy');

--- a/apps/rush-lib/src/data/test/jsonFiles/rushWithIndividualVersion.json
+++ b/apps/rush-lib/src/data/test/jsonFiles/rushWithIndividualVersion.json
@@ -1,0 +1,17 @@
+{
+  "npmVersion": "4.5.0",
+  "rushMinimumVersion": "2.5.0",
+  "nodeSupportedVersionRange": ">=6.9.0 <7.0.0",
+  "projectFolderMinDepth": 1,
+  "projectFolderMaxDepth": 99,
+
+  "versionPolicies": [
+    {
+      "policyName": "testPolicy2",
+      "baseType": "individualVersion",
+      "lockedMajor": 2
+    }
+  ],
+
+  "projects": [ ]
+}

--- a/apps/rush-lib/src/data/test/jsonFiles/rushWithIndividualVersion.json
+++ b/apps/rush-lib/src/data/test/jsonFiles/rushWithIndividualVersion.json
@@ -1,17 +1,7 @@
-{
-  "npmVersion": "4.5.0",
-  "rushMinimumVersion": "2.5.0",
-  "nodeSupportedVersionRange": ">=6.9.0 <7.0.0",
-  "projectFolderMinDepth": 1,
-  "projectFolderMaxDepth": 99,
-
-  "versionPolicies": [
-    {
-      "policyName": "testPolicy2",
-      "baseType": "individualVersion",
-      "lockedMajor": 2
-    }
-  ],
-
-  "projects": [ ]
-}
+[
+  {
+    "policyName": "testPolicy2",
+    "definitionName": "individualVersion",
+    "lockedMajor": 2
+  }
+]

--- a/apps/rush-lib/src/data/test/jsonFiles/rushWithLockVersion.json
+++ b/apps/rush-lib/src/data/test/jsonFiles/rushWithLockVersion.json
@@ -1,0 +1,18 @@
+{
+  "npmVersion": "4.5.0",
+  "rushMinimumVersion": "2.5.0",
+  "nodeSupportedVersionRange": ">=6.9.0 <7.0.0",
+  "projectFolderMinDepth": 1,
+  "projectFolderMaxDepth": 99,
+
+  "versionPolicies": [
+    {
+      "policyName": "testPolicy1",
+      "baseType": "lockStepVersion",
+      "version": "1.1.0",
+      "nextBump": "patch"
+    }
+  ],
+
+  "projects": [ ]
+}

--- a/apps/rush-lib/src/data/test/jsonFiles/rushWithLockVersion.json
+++ b/apps/rush-lib/src/data/test/jsonFiles/rushWithLockVersion.json
@@ -1,18 +1,8 @@
-{
-  "npmVersion": "4.5.0",
-  "rushMinimumVersion": "2.5.0",
-  "nodeSupportedVersionRange": ">=6.9.0 <7.0.0",
-  "projectFolderMinDepth": 1,
-  "projectFolderMaxDepth": 99,
-
-  "versionPolicies": [
-    {
-      "policyName": "testPolicy1",
-      "baseType": "lockStepVersion",
-      "version": "1.1.0",
-      "nextBump": "patch"
-    }
-  ],
-
-  "projects": [ ]
-}
+[
+  {
+    "policyName": "testPolicy1",
+    "definitionName": "lockStepVersion",
+    "version": "1.1.0",
+    "nextBump": "patch"
+  }
+]

--- a/apps/rush-lib/src/index.ts
+++ b/apps/rush-lib/src/index.ts
@@ -92,7 +92,10 @@ export {
 } from './data/VersionPolicy';
 
 export {
-  VersionPolicyConfiguration
+  VersionPolicyConfiguration,
+  IVersionPolicyJson,
+  ILockStepVersionJson,
+  IIndividualVersionJson
 } from './data/VersionPolicyConfiguration';
 
 export {

--- a/apps/rush-lib/src/index.ts
+++ b/apps/rush-lib/src/index.ts
@@ -84,12 +84,16 @@ export {
 } from './rushVersion';
 
 export {
-  BaseTypeName,
+  VersionPolicyDefinitionName,
   BumpType,
   LockStepVersionPolicy,
   IndividualVersionPolicy,
   VersionPolicy
 } from './data/VersionPolicy';
+
+export {
+  VersionPolicyConfiguration
+} from './data/VersionPolicyConfiguration';
 
 export {
   default as Npm

--- a/apps/rush-lib/src/index.ts
+++ b/apps/rush-lib/src/index.ts
@@ -84,6 +84,14 @@ export {
 } from './rushVersion';
 
 export {
+  BaseTypeName,
+  BumpType,
+  LockStepVersionPolicy,
+  IndividualVersionPolicy,
+  VersionPolicy
+} from './data/VersionPolicy';
+
+export {
   default as Npm
 } from './utilities/Npm';
 

--- a/apps/rush-lib/src/rush.schema.json
+++ b/apps/rush-lib/src/rush.schema.json
@@ -113,6 +113,10 @@
           "shouldPublish": {
             "description": "A flag indicating that changes to this project will be published to npm, which affects the Rush change and publish workflows.",
             "type": "boolean"
+          },
+          "versionPolicyName": {
+            "description": "Name of the version policy associated with the project.",
+            "type": "string"
           }
         },
         "additionalProperties": false,

--- a/apps/rush-lib/src/rush.schema.json
+++ b/apps/rush-lib/src/rush.schema.json
@@ -80,8 +80,8 @@
       "items": {
         "type": "object",
         "oneOf": [
-          { "#ref": "#/definitions/lockStepVersion" },
-          { "#ref": "#/definitions/individualVersion" }
+          { "$ref": "#/definitions/lockStepVersion" },
+          { "$ref": "#/definitions/individualVersion" }
         ]
       }
     },
@@ -177,8 +177,7 @@
         },
         "version": {
           "description": "Current version for projects with lockStepVersion policy",
-          "type":"string",
-          "pattern": "todo"
+          "type":"string"
         },
         "nextBump": {
           "description": "Type of next version bump",

--- a/apps/rush-lib/src/rush.schema.json
+++ b/apps/rush-lib/src/rush.schema.json
@@ -74,6 +74,17 @@
       "description": "Indicates whether telemetry data should be collected and stored in the Rush temp folder during Rush runs.",
       "type": "boolean"
     },
+    "versionPolicies": {
+      "description": "A list of version policies used by projects",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "oneOf": [
+          { "#ref": "#/definitions/lockStepVersion" },
+          { "#ref": "#/definitions/individualVersion" }
+        ]
+      }
+    },
     "projects": {
       "description": "A list of projects managed by this tool.",
       "type": "array",
@@ -149,5 +160,54 @@
     }
   },
   "additionalProperties": false,
-  "required": [ "npmVersion", "rushMinimumVersion", "projects" ]
+  "required": [ "npmVersion", "rushMinimumVersion", "projects" ],
+  "definitions": {
+    "lockStepVersion": {
+      "type":"object",
+      "description": "Lockstep version policy",
+      "properties": {
+        "policyName": {
+          "description": "The name of the version policy",
+          "type": "string"
+        },
+        "baseType": {
+          "description": "The name of base version policy",
+          "type": "string",
+          "enum": [ "lockStepVersion" ]
+        },
+        "version": {
+          "description": "Current version for projects with lockStepVersion policy",
+          "type":"string",
+          "pattern": "todo"
+        },
+        "nextBump": {
+          "description": "Type of next version bump",
+          "enum": [ "prerelease", "release", "minor", "patch", "major" ]
+        }
+      },
+      "required": [ "policyName", "baseType", "version", "nextBump" ],
+      "additionalProperties": false
+    },
+    "individualVersion": {
+      "type":"object",
+      "description": "Lockstep version policy",
+      "properties": {
+        "policyName": {
+          "description": "The name of the version policy",
+          "type": "string"
+        },
+        "baseType": {
+          "description": "The name of base version policy",
+          "type": "string",
+          "enum": [ "individualVersion" ]
+        },
+        "lockedMajor": {
+          "description": "The locked major version",
+          "type": "number"
+        }
+      },
+      "required": [ "policyName", "baseType" ],
+      "additionalProperties": false
+    }
+  }
 }

--- a/apps/rush-lib/src/rush.schema.json
+++ b/apps/rush-lib/src/rush.schema.json
@@ -74,17 +74,6 @@
       "description": "Indicates whether telemetry data should be collected and stored in the Rush temp folder during Rush runs.",
       "type": "boolean"
     },
-    "versionPolicies": {
-      "description": "A list of version policies used by projects",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "oneOf": [
-          { "$ref": "#/definitions/lockStepVersion" },
-          { "$ref": "#/definitions/individualVersion" }
-        ]
-      }
-    },
     "projects": {
       "description": "A list of projects managed by this tool.",
       "type": "array",
@@ -115,7 +104,7 @@
             "type": "boolean"
           },
           "versionPolicyName": {
-            "description": "Name of the version policy associated with the project.",
+            "description": "An optional version policy associated with the project. Version policies are defined in \"version-policies.json file.",
             "type": "string"
           }
         },
@@ -164,53 +153,5 @@
     }
   },
   "additionalProperties": false,
-  "required": [ "npmVersion", "rushMinimumVersion", "projects" ],
-  "definitions": {
-    "lockStepVersion": {
-      "type":"object",
-      "description": "Lockstep version policy",
-      "properties": {
-        "policyName": {
-          "description": "The name of the version policy",
-          "type": "string"
-        },
-        "baseType": {
-          "description": "The name of base version policy",
-          "type": "string",
-          "enum": [ "lockStepVersion" ]
-        },
-        "version": {
-          "description": "Current version for projects with lockStepVersion policy",
-          "type":"string"
-        },
-        "nextBump": {
-          "description": "Type of next version bump",
-          "enum": [ "prerelease", "release", "minor", "patch", "major" ]
-        }
-      },
-      "required": [ "policyName", "baseType", "version", "nextBump" ],
-      "additionalProperties": false
-    },
-    "individualVersion": {
-      "type":"object",
-      "description": "Lockstep version policy",
-      "properties": {
-        "policyName": {
-          "description": "The name of the version policy",
-          "type": "string"
-        },
-        "baseType": {
-          "description": "The name of base version policy",
-          "type": "string",
-          "enum": [ "individualVersion" ]
-        },
-        "lockedMajor": {
-          "description": "The locked major version",
-          "type": "number"
-        }
-      },
-      "required": [ "policyName", "baseType" ],
-      "additionalProperties": false
-    }
-  }
+  "required": [ "npmVersion", "rushMinimumVersion", "projects" ]
 }

--- a/apps/rush-lib/src/version-policies.schema.json
+++ b/apps/rush-lib/src/version-policies.schema.json
@@ -1,0 +1,61 @@
+{
+  "title": "Rush version policy definitions",
+  "description": "For use with the Rush tool, this file defines version policies",
+
+  "type": "array",
+  "items": {
+    "type": "object",
+      "oneOf": [
+        { "$ref": "#/definitions/lockStepVersion" },
+        { "$ref": "#/definitions/individualVersion" }
+      ]
+  },
+  "definitions": {
+    "lockStepVersion": {
+      "type":"object",
+      "description": "Lockstep version policy",
+      "properties": {
+        "policyName": {
+          "description": "The name of the version policy",
+          "type": "string"
+        },
+        "definitionName": {
+          "description": "The name of version policy definition",
+          "type": "string",
+          "enum": [ "lockStepVersion" ]
+        },
+        "version": {
+          "description": "Current version for projects with lockStepVersion policy",
+          "type":"string"
+        },
+        "nextBump": {
+          "description": "Type of next version bump",
+          "enum": [ "prerelease", "release", "minor", "patch", "major" ]
+        }
+      },
+      "required": [ "policyName", "definitionName", "version", "nextBump" ],
+      "additionalProperties": false
+    },
+    "individualVersion": {
+      "type":"object",
+      "description": "Lockstep version policy",
+      "properties": {
+        "policyName": {
+          "description": "The name of the version policy",
+          "type": "string"
+        },
+        "definitionName": {
+          "description": "The name of version policy definition",
+          "type": "string",
+          "enum": [ "individualVersion" ]
+        },
+        "lockedMajor": {
+          "description": "The locked major version",
+          "type": "number"
+        }
+      },
+      "required": [ "policyName", "definitionName" ],
+      "additionalProperties": false
+    }
+  }
+}

--- a/apps/rush/src/actions/RushCommandLineParser.ts
+++ b/apps/rush/src/actions/RushCommandLineParser.ts
@@ -20,6 +20,7 @@ import PublishAction from './PublishAction';
 import RebuildAction from './RebuildAction';
 import UnlinkAction from './UnlinkAction';
 import ScanAction from './ScanAction';
+import VersionAction from './VersionAction';
 
 import Telemetry from '../utilities/Telemetry';
 
@@ -100,6 +101,7 @@ export default class RushCommandLineParser extends CommandLineParser {
       this.addAction(new RebuildAction(this));
       this.addAction(new ScanAction(this));
       this.addAction(new UnlinkAction(this));
+      this.addAction(new VersionAction(this));
     } catch (error) {
       this._exitAndReportError(error);
     }

--- a/apps/rush/src/actions/VersionAction.ts
+++ b/apps/rush/src/actions/VersionAction.ts
@@ -2,13 +2,19 @@
 // See LICENSE in the project root for license information.
 
 import { EOL } from 'os';
+import * as fsx from 'fs-extra';
+import * as path from 'path';
+import * as semver from 'semver';
 
 import {
   CommandLineFlagParameter,
   CommandLineStringParameter
 } from '@microsoft/ts-command-line';
 import {
-  IPackageJson
+  IPackageJson,
+  IChangeInfo,
+  ChangeType,
+  RushConfigurationProject
 } from '@microsoft/rush-lib';
 
 import RushCommandLineParser from './RushCommandLineParser';
@@ -16,6 +22,7 @@ import GitPolicy from '../utilities/GitPolicy';
 import { BaseRushAction } from './BaseRushAction';
 import { VersionManager } from '../utilities/VersionManager';
 import { Git } from '../utilities/Git';
+import ChangelogGenerator from '../utilities/ChangelogGenerator';
 
 export default class VersionAction extends BaseRushAction {
   private _parser: RushCommandLineParser;
@@ -77,21 +84,77 @@ export default class VersionAction extends BaseRushAction {
       const tempBranch: string = 'version/ensure-' + new Date().getTime();
       const git: Git = new Git(this._targetBranch.value);
 
-      // Make changes in temp branch.
-      git.checkout(tempBranch, true);
       const updatedPackages: Map<string, IPackageJson> = this._versionManager.ensure(this._versionPolicy.value);
+      if (updatedPackages) {
+        console.log(`${updatedPackages.size} packages are getting updated.`);
+        this._updateFiles(updatedPackages);
+        // Make changes in temp branch.
+        git.checkout(tempBranch, true);
 
-      // Stage, commit, and push the changes to remote temp branch.
-      git.addChanges();
-      git.commit();
-      git.push(tempBranch);
+        // Stage, commit, and push the changes to remote temp branch.
+        git.addChanges();
+        git.commit();
+        git.push(tempBranch);
 
-      // Now merge to target branch.
-      git.checkout(this._targetBranch.value);
-      git.pull();
-      git.merge(tempBranch);
-      git.push(this._targetBranch.value);
-      git.deleteBranch(tempBranch);
+        // Now merge to target branch.
+        git.checkout(this._targetBranch.value);
+        git.pull();
+        git.merge(tempBranch);
+        git.push(this._targetBranch.value);
+        git.deleteBranch(tempBranch);
+      }
     }
+  }
+
+  private _updateFiles(updatedPackages: Map<string, IPackageJson>): void {
+    updatedPackages.forEach((newPackageJson, packageName) => {
+      const rushProject: RushConfigurationProject = this.rushConfiguration.getProjectByName(packageName);
+      // Update package.json
+      const packagePath: string = path.join(rushProject.projectFolder, 'package.json');
+      fsx.writeFileSync(packagePath, JSON.stringify(newPackageJson, undefined, 2), 'utf8');
+
+      if (newPackageJson.version !== rushProject.packageJson.version) {
+        // If package version changes, add an entry to changelog
+        const change: IChangeInfo = this._createChangeInfo(newPackageJson, rushProject);
+        ChangelogGenerator.updateIndividualChangelog(change,
+          rushProject.projectFolder,
+          true);
+      }
+      // TODO: if only package dependency changes, add change file.
+    });
+  }
+
+  private _createChangeInfo(newPackageJson: IPackageJson,
+    rushProject: RushConfigurationProject
+  ): IChangeInfo {
+    const changeType: ChangeType = this._getChangeType(rushProject.packageJson.version,
+      newPackageJson.version);
+    // TODO: need to absorb all existing change files
+    return {
+      changeType: changeType,
+      newVersion: newPackageJson.version,
+      packageName: newPackageJson.name,
+      changes: [
+        {
+          changeType: changeType,
+          comment: `Version bump to ${newPackageJson.version}`,
+          newVersion: newPackageJson.version,
+          packageName: newPackageJson.name
+        }
+      ]
+    };
+  }
+
+  private _getChangeType(oldVersionString: string, newVersionString: string): ChangeType {
+    const diff: string = semver.diff(oldVersionString, newVersionString);
+    let changeType: ChangeType = ChangeType.none;
+    if (diff === 'major') {
+      changeType = ChangeType.major;
+    } else if (diff === 'minor') {
+      changeType = ChangeType.minor;
+    } else if (diff === 'patch') {
+      changeType = ChangeType.patch;
+    }
+    return changeType;
   }
 }

--- a/apps/rush/src/actions/VersionAction.ts
+++ b/apps/rush/src/actions/VersionAction.ts
@@ -36,7 +36,7 @@ export default class VersionAction extends BaseRushAction {
   constructor(parser: RushCommandLineParser) {
     super({
       actionVerb: 'version',
-      summary: 'Manage package versions in the repo.',
+      summary: '(EXPERIMENTAL) Manage package versions in the repo.',
       documentation: 'use this "rush version" command to ensure version policies and bump versions.'
     });
     this._parser = parser;

--- a/apps/rush/src/actions/VersionAction.ts
+++ b/apps/rush/src/actions/VersionAction.ts
@@ -1,0 +1,97 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import { EOL } from 'os';
+
+import {
+  CommandLineFlagParameter,
+  CommandLineStringParameter
+} from '@microsoft/ts-command-line';
+import {
+  IPackageJson
+} from '@microsoft/rush-lib';
+
+import RushCommandLineParser from './RushCommandLineParser';
+import GitPolicy from '../utilities/GitPolicy';
+import { BaseRushAction } from './BaseRushAction';
+import { VersionManager } from '../utilities/VersionManager';
+import { Git } from '../utilities/Git';
+
+export default class VersionAction extends BaseRushAction {
+  private _parser: RushCommandLineParser;
+  private _ensureVersionPolicy: CommandLineFlagParameter;
+  private _bumpVersion: CommandLineFlagParameter;
+  private _versionPolicy: CommandLineStringParameter;
+  private _bypassPolicy: CommandLineFlagParameter;
+  private _targetBranch: CommandLineStringParameter;
+  private _versionManager: VersionManager;
+
+  constructor(parser: RushCommandLineParser) {
+    super({
+      actionVerb: 'version',
+      summary: 'Manage package versions in the repo.',
+      documentation: 'use this "rush version" command to ensure version policies and bump versions.'
+    });
+    this._parser = parser;
+  }
+
+  protected onDefineParameters(): void {
+    this._targetBranch = this.defineStringParameter({
+      parameterLongName: '--target-branch',
+      parameterShortName: '-b',
+      key: 'BRANCH',
+      description:
+      'If this flag is specified, changes will be committed and merged into the target branch.'
+    });
+    this._ensureVersionPolicy = this.defineFlagParameter({
+      parameterLongName: '--ensure-version-policy',
+      parameterShortName: '-e',
+      description: 'Updates package versions if needed to satisfy version policies.'
+    });
+    this._bumpVersion = this.defineFlagParameter({
+      parameterLongName: '--bump',
+      description: 'Bumps package version based on version policies.'
+    });
+    this._bypassPolicy = this.defineFlagParameter({
+      parameterLongName: '--bypass-policy',
+      description: 'Overrides "gitPolicy" enforcement (use honorably!)'
+    });
+    this._versionPolicy = this.defineStringParameter({
+      parameterLongName: '--version-policy',
+      parameterShortName: '-p',
+      description: 'The name of the version policy'
+    });
+  }
+
+  protected run(): void {
+    if (!this._bypassPolicy.value) {
+      if (!GitPolicy.check(this.rushConfiguration)) {
+        process.exit(1);
+        return;
+      }
+    }
+    console.log(`Starting "rush version" ${EOL}`);
+
+    this._versionManager = new VersionManager(this.rushConfiguration);
+    if (this._ensureVersionPolicy.value) {
+      const tempBranch: string = 'version/ensure-' + new Date().getTime();
+      const git: Git = new Git(this._targetBranch.value);
+
+      // Make changes in temp branch.
+      git.checkout(tempBranch, true);
+      const updatedPackages: Map<string, IPackageJson> = this._versionManager.ensure(this._versionPolicy.value);
+
+      // Stage, commit, and push the changes to remote temp branch.
+      git.addChanges();
+      git.commit();
+      git.push(tempBranch);
+
+      // Now merge to target branch.
+      git.checkout(this._targetBranch.value);
+      git.pull();
+      git.merge(tempBranch);
+      git.push(this._targetBranch.value);
+      git.deleteBranch(tempBranch);
+    }
+  }
+}

--- a/apps/rush/src/utilities/Git.ts
+++ b/apps/rush/src/utilities/Git.ts
@@ -1,0 +1,53 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import PublishUtilities from './PublishUtilities';
+
+export class Git {
+
+  constructor(private _targetBranch: string) {
+  }
+
+  public checkout(branchName: string, createBranch?: boolean): void {
+    const params: string = `checkout ${createBranch ? '-b ' : ''}${branchName}`;
+
+    PublishUtilities.execCommand(!!this._targetBranch, 'git', params.split(' '));
+  }
+
+  public merge(branchName: string): void {
+    PublishUtilities.execCommand(!!this._targetBranch, 'git', `merge ${branchName} --no-edit`.split(' '));
+  }
+
+  public deleteBranch(branchName: string): void {
+    PublishUtilities.execCommand(!!this._targetBranch, 'git', `branch -d ${branchName}`.split(' '));
+    PublishUtilities.execCommand(!!this._targetBranch, 'git', `push origin --delete ${branchName}`.split(' '));
+  }
+
+  public pull(): void {
+    PublishUtilities.execCommand(!!this._targetBranch, 'git', `pull origin ${this._targetBranch}`.split(' '));
+  }
+
+  public addChanges(): void {
+    PublishUtilities.execCommand(!!this._targetBranch, 'git', ['add', '.']);
+  }
+
+  public addTag(shouldExecute: boolean, packageName: string, packageVersion: string): void {
+    // Tagging only happens if we're publishing to real NPM and committing to git.
+    const tagName: string = PublishUtilities.createTagname(packageName, packageVersion);
+    PublishUtilities.execCommand(
+      !!this._targetBranch && shouldExecute,
+      'git',
+      ['tag', '-a', tagName, '-m', `${packageName} v${packageVersion}`]);
+  }
+
+  public commit(): void {
+    PublishUtilities.execCommand(!!this._targetBranch, 'git', ['commit', '-m', 'Applying package updates.']);
+  }
+
+  public push(branchName: string): void {
+    PublishUtilities.execCommand(
+      !!this._targetBranch,
+      'git',
+      ['push', 'origin', 'HEAD:' + branchName, '--follow-tags', '--verbose']);
+  }
+}

--- a/apps/rush/src/utilities/VersionManager.ts
+++ b/apps/rush/src/utilities/VersionManager.ts
@@ -1,0 +1,100 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import { cloneDeep } from 'lodash';
+import * as semver from 'semver';
+
+import {
+  RushConfiguration,
+  IPackageJson,
+  VersionPolicy
+} from '@microsoft/rush-lib';
+
+import PublishUtilities from './PublishUtilities';
+
+export class VersionManager {
+  constructor(private _rushConfiguration: RushConfiguration) {
+  }
+
+  /**
+   * Ensures project versions follow the provided version policy. If version policy is not
+   * provided, all projects will have their version checked according to the associated version policy.
+   * package.json files will be updated if needed.
+   * This method does not commit changes.
+   * @param versionPolicyName -- version policy name
+   */
+  public ensure(versionPolicyName?: string): Map<string, IPackageJson> {
+    const updatedProjects: Map<string, IPackageJson> = new Map<string, IPackageJson>();
+    const versionPolicies: Map<string, VersionPolicy> = this._rushConfiguration.versionPolicies;
+
+    // Update versions based on version policy
+    this._rushConfiguration.projects.forEach(rushProject => {
+      const versionPolicy: VersionPolicy = rushProject.versionPolicy;
+      if (versionPolicy &&
+        (!versionPolicyName || versionPolicy.policyName === versionPolicyName)) {
+        const updatedProject: IPackageJson = versionPolicy.ensure(rushProject);
+        if (updatedProject) {
+          updatedProjects.set(updatedProject.name, updatedProject);
+        }
+      }
+    });
+
+    // Update all dependencies if needed.
+    this._rushConfiguration.projects.forEach(rushProject => {
+      let clonedProject: IPackageJson = updatedProjects.get(rushProject.packageName);
+      if (!clonedProject) {
+        clonedProject = cloneDeep(rushProject.packageJson);
+      }
+      this._updateDependencies(clonedProject, updatedProjects);
+    });
+
+    return updatedProjects;
+  }
+
+  private _updateDependencies(clonedProject: IPackageJson,
+    updatedProjects: Map<string, IPackageJson>
+  ): void {
+    let needToUpdate: boolean = false;
+    const dependencies: { [key: string]: string; } = clonedProject.dependencies;
+
+    updatedProjects.forEach((updatedProject, updatedProjectName) => {
+      if (dependencies[updatedProjectName]) {
+        const newDependencyVersion: string = this._getNewDependencyVersion(
+          dependencies,
+          updatedProjectName,
+          updatedProject.version
+        );
+        if (newDependencyVersion !== dependencies[updatedProjectName]) {
+          dependencies[updatedProjectName] = newDependencyVersion;
+          needToUpdate = true;
+        }
+      }
+    });
+    if (needToUpdate) {
+      updatedProjects.set(clonedProject.name, clonedProject);
+    }
+  }
+
+  private _getNewDependencyVersion(dependencies: { [key: string]: string; },
+    dependencyName: string,
+    newProjectVersion: string
+  ): string {
+    const currentDependencyVersion: string = dependencies[dependencyName];
+    let newDependencyVersion: string;
+
+    if (PublishUtilities.isRangeDependency(currentDependencyVersion)) {
+      newDependencyVersion = this._getNewRangeDependency(newProjectVersion);
+    } else if (currentDependencyVersion.lastIndexOf('~', 0) === 0) {
+      newDependencyVersion = '~' + newProjectVersion;
+    } else if (currentDependencyVersion.lastIndexOf('^', 0) === 0) {
+      newDependencyVersion = '^' + newProjectVersion;
+    } else {
+      newDependencyVersion = newProjectVersion;
+    }
+    return newDependencyVersion;
+  }
+
+  private _getNewRangeDependency(newVersion: string): string {
+    return `>=${newVersion} <${semver.inc(newVersion, 'major')}`;
+  }
+}

--- a/apps/rush/src/utilities/VersionManager.ts
+++ b/apps/rush/src/utilities/VersionManager.ts
@@ -32,7 +32,7 @@ export class VersionManager {
       const versionPolicy: VersionPolicy = rushProject.versionPolicy;
       if (versionPolicy &&
         (!versionPolicyName || versionPolicy.policyName === versionPolicyName)) {
-        const updatedProject: IPackageJson = versionPolicy.ensure(rushProject);
+        const updatedProject: IPackageJson = versionPolicy.ensure(rushProject.packageJson);
         if (updatedProject) {
           updatedProjects.set(updatedProject.name, updatedProject);
         }
@@ -54,8 +54,11 @@ export class VersionManager {
   private _updateDependencies(clonedProject: IPackageJson,
     updatedProjects: Map<string, IPackageJson>
   ): void {
-    let needToUpdate: boolean = false;
+    if (!clonedProject.dependencies) {
+      return;
+    }
     const dependencies: { [key: string]: string; } = clonedProject.dependencies;
+    let needToUpdate: boolean = false;
 
     updatedProjects.forEach((updatedProject, updatedProjectName) => {
       if (dependencies[updatedProjectName]) {

--- a/apps/rush/src/utilities/VersionManager.ts
+++ b/apps/rush/src/utilities/VersionManager.ts
@@ -36,7 +36,8 @@ export class VersionManager {
     // Update versions based on version policy
     this._rushConfiguration.projects.forEach(rushProject => {
       const projectVersionPolicyName: string = rushProject.versionPolicyName;
-      if (!versionPolicyName || projectVersionPolicyName === versionPolicyName) {
+      if (projectVersionPolicyName &&
+          (!versionPolicyName || projectVersionPolicyName === versionPolicyName)) {
         const versionPolicy: VersionPolicy = this._versionPolicyConfiguration.getVersionPolicy(
           projectVersionPolicyName);
         const updatedProject: IPackageJson = versionPolicy.ensure(rushProject.packageJson);

--- a/apps/rush/src/utilities/VersionManager.ts
+++ b/apps/rush/src/utilities/VersionManager.ts
@@ -18,7 +18,7 @@ export class VersionManager {
   constructor(private _rushConfiguration: RushConfiguration,
     _versionPolicyConfiguration?: VersionPolicyConfiguration
   ) {
-    this._versionPolicyConfiguration = _versionPolicyConfiguration?
+    this._versionPolicyConfiguration = _versionPolicyConfiguration ?
       _versionPolicyConfiguration : this._rushConfiguration.versionPolicyConfiguration;
   }
 

--- a/apps/rush/src/utilities/VersionManager.ts
+++ b/apps/rush/src/utilities/VersionManager.ts
@@ -2,7 +2,6 @@
 // See LICENSE in the project root for license information.
 
 import { cloneDeep } from 'lodash';
-import * as semver from 'semver';
 
 import {
   RushConfiguration,
@@ -62,7 +61,7 @@ export class VersionManager {
 
     updatedProjects.forEach((updatedProject, updatedProjectName) => {
       if (dependencies[updatedProjectName]) {
-        const newDependencyVersion: string = this._getNewDependencyVersion(
+        const newDependencyVersion: string = PublishUtilities.getNewDependencyVersion(
           dependencies,
           updatedProjectName,
           updatedProject.version
@@ -76,28 +75,5 @@ export class VersionManager {
     if (needToUpdate) {
       updatedProjects.set(clonedProject.name, clonedProject);
     }
-  }
-
-  private _getNewDependencyVersion(dependencies: { [key: string]: string; },
-    dependencyName: string,
-    newProjectVersion: string
-  ): string {
-    const currentDependencyVersion: string = dependencies[dependencyName];
-    let newDependencyVersion: string;
-
-    if (PublishUtilities.isRangeDependency(currentDependencyVersion)) {
-      newDependencyVersion = this._getNewRangeDependency(newProjectVersion);
-    } else if (currentDependencyVersion.lastIndexOf('~', 0) === 0) {
-      newDependencyVersion = '~' + newProjectVersion;
-    } else if (currentDependencyVersion.lastIndexOf('^', 0) === 0) {
-      newDependencyVersion = '^' + newProjectVersion;
-    } else {
-      newDependencyVersion = newProjectVersion;
-    }
-    return newDependencyVersion;
-  }
-
-  private _getNewRangeDependency(newVersion: string): string {
-    return `>=${newVersion} <${semver.inc(newVersion, 'major')}`;
   }
 }

--- a/apps/rush/src/utilities/test/VersionManager.test.ts
+++ b/apps/rush/src/utilities/test/VersionManager.test.ts
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import { assert } from 'chai';
+import * as path from 'path';
+
+import {
+  RushConfiguration,
+  IPackageJson
+} from '@microsoft/rush-lib';
+
+import { VersionManager } from '../VersionManager';
+
+describe('VersionManager', () => {
+  const rushJsonFile: string = path.resolve(__dirname, 'repo', 'rush.json');
+  const rushConfiguration: RushConfiguration = RushConfiguration.loadFromConfigurationFile(rushJsonFile);
+  let versionManager: VersionManager;
+
+  beforeEach(() => {
+    versionManager = new VersionManager(rushConfiguration);
+  });
+
+  /* tslint:disable:no-string-literal */
+  describe('ensure', () => {
+    it('ensures lock step version', () => {
+      const updatedPackages: Map<string, IPackageJson> = versionManager.ensure('testPolicy1');
+      const expectedVersion: string = '10.10.0';
+      assert.equal(updatedPackages.size, 2);
+      assert.equal(updatedPackages.get('a').version, expectedVersion);
+      assert.equal(updatedPackages.get('b').version, expectedVersion);
+      assert.equal(updatedPackages.get('b').dependencies['a'], `~${expectedVersion}`);
+      assert.equal(updatedPackages.get('c').version, '3.0.0', 'c version should not change');
+      assert.equal(updatedPackages.get('c').dependencies['b'], `>=10.10.0 <11.0.0`);
+    });
+  });
+  /* tslint:enable:no-string-literal */
+});

--- a/apps/rush/src/utilities/test/VersionManager.test.ts
+++ b/apps/rush/src/utilities/test/VersionManager.test.ts
@@ -22,15 +22,33 @@ describe('VersionManager', () => {
 
   /* tslint:disable:no-string-literal */
   describe('ensure', () => {
-    it('ensures lock step version', () => {
+    it('fixes lock step versions', () => {
       const updatedPackages: Map<string, IPackageJson> = versionManager.ensure('testPolicy1');
       const expectedVersion: string = '10.10.0';
-      assert.equal(updatedPackages.size, 2);
+      assert.equal(updatedPackages.size, 4);
       assert.equal(updatedPackages.get('a').version, expectedVersion);
       assert.equal(updatedPackages.get('b').version, expectedVersion);
       assert.equal(updatedPackages.get('b').dependencies['a'], `~${expectedVersion}`);
-      assert.equal(updatedPackages.get('c').version, '3.0.0', 'c version should not change');
+      assert.equal(updatedPackages.get('c').version, '3.1.1', 'c version should not change');
       assert.equal(updatedPackages.get('c').dependencies['b'], `>=10.10.0 <11.0.0`);
+      assert.equal(updatedPackages.get('d').version, '4.1.1', 'd version should not change');
+      assert.equal(updatedPackages.get('d').dependencies['b'], `>=10.10.0 <11.0.0`);
+    });
+  });
+
+  describe('ensure', () => {
+    it('fixes major version for individual version policy', () => {
+      const updatedPackages: Map<string, IPackageJson> = versionManager.ensure('testPolicy2');
+      assert.equal(updatedPackages.size, 1);
+      assert.equal(updatedPackages.get('c').version, '5.0.0');
+      assert.equal(updatedPackages.get('c').dependencies['b'], `>=2.0.0 <3.0.0`);
+    });
+  });
+
+  describe('ensure', () => {
+    it('does not change packageJson if not needed by individual version policy', () => {
+      const updatedPackages: Map<string, IPackageJson> = versionManager.ensure('testPolicy3');
+      assert.equal(updatedPackages.size, 0);
     });
   });
   /* tslint:enable:no-string-literal */

--- a/apps/rush/src/utilities/test/VersionManager.test.ts
+++ b/apps/rush/src/utilities/test/VersionManager.test.ts
@@ -6,6 +6,7 @@ import * as path from 'path';
 
 import {
   RushConfiguration,
+  VersionPolicyConfiguration,
   IPackageJson
 } from '@microsoft/rush-lib';
 
@@ -14,10 +15,13 @@ import { VersionManager } from '../VersionManager';
 describe('VersionManager', () => {
   const rushJsonFile: string = path.resolve(__dirname, 'repo', 'rush.json');
   const rushConfiguration: RushConfiguration = RushConfiguration.loadFromConfigurationFile(rushJsonFile);
+  const versionConfigJsonFile: string = path.resolve(__dirname, 'repo', 'version-policies.json');
+  const versionPolicyConfiguration: VersionPolicyConfiguration =
+    new VersionPolicyConfiguration(versionConfigJsonFile);
   let versionManager: VersionManager;
 
   beforeEach(() => {
-    versionManager = new VersionManager(rushConfiguration);
+    versionManager = new VersionManager(rushConfiguration, versionPolicyConfiguration);
   });
 
   /* tslint:disable:no-string-literal */

--- a/apps/rush/src/utilities/test/repo/a/package.json
+++ b/apps/rush/src/utilities/test/repo/a/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "a",
+  "version": "1.0.0",
+  "description": "Test package a"
+}

--- a/apps/rush/src/utilities/test/repo/b/package.json
+++ b/apps/rush/src/utilities/test/repo/b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "b",
+  "version": "2.0.0",
+  "description": "Test package b",
+  "dependencies": {
+    "a": "~1.0.0"
+  }
+}

--- a/apps/rush/src/utilities/test/repo/c/package.json
+++ b/apps/rush/src/utilities/test/repo/c/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "c",
+  "version": "3.0.0",
+  "description": "Test package c",
+  "dependencies": {
+    "b": ">=2.0.0 <3.0.0"
+  }
+}

--- a/apps/rush/src/utilities/test/repo/c/package.json
+++ b/apps/rush/src/utilities/test/repo/c/package.json
@@ -1,6 +1,6 @@
 {
   "name": "c",
-  "version": "3.0.0",
+  "version": "3.1.1",
   "description": "Test package c",
   "dependencies": {
     "b": ">=2.0.0 <3.0.0"

--- a/apps/rush/src/utilities/test/repo/d/package.json
+++ b/apps/rush/src/utilities/test/repo/d/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "d",
+  "version": "4.1.1",
+  "description": "Test package d",
+  "dependencies": {
+    "b": ">=2.0.0 <3.0.0"
+  }
+}

--- a/apps/rush/src/utilities/test/repo/rush.json
+++ b/apps/rush/src/utilities/test/repo/rush.json
@@ -1,0 +1,40 @@
+{
+  "npmVersion": "3.10.8",
+  "rushMinimumVersion": "1.0.5",
+  "nodeSupportedVersionRange": ">=4.3.0 <7.0.0",
+
+  "versionPolicies": [
+    {
+      "policyName": "testPolicy1",
+      "baseType": "lockStepVersion",
+      "version": "10.10.0",
+      "nextBump": "patch"
+    },
+    {
+      "policyName": "testPolicy2",
+      "baseType": "individualVersion",
+      "lockedMajor": 5
+    }
+  ],
+
+  "projects": [
+    {
+      "packageName": "a",
+      "projectFolder": "a",
+      "reviewCategory": "third-party",
+      "versionPolicyName": "testPolicy1"
+    },
+    {
+      "packageName": "b",
+      "projectFolder": "b",
+      "reviewCategory": "third-party",
+      "versionPolicyName": "testPolicy1"
+    },
+    {
+      "packageName": "c",
+      "projectFolder": "c",
+      "reviewCategory": "third-party",
+      "versionPolicyName": "testPolicy2"
+    }
+  ]
+}

--- a/apps/rush/src/utilities/test/repo/rush.json
+++ b/apps/rush/src/utilities/test/repo/rush.json
@@ -14,6 +14,10 @@
       "policyName": "testPolicy2",
       "baseType": "individualVersion",
       "lockedMajor": 5
+    },
+    {
+      "policyName": "testPolicy3",
+      "baseType": "individualVersion"
     }
   ],
 
@@ -35,6 +39,12 @@
       "projectFolder": "c",
       "reviewCategory": "third-party",
       "versionPolicyName": "testPolicy2"
+    },
+    {
+      "packageName": "d",
+      "projectFolder": "d",
+      "reviewCategory": "third-party",
+      "versionPolicyName": "testPolicy3"
     }
   ]
 }

--- a/apps/rush/src/utilities/test/repo/rush.json
+++ b/apps/rush/src/utilities/test/repo/rush.json
@@ -3,24 +3,6 @@
   "rushMinimumVersion": "1.0.5",
   "nodeSupportedVersionRange": ">=4.3.0 <7.0.0",
 
-  "versionPolicies": [
-    {
-      "policyName": "testPolicy1",
-      "baseType": "lockStepVersion",
-      "version": "10.10.0",
-      "nextBump": "patch"
-    },
-    {
-      "policyName": "testPolicy2",
-      "baseType": "individualVersion",
-      "lockedMajor": 5
-    },
-    {
-      "policyName": "testPolicy3",
-      "baseType": "individualVersion"
-    }
-  ],
-
   "projects": [
     {
       "packageName": "a",

--- a/apps/rush/src/utilities/test/repo/version-policies.json
+++ b/apps/rush/src/utilities/test/repo/version-policies.json
@@ -1,0 +1,17 @@
+[
+  {
+    "policyName": "testPolicy1",
+    "definitionName": "lockStepVersion",
+    "version": "10.10.0",
+    "nextBump": "patch"
+  },
+  {
+    "policyName": "testPolicy2",
+    "definitionName": "individualVersion",
+    "lockedMajor": 5
+  },
+  {
+    "policyName": "testPolicy3",
+    "definitionName": "individualVersion"
+  }
+]

--- a/common/reviews/api/rush-lib.api.ts
+++ b/common/reviews/api/rush-lib.api.ts
@@ -39,14 +39,6 @@ class AsyncRecycler {
   public readonly recyclerFolder: string;
 }
 
-// @alpha
-enum BaseTypeName {
-  // (undocumented)
-  'individualVersion',
-  // (undocumented)
-  'lockStepVersion'
-}
-
 // @public
 class BuildTaskError extends TaskError {
   constructor(type: string, message: string, file: string, line: number, offset: number);
@@ -270,8 +262,6 @@ class RushConfiguration {
   public findProjectByShorthandName(shorthandProjectName: string): RushConfigurationProject;
   public findProjectByTempName(tempProjectName: string): RushConfigurationProject | undefined;
   public getProjectByName(projectName: string): RushConfigurationProject;
-  // @alpha
-  public getVersionPolicy(policyName: string): VersionPolicy;
   public readonly gitAllowedEmailRegExps: string[];
   public readonly gitSampleEmail: string;
   public readonly homeFolder: string;
@@ -294,8 +284,8 @@ class RushConfiguration {
   // @alpha
   public readonly telemetryEnabled: boolean;
   public readonly tempShrinkwrapFilename: string;
-  // @alpha
-  public readonly versionPolicies: Map<string, VersionPolicy>;
+  // @alpha (undocumented)
+  public readonly versionPolicyConfiguration: VersionPolicyConfiguration;
 }
 
 // @public
@@ -316,7 +306,7 @@ class RushConfigurationProject {
   public readonly tempPackageJsonFilename: string;
   public readonly tempProjectName: string;
   // @alpha
-  public readonly versionPolicy: VersionPolicy;
+  public readonly versionPolicyName: string;
 }
 
 // @public
@@ -450,7 +440,7 @@ class VersionPolicy {
   // WARNING: The type "IVersionPolicyJson" needs to be exported by the package (e.g. added to index.ts)
   constructor(versionPolicyJson: IVersionPolicyJson);
   // (undocumented)
-  public readonly baseType: BaseTypeName;
+  public readonly definitionName: VersionPolicyDefinitionName;
   // (undocumented)
   public abstract ensure(project: IPackageJson): IPackageJson | undefined;
   // WARNING: The type "IVersionPolicyJson" needs to be exported by the package (e.g. added to index.ts)
@@ -458,6 +448,23 @@ class VersionPolicy {
   public static load(versionPolicyJson: IVersionPolicyJson): VersionPolicy;
   // (undocumented)
   public readonly policyName: string;
+}
+
+// @alpha (undocumented)
+class VersionPolicyConfiguration {
+  public constructor(private _jsonFileName: string);
+  // @alpha
+  public getVersionPolicy(policyName: string): VersionPolicy;
+  // @alpha
+  public readonly versionPolicies: Map<string, VersionPolicy>;
+}
+
+// @alpha
+enum VersionPolicyDefinitionName {
+  // (undocumented)
+  'individualVersion',
+  // (undocumented)
+  'lockStepVersion'
 }
 
 // WARNING: Unsupported export: rushVersion

--- a/common/reviews/api/rush-lib.api.ts
+++ b/common/reviews/api/rush-lib.api.ts
@@ -355,6 +355,9 @@ module RushConstants {
 
   rushTempProjectsFolderName: string = 'projects';
 
+  // @alpha (undocumented)
+  versionPoliciesFileName: string = 'version-policies.json';
+
 }
 
 // @public

--- a/common/reviews/api/rush-lib.api.ts
+++ b/common/reviews/api/rush-lib.api.ts
@@ -159,7 +159,7 @@ class IndividualVersionPolicy extends VersionPolicy {
   // WARNING: The type "IIndividualVersionJson" needs to be exported by the package (e.g. added to index.ts)
   constructor(versionPolicyJson: IIndividualVersionJson);
   // (undocumented)
-  public ensure(project: RushConfigurationProject): IPackageJson | undefined;
+  public ensure(project: IPackageJson): IPackageJson | undefined;
   // (undocumented)
   public readonly lockedMajor: number | undefined;
 }
@@ -219,11 +219,11 @@ class LockStepVersionPolicy extends VersionPolicy {
   // WARNING: The type "ILockStepVersionJson" needs to be exported by the package (e.g. added to index.ts)
   constructor(versionPolicyJson: ILockStepVersionJson);
   // (undocumented)
-  public ensure(project: RushConfigurationProject): IPackageJson | undefined;
+  public ensure(project: IPackageJson): IPackageJson | undefined;
   // (undocumented)
   public readonly nextBump: BumpType;
   // (undocumented)
-  public readonly version: SemVer;
+  public readonly version: semver.SemVer;
 }
 
 // @public (undocumented)
@@ -452,7 +452,7 @@ class VersionPolicy {
   // (undocumented)
   public readonly baseType: BaseTypeName;
   // (undocumented)
-  public abstract ensure(project: RushConfigurationProject): IPackageJson | undefined;
+  public abstract ensure(project: IPackageJson): IPackageJson | undefined;
   // WARNING: The type "IVersionPolicyJson" needs to be exported by the package (e.g. added to index.ts)
   // (undocumented)
   public static load(versionPolicyJson: IVersionPolicyJson): VersionPolicy;

--- a/common/reviews/api/rush-lib.api.ts
+++ b/common/reviews/api/rush-lib.api.ts
@@ -39,6 +39,14 @@ class AsyncRecycler {
   public readonly recyclerFolder: string;
 }
 
+// @alpha
+enum BaseTypeName {
+  // (undocumented)
+  'individualVersion',
+  // (undocumented)
+  'lockStepVersion'
+}
+
 // @public
 class BuildTaskError extends TaskError {
   constructor(type: string, message: string, file: string, line: number, offset: number);
@@ -50,6 +58,20 @@ class BuildTaskError extends TaskError {
   protected _offset: number;
   // (undocumented)
   public toString(mode: ErrorDetectionMode): string;
+}
+
+// @alpha
+enum BumpType {
+  // (undocumented)
+  'major',
+  // (undocumented)
+  'minor',
+  // (undocumented)
+  'patch',
+  // (undocumented)
+  'prerelease',
+  // (undocumented)
+  'release'
 }
 
 // @public
@@ -132,6 +154,16 @@ interface IEventHooksJson {
   postRushBuild?: string[];
 }
 
+// @alpha
+class IndividualVersionPolicy extends VersionPolicy {
+  // WARNING: The type "IIndividualVersionJson" needs to be exported by the package (e.g. added to index.ts)
+  constructor(versionPolicyJson: IIndividualVersionJson);
+  // (undocumented)
+  public ensure(project: RushConfigurationProject): IPackageJson | undefined;
+  // (undocumented)
+  public readonly lockedMajor: number | undefined;
+}
+
 // @public
 interface IPackageJson {
   // (undocumented)
@@ -182,6 +214,18 @@ class JsonSchemaValidator {
   public validateObject(jsonObject: Object, errorCallback: ValidateErrorCallback): void;
 }
 
+// @alpha
+class LockStepVersionPolicy extends VersionPolicy {
+  // WARNING: The type "ILockStepVersionJson" needs to be exported by the package (e.g. added to index.ts)
+  constructor(versionPolicyJson: ILockStepVersionJson);
+  // (undocumented)
+  public ensure(project: RushConfigurationProject): IPackageJson | undefined;
+  // (undocumented)
+  public readonly nextBump: BumpType;
+  // (undocumented)
+  public readonly version: SemVer;
+}
+
 // @public (undocumented)
 class Npm {
   // (undocumented)
@@ -226,7 +270,7 @@ class RushConfiguration {
   public findProjectByShorthandName(shorthandProjectName: string): RushConfigurationProject;
   public findProjectByTempName(tempProjectName: string): RushConfigurationProject | undefined;
   public getProjectByName(projectName: string): RushConfigurationProject;
-  // WARNING: The type "VersionPolicy" needs to be exported by the package (e.g. added to index.ts)
+  // @alpha
   public getVersionPolicy(policyName: string): VersionPolicy;
   public readonly gitAllowedEmailRegExps: string[];
   public readonly gitSampleEmail: string;
@@ -250,6 +294,8 @@ class RushConfiguration {
   // @alpha
   public readonly telemetryEnabled: boolean;
   public readonly tempShrinkwrapFilename: string;
+  // @alpha
+  public readonly versionPolicies: Map<string, VersionPolicy>;
 }
 
 // @public
@@ -269,6 +315,8 @@ class RushConfigurationProject {
   public readonly shouldPublish: boolean;
   public readonly tempPackageJsonFilename: string;
   public readonly tempProjectName: string;
+  // @alpha
+  public readonly versionPolicy: VersionPolicy;
 }
 
 // @public
@@ -395,6 +443,21 @@ class VersionMismatchFinder {
   public getVersionsOfMismatch(mismatch: string): Array<string>;
   // (undocumented)
   public readonly numberOfMismatches: number;
+}
+
+// @alpha
+class VersionPolicy {
+  // WARNING: The type "IVersionPolicyJson" needs to be exported by the package (e.g. added to index.ts)
+  constructor(versionPolicyJson: IVersionPolicyJson);
+  // (undocumented)
+  public readonly baseType: BaseTypeName;
+  // (undocumented)
+  public abstract ensure(project: RushConfigurationProject): IPackageJson | undefined;
+  // WARNING: The type "IVersionPolicyJson" needs to be exported by the package (e.g. added to index.ts)
+  // (undocumented)
+  public static load(versionPolicyJson: IVersionPolicyJson): VersionPolicy;
+  // (undocumented)
+  public readonly policyName: string;
 }
 
 // WARNING: Unsupported export: rushVersion

--- a/common/reviews/api/rush-lib.api.ts
+++ b/common/reviews/api/rush-lib.api.ts
@@ -226,6 +226,8 @@ class RushConfiguration {
   public findProjectByShorthandName(shorthandProjectName: string): RushConfigurationProject;
   public findProjectByTempName(tempProjectName: string): RushConfigurationProject | undefined;
   public getProjectByName(projectName: string): RushConfigurationProject;
+  // WARNING: The type "VersionPolicy" needs to be exported by the package (e.g. added to index.ts)
+  public getVersionPolicy(policyName: string): VersionPolicy;
   public readonly gitAllowedEmailRegExps: string[];
   public readonly gitSampleEmail: string;
   public readonly homeFolder: string;

--- a/common/reviews/api/rush-lib.api.ts
+++ b/common/reviews/api/rush-lib.api.ts
@@ -146,9 +146,22 @@ interface IEventHooksJson {
   postRushBuild?: string[];
 }
 
+// @alpha (undocumented)
+interface IIndividualVersionJson extends IVersionPolicyJson {
+  // (undocumented)
+  lockedMajor?: number;
+}
+
+// @alpha (undocumented)
+interface ILockStepVersionJson extends IVersionPolicyJson {
+  // (undocumented)
+  nextBump: string;
+  // (undocumented)
+  version: string;
+}
+
 // @alpha
 class IndividualVersionPolicy extends VersionPolicy {
-  // WARNING: The type "IIndividualVersionJson" needs to be exported by the package (e.g. added to index.ts)
   constructor(versionPolicyJson: IIndividualVersionJson);
   // (undocumented)
   public ensure(project: IPackageJson): IPackageJson | undefined;
@@ -191,6 +204,14 @@ interface ISaveJsonFileOptions {
   onlyIfChanged?: boolean;
 }
 
+// @alpha (undocumented)
+interface IVersionPolicyJson {
+  // (undocumented)
+  definitionName: string;
+  // (undocumented)
+  policyName: string;
+}
+
 // @public
 class JsonFile {
   public static loadJsonFile(jsonFilename: string): any;
@@ -208,7 +229,6 @@ class JsonSchemaValidator {
 
 // @alpha
 class LockStepVersionPolicy extends VersionPolicy {
-  // WARNING: The type "ILockStepVersionJson" needs to be exported by the package (e.g. added to index.ts)
   constructor(versionPolicyJson: ILockStepVersionJson);
   // (undocumented)
   public ensure(project: IPackageJson): IPackageJson | undefined;
@@ -437,13 +457,11 @@ class VersionMismatchFinder {
 
 // @alpha
 class VersionPolicy {
-  // WARNING: The type "IVersionPolicyJson" needs to be exported by the package (e.g. added to index.ts)
   constructor(versionPolicyJson: IVersionPolicyJson);
   // (undocumented)
   public readonly definitionName: VersionPolicyDefinitionName;
   // (undocumented)
   public abstract ensure(project: IPackageJson): IPackageJson | undefined;
-  // WARNING: The type "IVersionPolicyJson" needs to be exported by the package (e.g. added to index.ts)
   // (undocumented)
   public static load(versionPolicyJson: IVersionPolicyJson): VersionPolicy;
   // (undocumented)


### PR DESCRIPTION
Add version policy configuration
Add a "rush version --ensure-version-policy" action that can update project versions to enforce version policy in the Rush repo.