### PR TITLE
Improve the bold/italics markdown generated by api-documenter

### DIFF
--- a/libraries/api-documenter/src/test/ExpectedOutput.md
+++ b/libraries/api-documenter/src/test/ExpectedOutput.md
@@ -24,8 +24,8 @@ This is a **bold** word.
 
 ## Adjacent bold regions
 
-**one**<!-- -->**two** **three**<!-- -->**four**<!-- -->nonbold<!-- -->**five**
+**onetwo threefour**<!-- -->nonbold<!-- -->**five**
 
 ## Bad characters
 
-**\*one\*two\***<!-- -->**three\*four**
+**\*one\*two\*three\*four**

--- a/libraries/api-documenter/src/test/ExpectedOutput.md
+++ b/libraries/api-documenter/src/test/ExpectedOutput.md
@@ -1,3 +1,31 @@
 <!-- docId=test-id -->
 
 # Test page
+
+
+## Simple bold test
+
+This is a **bold** word.
+
+## All whitespace bold
+
+
+
+## Newline bold
+
+**line 1**
+**line 2**
+
+## Newline bold with spaces
+
+  **line 1**
+  **line 2**
+  **line 3**
+
+## Adjacent bold regions
+
+**one**<!-- -->**two** **three**<!-- -->**four**<!-- -->nonbold<!-- -->**five**
+
+## Bad characters
+
+**\*one\*two\***<!-- -->**three\*four**

--- a/libraries/api-documenter/src/test/MarkdownPageRenderer.test.ts
+++ b/libraries/api-documenter/src/test/MarkdownPageRenderer.test.ts
@@ -18,6 +18,34 @@ describe('MarkdownPageRenderer', () => {
 
     const renderer: MarkdownPageRenderer = new MarkdownPageRenderer(outputFolder);
     const domPage: IDomPage = Domifier.createPage('Test page', 'test-id');
+
+    domPage.elements.push(Domifier.createHeading1('Simple bold test'));
+    domPage.elements.push(...Domifier.createTextElements('This is a '));
+    domPage.elements.push(...Domifier.createTextElements('bold', { bold: true }));
+    domPage.elements.push(...Domifier.createTextElements(' word.'));
+
+    domPage.elements.push(Domifier.createHeading1('All whitespace bold'));
+    domPage.elements.push(...Domifier.createTextElements('  ', { bold: true }));
+
+    domPage.elements.push(Domifier.createHeading1('Newline bold'));
+    domPage.elements.push(...Domifier.createTextElements('line 1\nline 2', { bold: true }));
+
+    domPage.elements.push(Domifier.createHeading1('Newline bold with spaces'));
+    domPage.elements.push(...Domifier.createTextElements('  line 1  \n  line 2  \n  line 3  ', { bold: true }));
+
+    domPage.elements.push(Domifier.createHeading1('Adjacent bold regions'));
+    domPage.elements.push(...Domifier.createTextElements('one', { bold: true }));
+    domPage.elements.push(...Domifier.createTextElements('two', { bold: true }));
+    domPage.elements.push(...Domifier.createTextElements(' three', { bold: true }));
+    domPage.elements.push(...Domifier.createTextElements('', { bold: false }));
+    domPage.elements.push(...Domifier.createTextElements('four', { bold: true }));
+    domPage.elements.push(...Domifier.createTextElements('nonbold', { bold: false }));
+    domPage.elements.push(...Domifier.createTextElements('five', { bold: true }));
+
+    domPage.elements.push(Domifier.createHeading1('Bad characters'));
+    domPage.elements.push(...Domifier.createTextElements('*one*two*', { bold: true }));
+    domPage.elements.push(...Domifier.createTextElements('three*four', { bold: true }));
+
     const outputFilename: string = renderer.writePage(domPage);
 
     FileDiffTest.assertEqual(outputFilename, path.join(__dirname, 'ExpectedOutput.md'));


### PR DESCRIPTION
This PR implements a couple improvements to the MarkdownPageRenderer class:

1. bold/italics are now handled correctly for strings that:
    - span multiple lines
    - have spaces in them
    - are preceded/followed by a non-whitespace character
    - are adjacent to other stylized regions (in which case `<!-- -->` is inserted between the incompatible blocks)

2. If two adjacent IDomText blocks have the same styling, then they are merged to avoid redundant markup (e.g. `**some boldstuff**` instead of `**some** **bold**<!-- -->**stuff**`)
