### PR TITLE
api-documenter now correctly supports enums for YAML

### DIFF
--- a/common/changes/@microsoft/api-extractor/pgonzal-yaml-documenter3_2017-09-06-03-12.json
+++ b/common/changes/@microsoft/api-extractor/pgonzal-yaml-documenter3_2017-09-06-03-12.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor",
+      "comment": "Fix incorrect schema/typings for enum members",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/reviews/api/api-extractor.api.ts
+++ b/common/reviews/api/api-extractor.api.ts
@@ -148,13 +148,8 @@ interface IApiEnum extends IApiBaseDefinition {
 }
 
 // @alpha
-interface IApiEnumMember {
-  // (undocumented)
-  deprecatedMessage?: IDocElement[];
-  // (undocumented)
-  remarks?: IDocElement[];
-  // (undocumented)
-  summary?: IDocElement[];
+interface IApiEnumMember extends IApiBaseDefinition {
+  kind: 'enum value';
   // (undocumented)
   value: string;
 }

--- a/libraries/api-documenter/src/DocItemSet.ts
+++ b/libraries/api-documenter/src/DocItemSet.ts
@@ -19,7 +19,8 @@ export enum DocItemKind {
   Constructor,
   Function,
   Property,
-  Enum
+  Enum,
+  EnumMember
 }
 
 /**
@@ -88,6 +89,13 @@ export class DocItem {
           break;
         case 'enum':
           this.kind = DocItemKind.Enum;
+          for (const memberName of Object.keys(this.apiItem.values)) {
+            const child: ApiItem = this.apiItem.values[memberName];
+            this.children.push(new DocItem(child, memberName, this.docItemSet, this));
+          }
+          break;
+        case 'enum value':
+          this.kind = DocItemKind.EnumMember;
           break;
         default:
           throw new Error('Unsupported item kind: ' + (this.apiItem as ApiItem).kind);

--- a/libraries/api-documenter/src/yaml/YamlGenerator.ts
+++ b/libraries/api-documenter/src/yaml/YamlGenerator.ts
@@ -5,7 +5,11 @@ import * as fsx from 'fs-extra';
 import * as path from 'path';
 import yaml = require('js-yaml');
 import { JsonFile, JsonSchema } from '@microsoft/node-core-library';
-import { MarkupElement, IDocElement } from '@microsoft/api-extractor';
+import {
+  MarkupElement,
+  IDocElement,
+  IApiEnumMember
+} from '@microsoft/api-extractor';
 
 import { DocItemSet, DocItem, DocItemKind, IDocItemSetResolveResult } from '../DocItemSet';
 import {
@@ -122,6 +126,14 @@ export class YamlGenerator {
         break;
       case DocItemKind.EnumMember:
         yamlItem.type = 'field';
+        const enumMember: IApiEnumMember = docItem.apiItem as IApiEnumMember;
+        if (enumMember.value) {
+          // NOTE: In TypeScript, enum members can be strings or integers.
+          // If it is an integer, then enumMember.value will be a string representation of the integer.
+          // If it is a string, then enumMember.value will include the quotation marks.
+          // Enum values can also be calculated numbers, however this is not implemented yet.
+          yamlItem.numericValue = enumMember.value as any; // tslint:disable-line:no-any
+        }
         break;
       case DocItemKind.Class:
         yamlItem.type = 'class';

--- a/libraries/api-documenter/src/yaml/YamlGenerator.ts
+++ b/libraries/api-documenter/src/yaml/YamlGenerator.ts
@@ -120,6 +120,9 @@ export class YamlGenerator {
       case DocItemKind.Enum:
         yamlItem.type = 'enum';
         break;
+      case DocItemKind.EnumMember:
+        yamlItem.type = 'field';
+        break;
       case DocItemKind.Class:
         yamlItem.type = 'class';
         break;
@@ -135,8 +138,11 @@ export class YamlGenerator {
       case DocItemKind.Property:
         yamlItem.type = 'property';
         break;
+      case DocItemKind.Function:
+        // Unimplemented
+        break;
       default:
-        return undefined;
+        throw new Error('Unimplemented item kind: ' + DocItemKind[docItem.kind as DocItemKind]);
     }
 
     if (docItem.kind !== DocItemKind.Package && !this._shouldEmbed(docItem.kind)) {

--- a/libraries/api-documenter/src/yaml/typescript.schema.json
+++ b/libraries/api-documenter/src/yaml/typescript.schema.json
@@ -1,210 +1,210 @@
 {
-  "title": "Universal Reference YAML Schema for TypeScript",
-  "$schema": "http://json-schema.org/draft-04/schema#",
-  "type": "object",
-  "additionalProperties": false,
-  "required": [
-    "items"
-  ],
-  "properties": {
+	"title": "Universal Reference YAML Schema for TypeScript",
+	"$schema": "http://json-schema.org/draft-04/schema#",
+	"type": "object",
+	"additionalProperties": false,
+	"required": [
+		"items"
+	],
+	"properties": {
     "$schema": {
       "description": "Part of the JSON Schema standard, this optional keyword declares the URL of the schema that the file conforms to. Editors may download the schema and use it to perform syntax highlighting.",
       "type": "string"
     },
-    "items": {
-      "description": "This collection represents the main item (the first element) and it's possible children items.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/item"
-      },
-      "minItems": 1,
-      "uniqueItems": true
-    },
-    "references": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/reference"
-      },
-      "minItems": 1,
-      "uniqueItems": true
-    }
-  },
-  "definitions":{
-    "exception": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "description": {
-          "type": "string"
-        },
-        "type": {
-          "type": "string"
-        }
-      }
-    },
-    "item": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "uid"
-      ],
-      "properties": {
-        "children": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "minItems": 1,
-          "uniqueItems": true
-        },
-        "exceptions": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/exception"
-          },
-          "minItems": 1,
-          "uniqueItems": true
-        },
-        "fullName": {
-          "type": "string",
-          "description": "The full friendly name of the object. (ex: Microsoft.FSharp.Linq.RuntimeHelpers.AnonymousObject<T1,T2>)"
-        },
-        "langs": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "minItems": 1,
-          "uniqueItems": true
-        },
-        "name": {
-          "type": "string",
-          "description": "The name of the object. (ex: AnonymousObject<T1,T2>)"
-        },
-        "numericValue": {
-          "type": "integer",
-          "description": "Used for Enum fields"
-        },
-        "package": {
-          "type": "string"
-        },
-        "source": {
-          "$ref": "#/definitions/source"
-        },
-        "summary": {
-          "type": "string"
-        },
-        "remarks": {
-          "type": "string"
-        },
-        "syntax": {
-          "$ref": "#/definitions/syntax"
-        },
-        "type": {
-          "enum": [ "class", "constructor", "enum", "field", "interface", "method", "package", "property" ]
-        },
-        "uid": {
-          "type": "string",
-          "description": "The fully qualified name of the object. (ex: Microsoft.FSharp.Linq.RuntimeHelpers.AnonymousObject`2)"
-        }
-      }
-    },
-    "parameter": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "description": {
-          "type": "string"
-        },
-        "id": {
-          "type": "string"
-        },
-        "type": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "reference": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "uid": {
-          "type": "string"
-        }
-      }
-    },
-    "remote": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "branch": {
-          "type": "string"
-        },
-        "path": {
-          "type": "string"
-        },
-        "repo": {
-          "type": "string"
-        }
-      }
-    },
-    "return": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "description": {
-          "type": "string"
-        },
-        "type": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "source": {
-      "type": "object",
-      "properties": {
-        "id": {
-          "type": "string"
-        },
-        "path": {
-          "type": "string"
-        },
-        "remote": {
-          "$ref": "#/definitions/remote"
-        },
-        "startLine": {
-          "type": "integer"
-        }
-      }
-    },
-    "syntax": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "content": {
-          "type": "string"
-        },
-        "parameters": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/parameter"
-          },
-          "minItems": 1,
-          "uniqueItems": true
-        },
-        "return": {
-          "$ref": "#/definitions/return"
-        }
-      }
-    }
-  }
+		"items": {
+			"description": "This collection represents the main item (the first element) and it's possible children items.",
+			"type": "array",
+			"items": {
+				"$ref": "#/definitions/item"
+			},
+			"minItems": 1,
+			"uniqueItems": true
+		},
+		"references": {
+			"type": "array",
+			"items": {
+				"$ref": "#/definitions/reference"
+			},
+			"minItems": 1,
+			"uniqueItems": true
+		}
+	},
+	"definitions":{
+		"exception": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"description": {
+					"type": "string"
+				},
+				"type": {
+					"type": "string"
+				}
+			}
+		},
+		"item": {
+			"type": "object",
+			"additionalProperties": false,
+			"required": [
+				"uid"
+			],
+			"properties": {
+				"children": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					},
+					"minItems": 1,
+					"uniqueItems": true
+				},
+				"exceptions": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/exception"
+					},
+					"minItems": 1,
+					"uniqueItems": true
+				},
+				"fullName": {
+					"type": "string",
+					"description": "The full friendly name of the object. (ex: Microsoft.FSharp.Linq.RuntimeHelpers.AnonymousObject<T1,T2>)"
+				},
+				"langs": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					},
+					"minItems": 1,
+					"uniqueItems": true
+				},
+				"name": {
+					"type": "string",
+					"description": "The name of the object. (ex: AnonymousObject<T1,T2>)"
+				},
+				"numericValue": {
+					"type": "string",
+					"description": "Used for Enum fields"
+				},
+				"package": {
+					"type": "string"
+				},
+				"source": {
+					"$ref": "#/definitions/source"
+				},
+				"summary": {
+					"type": "string"
+				},
+				"remarks": {
+					"type": "string"
+				},
+				"syntax": {
+					"$ref": "#/definitions/syntax"
+				},
+				"type": {
+					"enum": [ "class", "constructor", "enum", "field", "interface", "method", "package", "property" ]
+				},
+				"uid": {
+					"type": "string",
+					"description": "The fully qualified name of the object. (ex: Microsoft.FSharp.Linq.RuntimeHelpers.AnonymousObject`2)"
+				}
+			}
+		},
+		"parameter": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"description": {
+					"type": "string"
+				},
+				"id": {
+					"type": "string"
+				},
+				"type": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				}
+			}
+		},
+		"reference": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"name": {
+					"type": "string"
+				},
+				"uid": {
+					"type": "string"
+				}
+			}
+		},
+		"remote": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"branch": {
+					"type": "string"
+				},
+				"path": {
+					"type": "string"
+				},
+				"repo": {
+					"type": "string"
+				}
+			}
+		},
+		"return": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"description": {
+					"type": "string"
+				},
+				"type": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				}
+			}
+		},
+		"source": {
+			"type": "object",
+			"properties": {
+				"id": {
+					"type": "string"
+				},
+				"path": {
+					"type": "string"
+				},
+				"remote": {
+					"$ref": "#/definitions/remote"
+				},
+				"startLine": {
+					"type": "integer"
+				}
+			}
+		},
+		"syntax": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"content": {
+					"type": "string"
+				},
+				"parameters": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/parameter"
+					},
+					"minItems": 1,
+					"uniqueItems": true
+				},
+				"return": {
+					"$ref": "#/definitions/return"
+				}
+			}
+		}
+	}
 }

--- a/libraries/api-extractor/src/api/ApiItem.ts
+++ b/libraries/api-extractor/src/api/ApiItem.ts
@@ -46,20 +46,6 @@ export interface IApiItemReference {
 export type ApiAccessModifier = 'public' | 'private' | 'protected' | '';
 
 /**
- * The enum value of an IApiEnum.
- *
- * IApiEnumMember does not extend the IDocITem base class
- * because the summary is not required.
- * @alpha
- */
-export interface IApiEnumMember {
-  value: string;
-  summary?: IDocElement[];
-  remarks?: IDocElement[];
-  deprecatedMessage?: IDocElement[];
-}
-
-/**
  * Parameter Doc item.
  * @alpha
  */
@@ -276,6 +262,20 @@ export interface IApiEnum extends IApiBaseDefinition {
 }
 
 /**
+ * A member of an IApiEnum.
+ *
+ * @alpha
+ */
+export interface IApiEnumMember extends IApiBaseDefinition {
+  /**
+   * {@inheritdoc IApiBaseDefinition.kind}
+   */
+  kind: 'enum value';
+
+  value: string;
+}
+
+/**
  * IApiInterface represents an exported interface.
  * @alpha
  */
@@ -351,7 +351,7 @@ export type ApiMember = IApiProperty | IApiMethod;
  * @alpha
  */
 export type ApiItem = IApiProperty | ApiMember | IApiFunction | IApiConstructor |
-   IApiClass |IApiEnum | IApiInterface | IApiPackage;
+   IApiClass | IApiEnum | IApiEnumMember | IApiInterface | IApiPackage;
 
 /**
  * Describes a return type and description of the return type

--- a/libraries/api-extractor/src/api/api-json.schema.json
+++ b/libraries/api-extractor/src/api/api-json.schema.json
@@ -519,22 +519,7 @@
           "type": "object",
           "patternProperties": {
             "^[a-zA-Z_]+[a-zA-Z_0-9]*$": {
-              "type": "object",
-              "properties": {
-                "value": {
-                  "description": "The initializer to the enum value",
-                  "type": "string"
-                },
-                "deprecatedMessage": {
-                  "$ref": "#/definitions/docElementCollection"
-                },
-                "summary": {
-                  "$ref": "#/definitions/docElementCollection"
-                },
-                "remarks": {
-                  "$ref": "#/definitions/docElementCollection"
-                }
-              }
+              "$ref": "#/definitions/enumMemberApiItem"
             }
           },
           "additionalProperties": false
@@ -550,6 +535,41 @@
       },
       "additionalProperties": false,
       "required": [ "kind", "summary", "values", "isBeta" ]
+    },
+
+    //---------------------------------------------------------------------------------------------
+    "enumMemberApiItem": {
+      "description": "A TypeScript enum member definition",
+      "type": "object",
+
+      "properties": {
+        "kind": {
+          "description": "The kind of API definition",
+          "type": "string",
+          "enum": [ "enum value" ]
+        },
+        "summary": {
+          "$ref": "#/definitions/docElementCollection"
+        },
+        "isBeta": {
+          "description": "Whether the API enum member is beta",
+          "type": "boolean"
+        },
+        "value": {
+          "description": "The value of the enum, which may be a number, a string literal, or an empty string (if the value is automatically assigned)",
+          "type": "string"
+        },
+
+        // Optional properties:
+        "remarks": {
+          "$ref": "#/definitions/docElementCollection"
+        },
+        "deprecatedMessage": {
+          "$ref": "#/definitions/docElementCollection"
+        }
+      },
+      "additionalProperties": false,
+      "required": [ "kind", "summary", "isBeta" ]
     },
 
     //---------------------------------------------------------------------------------------------

--- a/libraries/api-extractor/src/api/api-json.schema.json
+++ b/libraries/api-extractor/src/api/api-json.schema.json
@@ -556,7 +556,7 @@
           "type": "boolean"
         },
         "value": {
-          "description": "The value of the enum, which may be a number, a string literal, or an empty string (if the value is automatically assigned)",
+          "description": "The value of the enum member. This string may be a number, a string literal (including quotation marks), or an empty string (e.g. if the number is an automatically assigned increment)",
           "type": "string"
         },
 

--- a/libraries/api-extractor/testInputs/example2/node_modules/@microsoft/sp-core-library/dist/sp-core-library.api.json
+++ b/libraries/api-extractor/testInputs/example2/node_modules/@microsoft/sp-core-library/dist/sp-core-library.api.json
@@ -1,11 +1,24 @@
 {
   "kind": "package",
   "name": "@microsoft/sp-core-library",
+  "summary": [
+    {
+      "kind": "textDocElement",
+      "value": "SharePoint Framework core libraries"
+    }
+  ],
+  "remarks": [
+    {
+      "kind": "textDocElement",
+      "value": "This package provides a core foundation of common definitions that ensure a consistent character across all the other SharePoint Framework APIs. Because this package is a dependency of every other package, it is effectively mandatory, so its design goals are small code size and broad applicability, versus flexibility or richness of features."
+    }
+  ],
   "exports": {
     "DisplayMode": {
       "kind": "enum",
       "values": {
         "Edit": {
+          "kind": "enum value",
           "value": "2",
           "deprecatedMessage": [],
           "summary": [],
@@ -13,6 +26,7 @@
           "isBeta": false
         },
         "Read": {
+          "kind": "enum value",
           "value": "1",
           "deprecatedMessage": [],
           "summary": [],
@@ -39,6 +53,7 @@
       "kind": "enum",
       "values": {
         "Edit": {
+          "kind": "enum value",
           "value": "2",
           "deprecatedMessage": [],
           "summary": [],
@@ -46,6 +61,7 @@
           "isBeta": false
         },
         "Read": {
+          "kind": "enum value",
           "value": "1",
           "deprecatedMessage": [],
           "summary": [],
@@ -110,6 +126,7 @@
       "kind": "enum",
       "values": {
         "ClassicSharePoint": {
+          "kind": "enum value",
           "value": "",
           "deprecatedMessage": [],
           "summary": [
@@ -122,6 +139,7 @@
           "isBeta": false
         },
         "Local": {
+          "kind": "enum value",
           "value": "",
           "deprecatedMessage": [],
           "summary": [
@@ -134,6 +152,7 @@
           "isBeta": false
         },
         "SharePoint": {
+          "kind": "enum value",
           "value": "",
           "deprecatedMessage": [],
           "summary": [
@@ -146,6 +165,7 @@
           "isBeta": false
         },
         "Test": {
+          "kind": "enum value",
           "value": "",
           "deprecatedMessage": [],
           "summary": [
@@ -185,7 +205,8 @@
             {
               "kind": "linkDocElement",
               "referenceType": "href",
-              "targetUrl": "https://www.ietf.org/rfc/rfc4122.txt"
+              "targetUrl": "https://www.ietf.org/rfc/rfc4122.txt",
+              "value": "https://www.ietf.org/rfc/rfc4122.txt"
             }
           ]
         }
@@ -237,7 +258,7 @@
         },
         "isValid": {
           "kind": "method",
-          "signature": "public static isValid(guid: string): boolean;",
+          "signature": "public static isValid(guid: string | undefined | null): boolean;",
           "accessModifier": "public",
           "isOptional": false,
           "isStatic": true,
@@ -261,7 +282,7 @@
               ],
               "isOptional": false,
               "isSpread": false,
-              "type": "string"
+              "type": "string | undefined | null"
             }
           },
           "deprecatedMessage": [],
@@ -302,7 +323,7 @@
         },
         "parse": {
           "kind": "method",
-          "signature": "public static parse(guidString: string): Guid;",
+          "signature": "public static parse(guidString: string | undefined | null): Guid;",
           "accessModifier": "public",
           "isOptional": false,
           "isStatic": true,
@@ -369,12 +390,12 @@
         },
         "tryParse": {
           "kind": "method",
-          "signature": "public static tryParse(guid: string): Guid;",
+          "signature": "public static tryParse(guid: string | undefined | null): Guid | undefined;",
           "accessModifier": "public",
           "isOptional": false,
           "isStatic": true,
           "returnValue": {
-            "type": "Guid",
+            "type": "Guid | undefined",
             "description": [
               {
                 "kind": "textDocElement",
@@ -393,7 +414,7 @@
               ],
               "isOptional": false,
               "isSpread": false,
-              "type": "string"
+              "type": "string | undefined | null"
             }
           },
           "deprecatedMessage": [],
@@ -813,20 +834,29 @@
       "isBeta": false,
       "members": {
         "__constructor": {
-          "kind": "method",
+          "kind": "constructor",
           "signature": "constructor(serviceScope: ServiceScope);",
-          "accessModifier": "",
-          "isOptional": false,
-          "isStatic": false,
-          "returnValue": {
-            "type": "",
-            "description": []
-          },
           "parameters": {},
           "deprecatedMessage": [],
-          "summary": [],
-          "remarks": [],
-          "isBeta": false
+          "summary": [
+            {
+              "kind": "textDocElement",
+              "value": "Constructs a new instance of the "
+            },
+            {
+              "kind": "linkDocElement",
+              "referenceType": "code",
+              "scopeName": "@microsoft",
+              "packageName": "sp-core-library",
+              "exportName": "RandomNumberGenerator",
+              "value": "RandomNumberGenerator"
+            },
+            {
+              "kind": "textDocElement",
+              "value": " class"
+            }
+          ],
+          "remarks": []
         },
         "generate": {
           "kind": "method",
@@ -879,27 +909,6 @@
       "remarks": [],
       "isBeta": false,
       "members": {
-        "__constructor": {
-          "kind": "method",
-          "signature": "constructor(id: string, name: string, defaultCreator: ServiceCreator<T>);",
-          "accessModifier": "",
-          "isOptional": false,
-          "isStatic": false,
-          "returnValue": {
-            "type": "",
-            "description": []
-          },
-          "parameters": {},
-          "deprecatedMessage": [],
-          "summary": [
-            {
-              "kind": "textDocElement",
-              "value": "PRIVATE - Do not call this from your own code."
-            }
-          ],
-          "remarks": [],
-          "isBeta": false
-        },
         "create": {
           "kind": "method",
           "signature": "public static create < T >(name: string,\r\n    serviceClass: { new (serviceScope: ServiceScope); }): ServiceKey<T>;",
@@ -1052,27 +1061,6 @@
       "remarks": [],
       "isBeta": false,
       "members": {
-        "__constructor": {
-          "kind": "method",
-          "signature": "constructor(parent: ServiceScope);",
-          "accessModifier": "",
-          "isOptional": false,
-          "isStatic": false,
-          "returnValue": {
-            "type": "",
-            "description": []
-          },
-          "parameters": {},
-          "deprecatedMessage": [],
-          "summary": [
-            {
-              "kind": "textDocElement",
-              "value": "PRIVATE CONSTRUCTOR - DO NOT CALL THIS FROM YOUR OWN CODE."
-            }
-          ],
-          "remarks": [],
-          "isBeta": false
-        },
         "consume": {
           "kind": "method",
           "signature": "public consume < T >(serviceKey: ServiceKey<T>): T;",
@@ -1225,12 +1213,12 @@
         },
         "getParent": {
           "kind": "method",
-          "signature": "public getParent(): ServiceScope;",
+          "signature": "public getParent(): ServiceScope | undefined;",
           "accessModifier": "public",
           "isOptional": false,
           "isStatic": false,
           "returnValue": {
-            "type": "ServiceScope",
+            "type": "ServiceScope | undefined",
             "description": [
               {
                 "kind": "textDocElement",
@@ -1437,6 +1425,44 @@
         }
       }
     },
+    "Text": {
+      "kind": "class",
+      "extends": "",
+      "implements": "",
+      "typeParameters": [],
+      "deprecatedMessage": [],
+      "summary": [
+        {
+          "kind": "textDocElement",
+          "value": "Common helper functions for working with strings. These utilities are intended to be simple, small, and very broadly applicable."
+        }
+      ],
+      "remarks": [],
+      "isBeta": false,
+      "members": {
+        "format": {
+          "kind": "method",
+          "signature": "public static format(s: string, ...values: any[]): string;",
+          "accessModifier": "public",
+          "isOptional": false,
+          "isStatic": true,
+          "returnValue": {
+            "type": "string",
+            "description": []
+          },
+          "parameters": {},
+          "deprecatedMessage": [],
+          "summary": [
+            {
+              "kind": "textDocElement",
+              "value": "String Format, like C# string format. Usage Example: StringUtilities.format(\"hello {0}!\", \"mike\") will return \"hello mike!\""
+            }
+          ],
+          "remarks": [],
+          "isBeta": false
+        }
+      }
+    },
     "TimeProvider": {
       "kind": "class",
       "extends": "",
@@ -1453,20 +1479,29 @@
       "isBeta": false,
       "members": {
         "__constructor": {
-          "kind": "method",
+          "kind": "constructor",
           "signature": "constructor(serviceScope: ServiceScope);",
-          "accessModifier": "",
-          "isOptional": false,
-          "isStatic": false,
-          "returnValue": {
-            "type": "",
-            "description": []
-          },
           "parameters": {},
           "deprecatedMessage": [],
-          "summary": [],
-          "remarks": [],
-          "isBeta": false
+          "summary": [
+            {
+              "kind": "textDocElement",
+              "value": "Constructs a new instance of the "
+            },
+            {
+              "kind": "linkDocElement",
+              "referenceType": "code",
+              "scopeName": "@microsoft",
+              "packageName": "sp-core-library",
+              "exportName": "TimeProvider",
+              "value": "TimeProvider"
+            },
+            {
+              "kind": "textDocElement",
+              "value": " class"
+            }
+          ],
+          "remarks": []
         },
         "getDate": {
           "kind": "method",
@@ -1499,6 +1534,22 @@
           "summary": [],
           "remarks": [],
           "isBeta": false
+        },
+        "serviceKey": {
+          "kind": "property",
+          "isOptional": false,
+          "isReadOnly": false,
+          "isStatic": true,
+          "type": "ServiceKey<ITimeProvider>",
+          "deprecatedMessage": [],
+          "summary": [
+            {
+              "kind": "textDocElement",
+              "value": "The service key for ITimeProvider."
+            }
+          ],
+          "remarks": [],
+          "isBeta": true
         }
       }
     },
@@ -1518,29 +1569,38 @@
       "isBeta": false,
       "members": {
         "__constructor": {
-          "kind": "method",
+          "kind": "constructor",
           "signature": "constructor(url: string);",
-          "accessModifier": "",
-          "isOptional": false,
-          "isStatic": false,
-          "returnValue": {
-            "type": "",
-            "description": []
-          },
           "parameters": {},
           "deprecatedMessage": [],
-          "summary": [],
-          "remarks": [],
-          "isBeta": false
+          "summary": [
+            {
+              "kind": "textDocElement",
+              "value": "Constructs a new instance of the "
+            },
+            {
+              "kind": "linkDocElement",
+              "referenceType": "code",
+              "scopeName": "@microsoft",
+              "packageName": "sp-core-library",
+              "exportName": "UrlQueryParameterCollection",
+              "value": "UrlQueryParameterCollection"
+            },
+            {
+              "kind": "textDocElement",
+              "value": " class"
+            }
+          ],
+          "remarks": []
         },
         "getValue": {
           "kind": "method",
-          "signature": "public getValue(param: string): string;",
+          "signature": "public getValue(param: string): string | undefined;",
           "accessModifier": "public",
           "isOptional": false,
           "isStatic": false,
           "returnValue": {
-            "type": "string",
+            "type": "string | undefined",
             "description": []
           },
           "parameters": {
@@ -1569,12 +1629,12 @@
         },
         "getValues": {
           "kind": "method",
-          "signature": "public getValues(param: string): string[];",
+          "signature": "public getValues(param: string): (string | undefined)[] | undefined;",
           "accessModifier": "public",
           "isOptional": false,
           "isStatic": false,
           "returnValue": {
-            "type": "string[]",
+            "type": "(string | undefined)[] | undefined",
             "description": []
           },
           "parameters": {
@@ -1603,78 +1663,6 @@
         }
       }
     },
-    "UrlUtilities": {
-      "kind": "class",
-      "extends": "",
-      "implements": "",
-      "typeParameters": [],
-      "deprecatedMessage": [],
-      "summary": [
-        {
-          "kind": "textDocElement",
-          "value": "Common helper functions for working with URLs. These utilities are intended to be simple, small, and very broadly applicable."
-        }
-      ],
-      "remarks": [],
-      "isBeta": false,
-      "members": {
-        "convertToODataStringLiteral": {
-          "kind": "method",
-          "signature": "public static convertToODataStringLiteral(value: string): string;",
-          "accessModifier": "public",
-          "isOptional": false,
-          "isStatic": true,
-          "returnValue": {
-            "type": "string",
-            "description": []
-          },
-          "parameters": {},
-          "deprecatedMessage": [],
-          "summary": [
-            {
-              "kind": "textDocElement",
-              "value": "Converts a variable to an OData string literal suitable for usage in a REST URL. The returned string will be enclosed in single quotes, and any single quotes will be escaped. Example usage: const url = \"/_api/web/GetFolderByServerRelativeUrl(\" + UrlUtilities.convertToODataStringLiteral(\"/SitePages/Alice's%20Page\") + \")/Files\"; // Produces this URL: // \"/_api/web/GetFolderByServerRelativeUrl('/SitePages/Alice''s%20Page')/Files\""
-            }
-          ],
-          "remarks": [],
-          "isBeta": false
-        },
-        "removeEndSlash": {
-          "kind": "method",
-          "signature": "public static removeEndSlash(url: string): string;",
-          "accessModifier": "public",
-          "isOptional": false,
-          "isStatic": true,
-          "returnValue": {
-            "type": "string",
-            "description": []
-          },
-          "parameters": {
-            "url": {
-              "name": "url",
-              "description": [
-                {
-                  "kind": "textDocElement",
-                  "value": "the URL to be normalized"
-                }
-              ],
-              "isOptional": false,
-              "isSpread": false,
-              "type": "string"
-            }
-          },
-          "deprecatedMessage": [],
-          "summary": [
-            {
-              "kind": "textDocElement",
-              "value": "Removes any slash characters from the end of the URL. This function assumes that the input is already a valid absolute or server-relative URL. Examples: removeEndSlash('http://example.com/') ---> 'http://example.com' removeEndSlash('/example') ---> '/example' removeEndSlash('/') ---> ''"
-            }
-          ],
-          "remarks": [],
-          "isBeta": false
-        }
-      }
-    },
     "Validate": {
       "kind": "class",
       "extends": "",
@@ -1692,7 +1680,7 @@
       "members": {
         "isNonemptyString": {
           "kind": "method",
-          "signature": "public static isNonemptyString(value: string, variableName: string): void;",
+          "signature": "public static isNonemptyString(value: string | undefined | null, variableName: string): void;",
           "accessModifier": "public",
           "isOptional": false,
           "isStatic": true,
@@ -1711,7 +1699,7 @@
               ],
               "isOptional": false,
               "isSpread": false,
-              "type": "string"
+              "type": "string | undefined | null"
             },
             "variableName": {
               "name": "variableName",
@@ -1784,7 +1772,7 @@
         },
         "isTrue": {
           "kind": "method",
-          "signature": "public static isTrue(value: boolean, variableName: string): void;",
+          "signature": "public static isTrue(value: boolean | undefined | null, variableName: string): void;",
           "accessModifier": "public",
           "isOptional": false,
           "isStatic": true,
@@ -1803,7 +1791,7 @@
               ],
               "isOptional": false,
               "isSpread": false,
-              "type": "boolean"
+              "type": "boolean | undefined | null"
             },
             "variableName": {
               "name": "variableName",
@@ -1845,6 +1833,57 @@
       "remarks": [],
       "isBeta": false,
       "members": {
+        "compare": {
+          "kind": "method",
+          "signature": "public static compare(v1: Version, v2: Version): number;",
+          "accessModifier": "public",
+          "isOptional": false,
+          "isStatic": true,
+          "returnValue": {
+            "type": "number",
+            "description": [
+              {
+                "kind": "textDocElement",
+                "value": "-1 if the first input is less than the second input, 0 if the first input is equal to the second input, 1 if the first input is greater than the second input."
+              }
+            ]
+          },
+          "parameters": {
+            "v1": {
+              "name": "v1",
+              "description": [
+                {
+                  "kind": "textDocElement",
+                  "value": "The first version class for comparison"
+                }
+              ],
+              "isOptional": false,
+              "isSpread": false,
+              "type": "Version"
+            },
+            "v2": {
+              "name": "v2",
+              "description": [
+                {
+                  "kind": "textDocElement",
+                  "value": "The second version class for comparison"
+                }
+              ],
+              "isOptional": false,
+              "isSpread": false,
+              "type": "Version"
+            }
+          },
+          "deprecatedMessage": [],
+          "summary": [
+            {
+              "kind": "textDocElement",
+              "value": "Compares two Version classes"
+            }
+          ],
+          "remarks": [],
+          "isBeta": false
+        },
         "equals": {
           "kind": "method",
           "signature": "public equals(compareWith: Version): boolean;",
@@ -1925,7 +1964,7 @@
         },
         "isValid": {
           "kind": "method",
-          "signature": "public static isValid(versionString: string): boolean;",
+          "signature": "public static isValid(versionString: string | undefined | null): boolean;",
           "accessModifier": "public",
           "isOptional": false,
           "isStatic": true,
@@ -1949,7 +1988,7 @@
               ],
               "isOptional": false,
               "isSpread": false,
-              "type": "string"
+              "type": "string | undefined | null"
             }
           },
           "deprecatedMessage": [],
@@ -2035,7 +2074,7 @@
         },
         "parse": {
           "kind": "method",
-          "signature": "public static parse(versionString: string): Version;",
+          "signature": "public static parse(versionString: string | undefined | null): Version;",
           "accessModifier": "public",
           "isOptional": false,
           "isStatic": true,
@@ -2059,7 +2098,7 @@
               ],
               "isOptional": false,
               "isSpread": false,
-              "type": "string"
+              "type": "string | undefined | null"
             }
           },
           "deprecatedMessage": [],
@@ -2077,7 +2116,7 @@
           "isOptional": false,
           "isReadOnly": true,
           "isStatic": false,
-          "type": "number",
+          "type": "number | undefined",
           "deprecatedMessage": [],
           "summary": [
             {
@@ -2093,12 +2132,51 @@
           "isOptional": false,
           "isReadOnly": true,
           "isStatic": false,
-          "type": "number",
+          "type": "number | undefined",
           "deprecatedMessage": [],
           "summary": [
             {
               "kind": "textDocElement",
               "value": "The fourth number in the version string indicating the revision number Set to undefined if the fourth number does not exist"
+            }
+          ],
+          "remarks": [],
+          "isBeta": false
+        },
+        "satisfies": {
+          "kind": "method",
+          "signature": "public satisfies(compareWith: Version): boolean;",
+          "accessModifier": "public",
+          "isOptional": false,
+          "isStatic": false,
+          "returnValue": {
+            "type": "boolean",
+            "description": [
+              {
+                "kind": "textDocElement",
+                "value": "A boolean indicating if this version is compatible with the input parameter"
+              }
+            ]
+          },
+          "parameters": {
+            "compareWith": {
+              "name": "compareWith",
+              "description": [
+                {
+                  "kind": "textDocElement",
+                  "value": "The version to compare with"
+                }
+              ],
+              "isOptional": false,
+              "isSpread": false,
+              "type": "Version"
+            }
+          },
+          "deprecatedMessage": [],
+          "summary": [
+            {
+              "kind": "textDocElement",
+              "value": "Checks if this version satisfies the input parameter, therefore it's backwards compatible. They have to share the same major version, and the input parameter must be an equal or more recent version. Examples: 1.0.0 satisfies 1.0.0 -> true 1.1.0 satisfies 1.0.0 -> true 2.0.0 satisfies 1.0.0 -> false 1.0.0 satisfies 1.1.0 -> false"
             }
           ],
           "remarks": [],
@@ -2127,12 +2205,12 @@
         },
         "tryParse": {
           "kind": "method",
-          "signature": "public static tryParse(versionString: string): Version;",
+          "signature": "public static tryParse(versionString: string | undefined | null): Version | undefined;",
           "accessModifier": "public",
           "isOptional": false,
           "isStatic": true,
           "returnValue": {
-            "type": "Version",
+            "type": "Version | undefined",
             "description": [
               {
                 "kind": "textDocElement",
@@ -2151,7 +2229,7 @@
               ],
               "isOptional": false,
               "isSpread": false,
-              "type": "string"
+              "type": "string | undefined | null"
             }
           },
           "deprecatedMessage": [],


### PR DESCRIPTION
- Correct the API Extractor typings to reflect the *.api.json change that Danny already made a while ago
- Correct the JSON Schema
- Update the sp-core-library.api.json test input based on a more recent build
- Make enum members into a proper ApiItem and DocItem object
- Emit the enum member as "field" items embedded in the YAML file for the enum