### PR TITLE
Upgrade build target to es6

### DIFF
--- a/apps/rush-lib/package.json
+++ b/apps/rush-lib/package.json
@@ -19,7 +19,7 @@
     "@microsoft/node-core-library": "~0.2.10",
     "@microsoft/stream-collator": "~2.0.7",
     "@types/fs-extra": "0.0.37",
-    "@types/node": "6.0.62",
+    "@types/node": "6.0.88",
     "@types/z-schema": "3.16.31",
     "fs-extra": "~0.26.7",
     "git-repo-info": "~1.1.4",

--- a/apps/rush-lib/tsconfig.json
+++ b/apps/rush-lib/tsconfig.json
@@ -1,13 +1,14 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es6",
     "forceConsistentCasingInFileNames": true,
     "module": "commonjs",
     "jsx": "react",
     "declaration": true,
     "sourceMap": true,
+    "types": [],
     "lib": [
-      "es5",
+      "es6",
       "es2015.collection"
     ]
   }

--- a/apps/rush-lib/tsconfig.json
+++ b/apps/rush-lib/tsconfig.json
@@ -6,9 +6,12 @@
     "jsx": "react",
     "declaration": true,
     "sourceMap": true,
-    "types": [],
+    "types": [
+      "node"
+    ],
     "lib": [
-      "es6",
+      "es5",
+      "es2015.iterable",
       "es2015.collection"
     ]
   }

--- a/apps/rush/package.json
+++ b/apps/rush/package.json
@@ -56,7 +56,7 @@
     "@types/lodash": "4.14.74",
     "@types/minimatch": "2.0.29",
     "@types/mocha": "2.2.38",
-    "@types/node": "6.0.62",
+    "@types/node": "6.0.88",
     "@types/semver": "5.3.33",
     "chai": "~3.5.0",
     "gulp": "~3.9.1"

--- a/apps/rush/tsconfig.json
+++ b/apps/rush/tsconfig.json
@@ -9,10 +9,11 @@
     "outDir": "lib",
     "listFiles": false,
     "types": [
+      "node",
       "mocha"
     ],
     "lib": [
-      "es6",
+      "es5",
       "scripthost",
       "es2015.collection",
       "es2015.promise",

--- a/apps/rush/tsconfig.json
+++ b/apps/rush/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es6",
     "forceConsistentCasingInFileNames": true,
     "module": "commonjs",
     "jsx": "react",
@@ -12,7 +12,7 @@
       "mocha"
     ],
     "lib": [
-      "es5",
+      "es6",
       "scripthost",
       "es2015.collection",
       "es2015.promise",

--- a/common/changes/@microsoft/api-extractor/nickpape-es6_2017-09-21-22-56.json
+++ b/common/changes/@microsoft/api-extractor/nickpape-es6_2017-09-21-22-56.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor",
+      "comment": "Upgrade to es6",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor",
+  "email": "nickpape@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/api-extractor/nickpape-es6_2017-09-21-22-56.json
+++ b/common/changes/@microsoft/api-extractor/nickpape-es6_2017-09-21-22-56.json
@@ -3,7 +3,7 @@
     {
       "packageName": "@microsoft/api-extractor",
       "comment": "Upgrade to es6",
-      "type": "patch"
+      "type": "minor"
     }
   ],
   "packageName": "@microsoft/api-extractor",

--- a/common/changes/@microsoft/gulp-core-build-karma/nickpape-es6_2017-09-21-22-56.json
+++ b/common/changes/@microsoft/gulp-core-build-karma/nickpape-es6_2017-09-21-22-56.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/gulp-core-build-karma",
+      "comment": "Upgrade to es6",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/gulp-core-build-karma",
+  "email": "nickpape@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/gulp-core-build-karma/nickpape-es6_2017-09-21-22-56.json
+++ b/common/changes/@microsoft/gulp-core-build-karma/nickpape-es6_2017-09-21-22-56.json
@@ -3,7 +3,7 @@
     {
       "packageName": "@microsoft/gulp-core-build-karma",
       "comment": "Upgrade to es6",
-      "type": "patch"
+      "type": "minor"
     }
   ],
   "packageName": "@microsoft/gulp-core-build-karma",

--- a/common/changes/@microsoft/gulp-core-build-mocha/nickpape-es6_2017-09-21-22-56.json
+++ b/common/changes/@microsoft/gulp-core-build-mocha/nickpape-es6_2017-09-21-22-56.json
@@ -3,7 +3,7 @@
     {
       "packageName": "@microsoft/gulp-core-build-mocha",
       "comment": "Upgrade to es6",
-      "type": "patch"
+      "type": "minor"
     }
   ],
   "packageName": "@microsoft/gulp-core-build-mocha",

--- a/common/changes/@microsoft/gulp-core-build-mocha/nickpape-es6_2017-09-21-22-56.json
+++ b/common/changes/@microsoft/gulp-core-build-mocha/nickpape-es6_2017-09-21-22-56.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/gulp-core-build-mocha",
+      "comment": "Upgrade to es6",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/gulp-core-build-mocha",
+  "email": "nickpape@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/gulp-core-build-sass/nickpape-es6_2017-09-21-22-56.json
+++ b/common/changes/@microsoft/gulp-core-build-sass/nickpape-es6_2017-09-21-22-56.json
@@ -3,7 +3,7 @@
     {
       "packageName": "@microsoft/gulp-core-build-sass",
       "comment": "Upgrade to es6",
-      "type": "patch"
+      "type": "minor"
     }
   ],
   "packageName": "@microsoft/gulp-core-build-sass",

--- a/common/changes/@microsoft/gulp-core-build-sass/nickpape-es6_2017-09-21-22-56.json
+++ b/common/changes/@microsoft/gulp-core-build-sass/nickpape-es6_2017-09-21-22-56.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/gulp-core-build-sass",
+      "comment": "Upgrade to es6",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/gulp-core-build-sass",
+  "email": "nickpape@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/gulp-core-build-serve/nickpape-es6_2017-09-21-22-56.json
+++ b/common/changes/@microsoft/gulp-core-build-serve/nickpape-es6_2017-09-21-22-56.json
@@ -3,7 +3,7 @@
     {
       "packageName": "@microsoft/gulp-core-build-serve",
       "comment": "Upgrade to es6",
-      "type": "patch"
+      "type": "minor"
     }
   ],
   "packageName": "@microsoft/gulp-core-build-serve",

--- a/common/changes/@microsoft/gulp-core-build-serve/nickpape-es6_2017-09-21-22-56.json
+++ b/common/changes/@microsoft/gulp-core-build-serve/nickpape-es6_2017-09-21-22-56.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/gulp-core-build-serve",
+      "comment": "Upgrade to es6",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/gulp-core-build-serve",
+  "email": "nickpape@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/gulp-core-build-typescript/nickpape-es6_2017-09-21-22-56.json
+++ b/common/changes/@microsoft/gulp-core-build-typescript/nickpape-es6_2017-09-21-22-56.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/gulp-core-build-typescript",
+      "comment": "Upgrade to es6",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/gulp-core-build-typescript",
+  "email": "nickpape@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/gulp-core-build-typescript/nickpape-es6_2017-09-21-22-56.json
+++ b/common/changes/@microsoft/gulp-core-build-typescript/nickpape-es6_2017-09-21-22-56.json
@@ -3,7 +3,7 @@
     {
       "packageName": "@microsoft/gulp-core-build-typescript",
       "comment": "Upgrade to es6",
-      "type": "patch"
+      "type": "minor"
     }
   ],
   "packageName": "@microsoft/gulp-core-build-typescript",

--- a/common/changes/@microsoft/gulp-core-build-webpack/nickpape-es6_2017-09-21-22-56.json
+++ b/common/changes/@microsoft/gulp-core-build-webpack/nickpape-es6_2017-09-21-22-56.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/gulp-core-build-webpack",
+      "comment": "Upgrade to es6",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/gulp-core-build-webpack",
+  "email": "nickpape@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/gulp-core-build-webpack/nickpape-es6_2017-09-21-22-56.json
+++ b/common/changes/@microsoft/gulp-core-build-webpack/nickpape-es6_2017-09-21-22-56.json
@@ -3,7 +3,7 @@
     {
       "packageName": "@microsoft/gulp-core-build-webpack",
       "comment": "Upgrade to es6",
-      "type": "patch"
+      "type": "minor"
     }
   ],
   "packageName": "@microsoft/gulp-core-build-webpack",

--- a/common/changes/@microsoft/gulp-core-build/nickpape-es6_2017-09-21-22-56.json
+++ b/common/changes/@microsoft/gulp-core-build/nickpape-es6_2017-09-21-22-56.json
@@ -3,7 +3,7 @@
     {
       "packageName": "@microsoft/gulp-core-build",
       "comment": "Upgrade to es6",
-      "type": "patch"
+      "type": "minor"
     }
   ],
   "packageName": "@microsoft/gulp-core-build",

--- a/common/changes/@microsoft/gulp-core-build/nickpape-es6_2017-09-21-22-56.json
+++ b/common/changes/@microsoft/gulp-core-build/nickpape-es6_2017-09-21-22-56.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/gulp-core-build",
+      "comment": "Upgrade to es6",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/gulp-core-build",
+  "email": "nickpape@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/load-themed-styles/nickpape-es6_2017-09-21-22-56.json
+++ b/common/changes/@microsoft/load-themed-styles/nickpape-es6_2017-09-21-22-56.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/load-themed-styles",
+      "comment": "Upgrade to es6",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/load-themed-styles",
+  "email": "nickpape@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/load-themed-styles/nickpape-es6_2017-09-21-22-56.json
+++ b/common/changes/@microsoft/load-themed-styles/nickpape-es6_2017-09-21-22-56.json
@@ -2,8 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/load-themed-styles",
-      "comment": "Upgrade to es6",
-      "type": "minor"
+      "type": "none"
     }
   ],
   "packageName": "@microsoft/load-themed-styles",

--- a/common/changes/@microsoft/load-themed-styles/nickpape-es6_2017-09-21-22-56.json
+++ b/common/changes/@microsoft/load-themed-styles/nickpape-es6_2017-09-21-22-56.json
@@ -3,7 +3,7 @@
     {
       "packageName": "@microsoft/load-themed-styles",
       "comment": "Upgrade to es6",
-      "type": "patch"
+      "type": "minor"
     }
   ],
   "packageName": "@microsoft/load-themed-styles",

--- a/common/changes/@microsoft/loader-load-themed-styles/nickpape-es6_2017-09-21-22-56.json
+++ b/common/changes/@microsoft/loader-load-themed-styles/nickpape-es6_2017-09-21-22-56.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/loader-load-themed-styles",
+      "comment": "Upgrade to es6",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/loader-load-themed-styles",
+  "email": "nickpape@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/loader-load-themed-styles/nickpape-es6_2017-09-21-22-56.json
+++ b/common/changes/@microsoft/loader-load-themed-styles/nickpape-es6_2017-09-21-22-56.json
@@ -3,7 +3,7 @@
     {
       "packageName": "@microsoft/loader-load-themed-styles",
       "comment": "Upgrade to es6",
-      "type": "patch"
+      "type": "minor"
     }
   ],
   "packageName": "@microsoft/loader-load-themed-styles",

--- a/common/changes/@microsoft/loader-raw-script/nickpape-es6_2017-09-21-22-56.json
+++ b/common/changes/@microsoft/loader-raw-script/nickpape-es6_2017-09-21-22-56.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/loader-raw-script",
+      "comment": "Upgrade to es6",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/loader-raw-script",
+  "email": "nickpape@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/loader-raw-script/nickpape-es6_2017-09-21-22-56.json
+++ b/common/changes/@microsoft/loader-raw-script/nickpape-es6_2017-09-21-22-56.json
@@ -3,7 +3,7 @@
     {
       "packageName": "@microsoft/loader-raw-script",
       "comment": "Upgrade to es6",
-      "type": "patch"
+      "type": "minor"
     }
   ],
   "packageName": "@microsoft/loader-raw-script",

--- a/common/changes/@microsoft/loader-set-webpack-public-path/nickpape-es6_2017-09-21-22-56.json
+++ b/common/changes/@microsoft/loader-set-webpack-public-path/nickpape-es6_2017-09-21-22-56.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/loader-set-webpack-public-path",
+      "comment": "Upgrade to es6",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/loader-set-webpack-public-path",
+  "email": "nickpape@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/loader-set-webpack-public-path/nickpape-es6_2017-09-21-22-56.json
+++ b/common/changes/@microsoft/loader-set-webpack-public-path/nickpape-es6_2017-09-21-22-56.json
@@ -3,7 +3,7 @@
     {
       "packageName": "@microsoft/loader-set-webpack-public-path",
       "comment": "Upgrade to es6",
-      "type": "patch"
+      "type": "minor"
     }
   ],
   "packageName": "@microsoft/loader-set-webpack-public-path",

--- a/common/changes/@microsoft/node-core-library/nickpape-es6_2017-09-21-22-56.json
+++ b/common/changes/@microsoft/node-core-library/nickpape-es6_2017-09-21-22-56.json
@@ -3,7 +3,7 @@
     {
       "packageName": "@microsoft/node-core-library",
       "comment": "Upgrade to es6",
-      "type": "patch"
+      "type": "minor"
     }
   ],
   "packageName": "@microsoft/node-core-library",

--- a/common/changes/@microsoft/node-core-library/nickpape-es6_2017-09-21-22-56.json
+++ b/common/changes/@microsoft/node-core-library/nickpape-es6_2017-09-21-22-56.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/node-core-library",
+      "comment": "Upgrade to es6",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/node-core-library",
+  "email": "nickpape@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/node-library-build/nickpape-es6_2017-09-21-22-56.json
+++ b/common/changes/@microsoft/node-library-build/nickpape-es6_2017-09-21-22-56.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/node-library-build",
+      "comment": "Upgrade to es6",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/node-library-build",
+  "email": "nickpape@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/node-library-build/nickpape-es6_2017-09-21-22-56.json
+++ b/common/changes/@microsoft/node-library-build/nickpape-es6_2017-09-21-22-56.json
@@ -3,7 +3,7 @@
     {
       "packageName": "@microsoft/node-library-build",
       "comment": "Upgrade to es6",
-      "type": "patch"
+      "type": "minor"
     }
   ],
   "packageName": "@microsoft/node-library-build",

--- a/common/changes/@microsoft/package-deps-hash/nickpape-es6_2017-09-21-22-56.json
+++ b/common/changes/@microsoft/package-deps-hash/nickpape-es6_2017-09-21-22-56.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/package-deps-hash",
+      "comment": "Upgrade to es6",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/package-deps-hash",
+  "email": "nickpape@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/package-deps-hash/nickpape-es6_2017-09-21-22-56.json
+++ b/common/changes/@microsoft/package-deps-hash/nickpape-es6_2017-09-21-22-56.json
@@ -3,7 +3,7 @@
     {
       "packageName": "@microsoft/package-deps-hash",
       "comment": "Upgrade to es6",
-      "type": "patch"
+      "type": "minor"
     }
   ],
   "packageName": "@microsoft/package-deps-hash",

--- a/common/changes/@microsoft/set-webpack-public-path-plugin/nickpape-es6_2017-09-21-22-56.json
+++ b/common/changes/@microsoft/set-webpack-public-path-plugin/nickpape-es6_2017-09-21-22-56.json
@@ -3,7 +3,7 @@
     {
       "packageName": "@microsoft/set-webpack-public-path-plugin",
       "comment": "Upgrade to es6",
-      "type": "patch"
+      "type": "minor"
     }
   ],
   "packageName": "@microsoft/set-webpack-public-path-plugin",

--- a/common/changes/@microsoft/set-webpack-public-path-plugin/nickpape-es6_2017-09-21-22-56.json
+++ b/common/changes/@microsoft/set-webpack-public-path-plugin/nickpape-es6_2017-09-21-22-56.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/set-webpack-public-path-plugin",
+      "comment": "Upgrade to es6",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/set-webpack-public-path-plugin",
+  "email": "nickpape@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/stream-collator/nickpape-es6_2017-09-21-22-56.json
+++ b/common/changes/@microsoft/stream-collator/nickpape-es6_2017-09-21-22-56.json
@@ -3,7 +3,7 @@
     {
       "packageName": "@microsoft/stream-collator",
       "comment": "Upgrade to es6",
-      "type": "patch"
+      "type": "minor"
     }
   ],
   "packageName": "@microsoft/stream-collator",

--- a/common/changes/@microsoft/stream-collator/nickpape-es6_2017-09-21-22-56.json
+++ b/common/changes/@microsoft/stream-collator/nickpape-es6_2017-09-21-22-56.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/stream-collator",
+      "comment": "Upgrade to es6",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/stream-collator",
+  "email": "nickpape@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/ts-command-line/nickpape-es6_2017-09-21-22-56.json
+++ b/common/changes/@microsoft/ts-command-line/nickpape-es6_2017-09-21-22-56.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/ts-command-line",
+      "comment": "Upgrade to es6",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/ts-command-line",
+  "email": "nickpape@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/ts-command-line/nickpape-es6_2017-09-21-22-56.json
+++ b/common/changes/@microsoft/ts-command-line/nickpape-es6_2017-09-21-22-56.json
@@ -3,7 +3,7 @@
     {
       "packageName": "@microsoft/ts-command-line",
       "comment": "Upgrade to es6",
-      "type": "patch"
+      "type": "minor"
     }
   ],
   "packageName": "@microsoft/ts-command-line",

--- a/common/changes/@microsoft/web-library-build/nickpape-es6_2017-09-21-22-56.json
+++ b/common/changes/@microsoft/web-library-build/nickpape-es6_2017-09-21-22-56.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/web-library-build",
+      "comment": "Upgrade to es6",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/web-library-build",
+  "email": "nickpape@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/web-library-build/nickpape-es6_2017-09-21-22-56.json
+++ b/common/changes/@microsoft/web-library-build/nickpape-es6_2017-09-21-22-56.json
@@ -3,7 +3,7 @@
     {
       "packageName": "@microsoft/web-library-build",
       "comment": "Upgrade to es6",
-      "type": "patch"
+      "type": "minor"
     }
   ],
   "packageName": "@microsoft/web-library-build",

--- a/common/config/rush/nonbrowser-approved-packages.json
+++ b/common/config/rush/nonbrowser-approved-packages.json
@@ -110,10 +110,6 @@
       "allowedCategories": [ "libraries" ]
     },
     {
-      "name": "es6-promise",
-      "allowedCategories": [ "libraries" ]
-    },
-    {
       "name": "express",
       "allowedCategories": [ "libraries" ]
     },

--- a/common/config/rush/npm-shrinkwrap.json
+++ b/common/config/rush/npm-shrinkwrap.json
@@ -7,6 +7,11 @@
       "from": "@microsoft/api-extractor@2.3.2",
       "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-2.3.2.tgz",
       "dependencies": {
+        "@types/node": {
+          "version": "6.0.62",
+          "from": "@types/node@6.0.62",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.62.tgz"
+        },
         "z-schema": {
           "version": "3.17.0",
           "from": "z-schema@>=3.17.0 <3.18.0",
@@ -19,6 +24,11 @@
       "from": "@microsoft/gulp-core-build@2.9.3",
       "resolved": "https://registry.npmjs.org/@microsoft/gulp-core-build/-/gulp-core-build-2.9.3.tgz",
       "dependencies": {
+        "@types/node": {
+          "version": "6.0.62",
+          "from": "@types/node@6.0.62",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.62.tgz"
+        },
         "z-schema": {
           "version": "3.17.0",
           "from": "z-schema@>=3.17.0 <3.18.0",
@@ -29,13 +39,25 @@
     "@microsoft/gulp-core-build-mocha": {
       "version": "2.1.8",
       "from": "@microsoft/gulp-core-build-mocha@2.1.8",
-      "resolved": "https://registry.npmjs.org/@microsoft/gulp-core-build-mocha/-/gulp-core-build-mocha-2.1.8.tgz"
+      "resolved": "https://registry.npmjs.org/@microsoft/gulp-core-build-mocha/-/gulp-core-build-mocha-2.1.8.tgz",
+      "dependencies": {
+        "@types/node": {
+          "version": "6.0.62",
+          "from": "@types/node@6.0.62",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.62.tgz"
+        }
+      }
     },
     "@microsoft/gulp-core-build-typescript": {
       "version": "3.4.0",
       "from": "@microsoft/gulp-core-build-typescript@3.4.0",
       "resolved": "https://registry.npmjs.org/@microsoft/gulp-core-build-typescript/-/gulp-core-build-typescript-3.4.0.tgz",
       "dependencies": {
+        "@types/node": {
+          "version": "6.0.62",
+          "from": "@types/node@6.0.62",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.62.tgz"
+        },
         "glob": {
           "version": "7.1.2",
           "from": "glob@>=7.1.1 <8.0.0",
@@ -51,7 +73,14 @@
     "@microsoft/node-library-build": {
       "version": "3.2.8",
       "from": "@microsoft/node-library-build@>=3.2.0 <3.3.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/node-library-build/-/node-library-build-3.2.8.tgz"
+      "resolved": "https://registry.npmjs.org/@microsoft/node-library-build/-/node-library-build-3.2.8.tgz",
+      "dependencies": {
+        "@types/node": {
+          "version": "6.0.62",
+          "from": "@types/node@6.0.62",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.62.tgz"
+        }
+      }
     },
     "@rush-temp/api-documenter": {
       "version": "0.0.0",
@@ -131,27 +160,62 @@
         "@microsoft/api-extractor": {
           "version": "2.3.5",
           "from": "@microsoft/api-extractor@2.3.5",
-          "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-2.3.5.tgz"
+          "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-2.3.5.tgz",
+          "dependencies": {
+            "@types/node": {
+              "version": "6.0.62",
+              "from": "@types/node@6.0.62",
+              "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.62.tgz"
+            }
+          }
         },
         "@microsoft/gulp-core-build": {
           "version": "2.9.6",
           "from": "@microsoft/gulp-core-build@2.9.6",
-          "resolved": "https://registry.npmjs.org/@microsoft/gulp-core-build/-/gulp-core-build-2.9.6.tgz"
+          "resolved": "https://registry.npmjs.org/@microsoft/gulp-core-build/-/gulp-core-build-2.9.6.tgz",
+          "dependencies": {
+            "@types/node": {
+              "version": "6.0.62",
+              "from": "@types/node@6.0.62",
+              "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.62.tgz"
+            }
+          }
         },
         "@microsoft/gulp-core-build-mocha": {
           "version": "2.1.11",
           "from": "@microsoft/gulp-core-build-mocha@2.1.11",
-          "resolved": "https://registry.npmjs.org/@microsoft/gulp-core-build-mocha/-/gulp-core-build-mocha-2.1.11.tgz"
+          "resolved": "https://registry.npmjs.org/@microsoft/gulp-core-build-mocha/-/gulp-core-build-mocha-2.1.11.tgz",
+          "dependencies": {
+            "@types/node": {
+              "version": "6.0.62",
+              "from": "@types/node@6.0.62",
+              "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.62.tgz"
+            }
+          }
         },
         "@microsoft/gulp-core-build-typescript": {
           "version": "3.5.1",
           "from": "@microsoft/gulp-core-build-typescript@3.5.1",
-          "resolved": "https://registry.npmjs.org/@microsoft/gulp-core-build-typescript/-/gulp-core-build-typescript-3.5.1.tgz"
+          "resolved": "https://registry.npmjs.org/@microsoft/gulp-core-build-typescript/-/gulp-core-build-typescript-3.5.1.tgz",
+          "dependencies": {
+            "@types/node": {
+              "version": "6.0.62",
+              "from": "@types/node@6.0.62",
+              "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.62.tgz"
+            }
+          }
         },
         "@microsoft/node-library-build": {
           "version": "3.3.2",
           "from": "@microsoft/node-library-build@>=3.3.2 <3.4.0",
-          "resolved": "https://registry.npmjs.org/@microsoft/node-library-build/-/node-library-build-3.3.2.tgz"
+          "resolved": "https://registry.npmjs.org/@microsoft/node-library-build/-/node-library-build-3.3.2.tgz",
+          "dependencies": {
+            "@types/node": {
+              "version": "6.0.62",
+              "from": "@types/node@6.0.62",
+              "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.62.tgz"
+            }
+          }
         }
       }
     },
@@ -311,9 +375,9 @@
       "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-2.2.38.tgz"
     },
     "@types/node": {
-      "version": "6.0.62",
-      "from": "@types/node@6.0.62",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.62.tgz"
+      "version": "6.0.88",
+      "from": "@types/node@6.0.88",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.88.tgz"
     },
     "@types/node-forge": {
       "version": "0.6.8",
@@ -473,9 +537,9 @@
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz"
     },
     "aproba": {
-      "version": "1.1.2",
+      "version": "1.2.0",
       "from": "aproba@>=1.0.3 <2.0.0",
-      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.2.tgz"
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz"
     },
     "archy": {
       "version": "1.0.0",
@@ -695,9 +759,9 @@
       "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz"
     },
     "big.js": {
-      "version": "3.1.3",
+      "version": "3.2.0",
       "from": "big.js@>=3.1.3 <4.0.0",
-      "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
+      "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz"
     },
     "binary-extensions": {
       "version": "1.10.0",
@@ -735,14 +799,14 @@
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz"
     },
     "body-parser": {
-      "version": "1.17.2",
+      "version": "1.18.1",
       "from": "body-parser@>=1.12.4 <2.0.0",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.17.2.tgz",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.1.tgz",
       "dependencies": {
         "debug": {
-          "version": "2.6.7",
-          "from": "debug@2.6.7",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.7.tgz"
+          "version": "2.6.8",
+          "from": "debug@2.6.8",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz"
         },
         "ms": {
           "version": "2.0.0",
@@ -844,9 +908,9 @@
       "resolved": "https://registry.npmjs.org/builtins/-/builtins-1.0.3.tgz"
     },
     "bytes": {
-      "version": "2.4.0",
-      "from": "bytes@2.4.0",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.4.0.tgz"
+      "version": "3.0.0",
+      "from": "bytes@3.0.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz"
     },
     "cache-swap": {
       "version": "0.3.0",
@@ -869,9 +933,9 @@
       "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz"
     },
     "caniuse-db": {
-      "version": "1.0.30000726",
+      "version": "1.0.30000733",
       "from": "caniuse-db@>=1.0.30000488 <2.0.0",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000726.tgz"
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000733.tgz"
     },
     "caseless": {
       "version": "0.12.0",
@@ -909,9 +973,9 @@
       "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz"
     },
     "clean-css": {
-      "version": "4.1.8",
+      "version": "4.1.9",
       "from": "clean-css@>=4.0.9 <5.0.0",
-      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.1.8.tgz",
+      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.1.9.tgz",
       "dependencies": {
         "source-map": {
           "version": "0.5.7",
@@ -1065,9 +1129,9 @@
       }
     },
     "connect": {
-      "version": "3.6.3",
+      "version": "3.6.4",
       "from": "connect@>=3.3.5 <4.0.0",
-      "resolved": "https://registry.npmjs.org/connect/-/connect-3.6.3.tgz",
+      "resolved": "https://registry.npmjs.org/connect/-/connect-3.6.4.tgz",
       "dependencies": {
         "debug": {
           "version": "2.6.8",
@@ -1129,9 +1193,9 @@
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz"
     },
     "content-type": {
-      "version": "1.0.2",
-      "from": "content-type@>=1.0.2 <1.1.0",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz"
+      "version": "1.0.4",
+      "from": "content-type@>=1.0.4 <1.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz"
     },
     "convert-source-map": {
       "version": "1.5.0",
@@ -1309,9 +1373,9 @@
       "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
     },
     "dateformat": {
-      "version": "2.0.0",
+      "version": "2.2.0",
       "from": "dateformat@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.2.0.tgz"
     },
     "deasync": {
       "version": "0.1.10",
@@ -1377,7 +1441,7 @@
     },
     "depd": {
       "version": "1.1.1",
-      "from": "depd@>=1.1.0 <1.2.0",
+      "from": "depd@>=1.1.1 <1.2.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz"
     },
     "deprecated": {
@@ -1765,6 +1829,11 @@
           "version": "6.2.0",
           "from": "qs@6.2.0",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.0.tgz"
+        },
+        "utils-merge": {
+          "version": "1.0.0",
+          "from": "utils-merge@1.0.0",
+          "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
         }
       }
     },
@@ -1797,6 +1866,11 @@
           "version": "2.0.0",
           "from": "uid-safe@>=2.0.0 <2.1.0",
           "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.0.0.tgz"
+        },
+        "utils-merge": {
+          "version": "1.0.0",
+          "from": "utils-merge@1.0.0",
+          "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
         }
       }
     },
@@ -1922,9 +1996,9 @@
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz"
     },
     "finalhandler": {
-      "version": "1.0.4",
-      "from": "finalhandler@1.0.4",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.4.tgz",
+      "version": "1.0.5",
+      "from": "finalhandler@1.0.5",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.5.tgz",
       "dependencies": {
         "debug": {
           "version": "2.6.8",
@@ -2006,9 +2080,9 @@
       "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.1.1.tgz"
     },
     "forwarded": {
-      "version": "0.1.0",
+      "version": "0.1.2",
       "from": "forwarded@>=0.1.0 <0.2.0",
-      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz"
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz"
     },
     "fresh": {
       "version": "0.3.0",
@@ -2528,6 +2602,11 @@
           "version": "0.3.3",
           "from": "split@>=0.3.0 <0.4.0",
           "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz"
+        },
+        "utils-merge": {
+          "version": "1.0.0",
+          "from": "utils-merge@1.0.0",
+          "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
         }
       }
     },
@@ -3008,8 +3087,13 @@
     },
     "http-errors": {
       "version": "1.6.2",
-      "from": "http-errors@>=1.6.1 <1.7.0",
+      "from": "http-errors@>=1.6.2 <1.7.0",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz"
+    },
+    "http-parser-js": {
+      "version": "0.4.7",
+      "from": "http-parser-js@>=0.4.0",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.7.tgz"
     },
     "http-proxy": {
       "version": "1.16.2",
@@ -3027,9 +3111,9 @@
       "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.1.tgz"
     },
     "iconv-lite": {
-      "version": "0.4.15",
-      "from": "iconv-lite@0.4.15",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.15.tgz"
+      "version": "0.4.19",
+      "from": "iconv-lite@0.4.19",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz"
     },
     "icss-replace-symbols": {
       "version": "1.1.0",
@@ -3089,9 +3173,9 @@
       }
     },
     "interpret": {
-      "version": "1.0.3",
+      "version": "1.0.4",
       "from": "interpret@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.3.tgz"
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.4.tgz"
     },
     "invert-kv": {
       "version": "1.0.0",
@@ -3425,9 +3509,9 @@
       "resolved": "https://registry.npmjs.org/jju/-/jju-1.3.0.tgz"
     },
     "js-base64": {
-      "version": "2.1.9",
+      "version": "2.3.2",
       "from": "js-base64@>=2.1.9 <3.0.0",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz"
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.3.2.tgz"
     },
     "js-tokens": {
       "version": "3.0.2",
@@ -4608,9 +4692,9 @@
       "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.5.tgz"
     },
     "parseurl": {
-      "version": "1.3.1",
-      "from": "parseurl@>=1.3.1 <1.4.0",
-      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz"
+      "version": "1.3.2",
+      "from": "parseurl@>=1.3.2 <1.4.0",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz"
     },
     "path-browserify": {
       "version": "0.0.0",
@@ -4678,9 +4762,9 @@
       "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz"
     },
     "pbkdf2": {
-      "version": "3.0.13",
+      "version": "3.0.14",
       "from": "pbkdf2@>=3.0.3 <4.0.0",
-      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.13.tgz"
+      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.14.tgz"
     },
     "pend": {
       "version": "1.2.0",
@@ -4990,9 +5074,9 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
     },
     "qs": {
-      "version": "6.4.0",
-      "from": "qs@6.4.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz"
+      "version": "6.5.1",
+      "from": "qs@6.5.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz"
     },
     "querystring": {
       "version": "0.2.0",
@@ -5044,9 +5128,9 @@
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz"
     },
     "raw-body": {
-      "version": "2.2.0",
-      "from": "raw-body@>=2.2.0 <2.3.0",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.2.0.tgz"
+      "version": "2.3.2",
+      "from": "raw-body@2.3.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz"
     },
     "read": {
       "version": "1.0.7",
@@ -5123,9 +5207,9 @@
       "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz"
     },
     "regenerate": {
-      "version": "1.3.2",
+      "version": "1.3.3",
       "from": "regenerate@>=1.2.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.2.tgz"
+      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.3.tgz"
     },
     "regex-cache": {
       "version": "0.4.4",
@@ -5173,9 +5257,9 @@
       "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
     },
     "replacestream": {
-      "version": "4.0.2",
+      "version": "4.0.3",
       "from": "replacestream@>=4.0.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/replacestream/-/replacestream-4.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/replacestream/-/replacestream-4.0.3.tgz",
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
@@ -5197,7 +5281,14 @@
     "request": {
       "version": "2.81.0",
       "from": "request@>=2.81.0 <2.82.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz"
+      "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+      "dependencies": {
+        "qs": {
+          "version": "6.4.0",
+          "from": "qs@>=6.4.0 <6.5.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz"
+        }
+      }
     },
     "request-progress": {
       "version": "2.0.1",
@@ -5940,9 +6031,9 @@
       "resolved": "https://registry.npmjs.org/to-iso-string/-/to-iso-string-0.0.2.tgz"
     },
     "tough-cookie": {
-      "version": "2.3.2",
+      "version": "2.3.3",
       "from": "tough-cookie@>=2.3.0 <2.4.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz"
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz"
     },
     "trim-newlines": {
       "version": "1.0.0",
@@ -6159,9 +6250,9 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
     },
     "utils-merge": {
-      "version": "1.0.0",
-      "from": "utils-merge@1.0.0",
-      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
+      "version": "1.0.1",
+      "from": "utils-merge@1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz"
     },
     "uuid": {
       "version": "3.1.0",
@@ -6408,14 +6499,14 @@
       }
     },
     "websocket-driver": {
-      "version": "0.6.5",
+      "version": "0.7.0",
       "from": "websocket-driver@>=0.5.1",
-      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.6.5.tgz"
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.0.tgz"
     },
     "websocket-extensions": {
-      "version": "0.1.1",
+      "version": "0.1.2",
       "from": "websocket-extensions@>=0.1.1",
-      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.1.tgz"
+      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.2.tgz"
     },
     "which": {
       "version": "1.3.0",
@@ -6510,14 +6601,14 @@
       "resolved": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz"
     },
     "z-schema": {
-      "version": "3.18.3",
+      "version": "3.18.4",
       "from": "z-schema@>=3.18.3 <3.19.0",
-      "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-3.18.3.tgz",
+      "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-3.18.4.tgz",
       "dependencies": {
         "validator": {
-          "version": "8.1.0",
+          "version": "8.2.0",
           "from": "validator@>=8.0.0 <9.0.0",
-          "resolved": "https://registry.npmjs.org/validator/-/validator-8.1.0.tgz"
+          "resolved": "https://registry.npmjs.org/validator/-/validator-8.2.0.tgz"
         }
       }
     }

--- a/core-build/gulp-core-build-karma/src/index.ts
+++ b/core-build/gulp-core-build-karma/src/index.ts
@@ -2,7 +2,6 @@
 // See LICENSE in the project root for license information.
 
 /* tslint:disable:export-name */
-'use strict';
 
 import { KarmaTask } from './KarmaTask';
 

--- a/core-build/gulp-core-build-karma/tsconfig.json
+++ b/core-build/gulp-core-build-karma/tsconfig.json
@@ -10,7 +10,8 @@
       "node"
     ],
     "lib": [
-      "es6"
+      "es5",
+      "es2015.iterable"
     ]
   }
 }

--- a/core-build/gulp-core-build-karma/tsconfig.json
+++ b/core-build/gulp-core-build-karma/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es6",
     "module": "commonjs",
     "jsx": "react",
     "declaration": true,
@@ -8,6 +8,9 @@
     "strictNullChecks": true,
     "types": [
       "node"
+    ],
+    "lib": [
+      "es6"
     ]
   }
 }

--- a/core-build/gulp-core-build-mocha/package.json
+++ b/core-build/gulp-core-build-mocha/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@microsoft/gulp-core-build": "3.0.7",
-    "@types/node": "6.0.62",
+    "@types/node": "6.0.88",
     "gulp": "~3.9.1",
     "gulp-istanbul": "~0.10.3",
     "gulp-mocha": "~2.2.0"

--- a/core-build/gulp-core-build-mocha/tsconfig.json
+++ b/core-build/gulp-core-build-mocha/tsconfig.json
@@ -10,7 +10,8 @@
       "node"
     ],
     "lib": [
-      "es6"
+      "es5",
+      "es2015.iterable"
     ]
   }
 }

--- a/core-build/gulp-core-build-mocha/tsconfig.json
+++ b/core-build/gulp-core-build-mocha/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es6",
     "module": "commonjs",
     "jsx": "react",
     "declaration": true,
@@ -8,6 +8,9 @@
     "strictNullChecks": true,
     "types": [
       "node"
+    ],
+    "lib": [
+      "es6"
     ]
   }
 }

--- a/core-build/gulp-core-build-sass/package.json
+++ b/core-build/gulp-core-build-sass/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@microsoft/gulp-core-build": "3.0.7",
     "@microsoft/load-themed-styles": "~1.7.4",
-    "@types/node": "6.0.62",
+    "@types/node": "6.0.88",
     "autoprefixer": "6.3.7",
     "gulp": "~3.9.1",
     "gulp-clean-css": "~3.0.4",

--- a/core-build/gulp-core-build-sass/tsconfig.json
+++ b/core-build/gulp-core-build-sass/tsconfig.json
@@ -10,7 +10,8 @@
       "node"
     ],
     "lib": [
-      "es6"
+      "es5",
+      "es2015.iterable"
     ]
   }
 }

--- a/core-build/gulp-core-build-sass/tsconfig.json
+++ b/core-build/gulp-core-build-sass/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es6",
     "module": "commonjs",
     "jsx": "react",
     "declaration": true,
@@ -8,6 +8,9 @@
     "strictNullChecks": true,
     "types": [
       "node"
+    ],
+    "lib": [
+      "es6"
     ]
   }
 }

--- a/core-build/gulp-core-build-serve/package.json
+++ b/core-build/gulp-core-build-serve/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@microsoft/gulp-core-build": "3.0.7",
-    "@types/node": "6.0.62",
+    "@types/node": "6.0.88",
     "deasync": "~0.1.7",
     "express": "~4.14.0",
     "gulp": "~3.9.1",

--- a/core-build/gulp-core-build-serve/tsconfig.json
+++ b/core-build/gulp-core-build-serve/tsconfig.json
@@ -9,7 +9,8 @@
       "node"
     ],
     "lib": [
-      "es6"
+      "es5",
+      "es2015.iterable"
     ]
   }
 }

--- a/core-build/gulp-core-build-serve/tsconfig.json
+++ b/core-build/gulp-core-build-serve/tsconfig.json
@@ -1,12 +1,15 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es6",
     "module": "commonjs",
     "jsx": "react",
     "declaration": true,
     "sourceMap": true,
     "types": [
       "node"
+    ],
+    "lib": [
+      "es6"
     ]
   }
 }

--- a/core-build/gulp-core-build-typescript/package.json
+++ b/core-build/gulp-core-build-typescript/package.json
@@ -20,7 +20,7 @@
     "@microsoft/node-core-library": "~0.2.10",
     "@types/fs-extra": "0.0.37",
     "@types/gulp": "3.8.32",
-    "@types/node": "6.0.62",
+    "@types/node": "6.0.88",
     "fs-extra": "~0.26.7",
     "gulp": "~3.9.1",
     "gulp-cache": "~0.4.5",

--- a/core-build/gulp-core-build-typescript/tsconfig.json
+++ b/core-build/gulp-core-build-typescript/tsconfig.json
@@ -11,7 +11,8 @@
       "node"
     ],
     "lib": [
-      "es6",
+      "es5",
+      "es2015.iterable",
       "es2015.collection"
     ]
   }

--- a/core-build/gulp-core-build-typescript/tsconfig.json
+++ b/core-build/gulp-core-build-typescript/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es6",
     "module": "commonjs",
     "jsx": "react",
     "declaration": true,
@@ -11,7 +11,7 @@
       "node"
     ],
     "lib": [
-      "es5",
+      "es6",
       "es2015.collection"
     ]
   }

--- a/core-build/gulp-core-build-webpack/package.json
+++ b/core-build/gulp-core-build-webpack/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@microsoft/gulp-core-build": "3.0.7",
     "@types/gulp": "3.8.32",
-    "@types/node": "6.0.62",
+    "@types/node": "6.0.88",
     "gulp": "~3.9.1",
     "gulp-util": "~3.0.7",
     "webpack": "~3.5.5"

--- a/core-build/gulp-core-build-webpack/tsconfig.json
+++ b/core-build/gulp-core-build-webpack/tsconfig.json
@@ -10,7 +10,8 @@
       "node"
     ],
     "lib": [
-      "es6"
+      "es5",
+      "es2015.iterable"
     ]
   }
 }

--- a/core-build/gulp-core-build-webpack/tsconfig.json
+++ b/core-build/gulp-core-build-webpack/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es6",
     "module": "commonjs",
     "jsx": "react",
     "declaration": true,
@@ -8,6 +8,9 @@
     "strictNullChecks": true,
     "types": [
       "node"
+    ],
+    "lib": [
+      "es6"
     ]
   }
 }

--- a/core-build/gulp-core-build/package.json
+++ b/core-build/gulp-core-build/package.json
@@ -21,7 +21,7 @@
     "@types/gulp": "3.8.32",
     "@types/gulp-util": "3.0.30",
     "@types/mocha": "2.2.38",
-    "@types/node": "6.0.62",
+    "@types/node": "6.0.88",
     "@types/node-notifier": "0.0.28",
     "@types/orchestrator": "0.0.30",
     "@types/q": "0.0.32",

--- a/core-build/gulp-core-build/src/logging.ts
+++ b/core-build/gulp-core-build/src/logging.ts
@@ -96,7 +96,6 @@ function isVerbose(): boolean {
 /* tslint:disable:no-any */
 function formatError(e: any): string | undefined {
 /* tslint:enable:no-any */
-  'use strict';
 
   if (!e.err) {
     if (isVerbose()) {
@@ -145,7 +144,6 @@ function formatError(e: any): string | undefined {
 }
 
 function afterStreamFlushed(streamName: string, callback: () => void): void {
-  'use strict';
   if (duringFastExit) {
     callback();
   } else {
@@ -170,7 +168,6 @@ function afterStreamFlushed(streamName: string, callback: () => void): void {
 }
 
 function afterStreamsFlushed(callback: () => void): void {
-  'use strict';
   afterStreamFlushed('stdout', () => {
     afterStreamFlushed('stderr', () => {
       callback();
@@ -179,7 +176,6 @@ function afterStreamsFlushed(callback: () => void): void {
 }
 
 function writeSummary(callback: () => void): void {
-  'use strict';
   const shouldRelogIssues: boolean = getFlagValue('relogIssues');
 
   localCache.writeSummaryCallbacks.push(callback);
@@ -269,7 +265,6 @@ function writeSummary(callback: () => void): void {
 /* tslint:disable:no-any */
 function _writeTaskError(e: any): void {
 /* tslint:enable:no-any */
-  'use strict';
   if (!e || !(e.err && e.err[WROTE_ERROR_KEY])) {
     writeError(e);
     localCache.taskErrors++;
@@ -277,7 +272,6 @@ function _writeTaskError(e: any): void {
 }
 
 function exitProcess(errorCode: number): void {
-  'use strict';
 
   if (!localCache.watchMode) {
     process.stdout.write('', () => {
@@ -287,11 +281,9 @@ function exitProcess(errorCode: number): void {
 }
 
 function wireUpProcessErrorHandling(): void {
-  'use strict';
   if (!wiredUpErrorHandling) {
     wiredUpErrorHandling = true;
     process.on('exit', (code: number) => {
-      'use strict';
       duringFastExit = true;
 
       if (!global['dontWatchExit']) { // tslint:disable-line:no-string-literal
@@ -313,7 +305,6 @@ function wireUpProcessErrorHandling(): void {
 
     process.on('uncaughtException',
       (err: Error) => {
-        'use strict';
         console.error(err);
 
         _writeTaskError(err);
@@ -346,7 +337,6 @@ function markErrorAsWritten(err: Error): void {
  * @public
  */
 export function logSummary(value: string): void {
-  'use strict';
   localCache.writeSummaryLogs.push(value);
 }
 
@@ -356,7 +346,6 @@ export function logSummary(value: string): void {
  * @public
  */
 export function log(...args: Array<string | Chalk.ChalkChain>): void {
-  'use strict';
   gutil.log.apply(this, args);
 }
 
@@ -365,7 +354,6 @@ export function log(...args: Array<string | Chalk.ChalkChain>): void {
  * @public
  */
 export function reset(): void {
-  'use strict';
   localCache.start = process.hrtime();
   localCache.warnings = [];
   localCache.errors = [];
@@ -407,7 +395,6 @@ export enum TestResultState {
  * @public
  */
 export function functionalTestRun(name: string, result: TestResultState, duration: number): void {
-  'use strict';
   localCache.testsRun++;
 
   switch (result) {
@@ -428,7 +415,6 @@ export function functionalTestRun(name: string, result: TestResultState, duratio
 
 /** @public */
 export function endTaskSrc(taskName: string, startHrtime: [number, number], fileCount: number): void {
-  'use strict';
   localCache.totalTaskSrc++;
   const taskDuration: [number, number] = process.hrtime(startHrtime);
   if (!localCache.totalTaskHrTime) {
@@ -456,7 +442,6 @@ export function endTaskSrc(taskName: string, startHrtime: [number, number], file
  * @public
  */
 export function coverageData(coverage: number, threshold: number, filePath: string): void {
-  'use strict';
   localCache.coverageResults++;
 
   if (coverage < threshold) {
@@ -476,7 +461,6 @@ const colorCodeRegex: RegExp = /\x1B[[(?);]{0,2}(;?\d)*./g;
  * @public
  */
 export function addSuppression(suppression: string | RegExp): void {
-  'use strict';
 
   if (typeof suppression === 'string') {
     suppression = normalizeMessage(suppression);
@@ -496,7 +480,6 @@ export function addSuppression(suppression: string | RegExp): void {
  * @public
  */
 export function warn(...args: Array<string | Chalk.ChalkChain>): void {
-  'use strict';
   args.splice(0, 0, 'Warning -');
 
   const stringMessage: string = normalizeMessage(args.join(' '));
@@ -513,7 +496,6 @@ export function warn(...args: Array<string | Chalk.ChalkChain>): void {
  * @public
  */
 export function error(...args: Array<string | Chalk.ChalkChain>): void {
-  'use strict';
   args.splice(0, 0, 'Error -');
 
   const stringMessage: string = normalizeMessage(args.join(' '));
@@ -544,7 +526,6 @@ export function fileLog(
   errorCode: string,
   message: string
 ): void {
-  'use strict';
 
   if (!filePath) {
     filePath = '<undefined path>';
@@ -601,7 +582,6 @@ export function fileError(
  * @public
  */
 export function verbose(...args: Array<string | Chalk.ChalkChain>): void {
-  'use strict';
 
   if (getFlagValue('verbose')) {
     log.apply(undefined, args);
@@ -636,7 +616,6 @@ export function generateGulpError(err: Object): Object {
  */
 export function writeError(e: any): void {
 /* tslint:enable:no-any */
-  'use strict';
   if (e) {
     if (!e[WROTE_ERROR_KEY]) {
       if (e.err) {
@@ -697,7 +676,6 @@ export function writeError(e: any): void {
  * @public
  */
 export function getWarnings(): string[] {
-  'use strict';
   return localCache.warnings;
 }
 
@@ -706,13 +684,11 @@ export function getWarnings(): string[] {
  * @public
  */
 export function getErrors(): string[] {
-  'use strict';
   return localCache.errors;
 }
 
 /** @public */
 export function getStart(): [number, number] | undefined {
-  'use strict';
   return localCache.start;
 }
 
@@ -720,7 +696,6 @@ export function getStart(): [number, number] | undefined {
  * @public
  */
 export function setWatchMode(): void {
-  'use strict';
   localCache.watchMode = true;
 }
 
@@ -728,7 +703,6 @@ export function setWatchMode(): void {
  * @public
  */
 export function getWatchMode(): boolean | undefined {
-  'use strict';
   return localCache.watchMode;
 }
 
@@ -736,7 +710,6 @@ export function getWatchMode(): boolean | undefined {
  * @public
  */
 export function setExitCode(exitCode: number): void {
-  'use strict';
   localCache.exitCode = exitCode;
 }
 
@@ -777,7 +750,6 @@ export function initialize(
   gulpErrorCallback?: (err: Error) => void,
   gulpStopCallback?: (err: Error) => void
 ): void {
-  'use strict';
   // This will add logging to the gulp execution
 
   localCache.gulp = gulp;
@@ -785,22 +757,22 @@ export function initialize(
   wireUpProcessErrorHandling();
 
   localCache.gulpErrorCallback = gulpErrorCallback || (() => {
-    'use strict';
+
     // Do Nothing
   });
 
   localCache.gulpStopCallback = gulpStopCallback || (() => {
-    'use strict';
+
     // Do Nothing
   });
 
   gulp.on('start', (err: Object) => {
-    'use strict';
+
     log('Starting gulp');
   });
 
   gulp.on('stop', (err: Object) => {
-    'use strict';
+
     writeSummary(() => {
       // error if we have any errors
       if (localCache.taskErrors > 0 ||
@@ -818,7 +790,7 @@ export function initialize(
   });
 
   gulp.on('err', (err: Object) => {
-    'use strict';
+
     _writeTaskError(err);
     writeSummary(() => {
       exitProcess(1);
@@ -831,7 +803,7 @@ export function initialize(
   /* tslint:disable:no-any */
   gulp.on('task_start', (e: any) => {
   /* tslint:enable:no-any */
-    'use strict';
+
     if (localCache.fromRunGulp) {
       log('Starting', '\'' + gutil.colors.cyan(e.task) + '\'...');
     }
@@ -842,7 +814,7 @@ export function initialize(
   /* tslint:disable:no-any */
   gulp.on('task_stop', (e: any) => {
   /* tslint:enable:no-any */
-    'use strict';
+
     const time: string = prettyTime(e.hrDuration);
 
     if (localCache.fromRunGulp) {
@@ -856,7 +828,7 @@ export function initialize(
   /* tslint:disable:no-any */
   gulp.on('task_err', (err: any) => {
   /* tslint:enable:no-any */
-    'use strict';
+
     _writeTaskError(err);
     writeSummary(() => {
       exitProcess(1);
@@ -866,7 +838,7 @@ export function initialize(
   /* tslint:disable:no-any */
   gulp.on('task_not_found', (err: any) => {
   /* tslint:enable:no-any */
-    'use strict';
+
     log(
       gutil.colors.red('Task \'' + err.task + '\' is not in your gulpfile')
     );
@@ -879,7 +851,6 @@ export function initialize(
  * @public
  */
 export function markTaskCreationTime(): void {
-  'use strict';
   localCache.taskCreationTime = process.hrtime(getStart());
 }
 

--- a/core-build/gulp-core-build/src/tasks/GulpTask.ts
+++ b/core-build/gulp-core-build/src/tasks/GulpTask.ts
@@ -277,11 +277,9 @@ export abstract class GulpTask<TTaskConfig> implements IExecutable {
             (file: gutil.File,
               encoding: string,
               callback: (p?: Object) => void) => {
-                'use strict';
                 callback();
             },
             (callback: () => void) => {
-              'use strict';
               callback();
             }));
 

--- a/core-build/gulp-core-build/src/test/GulpTask.test.ts
+++ b/core-build/gulp-core-build/src/test/GulpTask.test.ts
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-'use strict';
-
 import { assert, expect } from 'chai';
 import gutil = require('gulp-util');
 import * as Gulp  from 'gulp';

--- a/core-build/gulp-core-build/src/test/index.test.ts
+++ b/core-build/gulp-core-build/src/test/index.test.ts
@@ -1,9 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-'use strict';
-/// <reference path='../../typings/main.d.ts' />
-
 import { expect } from 'chai';
 
 import {

--- a/core-build/gulp-core-build/tsconfig.json
+++ b/core-build/gulp-core-build/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es6",
     "module": "commonjs",
     "declaration": true,
     "sourceMap": true,
@@ -14,7 +14,7 @@
       "typings-custom"
     ],
     "lib": [
-      "es5",
+      "es6",
       "scripthost",
       "es2015.promise",
       "dom"

--- a/core-build/gulp-core-build/tsconfig.json
+++ b/core-build/gulp-core-build/tsconfig.json
@@ -14,9 +14,10 @@
       "typings-custom"
     ],
     "lib": [
-      "es6",
+      "es5",
       "scripthost",
       "es2015.promise",
+      "es2015.iterable",
       "dom"
     ]
   }

--- a/core-build/node-library-build/package.json
+++ b/core-build/node-library-build/package.json
@@ -19,7 +19,7 @@
     "@microsoft/gulp-core-build-mocha": "3.0.7",
     "@microsoft/gulp-core-build-typescript": "4.0.7",
     "@types/gulp": "3.8.32",
-    "@types/node": "6.0.62",
+    "@types/node": "6.0.88",
     "gulp": "~3.9.1"
   },
   "devDependencies": {}

--- a/core-build/node-library-build/tsconfig.json
+++ b/core-build/node-library-build/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es6",
     "module": "commonjs",
     "declaration": true,
     "sourceMap": true,
@@ -9,7 +9,7 @@
       "node"
     ],
     "lib": [
-      "es5",
+      "es6",
       "es2015.collection"
     ]
   }

--- a/core-build/node-library-build/tsconfig.json
+++ b/core-build/node-library-build/tsconfig.json
@@ -9,7 +9,8 @@
       "node"
     ],
     "lib": [
-      "es6",
+      "es5",
+      "es2015.iterable",
       "es2015.collection"
     ]
   }

--- a/core-build/web-library-build/package.json
+++ b/core-build/web-library-build/package.json
@@ -24,7 +24,7 @@
     "@microsoft/gulp-core-build-typescript": "4.0.7",
     "@microsoft/gulp-core-build-webpack": "3.0.7",
     "@types/gulp": "3.8.32",
-    "@types/node": "6.0.62",
+    "@types/node": "6.0.88",
     "gulp": "~3.9.1",
     "gulp-replace": "^0.5.4"
   },

--- a/core-build/web-library-build/tsconfig.json
+++ b/core-build/web-library-build/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es6",
     "module": "commonjs",
     "declaration": true,
     "sourceMap": true,
@@ -10,7 +10,7 @@
       "node"
     ],
     "lib": [
-      "es5",
+      "es6",
       "es2015.collection"
     ]
   }

--- a/core-build/web-library-build/tsconfig.json
+++ b/core-build/web-library-build/tsconfig.json
@@ -10,7 +10,8 @@
       "node"
     ],
     "lib": [
-      "es6",
+      "es5",
+      "es2015.iterable",
       "es2015.collection"
     ]
   }

--- a/libraries/api-documenter/package.json
+++ b/libraries/api-documenter/package.json
@@ -27,7 +27,7 @@
     "@types/fs-extra": "0.0.37",
     "@types/js-yaml": "3.9.1",
     "@types/mocha": "2.2.38",
-    "@types/node": "6.0.62",
+    "@types/node": "6.0.88",
     "chai": "~3.5.0",
     "gulp": "~3.9.1",
     "mocha": "~3.4.2"

--- a/libraries/api-documenter/tsconfig.json
+++ b/libraries/api-documenter/tsconfig.json
@@ -11,9 +11,10 @@
       "node"
     ],
     "lib": [
-      "es6",
+      "es5",
       "scripthost",
       "es2015.collection",
+      "es2015.iterable",
       "es2015.promise",
       "dom"
     ],

--- a/libraries/api-documenter/tsconfig.json
+++ b/libraries/api-documenter/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es6",
     "forceConsistentCasingInFileNames": true,
     "module": "commonjs",
     "jsx": "react",
@@ -11,7 +11,7 @@
       "node"
     ],
     "lib": [
-      "es5",
+      "es6",
       "scripthost",
       "es2015.collection",
       "es2015.promise",

--- a/libraries/api-extractor/package.json
+++ b/libraries/api-extractor/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@microsoft/node-core-library": "~0.2.10",
     "@types/fs-extra": "0.0.37",
-    "@types/node": "6.0.62",
+    "@types/node": "6.0.88",
     "@types/z-schema": "3.16.31",
     "fs-extra": "~0.26.7",
     "jju": "~1.3.0",

--- a/libraries/api-extractor/tsconfig.json
+++ b/libraries/api-extractor/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es6",
     "forceConsistentCasingInFileNames": true,
     "module": "commonjs",
     "declaration": true,
@@ -10,7 +10,7 @@
       "node"
     ],
     "lib": [
-      "es5",
+      "es6",
       "scripthost",
       "es2015.collection",
       "es2015.promise",

--- a/libraries/api-extractor/tsconfig.json
+++ b/libraries/api-extractor/tsconfig.json
@@ -10,10 +10,11 @@
       "node"
     ],
     "lib": [
-      "es6",
+      "es5",
       "scripthost",
       "es2015.collection",
       "es2015.promise",
+      "es2015.iterable",
       "dom"
     ]
   }

--- a/libraries/decorators/package.json
+++ b/libraries/decorators/package.json
@@ -11,6 +11,7 @@
   "license": "MIT",
   "devDependencies": {
     "@microsoft/node-library-build": "~4.0.7",
+    "@types/node": "6.0.88",
     "@types/chai": "3.4.34",
     "@types/mocha": "2.2.38",
     "chai": "~3.5.0",

--- a/libraries/decorators/tsconfig.json
+++ b/libraries/decorators/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es6",
+    "target": "es5",
     "forceConsistentCasingInFileNames": true,
     "module": "commonjs",
     "jsx": "react",
@@ -12,8 +12,7 @@
       "node"
     ],
     "lib": [
-      "es5",
-      "es2015.iterable"
+      "es5"
     ]
   }
 }

--- a/libraries/decorators/tsconfig.json
+++ b/libraries/decorators/tsconfig.json
@@ -1,14 +1,17 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es6",
     "forceConsistentCasingInFileNames": true,
     "module": "commonjs",
     "jsx": "react",
     "declaration": true,
     "sourceMap": true,
     "experimentalDecorators": true,
+    "strictNullChecks": true,
     "types": [
     ],
-    "strictNullChecks": true
+    "lib": [
+      "es6"
+    ]
   }
 }

--- a/libraries/decorators/tsconfig.json
+++ b/libraries/decorators/tsconfig.json
@@ -9,9 +9,11 @@
     "experimentalDecorators": true,
     "strictNullChecks": true,
     "types": [
+      "node"
     ],
     "lib": [
-      "es6"
+      "es5",
+      "es2015.iterable"
     ]
   }
 }

--- a/libraries/load-themed-styles/tsconfig.json
+++ b/libraries/load-themed-styles/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es6",
+    "target": "es5",
     "forceConsistentCasingInFileNames": true,
     "module": "commonjs",
     "jsx": "react",
@@ -12,7 +12,6 @@
     ],
     "lib": [
       "es5",
-      "es2015.iterable",
       "dom"
     ],
     "strictNullChecks": true

--- a/libraries/load-themed-styles/tsconfig.json
+++ b/libraries/load-themed-styles/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es6",
     "forceConsistentCasingInFileNames": true,
     "module": "commonjs",
     "jsx": "react",

--- a/libraries/load-themed-styles/tsconfig.json
+++ b/libraries/load-themed-styles/tsconfig.json
@@ -10,6 +10,9 @@
     "types": [
       "webpack-env"
     ],
+    "lib": [
+      "es6"
+    ],
     "strictNullChecks": true
   }
 }

--- a/libraries/load-themed-styles/tsconfig.json
+++ b/libraries/load-themed-styles/tsconfig.json
@@ -11,7 +11,9 @@
       "webpack-env"
     ],
     "lib": [
-      "es6"
+      "es5",
+      "es2015.iterable",
+      "dom"
     ],
     "strictNullChecks": true
   }

--- a/libraries/node-core-library/package.json
+++ b/libraries/node-core-library/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@types/fs-extra": "0.0.37",
-    "@types/node": "6.0.62",
+    "@types/node": "6.0.88",
     "@types/z-schema": "3.16.31",
     "fs-extra": "~0.26.7",
     "jju": "~1.3.0",

--- a/libraries/node-core-library/tsconfig.json
+++ b/libraries/node-core-library/tsconfig.json
@@ -10,10 +10,11 @@
       "node"
     ],
     "lib": [
-      "es6",
+      "es5",
       "scripthost",
       "es2015.collection",
       "es2015.promise",
+      "es2015.iterable",
       "dom"
     ],
     "strictNullChecks": true

--- a/libraries/node-core-library/tsconfig.json
+++ b/libraries/node-core-library/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es6",
     "forceConsistentCasingInFileNames": true,
     "module": "commonjs",
     "declaration": true,
@@ -10,7 +10,7 @@
       "node"
     ],
     "lib": [
-      "es5",
+      "es6",
       "scripthost",
       "es2015.collection",
       "es2015.promise",

--- a/libraries/package-deps-hash/package.json
+++ b/libraries/package-deps-hash/package.json
@@ -20,6 +20,6 @@
     "gulp": "~3.9.1",
     "@types/chai": "3.4.34",
     "@types/mocha": "2.2.38",
-    "@types/node": "6.0.62"
+    "@types/node": "6.0.88"
   }
 }

--- a/libraries/package-deps-hash/tsconfig.json
+++ b/libraries/package-deps-hash/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es6",
     "module": "commonjs",
     "declaration": true,
     "sourceMap": true,
@@ -10,7 +10,7 @@
       "mocha"
     ],
     "lib": [
-      "es5",
+      "es6",
       "es2015.collection"
     ]
   }

--- a/libraries/package-deps-hash/tsconfig.json
+++ b/libraries/package-deps-hash/tsconfig.json
@@ -10,7 +10,8 @@
       "mocha"
     ],
     "lib": [
-      "es6",
+      "es5",
+      "es2015.iterable",
       "es2015.collection"
     ]
   }

--- a/libraries/stream-collator/package.json
+++ b/libraries/stream-collator/package.json
@@ -16,7 +16,7 @@
   "license": "MIT",
   "dependencies": {
     "colors": "~1.1.2",
-    "@types/node": "6.0.62"
+    "@types/node": "6.0.88"
   },
   "devDependencies": {
     "@types/chai": "3.4.34",

--- a/libraries/stream-collator/tsconfig.json
+++ b/libraries/stream-collator/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es6",
     "forceConsistentCasingInFileNames": true,
     "module": "commonjs",
     "jsx": "react",
@@ -10,7 +10,7 @@
       "node"
     ],
     "lib": [
-      "es5",
+      "es6",
       "es2015.collection"
     ]
   }

--- a/libraries/stream-collator/tsconfig.json
+++ b/libraries/stream-collator/tsconfig.json
@@ -10,7 +10,8 @@
       "node"
     ],
     "lib": [
-      "es6",
+      "es5",
+      "es2015.iterable",
       "es2015.collection"
     ]
   }

--- a/libraries/ts-command-line/package.json
+++ b/libraries/ts-command-line/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "argparse": "~1.0.7",
     "colors": "~1.1.2",
-    "@types/node": "6.0.62"
+    "@types/node": "6.0.88"
   },
   "devDependencies": {
     "@types/colors": "1.1.3",

--- a/libraries/ts-command-line/tsconfig.json
+++ b/libraries/ts-command-line/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es6",
     "forceConsistentCasingInFileNames": true,
     "module": "commonjs",
     "jsx": "react",
@@ -10,7 +10,7 @@
       "node"
     ],
     "lib": [
-      "es5",
+      "es6",
       "es2015.collection"
     ]
   }

--- a/libraries/ts-command-line/tsconfig.json
+++ b/libraries/ts-command-line/tsconfig.json
@@ -10,7 +10,8 @@
       "node"
     ],
     "lib": [
-      "es6",
+      "es5",
+      "es2015.iterable",
       "es2015.collection"
     ]
   }

--- a/rush.json
+++ b/rush.json
@@ -1,6 +1,6 @@
 {
   "npmVersion": "4.5.0",
-  "rushMinimumVersion": "3.0.15",
+  "rushMinimumVersion": "3.0.16",
   "nodeSupportedVersionRange": ">=6.9.0 <7.0.0",
   "projectFolderMinDepth": 1,
 

--- a/rush.json
+++ b/rush.json
@@ -1,7 +1,7 @@
 {
   "npmVersion": "4.5.0",
   "rushMinimumVersion": "3.0.16",
-  "nodeSupportedVersionRange": ">=6.9.0 <7.0.0",
+  "nodeSupportedVersionRange": ">=6.11.3 <7.0.0",
   "projectFolderMinDepth": 1,
 
   "approvedPackagesPolicy": {

--- a/rush.json
+++ b/rush.json
@@ -1,7 +1,7 @@
 {
   "npmVersion": "4.5.0",
   "rushMinimumVersion": "3.0.17",
-  "nodeSupportedVersionRange": ">=6.11.3 <7.0.0",
+  "nodeSupportedVersionRange": ">=6.5.0 <7.0.0",
   "projectFolderMinDepth": 1,
 
   "approvedPackagesPolicy": {

--- a/rush.json
+++ b/rush.json
@@ -1,7 +1,7 @@
 {
   "npmVersion": "4.5.0",
   "rushMinimumVersion": "3.0.17",
-  "nodeSupportedVersionRange": ">=6.5.0 <7.0.0",
+  "nodeSupportedVersionRange": ">=6.9.0 <7.0.0",
   "projectFolderMinDepth": 1,
 
   "approvedPackagesPolicy": {

--- a/webpack/loader-load-themed-styles/package.json
+++ b/webpack/loader-load-themed-styles/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "@types/mocha": "2.2.38",
-    "@types/node": "6.0.62",
+    "@types/node": "6.0.88",
     "@types/loader-utils": "~1.1.0",
     "@types/webpack": "3.0.10",
     "chai": "~3.5.0",

--- a/webpack/loader-load-themed-styles/tsconfig.json
+++ b/webpack/loader-load-themed-styles/tsconfig.json
@@ -6,9 +6,12 @@
     "declaration": true,
     "sourceMap": true,
     "strictNullChecks": true,
-    "types": [],
+    "types": [
+      "node"
+    ],
     "lib": [
-      "es6"
+      "es5",
+      "es2015.iterable"
     ]
   }
 }

--- a/webpack/loader-load-themed-styles/tsconfig.json
+++ b/webpack/loader-load-themed-styles/tsconfig.json
@@ -1,10 +1,14 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es6",
     "module": "commonjs",
     "jsx": "react",
     "declaration": true,
     "sourceMap": true,
-    "strictNullChecks": true
+    "strictNullChecks": true,
+    "types": [],
+    "lib": [
+      "es6"
+    ]
   }
 }

--- a/webpack/loader-raw-script/package.json
+++ b/webpack/loader-raw-script/package.json
@@ -16,7 +16,7 @@
   },
   "devDependencies": {
     "@types/mocha": "2.2.38",
-    "@types/node": "6.0.62",
+    "@types/node": "6.0.88",
     "chai": "~3.5.0",
     "gulp": "~3.9.1",
     "mocha": "~3.4.2",

--- a/webpack/loader-raw-script/tsconfig.json
+++ b/webpack/loader-raw-script/tsconfig.json
@@ -1,10 +1,14 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es6",
     "module": "commonjs",
     "jsx": "react",
     "declaration": true,
     "sourceMap": true,
-    "strictNullChecks": true
+    "strictNullChecks": true,
+    "types": [],
+    "lib": [
+      "es6"
+    ]
   }
 }

--- a/webpack/loader-raw-script/tsconfig.json
+++ b/webpack/loader-raw-script/tsconfig.json
@@ -6,9 +6,13 @@
     "declaration": true,
     "sourceMap": true,
     "strictNullChecks": true,
-    "types": [],
+    "types": [
+      "node",
+      "mocha"
+    ],
     "lib": [
-      "es6"
+      "es5",
+      "es2015.iterable"
     ]
   }
 }

--- a/webpack/loader-set-webpack-public-path/package.json
+++ b/webpack/loader-set-webpack-public-path/package.json
@@ -12,6 +12,7 @@
     "test": "gulp test"
   },
   "dependencies": {
+    "@types/node": "6.0.88",
     "@microsoft/set-webpack-public-path-plugin": "~1.2.3",
     "loader-utils": "~1.1.0",
     "lodash": "~4.15.0"

--- a/webpack/loader-set-webpack-public-path/tsconfig.json
+++ b/webpack/loader-set-webpack-public-path/tsconfig.json
@@ -1,10 +1,14 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es6",
     "module": "commonjs",
     "jsx": "react",
     "declaration": true,
     "sourceMap": true,
-    "strictNullChecks": true
+    "strictNullChecks": true,
+    "types": [],
+    "lib": [
+      "es6"
+    ]
   }
 }

--- a/webpack/loader-set-webpack-public-path/tsconfig.json
+++ b/webpack/loader-set-webpack-public-path/tsconfig.json
@@ -6,9 +6,13 @@
     "declaration": true,
     "sourceMap": true,
     "strictNullChecks": true,
-    "types": [],
+    "types": [
+      "node",
+      "mocha"
+    ],
     "lib": [
-      "es6"
+      "es5",
+      "es2015.iterable"
     ]
   }
 }

--- a/webpack/set-webpack-public-path-plugin/tsconfig.json
+++ b/webpack/set-webpack-public-path-plugin/tsconfig.json
@@ -6,9 +6,12 @@
     "declaration": true,
     "sourceMap": true,
     "strictNullChecks": true,
-    "types": [],
+    "types": [
+      "node"
+    ],
     "lib": [
-      "es6"
+      "es5",
+      "es2015.iterable"
     ]
   }
 }

--- a/webpack/set-webpack-public-path-plugin/tsconfig.json
+++ b/webpack/set-webpack-public-path-plugin/tsconfig.json
@@ -1,10 +1,14 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es6",
     "module": "commonjs",
     "jsx": "react",
     "declaration": true,
     "sourceMap": true,
-    "strictNullChecks": true
+    "strictNullChecks": true,
+    "types": [],
+    "lib": [
+      "es6"
+    ]
   }
 }


### PR DESCRIPTION
Note, this means users of our code will need to be using >= Node 6 (which is the current LTS version)