### PR TITLE
Major bump core build libraries to fix compatibility issue

### DIFF
--- a/common/changes/@microsoft/api-extractor/pgonzal-major-bump_2017-08-31-18-17.json
+++ b/common/changes/@microsoft/api-extractor/pgonzal-major-bump_2017-08-31-18-17.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor",
+      "comment": "Fix compatibility issues with old releases, by incrementing the major version number",
+      "type": "major"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/gulp-core-build-karma/pgonzal-major-bump_2017-08-31-18-17.json
+++ b/common/changes/@microsoft/gulp-core-build-karma/pgonzal-major-bump_2017-08-31-18-17.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/gulp-core-build-karma",
+      "comment": "Fix compatibility issues with old releases, by incrementing the major version number",
+      "type": "major"
+    }
+  ],
+  "packageName": "@microsoft/gulp-core-build-karma",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/gulp-core-build-mocha/pgonzal-major-bump_2017-08-31-18-17.json
+++ b/common/changes/@microsoft/gulp-core-build-mocha/pgonzal-major-bump_2017-08-31-18-17.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/gulp-core-build-mocha",
+      "comment": "Fix compatibility issues with old releases, by incrementing the major version number",
+      "type": "major"
+    }
+  ],
+  "packageName": "@microsoft/gulp-core-build-mocha",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/gulp-core-build-sass/pgonzal-major-bump_2017-08-31-18-17.json
+++ b/common/changes/@microsoft/gulp-core-build-sass/pgonzal-major-bump_2017-08-31-18-17.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/gulp-core-build-sass",
+      "comment": "Fix compatibility issues with old releases, by incrementing the major version number",
+      "type": "major"
+    }
+  ],
+  "packageName": "@microsoft/gulp-core-build-sass",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/gulp-core-build-serve/pgonzal-major-bump_2017-08-31-18-17.json
+++ b/common/changes/@microsoft/gulp-core-build-serve/pgonzal-major-bump_2017-08-31-18-17.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/gulp-core-build-serve",
+      "comment": "Fix compatibility issues with old releases, by incrementing the major version number",
+      "type": "major"
+    }
+  ],
+  "packageName": "@microsoft/gulp-core-build-serve",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/gulp-core-build-typescript/pgonzal-major-bump_2017-08-31-18-17.json
+++ b/common/changes/@microsoft/gulp-core-build-typescript/pgonzal-major-bump_2017-08-31-18-17.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/gulp-core-build-typescript",
+      "comment": "Fix compatibility issues with old releases, by incrementing the major version number",
+      "type": "major"
+    }
+  ],
+  "packageName": "@microsoft/gulp-core-build-typescript",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/gulp-core-build-webpack/pgonzal-major-bump_2017-08-31-18-17.json
+++ b/common/changes/@microsoft/gulp-core-build-webpack/pgonzal-major-bump_2017-08-31-18-17.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/gulp-core-build-webpack",
+      "comment": "Fix compatibility issues with old releases, by incrementing the major version number",
+      "type": "major"
+    }
+  ],
+  "packageName": "@microsoft/gulp-core-build-webpack",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/gulp-core-build/pgonzal-major-bump_2017-08-31-18-17.json
+++ b/common/changes/@microsoft/gulp-core-build/pgonzal-major-bump_2017-08-31-18-17.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/gulp-core-build",
+      "comment": "Fix compatibility issues with old releases, by incrementing the major version number",
+      "type": "major"
+    }
+  ],
+  "packageName": "@microsoft/gulp-core-build",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/node-library-build/pgonzal-major-bump_2017-08-31-18-17.json
+++ b/common/changes/@microsoft/node-library-build/pgonzal-major-bump_2017-08-31-18-17.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/node-library-build",
+      "comment": "Fix compatibility issues with old releases, by incrementing the major version number",
+      "type": "major"
+    }
+  ],
+  "packageName": "@microsoft/node-library-build",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/web-library-build/pgonzal-major-bump_2017-08-31-18-17.json
+++ b/common/changes/@microsoft/web-library-build/pgonzal-major-bump_2017-08-31-18-17.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/web-library-build",
+      "comment": "Fix compatibility issues with old releases, by incrementing the major version number",
+      "type": "major"
+    }
+  ],
+  "packageName": "@microsoft/web-library-build",
+  "email": "pgonzal@users.noreply.github.com"
+}


### PR DESCRIPTION
Some old SPFx releases used a caret dependency for various toolchain libraries, which has been causing regressions because we don't actively retest these old releases.  (SemVer compatibility should avoid breaking changes to APIs, however it doesn't prevent an upgrade from invalidating all the testing and validation that was done for an earlier release.)

This is part of the fix for [SPFx GitHub # 820](https://github.com/SharePoint/sp-dev-docs/issues/820).