### PR TITLE
api-documenter now correctly supports function parameters and property types

### DIFF
--- a/common/changes/@microsoft/node-core-library/pgonzal-yaml-documenter4_2017-09-07-03-39.json
+++ b/common/changes/@microsoft/node-core-library/pgonzal-yaml-documenter4_2017-09-07-03-39.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/node-core-library",
+      "comment": "Improve error reporting for JsonFile.validateNoUndefinedMembers()",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/node-core-library",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/libraries/api-documenter/src/DocItemSet.ts
+++ b/libraries/api-documenter/src/DocItemSet.ts
@@ -69,9 +69,11 @@ export class DocItem {
       case 'class':
       case 'interface':
         this.kind = this.apiItem.kind === 'class' ? DocItemKind.Class : DocItemKind.Interface;
-        for (const memberName of Object.keys(this.apiItem.members)) {
-          const child: ApiItem = this.apiItem.members[memberName];
-          this.children.push(new DocItem(child, memberName, this.docItemSet, this));
+        if (this.apiItem.members) {
+          for (const memberName of Object.keys(this.apiItem.members)) {
+            const child: ApiItem = this.apiItem.members[memberName];
+            this.children.push(new DocItem(child, memberName, this.docItemSet, this));
+          }
         }
         break;
 
@@ -89,9 +91,11 @@ export class DocItem {
           break;
         case 'enum':
           this.kind = DocItemKind.Enum;
-          for (const memberName of Object.keys(this.apiItem.values)) {
-            const child: ApiItem = this.apiItem.values[memberName];
-            this.children.push(new DocItem(child, memberName, this.docItemSet, this));
+          if (this.apiItem.values) {
+            for (const memberName of Object.keys(this.apiItem.values)) {
+              const child: ApiItem = this.apiItem.values[memberName];
+              this.children.push(new DocItem(child, memberName, this.docItemSet, this));
+            }
           }
           break;
         case 'enum value':

--- a/libraries/api-documenter/src/yaml/YamlGenerator.ts
+++ b/libraries/api-documenter/src/yaml/YamlGenerator.ts
@@ -8,13 +8,17 @@ import { JsonFile, JsonSchema } from '@microsoft/node-core-library';
 import {
   MarkupElement,
   IDocElement,
+  IApiMethod,
+  IApiParameter,
   IApiEnumMember
 } from '@microsoft/api-extractor';
 
 import { DocItemSet, DocItem, DocItemKind, IDocItemSetResolveResult } from '../DocItemSet';
 import {
   IYamlFile,
-  IYamlItem
+  IYamlItem,
+  IYamlSyntax,
+  IYamlParameter
 } from './IYamlFile';
 import { RenderingHelpers } from '../RenderingHelpers';
 import { MarkupBuilder } from '../MarkupBuilder';
@@ -143,6 +147,7 @@ export class YamlGenerator {
         break;
       case DocItemKind.Method:
         yamlItem.type = 'method';
+        this._populateYamlMethod(yamlItem, docItem);
         break;
       case DocItemKind.Constructor:
         yamlItem.type = 'constructor';
@@ -162,6 +167,40 @@ export class YamlGenerator {
     }
 
     return yamlItem as IYamlItem;
+  }
+
+  private _populateYamlMethod(yamlItem: Partial<IYamlItem>, docItem: DocItem): void {
+    const apiMethod: IApiMethod = docItem.apiItem as IApiMethod;
+    yamlItem.name = RenderingHelpers.getConciseSignature(docItem.name, apiMethod);
+
+    const syntax: IYamlSyntax = {
+      content: apiMethod.signature
+    };
+    yamlItem.syntax = syntax;
+
+    if (apiMethod.returnValue) {
+      syntax.return = {
+        type: [ apiMethod.returnValue.type ],
+        description: this._renderMarkdownFromDocElement(apiMethod.returnValue.description, docItem)
+      };
+    }
+
+    const parameters: IYamlParameter[] = [];
+    for (const parameterName of Object.keys(apiMethod.parameters)) {
+      const apiParameter: IApiParameter = apiMethod.parameters[parameterName];
+      parameters.push(
+        {
+           id: parameterName,
+           description:  this._renderMarkdownFromDocElement(apiParameter.description, docItem),
+           type: [ apiParameter.type || '' ]
+        } as IYamlParameter
+      );
+    }
+
+    if (parameters.length) {
+      syntax.parameters = parameters;
+    }
+
   }
 
   private _renderMarkdownFromDocElement(docElements: IDocElement[] | undefined, containingDocItem: DocItem): string {

--- a/libraries/api-documenter/src/yaml/YamlGenerator.ts
+++ b/libraries/api-documenter/src/yaml/YamlGenerator.ts
@@ -10,6 +10,7 @@ import {
   IDocElement,
   IApiMethod,
   IApiParameter,
+  IApiProperty,
   IApiEnumMember
 } from '@microsoft/api-extractor';
 
@@ -154,6 +155,7 @@ export class YamlGenerator {
         break;
       case DocItemKind.Property:
         yamlItem.type = 'property';
+        this._populateYamlProperty(yamlItem, docItem);
         break;
       case DocItemKind.Function:
         // Unimplemented
@@ -201,6 +203,21 @@ export class YamlGenerator {
       syntax.parameters = parameters;
     }
 
+  }
+
+  private _populateYamlProperty(yamlItem: Partial<IYamlItem>, docItem: DocItem): void {
+    const apiProperty: IApiProperty = docItem.apiItem as IApiProperty;
+
+    const syntax: IYamlSyntax = {
+      content: docItem.name + ': ' + apiProperty.type + ';' // TODO
+    };
+    yamlItem.syntax = syntax;
+
+    if (apiProperty.type) {
+      syntax.return = {
+        type: [ apiProperty.type ]
+      };
+    }
   }
 
   private _renderMarkdownFromDocElement(docElements: IDocElement[] | undefined, containingDocItem: DocItem): string {

--- a/libraries/node-core-library/src/JsonFile.ts
+++ b/libraries/node-core-library/src/JsonFile.ts
@@ -146,17 +146,35 @@ export class JsonFile {
    */
   // tslint:disable-next-line:no-any
   public static validateNoUndefinedMembers(jsonObject: Object): void {
+    return JsonFile._validateNoUndefinedMembers(jsonObject, '');
+  }
+
+  // Private implementation of validateNoUndefinedMembers()
+  private static _validateNoUndefinedMembers(jsonObject: Object, path: string): void {
     if (!jsonObject) {
       return;
     }
     if (typeof jsonObject === 'object') {
       for (const key of Object.keys(jsonObject)) {
+        let fullPath: string = path;
+        if (Array.isArray(jsonObject)) {
+          fullPath += `[${key}]`;
+        } else if (/^[a-z_0-9]+$/i.test(key)) {
+          if (fullPath) {
+            fullPath += '.';
+          }
+          fullPath += `${key}`;
+        } else {
+          fullPath += `["${key.replace(/["]/g, '\\"')}"]`;
+        }
+
         // tslint:disable-next-line:no-any
         const value: any = jsonObject[key];
         if (value === undefined) {
-          throw new Error(`The key "${key}" is undefined`);
+          throw new Error(`The value for ${fullPath} is undefined`);
         }
-        JsonFile.validateNoUndefinedMembers(value);
+
+        JsonFile._validateNoUndefinedMembers(value, fullPath);
       }
     }
   }


### PR DESCRIPTION
This fills out some more content fields in the generated YAML fields.

It also improves `JsonFile.validateNoUndefinedMembers()` to show the full path of where the "undefined" value occurs in the JSON object.  An example error:

```
The value for items[4].syntax.parameters["string \"with\" symbols"].type[0] is undefined
```