### PR TITLE
Add support for paragraph separators in *.api.json files

### DIFF
--- a/common/changes/@microsoft/api-extractor/pgonzal-yaml-documenter8_2017-09-10-00-50.json
+++ b/common/changes/@microsoft/api-extractor/pgonzal-yaml-documenter8_2017-09-10-00-50.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor",
+      "comment": "Skipping two lines in an AEDoc comment now creates a paragraph separator for the generated documentation",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/reviews/api/api-extractor.api.ts
+++ b/common/reviews/api/api-extractor.api.ts
@@ -390,6 +390,12 @@ interface IMarkupWebLink {
 }
 
 // @alpha
+interface IParagraphElement extends IBaseDocElement {
+  // (undocumented)
+  kind: 'paragraphDocElement';
+}
+
+// @alpha
 interface ISeeDocElement extends IBaseDocElement {
   // (undocumented)
   kind: 'seeDocElement';

--- a/libraries/api-documenter/src/MarkupBuilder.ts
+++ b/libraries/api-documenter/src/MarkupBuilder.ts
@@ -195,6 +195,9 @@ export class MarkupBuilder {
           const textDocElement: ITextElement = docElement as ITextElement;
           result.push(...MarkupBuilder.createTextElements(textDocElement.value));
           break;
+        case 'paragraphDocElement':
+          result.push(MarkupBuilder.PARAGRAPH);
+          break;
         case 'linkDocElement':
           const linkDocElement: ILinkDocElement = docElement as ILinkDocElement;
           if (linkDocElement.referenceType === 'code') {

--- a/libraries/api-documenter/src/yaml/YamlGenerator.ts
+++ b/libraries/api-documenter/src/yaml/YamlGenerator.ts
@@ -359,7 +359,7 @@ export class YamlGenerator {
           args.suffix = `](xref:${this._getUid(result.docItem)})`;
         }
       }
-    });
+    }).trim();
   }
 
   private _writeYamlFile(dataObject: {}, filePath: string, yamlMimeType: string,

--- a/libraries/api-documenter/src/yaml/YamlGenerator.ts
+++ b/libraries/api-documenter/src/yaml/YamlGenerator.ts
@@ -300,9 +300,12 @@ export class YamlGenerator {
     yamlItem.syntax = syntax;
 
     if (apiMethod.returnValue) {
+      const returnDescription: string = this._renderMarkdownFromDocElement(apiMethod.returnValue.description, docItem)
+        .replace(/^\s*-\s+/, ''); // temporary workaround for people who mistakenly add a hyphen, e.g. "@returns - blah"
+
       syntax.return = {
         type: [ apiMethod.returnValue.type ],
-        description: this._renderMarkdownFromDocElement(apiMethod.returnValue.description, docItem)
+        description: returnDescription
       };
     }
 

--- a/libraries/api-extractor/src/aedoc/test/Tokenizer.test.ts
+++ b/libraries/api-extractor/src/aedoc/test/Tokenizer.test.ts
@@ -40,19 +40,19 @@ describe('Tokenizer tests', function (): void {
         @tagc this is {   @inlineTag param1  param2   } and this is {just curly braces}`;
 
       const expectedTokens: Token[] = [
-        new Token(TokenType.Text, '', 'this is a mock documentation'),
+        new Token(TokenType.Text, '', 'this is a mock documentation\n'),
         new Token(TokenType.BlockTag, '@taga'),
-        new Token(TokenType.Text, '', 'hi'),
+        new Token(TokenType.Text, '', ' hi\n'),
         new Token(TokenType.BlockTag, '@tagb'),
-        new Token(TokenType.Text, '', 'hello @invalid@tag email@domain.com'),
+        new Token(TokenType.Text, '', ' hello @invalid@tag email@domain.com\n       '),
         new Token(TokenType.BlockTag, '@tagc'),
-        new Token(TokenType.Text, '', 'this is'),
-        new Token(TokenType.Text, '', 'and this is {just curly braces}')
+        new Token(TokenType.Text, '', ' this is '),
+        new Token(TokenType.Text, '', ' and this is {just curly braces}')
       ];
 
       const actualTokens: Token[] = testTokenizer.tokenizeDocs(docs);
-      JsonFile.save(JSON.stringify(expectedTokens), './lib/tokenizeDocsExpected.json');
-      JsonFile.save(JSON.stringify(actualTokens), './lib/tokenizeDocsActual.json');
+      JsonFile.save(expectedTokens, './lib/tokenizeDocsExpected.json');
+      JsonFile.save(actualTokens, './lib/tokenizeDocsActual.json');
       TestFileComparer.assertFileMatchesExpected('./lib/tokenizeDocsActual.json', './lib/tokenizeDocsExpected.json');
     });
 

--- a/libraries/api-extractor/src/api/api-json.schema.json
+++ b/libraries/api-extractor/src/api/api-json.schema.json
@@ -28,6 +28,22 @@
     },
 
     //---------------------------------------------------------------------------------------------
+    "paragraphDocElement": {
+      "description": "A documentation element representing a break between paragraphs",
+      "type": "object",
+
+      "properties": {
+        "kind": {
+          "description": "The kind of documentation element",
+          "type": "string",
+          "enum": [ "paragraphDocElement" ]
+        }
+      },
+      "additionalProperties": false,
+      "required": [ "kind" ]
+    },
+
+    //---------------------------------------------------------------------------------------------
     "linkDocElement": {
       "description": "A documentation element representing a hyperlink",
       "type": "object",
@@ -90,6 +106,7 @@
           "items": {
             "oneOf": [
               { "$ref": "#/definitions/textDocElement" },
+              { "$ref": "#/definitions/paragraphDocElement" },
               { "$ref": "#/definitions/linkDocElement" }
             ]
           }
@@ -106,6 +123,7 @@
       "items": {
         "oneOf": [
           { "$ref": "#/definitions/textDocElement" },
+          { "$ref": "#/definitions/paragraphDocElement" },
           { "$ref": "#/definitions/linkDocElement" },
           { "$ref": "#/definitions/seeDocElement" }
         ]

--- a/libraries/api-extractor/src/markup/OldMarkup.ts
+++ b/libraries/api-extractor/src/markup/OldMarkup.ts
@@ -91,6 +91,14 @@ export interface ICodeLinkElement extends IBaseDocElement {
 }
 
 /**
+ * A paragrpah separator, similar to <p /> in HTML.
+ * @alpha
+ */
+export interface IParagraphElement extends IBaseDocElement {
+  kind: 'paragraphDocElement';
+}
+
+/**
  * An element that denotes one of more elements to see for reference.
  *
  * Example:
@@ -116,4 +124,4 @@ export interface ISeeDocElement extends IBaseDocElement {
 export type ILinkDocElement = IHrefLinkElement | ICodeLinkElement;
 
 /** @alpha */
-export type IDocElement = ITextElement | ILinkDocElement | ISeeDocElement;
+export type IDocElement = ITextElement | ILinkDocElement | IParagraphElement | ISeeDocElement;

--- a/libraries/api-extractor/src/test/DocElementParser.test.ts
+++ b/libraries/api-extractor/src/test/DocElementParser.test.ts
@@ -109,7 +109,7 @@ describe('DocElementParser tests', function (): void {
 
       // Testing Summary Doc Elements
       const expectedSummary: IDocElement[] = [
-          {kind: 'textDocElement', value: 'This function parses docTokens for the apiLint website'} as ITextElement,
+          {kind: 'textDocElement', value: 'This function parses docTokens for the apiLint website '} as ITextElement,
           {
               kind: 'linkDocElement',
               referenceType: 'href',
@@ -117,9 +117,10 @@ describe('DocElementParser tests', function (): void {
               value: 'https://github.com/OfficeDev/office-ui-fabric-react'
         } as IHrefLinkElement
       ];
-      const actualSummary: IDocElement[] = DocElementParser.parse(myDocumentedClass.documentation, tokenizer);
-      JsonFile.save(JSON.stringify(expectedSummary), './lib/basicDocExpected.json');
-      JsonFile.save(JSON.stringify(actualSummary), './lib/basicDocActual.json');
+      const actualSummary: IDocElement[] = DocElementParser.getTrimmedSpan(
+        DocElementParser.parse(myDocumentedClass.documentation, tokenizer));
+      JsonFile.save(expectedSummary, './lib/basicDocExpected.json');
+      JsonFile.save(actualSummary, './lib/basicDocActual.json');
       TestFileComparer.assertFileMatchesExpected('./lib/basicDocActual.json', './lib/basicDocExpected.json');
 
       // Testing Returns Doc Elements
@@ -127,9 +128,10 @@ describe('DocElementParser tests', function (): void {
           {kind: 'textDocElement', value: 'an object'} as ITextElement
       ];
       tokenizer.getToken();
-      const actualReturn: IDocElement[] = DocElementParser.parse(myDocumentedClass.documentation, tokenizer);
-      JsonFile.save(JSON.stringify(expectedReturn), './lib/returnDocExpected.json');
-      JsonFile.save(JSON.stringify(actualReturn), './lib/returnDocActual.json');
+      const actualReturn: IDocElement[] = DocElementParser.getTrimmedSpan(
+        DocElementParser.parse(myDocumentedClass.documentation, tokenizer));
+      JsonFile.save(expectedReturn, './lib/returnDocExpected.json');
+      JsonFile.save(actualReturn, './lib/returnDocActual.json');
       TestFileComparer.assertFileMatchesExpected('./lib/returnDocActual.json', './lib/returnDocExpected.json');
 
       // Testing Params Doc Elements
@@ -149,8 +151,8 @@ describe('DocElementParser tests', function (): void {
       tokenizer.getToken();
       actualParam.push(apiDoc.parseParam(tokenizer));
 
-      JsonFile.save(JSON.stringify(expectedParam), './lib/paramDocExpected.json');
-      JsonFile.save(JSON.stringify(actualParam), './lib/paramDocActual.json');
+      JsonFile.save(expectedParam, './lib/paramDocExpected.json');
+      JsonFile.save(actualParam, './lib/paramDocActual.json');
       TestFileComparer.assertFileMatchesExpected('./lib/paramDocActual.json', './lib/paramDocExpected.json');
       assertCapturedErrors([]);
     });
@@ -165,9 +167,10 @@ describe('DocElementParser tests', function (): void {
           {kind: 'textDocElement', value: '- description of the deprecation'} as ITextElement
       ];
       tokenizer.getToken();
-      const actualDeprecated: IDocElement[] = DocElementParser.parse(myDocumentedClass.documentation, tokenizer);
-      JsonFile.save(JSON.stringify(expectedDeprecated), './lib/deprecatedDocExpected.json');
-      JsonFile.save(JSON.stringify(actualDeprecated), './lib/deprecatedDocActual.json');
+      const actualDeprecated: IDocElement[] = DocElementParser.getTrimmedSpan(
+        DocElementParser.parse(myDocumentedClass.documentation, tokenizer));
+      JsonFile.save(expectedDeprecated, './lib/deprecatedDocExpected.json');
+      JsonFile.save(actualDeprecated, './lib/deprecatedDocActual.json');
       TestFileComparer.assertFileMatchesExpected('./lib/deprecatedDocActual.json', './lib/deprecatedDocExpected.json');
       assertCapturedErrors([]);
     });
@@ -180,7 +183,7 @@ describe('DocElementParser tests', function (): void {
 
       // Testing Summary Elements
       const expectedSummary: IDocElement[] = [
-          {kind: 'textDocElement', value: 'Text describing the function’s purpose/nuances/context.'} as ITextElement,
+          {kind: 'textDocElement', value: 'Text describing the function’s purpose/nuances/context. '} as ITextElement,
           {
               kind: 'seeDocElement',
               seeElements: [
@@ -193,9 +196,10 @@ describe('DocElementParser tests', function (): void {
               ]
           } as ISeeDocElement
       ];
-      const actualSummary: IDocElement[] = DocElementParser.parse(myDocumentedClass.documentation, tokenizer);
-      JsonFile.save(JSON.stringify(expectedSummary), './lib/seeDocExpected.json');
-      JsonFile.save(JSON.stringify(actualSummary), './lib/seeDocActual.json');
+      const actualSummary: IDocElement[] = DocElementParser.getTrimmedSpan(
+        DocElementParser.parse(myDocumentedClass.documentation, tokenizer));
+      JsonFile.save(expectedSummary, './lib/seeDocExpected.json');
+      JsonFile.save(actualSummary, './lib/seeDocActual.json');
       TestFileComparer.assertFileMatchesExpected('./lib/seeDocExpected.json', './lib/seeDocActual.json');
       assertCapturedErrors([]);
     });
@@ -225,8 +229,8 @@ describe('DocElementParser tests', function (): void {
       } as IAedocParameter;
       const actualParam: IAedocParameter = apiDoc.parseParam(tokenizer);
 
-      JsonFile.save(JSON.stringify(expectedParam), './lib/nestedParamDocExpected.json');
-      JsonFile.save(JSON.stringify(actualParam), './lib/nestedParamDocActual.json');
+      JsonFile.save(expectedParam, './lib/nestedParamDocExpected.json');
+      JsonFile.save(actualParam, './lib/nestedParamDocActual.json');
       TestFileComparer.assertFileMatchesExpected(
         './lib/nestedParamDocActual.json',
         './lib/nestedParamDocExpected.json'

--- a/libraries/api-extractor/testInputs/example1/example1-output.api.ts
+++ b/libraries/api-extractor/testInputs/example1/example1-output.api.ts
@@ -70,6 +70,7 @@ class MyClass {
   public field: number;
   // (undocumented)
   public myProp: number;
+  public paragraphTest(): void;
   // (undocumented)
   public test(): void;
 }

--- a/libraries/api-extractor/testInputs/example1/example1-output.json
+++ b/libraries/api-extractor/testInputs/example1/example1-output.json
@@ -218,6 +218,54 @@
           "remarks": [],
           "isBeta": false
         },
+        "paragraphTest": {
+          "kind": "method",
+          "signature": "public paragraphTest(): void;",
+          "accessModifier": "public",
+          "isOptional": false,
+          "isStatic": false,
+          "returnValue": {
+            "type": "void",
+            "description": []
+          },
+          "parameters": {},
+          "deprecatedMessage": [],
+          "summary": [
+            {
+              "kind": "textDocElement",
+              "value": "This is the first paragraph. "
+            },
+            {
+              "kind": "paragraphDocElement"
+            },
+            {
+              "kind": "textDocElement",
+              "value": " This is the "
+            },
+            {
+              "kind": "linkDocElement",
+              "referenceType": "code",
+              "scopeName": "",
+              "packageName": "example1",
+              "exportName": "MyClass",
+              "memberName": "",
+              "value": "MyClass"
+            },
+            {
+              "kind": "textDocElement",
+              "value": " paragraph. "
+            },
+            {
+              "kind": "paragraphDocElement"
+            },
+            {
+              "kind": "textDocElement",
+              "value": " This is the third paragraph"
+            }
+          ],
+          "remarks": [],
+          "isBeta": false
+        },
         "test": {
           "kind": "method",
           "signature": "public test(): void;",

--- a/libraries/api-extractor/testInputs/example1/folder/MyClass.ts
+++ b/libraries/api-extractor/testInputs/example1/folder/MyClass.ts
@@ -22,6 +22,22 @@ export default class MyClass {
   public set myProp(value: number) {
     console.log(value);
   }
+
+  /**
+   *    This is   the
+   * first paragraph.
+   *
+   * This is the {@link MyClass} paragraph.
+   *
+   *
+   *
+   * This is the third paragraph
+   *
+   *
+   */
+  public paragraphTest(): void {
+    return;
+  }
 }
 
 class PrivateClass {

--- a/libraries/api-extractor/testInputs/example2/example2-output.json
+++ b/libraries/api-extractor/testInputs/example2/example2-output.json
@@ -130,7 +130,7 @@
       "summary": [
         {
           "kind": "textDocElement",
-          "value": "This is a class to test AEDoc parser and this is description that can span to multiple lines and we need to make sure we parse this block correctly. It can contain a"
+          "value": "This is a class to test AEDoc parser and this is description that can span to multiple lines and we need to make sure we parse this block correctly. It can contain a "
         },
         {
           "kind": "linkDocElement",
@@ -140,7 +140,7 @@
         },
         {
           "kind": "textDocElement",
-          "value": ". This block is entirely valid and a correct documentation object should be built for this ApiItem."
+          "value": " . This block is entirely valid and a correct documentation object should be built for this ApiItem."
         }
       ],
       "remarks": [
@@ -238,11 +238,11 @@
           "summary": [
             {
               "kind": "textDocElement",
-              "value": "This doc has {curly braces} which is valid but the inline @link token is missing a pipe between the URL and the display text"
+              "value": "This doc has {curly braces} which is valid but the inline @link token is missing a pipe between the URL and the display text "
             },
             {
               "kind": "textDocElement",
-              "value": "The displayName is not allowed to have non word characters."
+              "value": " The displayName is not allowed to have non word characters."
             }
           ],
           "remarks": [],

--- a/libraries/api-extractor/testInputs/example3/example3-output.json
+++ b/libraries/api-extractor/testInputs/example3/example3-output.json
@@ -315,7 +315,7 @@
       "summary": [
         {
           "kind": "textDocElement",
-          "value": "Here we test that an error is reported when attempting to link to an internal API item."
+          "value": "Here we test that an error is reported when attempting to link to an internal API item. "
         },
         {
           "kind": "linkDocElement",


### PR DESCRIPTION
Currently the AEDoc parser removes all newlines and collapses all white space from documentation comments.  This causes long descriptions to get collapsed into a single paragraph (e.g. [here](https://dev.office.com/sharepoint/reference/spfx/sp-core-library/class/servicescope)).  This PR makes it so that two newlines will be interpreted as a paragraph separator.  This is the first of a series of formatting syntax features that will be eventually modeled using the [MarkupElement](https://github.com/Microsoft/web-build-tools/blob/master/libraries/api-extractor/src/markup/MarkupElement.ts) system.  However, to minimize compatibility issues, for now I am simply adding an IParagraphElement to OldMarkup.ts.

This is a somewhat large change because the DocElementParser is a little squirrelly.  Also there was tons of unit test churn, because we aren't using the [FileDiffTest](https://microsoft.github.io/web-build-tools/api/node-core-library.filedifftest.html) pattern yet.  I intend to do some housekeeping in this area when I get back, because this change took way too much time. :-)