### PR TITLE
Replace documentation workarounds with YAML fields

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -32,15 +32,6 @@ groups:
       - pgonzal
       - qz2017
 
-  api-extractor-approvers:
-    conditions:
-      files:
-        - "libraries/api-extractor/*"
-    required: 1
-    users:
-      - pgonzal
-      - dgaeta
-
   gcb-approvers:
     conditions:
       files:

--- a/common/changes/@microsoft/api-extractor/pgonzal-yaml-documenter9_2017-09-28-01-01.json
+++ b/common/changes/@microsoft/api-extractor/pgonzal-yaml-documenter9_2017-09-28-01-01.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@microsoft/api-extractor",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/libraries/api-documenter/src/yaml/IYamlApiFile.ts
+++ b/libraries/api-documenter/src/yaml/IYamlApiFile.ts
@@ -10,6 +10,10 @@ export interface IYamlApiFile {
   references?: IYamlReference[];
 }
 
+export interface IYamlDeprecatedNotice {
+  content: string;
+}
+
 /**
  * Part of the IYamlApiFile structure.  Used to document exceptions that can be thrown
  * by a method, property, function, or constructor.
@@ -22,7 +26,8 @@ export interface IYamlException {
 /**
  * Part of the IYamlApiFile structure.  Represents the type of an IYamlItem.
  */
-export type YamlTypeId = 'class' | 'constructor' | 'enum' | 'field' | 'interface' | 'method' | 'package' | 'property';
+export type YamlTypeId = 'class' | 'constructor' | 'enum' | 'field' | 'function' | 'interface'
+  | 'method' | 'package' | 'property';
 
 /**
  * Part of the IYamlApiFile structure.  Represents basic API elements such as
@@ -32,8 +37,12 @@ export interface IYamlItem {
   type: YamlTypeId;
 
   children?: string[];
+  deprecated?: IYamlDeprecatedNotice;
   exceptions?: IYamlException[];
+  extends?: string[];
   fullName?: string;
+  implements?: string[];
+  isPreview?: boolean;
   langs?: string[];
   name?: string;
   numericValue?: number;

--- a/libraries/api-documenter/src/yaml/YamlGenerator.ts
+++ b/libraries/api-documenter/src/yaml/YamlGenerator.ts
@@ -269,17 +269,12 @@ export class YamlGenerator {
   private _populateYamlClassOrInterface(yamlItem: Partial<IYamlItem>, docItem: DocItem): void {
     const apiStructure: IApiClass | IApiInterface = docItem.apiItem as IApiClass | IApiInterface;
 
-    let text: string = '';
-
     if (apiStructure.extends) {
-      text += `**Extends:** \`${apiStructure.extends}\`\n\n`;
-    }
-    if (apiStructure.implements) {
-      text += `**Implements:** \`${apiStructure.implements}\`\n\n`;
+      yamlItem.extends = [ apiStructure.extends ];
     }
 
-    if (text) {
-      yamlItem.remarks = text + (yamlItem.remarks || '');
+    if (apiStructure.implements) {
+      yamlItem.implements = [ apiStructure.implements ];
     }
   }
 

--- a/libraries/api-documenter/src/yaml/YamlGenerator.ts
+++ b/libraries/api-documenter/src/yaml/YamlGenerator.ts
@@ -186,19 +186,11 @@ export class YamlGenerator {
 
     if ((docItem.apiItem.deprecatedMessage || []).length > 0) {
       const deprecatedMessage: string = this._renderMarkdownFromDocElement(docItem.apiItem.deprecatedMessage, docItem);
-
-      summary = '> [!NOTE]\n'
-        + '> _This API is now obsolete._\n'
-        + '> \n'
-        + `> _${deprecatedMessage.trim()}_\n\n`
-        + summary;
+      yamlItem.deprecated = { content: deprecatedMessage };
     }
 
     if (docItem.apiItem.isBeta) {
-      summary = '> [!NOTE]\n'
-        + '> _This API is provided as a preview for developers and may change based on feedback_\n'
-        + '> _that we receive. Do not use this API in a production environment._\n\n'
-        + summary;
+      yamlItem.isPreview = true;
     }
 
     if (remarks && this._shouldEmbed(docItem.kind)) {

--- a/libraries/api-documenter/src/yaml/YamlGenerator.ts
+++ b/libraries/api-documenter/src/yaml/YamlGenerator.ts
@@ -181,8 +181,15 @@ export class YamlGenerator {
     const yamlItem: Partial<IYamlItem> = { };
     yamlItem.uid = this._getUid(docItem);
 
-    let summary: string = this._renderMarkdownFromDocElement(docItem.apiItem.summary, docItem);
+    const summary: string = this._renderMarkdownFromDocElement(docItem.apiItem.summary, docItem);
+    if (summary) {
+      yamlItem.summary = summary;
+    }
+
     const remarks: string = this._renderMarkdownFromDocElement(docItem.apiItem.remarks, docItem);
+    if (remarks) {
+      yamlItem.remarks = remarks;
+    }
 
     if ((docItem.apiItem.deprecatedMessage || []).length > 0) {
       const deprecatedMessage: string = this._renderMarkdownFromDocElement(docItem.apiItem.deprecatedMessage, docItem);
@@ -191,22 +198,6 @@ export class YamlGenerator {
 
     if (docItem.apiItem.isBeta) {
       yamlItem.isPreview = true;
-    }
-
-    if (remarks && this._shouldEmbed(docItem.kind)) {
-      // This is a temporary workaround, since "Remarks" are not currently being displayed for embedded items
-      if (summary) {
-        summary += '\n\n';
-      }
-      summary += '### Remarks\n\n' + remarks;
-    }
-
-    if (summary) {
-      yamlItem.summary = summary;
-    }
-
-    if (remarks) {
-      yamlItem.remarks = remarks;
     }
 
     yamlItem.name = docItem.name;

--- a/libraries/api-documenter/src/yaml/YamlGenerator.ts
+++ b/libraries/api-documenter/src/yaml/YamlGenerator.ts
@@ -260,7 +260,8 @@ export class YamlGenerator {
         this._populateYamlProperty(yamlItem, docItem);
         break;
       case DocItemKind.Function:
-        // Unimplemented
+        yamlItem.type = 'function';
+        this._populateYamlMethod(yamlItem, docItem);
         break;
       default:
         throw new Error('Unimplemented item kind: ' + DocItemKind[docItem.kind as DocItemKind]);

--- a/libraries/api-documenter/src/yaml/typescript.schema.json
+++ b/libraries/api-documenter/src/yaml/typescript.schema.json
@@ -7,10 +7,6 @@
 		"items"
 	],
 	"properties": {
-    "$schema": {
-      "description": "Part of the JSON Schema standard, this optional keyword declares the URL of the schema that the file conforms to. Editors may download the schema and use it to perform syntax highlighting.",
-      "type": "string"
-    },
 		"items": {
 			"description": "This collection represents the main item (the first element) and it's possible children items.",
 			"type": "array",
@@ -30,6 +26,16 @@
 		}
 	},
 	"definitions":{
+		"deprecated": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"content": {
+					"description": "The string following the default obsolete message. Supports markdown.",
+					"type": "string"
+				}
+			}
+		},
 		"exception": {
 			"type": "object",
 			"additionalProperties": false,
@@ -57,6 +63,9 @@
 					"minItems": 1,
 					"uniqueItems": true
 				},
+				"deprecated": {
+					"$ref": "#/definitions/deprecated"
+				},
 				"exceptions": {
 					"type": "array",
 					"items": {
@@ -65,9 +74,28 @@
 					"minItems": 1,
 					"uniqueItems": true
 				},
+				"extends": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					},
+					"minItems": 1,
+					"uniqueItems": true
+				},
 				"fullName": {
 					"type": "string",
 					"description": "The full friendly name of the object. (ex: Microsoft.FSharp.Linq.RuntimeHelpers.AnonymousObject<T1,T2>)"
+				},
+				"implements": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					},
+					"minItems": 1,
+					"uniqueItems": true
+				},
+				"isPreview": {
+					"type": "boolean"
 				},
 				"langs": {
 					"type": "array",
@@ -101,7 +129,7 @@
 					"$ref": "#/definitions/syntax"
 				},
 				"type": {
-					"enum": [ "class", "constructor", "enum", "field", "interface", "method", "package", "property" ]
+					"enum": [ "class", "constructor", "enum", "field", "function", "interface", "method", "package", "property" ]
 				},
 				"uid": {
 					"type": "string",

--- a/libraries/api-extractor/src/aedoc/ApiDocumentation.ts
+++ b/libraries/api-extractor/src/aedoc/ApiDocumentation.ts
@@ -312,7 +312,7 @@ export default class ApiDocumentation {
       } else if (token.type === TokenType.Text)  {
         tokenizer.getToken();
 
-        if (token.text.trim().length) {
+        if (token.text.trim().length !== 0) {
           // Shorten "This is too long text" to "This is..."
           const MAX_LENGTH: number = 40;
           let problemText: string = token.text.trim();


### PR DESCRIPTION
The updated YAML schema supports a number of features that were previously solved using workarounds.

I am also removing the "api-extractor-approvers" group, since it was basically requiring me to self-approve all my PRs.