### PR TITLE
Upgrade gulp-core-build-typescript to tslint 5.6

### DIFF
--- a/common/changes/@microsoft/gulp-core-build-typescript/update-tslint_2017-08-22-22-49.json
+++ b/common/changes/@microsoft/gulp-core-build-typescript/update-tslint_2017-08-22-22-49.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/gulp-core-build-typescript",
+      "comment": "Upgrade to tslint 5.6.0",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@microsoft/gulp-core-build-typescript",
+  "email": "christiango@users.noreply.github.com"
+}

--- a/common/config/rush/npm-shrinkwrap.json
+++ b/common/config/rush/npm-shrinkwrap.json
@@ -20,7 +20,24 @@
     "@microsoft/gulp-core-build-typescript": {
       "version": "3.4.0",
       "from": "@microsoft/gulp-core-build-typescript@3.4.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/gulp-core-build-typescript/-/gulp-core-build-typescript-3.4.0.tgz"
+      "resolved": "https://registry.npmjs.org/@microsoft/gulp-core-build-typescript/-/gulp-core-build-typescript-3.4.0.tgz",
+      "dependencies": {
+        "diff": {
+          "version": "3.3.0",
+          "from": "diff@>=3.2.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.0.tgz"
+        },
+        "glob": {
+          "version": "7.1.2",
+          "from": "glob@>=7.1.1 <8.0.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz"
+        },
+        "tslint": {
+          "version": "5.5.0",
+          "from": "tslint@>=5.5.0 <5.6.0",
+          "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.5.0.tgz"
+        }
+      }
     },
     "@microsoft/node-library-build": {
       "version": "3.2.8",
@@ -760,9 +777,9 @@
       "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz"
     },
     "caniuse-db": {
-      "version": "1.0.30000716",
+      "version": "1.0.30000717",
       "from": "caniuse-db@>=1.0.30000488 <2.0.0",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000716.tgz"
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000717.tgz"
     },
     "caseless": {
       "version": "0.12.0",
@@ -812,9 +829,9 @@
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz"
     },
     "cli-width": {
-      "version": "2.1.0",
+      "version": "2.2.0",
       "from": "cli-width@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz"
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz"
     },
     "cliui": {
       "version": "3.2.0",
@@ -5477,9 +5494,9 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.7.1.tgz"
     },
     "tslint": {
-      "version": "5.5.0",
-      "from": "tslint@>=5.5.0 <5.6.0",
-      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.5.0.tgz",
+      "version": "5.6.0",
+      "from": "tslint@>=5.6.0 <5.7.0",
+      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.6.0.tgz",
       "dependencies": {
         "diff": {
           "version": "3.3.0",

--- a/core-build/gulp-core-build-typescript/package.json
+++ b/core-build/gulp-core-build-typescript/package.json
@@ -35,7 +35,7 @@
     "merge2": "~1.0.2",
     "object-assign": "~4.1.0",
     "through2": "~2.0.1",
-    "tslint": "~5.5.0",
+    "tslint": "~5.6.0",
     "tslint-microsoft-contrib": "~5.0.0",
     "typescript": "~2.4.1"
   },


### PR DESCRIPTION
Upgrades to tslint 5.6 so we can get this [fix](https://github.com/palantir/tslint/commit/a479f436530f0afd52fc65c5a45645bd4a2b5b29)