### PR TITLE
Rush should create .tgz files instead of package.json for temp_modules

### DIFF
--- a/apps/rush-lib/src/data/RushConfigurationProject.ts
+++ b/apps/rush-lib/src/data/RushConfigurationProject.ts
@@ -33,7 +33,7 @@ export default class RushConfigurationProject {
   private _reviewCategory: string;
   private _packageJson: IPackageJson;
   private _tempProjectName: string;
-  private _tempPackageJsonFilename: string;
+  private _tempPackageTarballFilename: string;
   private _cyclicDependencyProjects: Set<string>;
   private _versionPolicyName: string;
   private _shouldPublish: boolean;
@@ -95,10 +95,10 @@ export default class RushConfigurationProject {
     // Example: "my-project-2"
     const unscopedTempProjectName: string = Utilities.parseScopedPackageName(tempProjectName).name;
 
-    // Example: "C:\MyRepo\common\temp\projects\my-project-2\package.json"
-    this._tempPackageJsonFilename = path.join(rushConfiguration.commonTempFolder,
-      RushConstants.rushTempProjectsFolderName, unscopedTempProjectName,
-      RushConstants.packageJsonFilename);
+    // Example: "C:\MyRepo\common\temp\projects\my-project-2.tgz"
+    this._tempPackageTarballFilename = path.join(rushConfiguration.commonTempFolder,
+      RushConstants.rushTempProjectsFolderName,
+      `${unscopedTempProjectName}.tgz`);
 
     this._cyclicDependencyProjects = new Set<string>();
     if (projectJson.cyclicDependencyProjects) {
@@ -184,12 +184,12 @@ export default class RushConfigurationProject {
   }
 
   /**
-   * The absolute path of the package.json file for the temp project.
+   * The absolute path of the package tarball file for the temp project.
    *
-   * Example: "C:\MyRepo\common\temp\projects\my-project-2\package.json"
+   * Example: "C:\MyRepo\common\temp\projects\my-project-2.tgz"
    */
-  public get tempPackageJsonFilename(): string {
-    return this._tempPackageJsonFilename;
+  public get tempPackageTarballFilename(): string {
+    return this._tempPackageTarballFilename;
   }
 
   /**

--- a/apps/rush-lib/src/data/RushConfigurationProject.ts
+++ b/apps/rush-lib/src/data/RushConfigurationProject.ts
@@ -7,7 +7,6 @@ import IPackageJson from '../utilities/IPackageJson';
 import JsonFile from '../utilities/JsonFile';
 import Utilities from '../utilities/Utilities';
 import RushConfiguration from '../data/RushConfiguration';
-import { RushConstants } from '../RushConstants';
 
 /**
  * This represents the JSON data object for a project entry in the rush.json configuration file.
@@ -33,7 +32,7 @@ export default class RushConfigurationProject {
   private _reviewCategory: string;
   private _packageJson: IPackageJson;
   private _tempProjectName: string;
-  private _tempPackageTarballFilename: string;
+  private _unscopedTempProjectName: string;
   private _cyclicDependencyProjects: Set<string>;
   private _versionPolicyName: string;
   private _shouldPublish: boolean;
@@ -93,12 +92,7 @@ export default class RushConfigurationProject {
     // The "rushProject.tempProjectName" is guaranteed to be unique name (e.g. by adding the "-2"
     // suffix).  Even after we strip the NPM scope, it will still be unique.
     // Example: "my-project-2"
-    const unscopedTempProjectName: string = Utilities.parseScopedPackageName(tempProjectName).name;
-
-    // Example: "C:\MyRepo\common\temp\projects\my-project-2.tgz"
-    this._tempPackageTarballFilename = path.join(rushConfiguration.commonTempFolder,
-      RushConstants.rushTempProjectsFolderName,
-      `${unscopedTempProjectName}.tgz`);
+    this._unscopedTempProjectName = Utilities.parseScopedPackageName(tempProjectName).name;
 
     this._cyclicDependencyProjects = new Set<string>();
     if (projectJson.cyclicDependencyProjects) {
@@ -184,12 +178,12 @@ export default class RushConfigurationProject {
   }
 
   /**
-   * The absolute path of the package tarball file for the temp project.
+   * The unscoped temporary project name
    *
-   * Example: "C:\MyRepo\common\temp\projects\my-project-2.tgz"
+   * Example: "my-project-2"
    */
-  public get tempPackageTarballFilename(): string {
-    return this._tempPackageTarballFilename;
+  public get unscopedTempProjectName(): string {
+    return this._unscopedTempProjectName;
   }
 
   /**

--- a/apps/rush-lib/src/data/test/RushConfiguration.test.ts
+++ b/apps/rush-lib/src/data/test/RushConfiguration.test.ts
@@ -76,8 +76,8 @@ describe('RushConfiguration', () => {
     assert.equal(project1.packageName, 'project1', 'Failed to validate project1.packageName');
     assertPathProperty('project1.projectFolder', project1.projectFolder, './repo/project1');
     assert.equal(project1.tempProjectName, '@rush-temp/project1', 'Failed to validate project1.tempProjectName');
-    assertPathProperty('project1.tempPackageJsonFilename', project1.tempPackageJsonFilename,
-      './repo/common/temp/projects/project1/package.json');
+    assertPathProperty('project1.tempPackageTarballFilename', project1.tempPackageTarballFilename,
+      './repo/common/temp/projects/project1.tgz');
 
     done();
   });

--- a/apps/rush-lib/src/data/test/RushConfiguration.test.ts
+++ b/apps/rush-lib/src/data/test/RushConfiguration.test.ts
@@ -76,8 +76,7 @@ describe('RushConfiguration', () => {
     assert.equal(project1.packageName, 'project1', 'Failed to validate project1.packageName');
     assertPathProperty('project1.projectFolder', project1.projectFolder, './repo/project1');
     assert.equal(project1.tempProjectName, '@rush-temp/project1', 'Failed to validate project1.tempProjectName');
-    assertPathProperty('project1.tempPackageTarballFilename', project1.tempPackageTarballFilename,
-      './repo/common/temp/projects/project1.tgz');
+    assert.equal(project1.unscopedTempProjectName, 'project1');
 
     done();
   });

--- a/apps/rush-lib/src/utilities/JsonFile.ts
+++ b/apps/rush-lib/src/utilities/JsonFile.ts
@@ -42,14 +42,18 @@ export default class JsonFile {
     }
   }
 
+  // tslint:disable-next-line:no-any
+  public static normalize(jsonData: any): string {
+    const stringified: string = JSON.stringify(jsonData, undefined, 2) + '\n';
+    return Utilities.getAllReplaced(stringified, '\n', '\r\n');
+  }
+
   /**
    * Saves the file to disk.  Returns false if nothing was written due to options.onlyIfChanged.
    */
   // tslint:disable-next-line:no-any
   public static saveJsonFile(jsonData: any, jsonFilename: string, options: ISaveJsonFileOptions = {}): boolean {
-    const stringified: string = JSON.stringify(jsonData, undefined, 2) + '\n';
-    const normalized: string = Utilities.getAllReplaced(stringified, '\n', '\r\n');
-
+    const normalized: string = JsonFile.normalize(jsonData);
     const buffer: Buffer = new Buffer(normalized); // utf8 encoding happens here
 
     if (options.onlyIfChanged) {

--- a/apps/rush/package.json
+++ b/apps/rush/package.json
@@ -57,7 +57,6 @@
     "@types/mocha": "2.2.38",
     "@types/node": "6.0.62",
     "@types/semver": "5.3.33",
-    "@types/tar": "1.0.29",
     "chai": "~3.5.0",
     "gulp": "~3.9.1"
   }

--- a/apps/rush/src/utilities/InstallManager.ts
+++ b/apps/rush/src/utilities/InstallManager.ts
@@ -18,7 +18,8 @@ import {
   RushConfigurationProject,
   IPackageJson,
   RushConstants,
-  Utilities
+  Utilities,
+  Stopwatch
 } from '@microsoft/rush-lib';
 
 import { IRushTempPackageJson } from '../utilities/Package';
@@ -218,6 +219,8 @@ export default class InstallManager {
    * the return value is false.
    */
   public createTempModulesAndCheckShrinkwrap(shrinkwrapFile: ShrinkwrapFile | undefined): boolean {
+    const stopwatch: Stopwatch = Stopwatch.start();
+
     // Example: "C:\MyRepo\common\temp\projects"
     const tempProjectsFolder: string = path.join(this._rushConfiguration.commonTempFolder,
       RushConstants.rushTempProjectsFolderName);
@@ -462,6 +465,9 @@ export default class InstallManager {
     // Don't update the file timestamp unless the content has changed, since "rush install"
     // will consider this timestamp
     JsonFile.saveJsonFile(commonPackageJson, commonPackageJsonFilename, { onlyIfChanged: true });
+
+    stopwatch.stop();
+    console.log(`Finished creating temporary modules (${stopwatch.toString()})`);
 
     return shrinkwrapIsValid;
   }

--- a/apps/rush/src/utilities/InstallManager.ts
+++ b/apps/rush/src/utilities/InstallManager.ts
@@ -393,7 +393,7 @@ export default class InstallManager {
       // Example: "C:\MyRepo\common\temp\projects\my-project-2\package.json"
       const tempPackageJsonFilename: string = path.join(tempProjectFolder, RushConstants.packageJsonFilename);
 
-      // Example: "C:\MyRepo\common\temp\projects\my-project-2.gzip"
+      // Example: "C:\MyRepo\common\temp\projects\my-project-2.tgz"
       const tarballFile: string = rushProject.tempPackageTarballFilename;
 
       // Example: "C:\MyRepo\common\temp\projects\my-project-2.old"
@@ -405,9 +405,8 @@ export default class InstallManager {
         // extract the tarball and compare the package.json directly
         if (fsx.existsSync(tarballFile)) {
 
-          // ensure the folder we are about to extract into is clean
-          fsx.removeSync(extractedFolder);
-          fsx.mkdirpSync(extractedFolder);
+          // ensure the folder we are about to extract into exists
+          Utilities.createFolderWithRetry(extractedFolder);
 
           tar.extract({
             cwd: extractedFolder,
@@ -431,9 +430,8 @@ export default class InstallManager {
       }
 
       if (shouldOverwrite) {
-        // ensure the folder we are about to zip is clean
-        fsx.removeSync(tempProjectFolder);
-        fsx.mkdirpSync(tempProjectFolder);
+        // ensure the folder we are about to zip exists
+        Utilities.createFolderWithRetry(tempProjectFolder);
 
         // write the expected package.json file into the zip staging folder
         JsonFile.saveJsonFile(tempPackageJson, tempPackageJsonFilename);

--- a/apps/rush/src/utilities/InstallManager.ts
+++ b/apps/rush/src/utilities/InstallManager.ts
@@ -465,8 +465,6 @@ export default class InstallManager {
     // will consider this timestamp
     JsonFile.saveJsonFile(commonPackageJson, commonPackageJsonFilename, { onlyIfChanged: true });
 
-    process.exit(1);
-
     return shrinkwrapIsValid;
   }
 

--- a/apps/rush/typings/tar/tar.d.ts
+++ b/apps/rush/typings/tar/tar.d.ts
@@ -21,8 +21,17 @@ declare module 'tar' {
       noPax?: boolean;
     }
 
+    interface IExtractOptions {
+      cwd?: string;
+      file?: string;
+      sync?: boolean;
+    }
+
     interface Tar {
-       c(opts: NodeTar.ICreateOptions, fileList: string[], cb?: () => void): undefined | NodeJS.ReadableStream;
+      create(opts: NodeTar.ICreateOptions, fileList?: string[], cb?: () => void):
+        undefined | NodeJS.ReadableStream | NodeJS.WritableStream;
+
+      extract(opts: NodeTar.IExtractOptions): void;
     }
   }
 

--- a/apps/rush/typings/tar/tar.d.ts
+++ b/apps/rush/typings/tar/tar.d.ts
@@ -1,0 +1,31 @@
+/// <reference types="node" />
+
+// incomplete types for tar@3.1.13
+
+declare module 'tar' {
+  namespace NodeTar {
+    interface ICreateOptions {
+      file?: string;
+      sync?: boolean;
+      onwarn?: (message: string, data: Object) => void;
+      strict?: boolean;
+      cwd?: string;
+      prefix?: string;
+      gzip?: boolean | Object;
+      filter?: (path: string, stat: Object) => boolean;
+      portable?: boolean;
+      preservePaths?: boolean;
+      mode?: Object;
+      noDirRecurse?: boolean;
+      follow?: boolean;
+      noPax?: boolean;
+    }
+
+    interface Tar {
+       c(opts: NodeTar.ICreateOptions, fileList: string[], cb?: () => void): undefined | NodeJS.ReadableStream;
+    }
+  }
+
+  var tar: NodeTar.Tar;
+  export = tar;
+}

--- a/apps/rush/typings/tsd.d.ts
+++ b/apps/rush/typings/tsd.d.ts
@@ -7,4 +7,5 @@
 /// <reference path="inquirer/inquirer.d.ts" />
 /// <reference path="npm-package-arg/npm-package-arg.d.ts" />
 /// <reference path="read-package-tree/read-package-tree.d.ts" />
+/// <reference path="tar/tar.d.ts" />
 /// <reference path="wordwrap/wordwrap.d.ts" />

--- a/common/config/rush/npm-shrinkwrap.json
+++ b/common/config/rush/npm-shrinkwrap.json
@@ -29,118 +29,118 @@
     },
     "@rush-temp/api-extractor": {
       "version": "0.0.0",
-      "from": "projects\\api-extractor",
-      "resolved": "file:projects\\api-extractor"
+      "from": "projects\\api-extractor.tgz",
+      "resolved": "file:projects\\api-extractor.tgz"
     },
     "@rush-temp/decorators": {
       "version": "0.0.0",
-      "from": "projects\\decorators",
-      "resolved": "file:projects\\decorators"
+      "from": "projects\\decorators.tgz",
+      "resolved": "file:projects\\decorators.tgz"
     },
     "@rush-temp/gulp-core-build": {
       "version": "0.0.0",
-      "from": "projects\\gulp-core-build",
-      "resolved": "file:projects\\gulp-core-build"
+      "from": "projects\\gulp-core-build.tgz",
+      "resolved": "file:projects\\gulp-core-build.tgz"
     },
     "@rush-temp/gulp-core-build-karma": {
       "version": "0.0.0",
-      "from": "projects\\gulp-core-build-karma",
-      "resolved": "file:projects\\gulp-core-build-karma"
+      "from": "projects\\gulp-core-build-karma.tgz",
+      "resolved": "file:projects\\gulp-core-build-karma.tgz"
     },
     "@rush-temp/gulp-core-build-mocha": {
       "version": "0.0.0",
-      "from": "projects\\gulp-core-build-mocha",
-      "resolved": "file:projects\\gulp-core-build-mocha"
+      "from": "projects\\gulp-core-build-mocha.tgz",
+      "resolved": "file:projects\\gulp-core-build-mocha.tgz"
     },
     "@rush-temp/gulp-core-build-sass": {
       "version": "0.0.0",
-      "from": "projects\\gulp-core-build-sass",
-      "resolved": "file:projects\\gulp-core-build-sass"
+      "from": "projects\\gulp-core-build-sass.tgz",
+      "resolved": "file:projects\\gulp-core-build-sass.tgz"
     },
     "@rush-temp/gulp-core-build-serve": {
       "version": "0.0.0",
-      "from": "projects\\gulp-core-build-serve",
-      "resolved": "file:projects\\gulp-core-build-serve"
+      "from": "projects\\gulp-core-build-serve.tgz",
+      "resolved": "file:projects\\gulp-core-build-serve.tgz"
     },
     "@rush-temp/gulp-core-build-typescript": {
       "version": "0.0.0",
-      "from": "projects\\gulp-core-build-typescript",
-      "resolved": "file:projects\\gulp-core-build-typescript"
+      "from": "projects\\gulp-core-build-typescript.tgz",
+      "resolved": "file:projects\\gulp-core-build-typescript.tgz"
     },
     "@rush-temp/gulp-core-build-webpack": {
       "version": "0.0.0",
-      "from": "projects\\gulp-core-build-webpack",
-      "resolved": "file:projects\\gulp-core-build-webpack"
+      "from": "projects\\gulp-core-build-webpack.tgz",
+      "resolved": "file:projects\\gulp-core-build-webpack.tgz"
     },
     "@rush-temp/load-themed-styles": {
       "version": "0.0.0",
-      "from": "projects\\load-themed-styles",
-      "resolved": "file:projects\\load-themed-styles"
+      "from": "projects\\load-themed-styles.tgz",
+      "resolved": "file:projects\\load-themed-styles.tgz"
     },
     "@rush-temp/loader-load-themed-styles": {
       "version": "0.0.0",
-      "from": "projects\\loader-load-themed-styles",
-      "resolved": "file:projects\\loader-load-themed-styles"
+      "from": "projects\\loader-load-themed-styles.tgz",
+      "resolved": "file:projects\\loader-load-themed-styles.tgz"
     },
     "@rush-temp/loader-raw-script": {
       "version": "0.0.0",
-      "from": "projects\\loader-raw-script",
-      "resolved": "file:projects\\loader-raw-script"
+      "from": "projects\\loader-raw-script.tgz",
+      "resolved": "file:projects\\loader-raw-script.tgz"
     },
     "@rush-temp/loader-set-webpack-public-path": {
       "version": "0.0.0",
-      "from": "projects\\loader-set-webpack-public-path",
-      "resolved": "file:projects\\loader-set-webpack-public-path"
+      "from": "projects\\loader-set-webpack-public-path.tgz",
+      "resolved": "file:projects\\loader-set-webpack-public-path.tgz"
     },
     "@rush-temp/node-core-library": {
       "version": "0.0.0",
-      "from": "projects\\node-core-library",
-      "resolved": "file:projects\\node-core-library"
+      "from": "projects\\node-core-library.tgz",
+      "resolved": "file:projects\\node-core-library.tgz"
     },
     "@rush-temp/node-library-build": {
       "version": "0.0.0",
-      "from": "projects\\node-library-build",
-      "resolved": "file:projects\\node-library-build"
+      "from": "projects\\node-library-build.tgz",
+      "resolved": "file:projects\\node-library-build.tgz"
     },
     "@rush-temp/package-deps-hash": {
       "version": "0.0.0",
-      "from": "projects\\package-deps-hash",
-      "resolved": "file:projects\\package-deps-hash"
+      "from": "projects\\package-deps-hash.tgz",
+      "resolved": "file:projects\\package-deps-hash.tgz"
     },
     "@rush-temp/rush": {
       "version": "0.0.0",
-      "from": "projects\\rush",
-      "resolved": "file:projects\\rush"
+      "from": "projects\\rush.tgz",
+      "resolved": "file:projects\\rush.tgz"
     },
     "@rush-temp/rush-lib": {
       "version": "0.0.0",
-      "from": "projects\\rush-lib",
-      "resolved": "file:projects\\rush-lib"
+      "from": "projects\\rush-lib.tgz",
+      "resolved": "file:projects\\rush-lib.tgz"
     },
     "@rush-temp/set-webpack-public-path-plugin": {
       "version": "0.0.0",
-      "from": "projects\\set-webpack-public-path-plugin",
-      "resolved": "file:projects\\set-webpack-public-path-plugin"
+      "from": "projects\\set-webpack-public-path-plugin.tgz",
+      "resolved": "file:projects\\set-webpack-public-path-plugin.tgz"
     },
     "@rush-temp/stream-collator": {
       "version": "0.0.0",
-      "from": "projects\\stream-collator",
-      "resolved": "file:projects\\stream-collator"
+      "from": "projects\\stream-collator.tgz",
+      "resolved": "file:projects\\stream-collator.tgz"
     },
     "@rush-temp/test-web-library-build": {
       "version": "0.0.0",
-      "from": "projects\\test-web-library-build",
-      "resolved": "file:projects\\test-web-library-build"
+      "from": "projects\\test-web-library-build.tgz",
+      "resolved": "file:projects\\test-web-library-build.tgz"
     },
     "@rush-temp/ts-command-line": {
       "version": "0.0.0",
-      "from": "projects\\ts-command-line",
-      "resolved": "file:projects\\ts-command-line"
+      "from": "projects\\ts-command-line.tgz",
+      "resolved": "file:projects\\ts-command-line.tgz"
     },
     "@rush-temp/web-library-build": {
       "version": "0.0.0",
-      "from": "projects\\web-library-build",
-      "resolved": "file:projects\\web-library-build"
+      "from": "projects\\web-library-build.tgz",
+      "resolved": "file:projects\\web-library-build.tgz"
     },
     "@types/assertion-error": {
       "version": "1.0.30",
@@ -296,11 +296,6 @@
       "version": "0.2.3",
       "from": "@types/tapable@0.2.3",
       "resolved": "https://registry.npmjs.org/@types/tapable/-/tapable-0.2.3.tgz"
-    },
-    "@types/tar": {
-      "version": "1.0.29",
-      "from": "@types/tar@1.0.29",
-      "resolved": "https://registry.npmjs.org/@types/tar/-/tar-1.0.29.tgz"
     },
     "@types/through2": {
       "version": "2.0.32",
@@ -604,12 +599,6 @@
       "from": "batch@>=0.5.3 <0.6.0",
       "resolved": "https://registry.npmjs.org/batch/-/batch-0.5.3.tgz"
     },
-    "bcrypt-pbkdf": {
-      "version": "1.0.1",
-      "from": "bcrypt-pbkdf@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-      "optional": true
-    },
     "beeper": {
       "version": "1.1.1",
       "from": "beeper@>=1.0.0 <2.0.0",
@@ -852,9 +841,9 @@
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz"
     },
     "commander": {
-      "version": "2.11.0",
-      "from": "commander@>=2.7.1 <3.0.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz"
+      "version": "2.3.0",
+      "from": "commander@2.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz"
     },
     "component-bind": {
       "version": "1.0.0",
@@ -1294,12 +1283,6 @@
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz"
         }
       }
-    },
-    "ecc-jsbn": {
-      "version": "0.1.1",
-      "from": "ecc-jsbn@>=0.1.1 <0.2.0",
-      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-      "optional": true
     },
     "ee-first": {
       "version": "1.1.1",
@@ -2390,11 +2373,6 @@
       "from": "gulp-mocha@>=2.2.0 <2.3.0",
       "resolved": "https://registry.npmjs.org/gulp-mocha/-/gulp-mocha-2.2.0.tgz",
       "dependencies": {
-        "commander": {
-          "version": "2.3.0",
-          "from": "commander@2.3.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz"
-        },
         "escape-string-regexp": {
           "version": "1.0.2",
           "from": "escape-string-regexp@1.0.2",
@@ -2627,14 +2605,7 @@
     "handlebars": {
       "version": "4.0.10",
       "from": "handlebars@>=4.0.1 <5.0.0",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.10.tgz",
-      "dependencies": {
-        "source-map": {
-          "version": "0.4.4",
-          "from": "source-map@>=0.4.4 <0.5.0",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz"
-        }
-      }
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.10.tgz"
     },
     "har-schema": {
       "version": "1.0.5",
@@ -3141,12 +3112,6 @@
         }
       }
     },
-    "jsbn": {
-      "version": "0.1.1",
-      "from": "jsbn@>=0.1.0 <0.2.0",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "optional": true
-    },
     "jsesc": {
       "version": "0.5.0",
       "from": "jsesc@>=0.5.0 <0.6.0",
@@ -3164,7 +3129,7 @@
     },
     "json-stable-stringify": {
       "version": "1.0.1",
-      "from": "json-stable-stringify@>=1.0.1 <2.0.0",
+      "from": "json-stable-stringify@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz"
     },
     "json-stringify-safe": {
@@ -3777,7 +3742,7 @@
     },
     "mime-types": {
       "version": "2.1.16",
-      "from": "mime-types@>=2.1.7 <2.2.0",
+      "from": "mime-types@>=2.1.15 <2.2.0",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.16.tgz"
     },
     "minimatch": {
@@ -4574,7 +4539,7 @@
     },
     "qs": {
       "version": "6.4.0",
-      "from": "qs@>=6.4.0 <6.5.0",
+      "from": "qs@6.4.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz"
     },
     "querystring": {
@@ -4774,7 +4739,7 @@
     },
     "request": {
       "version": "2.81.0",
-      "from": "request@>=2.54.0 <3.0.0",
+      "from": "request@>=2.81.0 <2.82.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz"
     },
     "request-progress": {
@@ -4892,14 +4857,7 @@
     "scss-tokenizer": {
       "version": "0.2.3",
       "from": "scss-tokenizer@>=0.2.3 <0.3.0",
-      "resolved": "https://registry.npmjs.org/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz",
-      "dependencies": {
-        "source-map": {
-          "version": "0.4.4",
-          "from": "source-map@>=0.4.2 <0.5.0",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz"
-        }
-      }
+      "resolved": "https://registry.npmjs.org/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz"
     },
     "semver": {
       "version": "5.3.0",
@@ -5106,10 +5064,9 @@
       "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-0.1.8.tgz"
     },
     "source-map": {
-      "version": "0.2.0",
-      "from": "source-map@>=0.2.0 <0.3.0",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
-      "optional": true
+      "version": "0.4.4",
+      "from": "source-map@>=0.4.4 <0.5.0",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz"
     },
     "sparkles": {
       "version": "1.0.0",
@@ -5278,9 +5235,9 @@
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-0.1.10.tgz"
     },
     "tar": {
-      "version": "3.1.13",
+      "version": "3.1.14",
       "from": "tar@>=3.1.12 <3.2.0",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-3.1.13.tgz",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-3.1.14.tgz",
       "dependencies": {
         "yallist": {
           "version": "3.0.2",
@@ -5459,6 +5416,11 @@
       "from": "tslint@>=5.5.0 <5.6.0",
       "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.5.0.tgz",
       "dependencies": {
+        "commander": {
+          "version": "2.11.0",
+          "from": "commander@>=2.9.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz"
+        },
         "diff": {
           "version": "3.3.0",
           "from": "diff@>=3.2.0 <4.0.0",
@@ -5502,12 +5464,6 @@
       "version": "0.6.0",
       "from": "tunnel-agent@>=0.6.0 <0.7.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz"
-    },
-    "tweetnacl": {
-      "version": "0.14.5",
-      "from": "tweetnacl@>=0.14.0 <0.15.0",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "optional": true
     },
     "type-check": {
       "version": "0.3.2",
@@ -5862,14 +5818,7 @@
     "webpack-core": {
       "version": "0.6.9",
       "from": "webpack-core@>=0.6.0 <0.7.0",
-      "resolved": "https://registry.npmjs.org/webpack-core/-/webpack-core-0.6.9.tgz",
-      "dependencies": {
-        "source-map": {
-          "version": "0.4.4",
-          "from": "source-map@>=0.4.1 <0.5.0",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz"
-        }
-      }
+      "resolved": "https://registry.npmjs.org/webpack-core/-/webpack-core-0.6.9.tgz"
     },
     "webpack-dev-middleware": {
       "version": "1.12.0",

--- a/common/config/rush/npm-shrinkwrap.json
+++ b/common/config/rush/npm-shrinkwrap.json
@@ -29,118 +29,118 @@
     },
     "@rush-temp/api-extractor": {
       "version": "0.0.0",
-      "from": "projects\\api-extractor.tgz",
-      "resolved": "file:projects\\api-extractor.tgz"
+      "from": "projects\\api-extractor",
+      "resolved": "file:projects\\api-extractor"
     },
     "@rush-temp/decorators": {
       "version": "0.0.0",
-      "from": "projects\\decorators.tgz",
-      "resolved": "file:projects\\decorators.tgz"
+      "from": "projects\\decorators",
+      "resolved": "file:projects\\decorators"
     },
     "@rush-temp/gulp-core-build": {
       "version": "0.0.0",
-      "from": "projects\\gulp-core-build.tgz",
-      "resolved": "file:projects\\gulp-core-build.tgz"
+      "from": "projects\\gulp-core-build",
+      "resolved": "file:projects\\gulp-core-build"
     },
     "@rush-temp/gulp-core-build-karma": {
       "version": "0.0.0",
-      "from": "projects\\gulp-core-build-karma.tgz",
-      "resolved": "file:projects\\gulp-core-build-karma.tgz"
+      "from": "projects\\gulp-core-build-karma",
+      "resolved": "file:projects\\gulp-core-build-karma"
     },
     "@rush-temp/gulp-core-build-mocha": {
       "version": "0.0.0",
-      "from": "projects\\gulp-core-build-mocha.tgz",
-      "resolved": "file:projects\\gulp-core-build-mocha.tgz"
+      "from": "projects\\gulp-core-build-mocha",
+      "resolved": "file:projects\\gulp-core-build-mocha"
     },
     "@rush-temp/gulp-core-build-sass": {
       "version": "0.0.0",
-      "from": "projects\\gulp-core-build-sass.tgz",
-      "resolved": "file:projects\\gulp-core-build-sass.tgz"
+      "from": "projects\\gulp-core-build-sass",
+      "resolved": "file:projects\\gulp-core-build-sass"
     },
     "@rush-temp/gulp-core-build-serve": {
       "version": "0.0.0",
-      "from": "projects\\gulp-core-build-serve.tgz",
-      "resolved": "file:projects\\gulp-core-build-serve.tgz"
+      "from": "projects\\gulp-core-build-serve",
+      "resolved": "file:projects\\gulp-core-build-serve"
     },
     "@rush-temp/gulp-core-build-typescript": {
       "version": "0.0.0",
-      "from": "projects\\gulp-core-build-typescript.tgz",
-      "resolved": "file:projects\\gulp-core-build-typescript.tgz"
+      "from": "projects\\gulp-core-build-typescript",
+      "resolved": "file:projects\\gulp-core-build-typescript"
     },
     "@rush-temp/gulp-core-build-webpack": {
       "version": "0.0.0",
-      "from": "projects\\gulp-core-build-webpack.tgz",
-      "resolved": "file:projects\\gulp-core-build-webpack.tgz"
+      "from": "projects\\gulp-core-build-webpack",
+      "resolved": "file:projects\\gulp-core-build-webpack"
     },
     "@rush-temp/load-themed-styles": {
       "version": "0.0.0",
-      "from": "projects\\load-themed-styles.tgz",
-      "resolved": "file:projects\\load-themed-styles.tgz"
+      "from": "projects\\load-themed-styles",
+      "resolved": "file:projects\\load-themed-styles"
     },
     "@rush-temp/loader-load-themed-styles": {
       "version": "0.0.0",
-      "from": "projects\\loader-load-themed-styles.tgz",
-      "resolved": "file:projects\\loader-load-themed-styles.tgz"
+      "from": "projects\\loader-load-themed-styles",
+      "resolved": "file:projects\\loader-load-themed-styles"
     },
     "@rush-temp/loader-raw-script": {
       "version": "0.0.0",
-      "from": "projects\\loader-raw-script.tgz",
-      "resolved": "file:projects\\loader-raw-script.tgz"
+      "from": "projects\\loader-raw-script",
+      "resolved": "file:projects\\loader-raw-script"
     },
     "@rush-temp/loader-set-webpack-public-path": {
       "version": "0.0.0",
-      "from": "projects\\loader-set-webpack-public-path.tgz",
-      "resolved": "file:projects\\loader-set-webpack-public-path.tgz"
+      "from": "projects\\loader-set-webpack-public-path",
+      "resolved": "file:projects\\loader-set-webpack-public-path"
     },
     "@rush-temp/node-core-library": {
       "version": "0.0.0",
-      "from": "projects\\node-core-library.tgz",
-      "resolved": "file:projects\\node-core-library.tgz"
+      "from": "projects\\node-core-library",
+      "resolved": "file:projects\\node-core-library"
     },
     "@rush-temp/node-library-build": {
       "version": "0.0.0",
-      "from": "projects\\node-library-build.tgz",
-      "resolved": "file:projects\\node-library-build.tgz"
+      "from": "projects\\node-library-build",
+      "resolved": "file:projects\\node-library-build"
     },
     "@rush-temp/package-deps-hash": {
       "version": "0.0.0",
-      "from": "projects\\package-deps-hash.tgz",
-      "resolved": "file:projects\\package-deps-hash.tgz"
+      "from": "projects\\package-deps-hash",
+      "resolved": "file:projects\\package-deps-hash"
     },
     "@rush-temp/rush": {
       "version": "0.0.0",
-      "from": "projects\\rush.tgz",
-      "resolved": "file:projects\\rush.tgz"
+      "from": "projects\\rush",
+      "resolved": "file:projects\\rush"
     },
     "@rush-temp/rush-lib": {
       "version": "0.0.0",
-      "from": "projects\\rush-lib.tgz",
-      "resolved": "file:projects\\rush-lib.tgz"
+      "from": "projects\\rush-lib",
+      "resolved": "file:projects\\rush-lib"
     },
     "@rush-temp/set-webpack-public-path-plugin": {
       "version": "0.0.0",
-      "from": "projects\\set-webpack-public-path-plugin.tgz",
-      "resolved": "file:projects\\set-webpack-public-path-plugin.tgz"
+      "from": "projects\\set-webpack-public-path-plugin",
+      "resolved": "file:projects\\set-webpack-public-path-plugin"
     },
     "@rush-temp/stream-collator": {
       "version": "0.0.0",
-      "from": "projects\\stream-collator.tgz",
-      "resolved": "file:projects\\stream-collator.tgz"
+      "from": "projects\\stream-collator",
+      "resolved": "file:projects\\stream-collator"
     },
     "@rush-temp/test-web-library-build": {
       "version": "0.0.0",
-      "from": "projects\\test-web-library-build.tgz",
-      "resolved": "file:projects\\test-web-library-build.tgz"
+      "from": "projects\\test-web-library-build",
+      "resolved": "file:projects\\test-web-library-build"
     },
     "@rush-temp/ts-command-line": {
       "version": "0.0.0",
-      "from": "projects\\ts-command-line.tgz",
-      "resolved": "file:projects\\ts-command-line.tgz"
+      "from": "projects\\ts-command-line",
+      "resolved": "file:projects\\ts-command-line"
     },
     "@rush-temp/web-library-build": {
       "version": "0.0.0",
-      "from": "projects\\web-library-build.tgz",
-      "resolved": "file:projects\\web-library-build.tgz"
+      "from": "projects\\web-library-build",
+      "resolved": "file:projects\\web-library-build"
     },
     "@types/assertion-error": {
       "version": "1.0.30",
@@ -599,6 +599,12 @@
       "from": "batch@>=0.5.3 <0.6.0",
       "resolved": "https://registry.npmjs.org/batch/-/batch-0.5.3.tgz"
     },
+    "bcrypt-pbkdf": {
+      "version": "1.0.1",
+      "from": "bcrypt-pbkdf@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+      "optional": true
+    },
     "beeper": {
       "version": "1.1.1",
       "from": "beeper@>=1.0.0 <2.0.0",
@@ -841,9 +847,9 @@
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz"
     },
     "commander": {
-      "version": "2.3.0",
-      "from": "commander@2.3.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz"
+      "version": "2.11.0",
+      "from": "commander@>=2.7.1 <3.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz"
     },
     "component-bind": {
       "version": "1.0.0",
@@ -1283,6 +1289,12 @@
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz"
         }
       }
+    },
+    "ecc-jsbn": {
+      "version": "0.1.1",
+      "from": "ecc-jsbn@>=0.1.1 <0.2.0",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+      "optional": true
     },
     "ee-first": {
       "version": "1.1.1",
@@ -2373,6 +2385,11 @@
       "from": "gulp-mocha@>=2.2.0 <2.3.0",
       "resolved": "https://registry.npmjs.org/gulp-mocha/-/gulp-mocha-2.2.0.tgz",
       "dependencies": {
+        "commander": {
+          "version": "2.3.0",
+          "from": "commander@2.3.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz"
+        },
         "escape-string-regexp": {
           "version": "1.0.2",
           "from": "escape-string-regexp@1.0.2",
@@ -2605,7 +2622,14 @@
     "handlebars": {
       "version": "4.0.10",
       "from": "handlebars@>=4.0.1 <5.0.0",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.10.tgz"
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.10.tgz",
+      "dependencies": {
+        "source-map": {
+          "version": "0.4.4",
+          "from": "source-map@>=0.4.4 <0.5.0",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz"
+        }
+      }
     },
     "har-schema": {
       "version": "1.0.5",
@@ -3112,6 +3136,12 @@
         }
       }
     },
+    "jsbn": {
+      "version": "0.1.1",
+      "from": "jsbn@>=0.1.0 <0.2.0",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "optional": true
+    },
     "jsesc": {
       "version": "0.5.0",
       "from": "jsesc@>=0.5.0 <0.6.0",
@@ -3129,7 +3159,7 @@
     },
     "json-stable-stringify": {
       "version": "1.0.1",
-      "from": "json-stable-stringify@>=1.0.0 <2.0.0",
+      "from": "json-stable-stringify@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz"
     },
     "json-stringify-safe": {
@@ -3742,7 +3772,7 @@
     },
     "mime-types": {
       "version": "2.1.16",
-      "from": "mime-types@>=2.1.15 <2.2.0",
+      "from": "mime-types@>=2.1.7 <2.2.0",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.16.tgz"
     },
     "minimatch": {
@@ -4539,7 +4569,7 @@
     },
     "qs": {
       "version": "6.4.0",
-      "from": "qs@6.4.0",
+      "from": "qs@>=6.4.0 <6.5.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz"
     },
     "querystring": {
@@ -4739,7 +4769,7 @@
     },
     "request": {
       "version": "2.81.0",
-      "from": "request@>=2.81.0 <2.82.0",
+      "from": "request@>=2.54.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz"
     },
     "request-progress": {
@@ -4857,7 +4887,14 @@
     "scss-tokenizer": {
       "version": "0.2.3",
       "from": "scss-tokenizer@>=0.2.3 <0.3.0",
-      "resolved": "https://registry.npmjs.org/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz"
+      "resolved": "https://registry.npmjs.org/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz",
+      "dependencies": {
+        "source-map": {
+          "version": "0.4.4",
+          "from": "source-map@>=0.4.2 <0.5.0",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz"
+        }
+      }
     },
     "semver": {
       "version": "5.3.0",
@@ -4956,9 +4993,9 @@
       "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.2.6.tgz"
     },
     "shellwords": {
-      "version": "0.1.0",
+      "version": "0.1.1",
       "from": "shellwords@>=0.1.0 <0.2.0",
-      "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.0.tgz"
+      "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz"
     },
     "sigmund": {
       "version": "1.0.1",
@@ -5064,9 +5101,10 @@
       "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-0.1.8.tgz"
     },
     "source-map": {
-      "version": "0.4.4",
-      "from": "source-map@>=0.4.4 <0.5.0",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz"
+      "version": "0.2.0",
+      "from": "source-map@>=0.2.0 <0.3.0",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
+      "optional": true
     },
     "sparkles": {
       "version": "1.0.0",
@@ -5235,9 +5273,9 @@
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-0.1.10.tgz"
     },
     "tar": {
-      "version": "3.1.14",
+      "version": "3.1.15",
       "from": "tar@>=3.1.12 <3.2.0",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-3.1.14.tgz",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-3.1.15.tgz",
       "dependencies": {
         "yallist": {
           "version": "3.0.2",
@@ -5416,11 +5454,6 @@
       "from": "tslint@>=5.5.0 <5.6.0",
       "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.5.0.tgz",
       "dependencies": {
-        "commander": {
-          "version": "2.11.0",
-          "from": "commander@>=2.9.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz"
-        },
         "diff": {
           "version": "3.3.0",
           "from": "diff@>=3.2.0 <4.0.0",
@@ -5464,6 +5497,12 @@
       "version": "0.6.0",
       "from": "tunnel-agent@>=0.6.0 <0.7.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz"
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "from": "tweetnacl@>=0.14.0 <0.15.0",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "optional": true
     },
     "type-check": {
       "version": "0.3.2",
@@ -5818,7 +5857,14 @@
     "webpack-core": {
       "version": "0.6.9",
       "from": "webpack-core@>=0.6.0 <0.7.0",
-      "resolved": "https://registry.npmjs.org/webpack-core/-/webpack-core-0.6.9.tgz"
+      "resolved": "https://registry.npmjs.org/webpack-core/-/webpack-core-0.6.9.tgz",
+      "dependencies": {
+        "source-map": {
+          "version": "0.4.4",
+          "from": "source-map@>=0.4.1 <0.5.0",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz"
+        }
+      }
     },
     "webpack-dev-middleware": {
       "version": "1.12.0",

--- a/common/reviews/api/rush-lib.api.ts
+++ b/common/reviews/api/rush-lib.api.ts
@@ -359,8 +359,8 @@ class RushConfigurationProject {
   public readonly projectRelativeFolder: string;
   public readonly reviewCategory: string;
   public readonly shouldPublish: boolean;
-  public readonly tempPackageTarballFilename: string;
   public readonly tempProjectName: string;
+  public readonly unscopedTempProjectName: string;
   // @alpha
   public readonly versionPolicyName: string;
 }

--- a/common/reviews/api/rush-lib.api.ts
+++ b/common/reviews/api/rush-lib.api.ts
@@ -249,6 +249,8 @@ interface IVersionPolicyJson {
 // @public
 class JsonFile {
   public static loadJsonFile(jsonFilename: string): any;
+  // (undocumented)
+  public static normalize(jsonData: any): string;
   public static saveJsonFile(jsonData: any, jsonFilename: string, options: ISaveJsonFileOptions = {}): boolean;
 }
 
@@ -357,7 +359,7 @@ class RushConfigurationProject {
   public readonly projectRelativeFolder: string;
   public readonly reviewCategory: string;
   public readonly shouldPublish: boolean;
-  public readonly tempPackageJsonFilename: string;
+  public readonly tempPackageTarballFilename: string;
   public readonly tempProjectName: string;
   // @alpha
   public readonly versionPolicyName: string;


### PR DESCRIPTION
Rush needs to make `file:` references to tgz files. NPM has decided to deprecate the behavior of the `file:./...` specified, which used to treat the folder as a project that needed to be installed. Instead, `file:./...` references now just create a symlink, **unless** one is referencing a `.tgz` file. PNPM has also decided to use this behavior.

We should merge this PR to:
1) maintain forwards compatibility with NPM
2) allow us to use PNPM

See:
https://github.com/npm/npm/pull/15900
and
https://github.com/pnpm/pnpm/issues/772