### PR TITLE
Only warn for missing theme slots if DEBUG is true

### DIFF
--- a/common/changes/@microsoft/load-themed-styles/msilver-theme-slot-warning-debug-only_2017-07-28-23-44.json
+++ b/common/changes/@microsoft/load-themed-styles/msilver-theme-slot-warning-debug-only_2017-07-28-23-44.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/load-themed-styles",
+      "comment": "Only warn for missing theme slots if DEBUG is true",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/load-themed-styles",
+  "email": "msilver@microsoft.com"
+}

--- a/libraries/load-themed-styles/src/index.ts
+++ b/libraries/load-themed-styles/src/index.ts
@@ -276,9 +276,9 @@ function resolveThemableArray(splitStyleArray: ThemableArray): string {
       const themedValue: string | undefined = theme ? theme[themeSlot] : undefined;
       const defaultValue: string = currentValue.defaultValue || 'inherit';
 
-      // Warn to console if we hit an unthemed value even when themes are provided, unless "DEBUG" is false
+      // Warn to console if we hit an unthemed value even when themes are provided, but only if "DEBUG" is true.
       // Allow the themedValue to be undefined to explicitly request the default value.
-      if (theme && !themedValue && console && !(themeSlot in theme) && (typeof DEBUG === 'undefined' || DEBUG)) {
+      if (theme && !themedValue && console && !(themeSlot in theme) && typeof DEBUG !== 'undefined' && DEBUG) {
         console.warn(`Theming value not provided for "${themeSlot}". Falling back to "${defaultValue}".`);
       }
 


### PR DESCRIPTION
Making warnings opt-in rather than opt-out.