### PR TITLE
Fix a bug where devDependency version does not get updated when there is no dependency.

### DIFF
--- a/apps/rush/src/utilities/VersionManager.ts
+++ b/apps/rush/src/utilities/VersionManager.ts
@@ -189,7 +189,7 @@ export class VersionManager {
     clonedProject: IPackageJson,
     projectVersionChanged: boolean
   ): void {
-    if (!clonedProject.dependencies) {
+    if (!clonedProject.dependencies && !clonedProject.devDependencies) {
       return;
     }
     const changes: IChangeInfo[] = [];

--- a/apps/rush/src/utilities/test/VersionManager.test.ts
+++ b/apps/rush/src/utilities/test/VersionManager.test.ts
@@ -43,7 +43,7 @@ describe('VersionManager', () => {
       versionManager.ensure('testPolicy1');
       const updatedPackages: Map<string, IPackageJson> = versionManager.updatedProjects;
       const expectedVersion: string = '10.10.0';
-      assert.equal(updatedPackages.size, 5, 'The number of updated packages matches');
+      assert.equal(updatedPackages.size, 6, 'The number of updated packages matches');
       assert.equal(updatedPackages.get('a').version, expectedVersion);
       assert.equal(updatedPackages.get('b').version, expectedVersion);
       assert.equal(updatedPackages.get('b').dependencies['a'], `~${expectedVersion}`);
@@ -53,6 +53,7 @@ describe('VersionManager', () => {
       assert.equal(updatedPackages.get('d').dependencies['b'], `>=10.10.0 <11.0.0`);
       assert.equal(updatedPackages.get('f').version, '1.0.0', 'f version should not change');
       assert.equal(updatedPackages.get('f').dependencies['a'], `~10.10.0`);
+      assert.equal(updatedPackages.get('g').devDependencies['a'], `~10.10.0`);
 
       const changeFiles: Map<string, ChangeFile> = versionManager.changeFiles;
       assert.equal(changeFiles.size, 4, 'The number of change files matches');
@@ -104,6 +105,8 @@ describe('VersionManager', () => {
       assert.equal(updatedPackages.get('a').version, expectedVersion, `a version is not expected`);
       assert.equal(updatedPackages.get('b').version, expectedVersion, `b version is not expected`);
       assert.equal(updatedPackages.get('e').version, expectedVersion, `e version is not expected`);
+      assert.equal(updatedPackages.get('g').devDependencies['a'], `~${expectedVersion}`,
+        'a version is not expected in dev dependency');
       assert.isUndefined(_getChanges(changeFiles, 'a'), 'a has change entry.');
       assert.isUndefined(_getChanges(changeFiles, 'b'), 'b has change entry');
     });

--- a/apps/rush/src/utilities/test/repo/g/package.json
+++ b/apps/rush/src/utilities/test/repo/g/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "g",
+  "version": "0.0.1",
+  "description": "Test package g",
+  "devDependencies": {
+    "a": "~1.0.0"
+  }
+}

--- a/apps/rush/src/utilities/test/repo/rush.json
+++ b/apps/rush/src/utilities/test/repo/rush.json
@@ -38,6 +38,11 @@
       "packageName": "f",
       "projectFolder": "f",
       "reviewCategory": "third-party"
+    },
+    {
+      "packageName": "g",
+      "projectFolder": "g",
+      "reviewCategory": "third-party"
     }
   ]
 }


### PR DESCRIPTION
Add a test case for it as well.