### PR TITLE
Fix web-library-buld's gulp serve command

### DIFF
--- a/common/changes/@microsoft/web-library-build/nickpape-fix-serve_2017-07-26-21-38.json
+++ b/common/changes/@microsoft/web-library-build/nickpape-fix-serve_2017-07-26-21-38.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/web-library-build",
+      "comment": "Fix an issue with 'gulp serve' where the server was not being launched.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/web-library-build",
+  "email": "nickpape@users.noreply.github.com"
+}

--- a/core-build/web-library-build/src/index.ts
+++ b/core-build/web-library-build/src/index.ts
@@ -66,10 +66,12 @@ task('test-watch', watch(sourceMatch, testTasks));
 
 // For watch scenarios like serve, make sure to exclude generated files from src (like *.scss.ts.)
 task('serve',
+  serial(
+  serve,
   watch(
     sourceMatch, serial(preCopy, sass, compileTsTasks,
       postCopy, webpack, postProcessSourceMapsTask, reload)
-  )
+  ))
 );
 
 task('default', defaultTasks);


### PR DESCRIPTION
It was not spinning up the server due to a regression in #253 . Fixes #284.