### PR TITLE
YamlGenerator now supports hyperlinks to API items

### DIFF
--- a/common/changes/@microsoft/api-extractor/pgonzal-yaml-documenter2_2017-09-06-00-28.json
+++ b/common/changes/@microsoft/api-extractor/pgonzal-yaml-documenter2_2017-09-06-00-28.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor",
+      "comment": "Converted IMarkupDocumentationLink to IMarkupApiLink, which exposes the underlying IApiItemReference rather than assuming a particular \"document ID\" model",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/reviews/api/api-extractor.api.ts
+++ b/common/reviews/api/api-extractor.api.ts
@@ -180,6 +180,14 @@ interface IApiInterface extends IApiBaseDefinition {
 }
 
 // @alpha
+interface IApiItemReference {
+  exportName: string;
+  memberName: string;
+  packageName: string;
+  scopeName: string;
+}
+
+// @alpha
 interface IApiMethod extends IApiBaseDefinition {
   accessModifier: ApiAccessModifier;
   isOptional: boolean;
@@ -272,22 +280,22 @@ interface IHrefLinkElement extends IBaseDocElement {
 }
 
 // @alpha
+interface IMarkupApiLink {
+  // (undocumented)
+  elements: MarkupLinkTextElement[];
+  // (undocumented)
+  kind: 'api-link';
+  // (undocumented)
+  target: IApiItemReference;
+}
+
+// @alpha
 interface IMarkupCodeBox {
   // (undocumented)
   highlighter: MarkupHighlighter;
   // (undocumented)
   kind: 'code-box';
   text: string;
-}
-
-// @alpha
-interface IMarkupDocumentationLink {
-  // (undocumented)
-  elements: MarkupLinkTextElement[];
-  // (undocumented)
-  kind: 'doc-link';
-  // (undocumented)
-  targetDocId: string;
 }
 
 // @alpha

--- a/libraries/api-documenter/src/DocumentationNode.ts
+++ b/libraries/api-documenter/src/DocumentationNode.ts
@@ -3,7 +3,7 @@
 
 import {
   ApiItem,
-  ICodeLinkElement
+  IApiItemReference
 } from '@microsoft/api-extractor';
 
 export class DocumentationNode {
@@ -14,7 +14,7 @@ export class DocumentationNode {
 
   // TODO: This is not really correct.  We need to validate that the referenced object
   // actually exists, and avoid creating a broken link if not.
-  public static getDocIdForCodeLink(codeLink: ICodeLinkElement): string {
+  public static getDocIdForCodeLink(codeLink: Partial<IApiItemReference>): string {
     let result: string = '';
     if (codeLink.packageName) {
       result += codeLink.packageName;
@@ -54,5 +54,21 @@ export class DocumentationNode {
       this._docId = result;
     }
     return this._docId;
+  }
+
+  // This is a temporary workaround until the DocumentationNode class is replaced by DocItem
+  public getApiReference(): IApiItemReference {
+    const result: string[] = [];
+    for (let current: DocumentationNode | undefined = this; current; current = current.parent) {
+      result.unshift(current.name);
+    }
+    result.push('', '', '');
+
+    return {
+      scopeName: '',
+      packageName: result[0],
+      exportName: result[1],
+      memberName: result[2]
+    };
   }
 }

--- a/libraries/api-documenter/src/Documenter.ts
+++ b/libraries/api-documenter/src/Documenter.ts
@@ -91,9 +91,9 @@ export class Documenter {
       const exportNode: DocumentationNode = new DocumentationNode(docItem, exportName, packageNode);
 
       const docItemTitle: MarkupBasicElement[] = [
-        MarkupBuilder.createDocumentationLink(
+        MarkupBuilder.createApiLink(
           [ MarkupBuilder.createCode(exportName, 'javascript') ],
-          exportNode.docId)
+          exportNode.getApiReference())
       ];
 
       const docItemDescription: MarkupBasicElement[] = [];
@@ -217,9 +217,9 @@ export class Documenter {
       switch (member.kind) {
         case 'property':
           const propertyTitle: MarkupBasicElement[] = [
-            MarkupBuilder.createDocumentationLink(
+            MarkupBuilder.createApiLink(
               [MarkupBuilder.createCode(memberName, 'javascript')],
-              memberNode.docId)
+              memberNode.getApiReference())
           ];
 
           propertiesTable.rows.push(
@@ -235,9 +235,9 @@ export class Documenter {
 
         case 'method':
           const methodTitle: MarkupBasicElement[] = [
-            MarkupBuilder.createDocumentationLink(
+            MarkupBuilder.createApiLink(
               [MarkupBuilder.createCode(RenderingHelpers.getConciseSignature(memberName, member), 'javascript')],
-              memberNode.docId)
+              memberNode.getApiReference())
           ];
 
           methodsTable.rows.push(
@@ -308,9 +308,9 @@ export class Documenter {
       switch (member.kind) {
         case 'property':
           const propertyTitle: MarkupBasicElement[] = [
-            MarkupBuilder.createDocumentationLink(
+            MarkupBuilder.createApiLink(
               [MarkupBuilder.createCode(memberName, 'javascript')],
-              memberNode.docId)
+              memberNode.getApiReference())
           ];
 
           propertiesTable.rows.push(
@@ -325,9 +325,9 @@ export class Documenter {
 
         case 'method':
           const methodTitle: MarkupBasicElement[] = [
-            MarkupBuilder.createDocumentationLink(
+            MarkupBuilder.createApiLink(
               [MarkupBuilder.createCode(RenderingHelpers.getConciseSignature(memberName, member), 'javascript')],
-              memberNode.docId)
+              memberNode.getApiReference())
           ];
 
           methodsTable.rows.push(
@@ -550,7 +550,7 @@ export class Documenter {
   }
 
   private _writeBreadcrumb(markupPage: IMarkupPage, currentNode: DocumentationNode): void {
-    markupPage.breadcrumb.push(MarkupBuilder.createDocumentationLinkFromText('Home', 'index'));
+    markupPage.breadcrumb.push(MarkupBuilder.createWebLinkFromText('Home', './index'));
 
     const reversedNodes: DocumentationNode[] = [];
     for (let node: DocumentationNode|undefined = currentNode.parent; node; node = node.parent) {
@@ -558,7 +558,7 @@ export class Documenter {
     }
     for (const node of reversedNodes) {
       markupPage.breadcrumb.push(...MarkupBuilder.createTextElements(' > '));
-      markupPage.breadcrumb.push(MarkupBuilder.createDocumentationLinkFromText(node.name, node.docId));
+      markupPage.breadcrumb.push(MarkupBuilder.createApiLinkFromText(node.name, node.getApiReference()));
     }
   }
 

--- a/libraries/api-documenter/src/MarkdownPageRenderer.ts
+++ b/libraries/api-documenter/src/MarkdownPageRenderer.ts
@@ -5,10 +5,9 @@ import * as fsx from 'fs-extra';
 import * as path from 'path';
 
 import { IMarkupPage } from '@microsoft/api-extractor';
-
 import { BasePageRenderer } from './BasePageRenderer';
-
-import { MarkdownRenderer } from './MarkdownRenderer';
+import { DocumentationNode } from './DocumentationNode';
+import { MarkdownRenderer, IMarkdownRenderApiLinkArgs } from './MarkdownRenderer';
 
 /**
  * Renders API documentation in the Markdown file format.
@@ -23,8 +22,11 @@ export class MarkdownPageRenderer extends BasePageRenderer {
     const filename: string = path.join(this.outputFolder, this.getFilenameForDocId(markupPage.docId));
 
     const content: string = MarkdownRenderer.renderElements([markupPage], {
-      docIdResolver: (docId: string) => {
-        return this.getFilenameForDocId(docId);
+      onRenderApiLink: (args: IMarkdownRenderApiLinkArgs) => {
+        const docId: string = DocumentationNode.getDocIdForCodeLink(args.reference);
+        const docFilename: string = this.getFilenameForDocId(docId);
+        args.prefix = '[';
+        args.suffix = '](' + docFilename + ')';
       }
     });
 

--- a/libraries/api-documenter/src/MarkdownRenderer.ts
+++ b/libraries/api-documenter/src/MarkdownRenderer.ts
@@ -242,7 +242,12 @@ export class MarkdownRenderer {
             suffix: ''
           };
 
+          // NOTE: The onRenderApiLink() callback will assign values to the args.prefix
+          // and args.suffix properties, which are used below.  (It is modeled this way because
+          // MarkdownRenderer._writeElements() may need to emit different escaping e.g. depending
+          // on what characters were written by writer.write(args.prefix).)
           context.options.onRenderApiLink(args);
+
           if (args.prefix) {
             writer.write(args.prefix);
           }

--- a/libraries/api-documenter/src/MarkdownRenderer.ts
+++ b/libraries/api-documenter/src/MarkdownRenderer.ts
@@ -3,7 +3,8 @@
 
 import {
   IMarkupText,
-  MarkupElement
+  MarkupElement,
+  IApiItemReference
 } from '@microsoft/api-extractor';
 
 /**
@@ -59,15 +60,30 @@ interface IRenderContext {
   depth: number;
 }
 
+export interface IMarkdownRenderApiLinkArgs {
+  /**
+   * The IApiItemReference being rendered.
+   */
+  readonly reference: IApiItemReference;
+  /**
+   * The callback can assign text here that will be inserted before the link text.
+   * Example: "["
+   */
+  prefix: string;
+
+  /**
+   * The callback can assign text here that will be inserted after the link text.
+   * Example: "](./TargetPage.md)"
+   */
+  suffix: string;
+}
+
 export interface IMarkdownRendererOptions {
   /**
-   * For IMarkupDocumentationLink elements, this callback receives a docId and returns a
-   * path that will be used for the Markdown hyperlink.  If the function returns an empty
-   * string, then the text will be rendered without a hyperlink.
-   * If the docIdResolver callback is not provided, an error occurs if IMarkupDocumentationLink
-   * is encountered.
+   * This callback receives an IMarkupApiLink, and returns the rendered markdown content.
+   * If the callback is not provided, an error occurs if an IMarkupApiLink is encountered.
    */
-  docIdResolver?: (docId: string) => string;
+  onRenderApiLink?: (args: IMarkdownRenderApiLinkArgs) => void;
 }
 
 /**
@@ -215,18 +231,24 @@ export class MarkdownRenderer {
           writer.write(element.text);
           writer.write('`');
           break;
-        case 'doc-link':
-          if (!context.options.docIdResolver) {
-            throw new Error('IMarkupDocumentationLink cannot be rendered because a docIdResolver was not provided');
+        case 'api-link':
+          if (!context.options.onRenderApiLink) {
+            throw new Error('IMarkupApiLink cannot be rendered because a renderApiLink handler was not provided');
           }
-          const linkTarget: string = context.options.docIdResolver(element.targetDocId);
-          if (linkTarget) {
-            writer.write('[');
-            MarkdownRenderer._writeElements(element.elements, context);
-            writer.write(`](./${linkTarget})`);
-          } else {
-            // No link
-            MarkdownRenderer._writeElements(element.elements, context);
+
+          const args: IMarkdownRenderApiLinkArgs = {
+            reference: element.target,
+            prefix: '',
+            suffix: ''
+          };
+
+          context.options.onRenderApiLink(args);
+          if (args.prefix) {
+            writer.write(args.prefix);
+          }
+          MarkdownRenderer._writeElements(element.elements, context);
+          if (args.suffix) {
+            writer.write(args.suffix);
           }
 
           break;

--- a/libraries/api-documenter/src/RenderingHelpers.ts
+++ b/libraries/api-documenter/src/RenderingHelpers.ts
@@ -40,6 +40,18 @@ export class RenderingHelpers {
   }
 
   /**
+   * Creates a scoped package name by assembling the scope name and unscoped package name.
+   * For example, getScopedPackageName("", "example") returns "example", whereas
+   * getScopedPackageName("@ms", "example") returns "@ms/example".
+   */
+  public static getScopedPackageName(scopeName: string, packageName: string): string {
+    if (scopeName) {
+      return scopeName + '/' + packageName;
+    }
+    return packageName;
+  }
+
+  /**
    * Generates a concise signature for a function.  Example: "getArea(width, height)"
    */
   public static getConciseSignature(methodName: string, method: IApiMethod): string {

--- a/libraries/api-documenter/src/test/ExpectedOutput.md
+++ b/libraries/api-documenter/src/test/ExpectedOutput.md
@@ -2,14 +2,13 @@
 
 # Test page
 
-
 ## Simple bold test
 
 This is a **bold** word.
 
 ## All whitespace bold
 
-
+  
 
 ## Newline bold
 
@@ -18,9 +17,9 @@ This is a **bold** word.
 
 ## Newline bold with spaces
 
-  **line 1**
-  **line 2**
-  **line 3**
+  **line 1**  
+  **line 2**  
+  **line 3**  
 
 ## Adjacent bold regions
 

--- a/libraries/api-documenter/src/test/MarkdownPageRenderer.test.ts
+++ b/libraries/api-documenter/src/test/MarkdownPageRenderer.test.ts
@@ -44,7 +44,7 @@ describe('MarkdownPageRenderer', () => {
 
     markupPage.elements.push(MarkupBuilder.createHeading1('Adjacent to other characters'));
     // Creates a "[" before the bold text
-    markupPage.elements.push(MarkupBuilder.createDocumentationLinkFromText('a link', 'index'));
+    markupPage.elements.push(MarkupBuilder.createWebLinkFromText('a link', './index.md'));
     markupPage.elements.push(...MarkupBuilder.createTextElements('bold', { bold: true }));
     markupPage.elements.push(...MarkupBuilder.createTextElements('non-bold', { bold: false }));
     markupPage.elements.push(...MarkupBuilder.createTextElements('more-non-bold', { bold: false }));

--- a/libraries/api-documenter/src/yaml/YamlGenerator.ts
+++ b/libraries/api-documenter/src/yaml/YamlGenerator.ts
@@ -15,7 +15,7 @@ import {
 } from './IYamlFile';
 import { RenderingHelpers } from '../RenderingHelpers';
 import { MarkupBuilder } from '../MarkupBuilder';
-import { MarkdownRenderer } from '../MarkdownRenderer';
+import { MarkdownRenderer, IMarkdownRenderApiLinkArgs } from '../MarkdownRenderer';
 
 const yamlSchema: JsonSchema = JsonSchema.fromFile(path.join(__dirname, 'typescript.schema.json'));
 
@@ -157,8 +157,8 @@ export class YamlGenerator {
     }
 
     return MarkdownRenderer.renderElements(markupElements, {
-      docIdResolver: (docId: string) => {
-        return ''; // no link for now
+      onRenderApiLink: (args: IMarkdownRenderApiLinkArgs) => {
+        // no link for now
       }
     });
   }

--- a/libraries/api-documenter/src/yaml/YamlGenerator.ts
+++ b/libraries/api-documenter/src/yaml/YamlGenerator.ts
@@ -7,11 +7,10 @@ import yaml = require('js-yaml');
 import { JsonFile, JsonSchema } from '@microsoft/node-core-library';
 import { MarkupElement, IDocElement } from '@microsoft/api-extractor';
 
-import { DocItemSet, DocItem, DocItemKind } from '../DocItemSet';
+import { DocItemSet, DocItem, DocItemKind, IDocItemSetResolveResult } from '../DocItemSet';
 import {
   IYamlFile,
-  IYamlItem,
-  YamlTypeId
+  IYamlItem
 } from './IYamlFile';
 import { RenderingHelpers } from '../RenderingHelpers';
 import { MarkupBuilder } from '../MarkupBuilder';
@@ -47,7 +46,7 @@ export class YamlGenerator {
       return false;
     }
 
-    if (this._shouldEmbed(yamlItem.type)) {
+    if (this._shouldEmbed(docItem.kind)) {
       if (!parentYamlFile) {
         throw new Error('Missing file context'); // program bug
       }
@@ -85,12 +84,12 @@ export class YamlGenerator {
     return true;
   }
 
-  private _shouldEmbed(yamlTypeId: YamlTypeId): boolean {
-    switch (yamlTypeId) {
-      case 'class':
-      case 'package':
-      case 'interface':
-      case 'enum':
+  private _shouldEmbed(docItemKind: DocItemKind): boolean {
+    switch (docItemKind) {
+      case DocItemKind.Class:
+      case DocItemKind.Package:
+      case DocItemKind.Interface:
+      case DocItemKind.Enum:
       return false;
     }
     return true;
@@ -100,12 +99,12 @@ export class YamlGenerator {
     const yamlItem: Partial<IYamlItem> = { };
     yamlItem.uid = this._getUid(docItem);
 
-    const summary: string = this._renderMarkdownFromDocElement(docItem.apiItem.summary);
+    const summary: string = this._renderMarkdownFromDocElement(docItem.apiItem.summary, docItem);
     if (summary) {
       yamlItem.summary = summary;
     }
 
-    const remarks: string = this._renderMarkdownFromDocElement(docItem.apiItem.remarks);
+    const remarks: string = this._renderMarkdownFromDocElement(docItem.apiItem.remarks, docItem);
     if (remarks) {
       yamlItem.remarks = remarks;
     }
@@ -140,25 +139,59 @@ export class YamlGenerator {
         return undefined;
     }
 
-    if (docItem.kind !== DocItemKind.Package && !this._shouldEmbed(yamlItem.type)) {
+    if (docItem.kind !== DocItemKind.Package && !this._shouldEmbed(docItem.kind)) {
       yamlItem.package = this._getUid(docItem.getHierarchy()[0]);
     }
 
     return yamlItem as IYamlItem;
   }
 
-  private _renderMarkdownFromDocElement(docElements: IDocElement[] | undefined): string {
-    return this._renderMarkdown(MarkupBuilder.renderDocElements(docElements || []));
+  private _renderMarkdownFromDocElement(docElements: IDocElement[] | undefined, containingDocItem: DocItem): string {
+    return this._renderMarkdown(MarkupBuilder.renderDocElements(docElements || []), containingDocItem);
   }
 
-  private _renderMarkdown(markupElements: MarkupElement[]): string {
+  private _renderMarkdown(markupElements: MarkupElement[], containingDocItem: DocItem): string {
     if (!markupElements.length) {
       return '';
     }
 
     return MarkdownRenderer.renderElements(markupElements, {
       onRenderApiLink: (args: IMarkdownRenderApiLinkArgs) => {
-        // no link for now
+        const result: IDocItemSetResolveResult = this._docItemSet.resolveApiItemReference(args.reference);
+        if (!result.docItem) {
+          // Eventually we should introduce a warnings file
+          console.error('==> UNRESOLVED REFERENCE: ' + JSON.stringify(args.reference));
+        } else {
+          // We will calculate a relativeUrl to the nearest non-embedded DocItem.
+          // (The rest will be determined by the URL fragment.)
+          let nonEmbeddedDocItem: DocItem = result.docItem;
+          while (this._shouldEmbed(nonEmbeddedDocItem.kind) && nonEmbeddedDocItem.parent) {
+            nonEmbeddedDocItem = nonEmbeddedDocItem.parent;
+          }
+
+          const currentFolder: string = path.dirname(this._getYamlFilePath(containingDocItem));
+          const targetFilePath: string = this._getYamlFilePath(nonEmbeddedDocItem);
+          const relativePath: string = path.relative(currentFolder, targetFilePath);
+          let relativeUrl: string = relativePath
+            .replace(/[\\]/g, '/') // replace all backslashes with slashes
+            .replace(/\.[^\.\\/]+$/, ''); // remove file extension
+
+          if (relativeUrl.substr(0, 1) !== '.') {
+            // If the path doesn't already start with "./", then add this prefix.
+            relativeUrl = './' + relativeUrl;
+          }
+
+          // Do we need to link to a fragment within the page?
+          if (nonEmbeddedDocItem !== result.docItem) {
+            const urlFragment: string = this._getEmbeddedUrlFragment(result.docItem);
+            args.prefix = '[';
+            args.suffix = `](${relativeUrl}#${urlFragment})`;
+          } else {
+            args.prefix = '[';
+            args.suffix = `](${relativeUrl})`;
+          }
+
+        }
       }
     });
   }
@@ -166,7 +199,9 @@ export class YamlGenerator {
   private _writeYamlFile(yamlFile: IYamlFile, docItem: DocItem): void {
     const yamlFilePath: string = this._getYamlFilePath(docItem);
 
-    console.log('Writing ' + yamlFilePath);
+    if (docItem.kind === DocItemKind.Package) {
+      console.log('Writing ' + this._getYamlFilePath(docItem));
+    }
 
     JsonFile.validateNoUndefinedMembers(yamlFile);
 
@@ -180,6 +215,10 @@ export class YamlGenerator {
     yamlSchema.validateObject(yamlFile, yamlFilePath);
   }
 
+  /**
+   * Calculate the docfx "uid" for the DocItem
+   * Example:  node-core-library.JsonFile.load
+   */
   private _getUid(docItem: DocItem): string {
     let result: string = '';
     for (const current of docItem.getHierarchy()) {
@@ -194,6 +233,15 @@ export class YamlGenerator {
       }
     }
     return result;
+  }
+
+  /**
+   * Calculate the HTML anchor fragment for DocItems that are embedded in a web page containing
+   * other items.
+   * Example:  node_core_library_JsonFile_load
+   */
+  private _getEmbeddedUrlFragment(docItem: DocItem): string {
+    return this._getUid(docItem).replace(/\./g, '_'); // replace all periods with underscores
   }
 
   private _getYamlFilePath(docItem: DocItem): string {

--- a/libraries/api-extractor/src/api/ApiItem.ts
+++ b/libraries/api-extractor/src/api/ApiItem.ts
@@ -4,6 +4,42 @@
 import { IDocElement } from '../markup/OldMarkup';
 
 /**
+ * Represents a reference to an ApiItem.
+ * @alpha
+ */
+export interface IApiItemReference {
+  /**
+   * The name of the NPM scope, or an empty string if there is no scope.
+   * @remarks
+   * Example: "@microsoft"
+   */
+  scopeName: string;
+
+  /**
+   * The name of the NPM package that the API item belongs to, without the NPM scope.
+   * @remarks
+   * Example: "sample-package"
+   */
+  packageName: string;
+
+  /**
+   * The name of an exported API item, or an empty string.
+   * @remarks
+   * The name does not include any generic parameters or other punctuation.
+   * Example: "SampleClass"
+   */
+  exportName: string;
+
+  /**
+   * The name of a member of the exported item, or an empty string.
+   * @remarks
+   * The name does not include any parameters or punctuation.
+   * Example: "toString"
+   */
+  memberName: string;
+}
+
+/**
  * Whether the function is public, private, or protected.
  * @alpha
  */

--- a/libraries/api-extractor/src/markup/MarkupElement.ts
+++ b/libraries/api-extractor/src/markup/MarkupElement.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
+import { IApiItemReference } from '../api/ApiItem';
+
 // ----------------------------------------------------------------------------
 
 /**
@@ -63,10 +65,10 @@ export type MarkupLinkTextElement = IMarkupText | IMarkupHighlightedText;
  * A block of plain text, possibly with simple formatting.
  * @alpha
  */
-export interface IMarkupDocumentationLink {
-  kind: 'doc-link';
+export interface IMarkupApiLink {
+  kind: 'api-link';
   elements: MarkupLinkTextElement[];
-  targetDocId: string;
+  target: IApiItemReference;
 }
 
 /**
@@ -100,7 +102,7 @@ export interface IMarkupLineBreak {
  *
  * @alpha
  */
-export type MarkupBasicElement = MarkupLinkTextElement | IMarkupDocumentationLink | IMarkupWebLink | IMarkupParagraph
+export type MarkupBasicElement = MarkupLinkTextElement | IMarkupApiLink | IMarkupWebLink | IMarkupParagraph
   | IMarkupLineBreak;
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
This includes a change to the IMarkupDocumentationLink interface from API Extractor (still an \@alpha API).  This element type is replaced with IMarkupApiLink, which exposes the underlying IApiItemReference.

