### PR TITLE
Fix issue where api-extractor failed to find node-core-library

### DIFF
--- a/common/changes/@microsoft/api-extractor/pgonzal-fix-dependencies_2017-08-31-17-20.json
+++ b/common/changes/@microsoft/api-extractor/pgonzal-fix-dependencies_2017-08-31-17-20.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Fix issue where node-core-library was not an explicit dependency",
+      "packageName": "@microsoft/api-extractor",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/node-core-library/pgonzal-fix-dependencies_2017-08-31-17-20.json
+++ b/common/changes/@microsoft/node-core-library/pgonzal-fix-dependencies_2017-08-31-17-20.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@microsoft/node-core-library",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/node-core-library",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/config/rush/npm-shrinkwrap.json
+++ b/common/config/rush/npm-shrinkwrap.json
@@ -4837,9 +4837,9 @@
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz"
         },
         "supports-color": {
-          "version": "4.3.0",
+          "version": "4.4.0",
           "from": "supports-color@>=4.2.1 <5.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.3.0.tgz"
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz"
         }
       }
     },
@@ -4874,9 +4874,9 @@
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz"
         },
         "supports-color": {
-          "version": "4.3.0",
+          "version": "4.4.0",
           "from": "supports-color@>=4.2.1 <5.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.3.0.tgz"
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz"
         }
       }
     },
@@ -4911,9 +4911,9 @@
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz"
         },
         "supports-color": {
-          "version": "4.3.0",
+          "version": "4.4.0",
           "from": "supports-color@>=4.2.1 <5.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.3.0.tgz"
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz"
         }
       }
     },
@@ -4948,9 +4948,9 @@
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz"
         },
         "supports-color": {
-          "version": "4.3.0",
+          "version": "4.4.0",
           "from": "supports-color@>=4.2.1 <5.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.3.0.tgz"
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz"
         }
       }
     },
@@ -6402,9 +6402,9 @@
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz"
         },
         "supports-color": {
-          "version": "4.3.0",
+          "version": "4.4.0",
           "from": "supports-color@>=4.2.1 <5.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.3.0.tgz"
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz"
         },
         "yargs": {
           "version": "8.0.2",

--- a/libraries/api-documenter/package.json
+++ b/libraries/api-documenter/package.json
@@ -13,9 +13,15 @@
     "clean": "gulp clean",
     "test": "gulp test"
   },
+  "dependencies": {
+    "@microsoft/api-extractor": "2.3.6",
+    "@microsoft/node-core-library": "~0.2.0",
+    "colors": "~1.1.2",
+    "fs-extra": "~0.26.7",
+    "js-yaml": "~3.9.1"
+  },
   "devDependencies": {
     "@microsoft/node-library-build": "~3.4.0",
-    "@microsoft/node-core-library": "~0.2.0",
     "@types/chai": "3.4.34",
     "@types/colors": "1.1.3",
     "@types/es6-collections": "0.5.29",
@@ -26,11 +32,5 @@
     "chai": "~3.5.0",
     "gulp": "~3.9.1",
     "mocha": "~3.4.2"
-  },
-  "dependencies": {
-    "@microsoft/api-extractor": "2.3.6",
-    "colors": "~1.1.2",
-    "fs-extra": "~0.26.7",
-    "js-yaml": "~3.9.1"
   }
 }

--- a/libraries/api-extractor/package.json
+++ b/libraries/api-extractor/package.json
@@ -26,16 +26,8 @@
     "clean": "gulp clean",
     "test": "gulp test"
   },
-  "devDependencies": {
-    "@types/chai": "3.4.34",
-    "@types/mocha": "2.2.38",
-    "chai": "~3.5.0",
-    "gulp": "~3.9.1",
-    "mocha": "~3.4.2",
-    "@microsoft/node-core-library": "~0.2.0",
-    "@microsoft/node-library-build": "~3.2.0"
-  },
   "dependencies": {
+    "@microsoft/node-core-library": "~0.2.0",
     "@types/es6-collections": "0.5.29",
     "@types/fs-extra": "0.0.37",
     "@types/node": "6.0.62",
@@ -44,5 +36,13 @@
     "jju": "~1.3.0",
     "typescript": "~2.4.1",
     "z-schema": "~3.18.3"
+  },
+  "devDependencies": {
+    "@types/chai": "3.4.34",
+    "@types/mocha": "2.2.38",
+    "chai": "~3.5.0",
+    "gulp": "~3.9.1",
+    "mocha": "~3.4.2",
+    "@microsoft/node-library-build": "~3.2.0"
   }
 }

--- a/libraries/node-core-library/package.json
+++ b/libraries/node-core-library/package.json
@@ -10,14 +10,6 @@
     "clean": "gulp clean",
     "test": "gulp test"
   },
-  "devDependencies": {
-    "@types/chai": "3.4.34",
-    "@types/mocha": "2.2.38",
-    "chai": "~3.5.0",
-    "gulp": "~3.9.1",
-    "mocha": "~3.4.2",
-    "@microsoft/node-library-build": "~3.3.2"
-  },
   "dependencies": {
     "@types/es6-collections": "0.5.29",
     "@types/fs-extra": "0.0.37",
@@ -26,5 +18,13 @@
     "fs-extra": "~0.26.7",
     "jju": "~1.3.0",
     "z-schema": "~3.18.3"
+  },
+  "devDependencies": {
+    "@types/chai": "3.4.34",
+    "@types/mocha": "2.2.38",
+    "chai": "~3.5.0",
+    "gulp": "~3.9.1",
+    "mocha": "~3.4.2",
+    "@microsoft/node-library-build": "~3.3.2"
   }
 }


### PR DESCRIPTION
This is a fix for [SPFx GitHub # 820](https://github.com/SharePoint/sp-dev-docs/issues/820).

The error looked like this:
```
TypeError: Cannot read property 'readCommentedJsonFile' of undefined
TypeError: Cannot read property 'readCommentedJsonFile' of undefined
```

The problem was that **api-extractor** recently took a dependency on **node-core-library**, but it was incorrectly listed as a dev dependency.