### PR TITLE
Fix "rush rebuild" a stack overflow error when a cyclic dependency is encountered

### DIFF
--- a/apps/rush/src/taskRunner/TaskRunner.ts
+++ b/apps/rush/src/taskRunner/TaskRunner.ts
@@ -101,6 +101,8 @@ export default class TaskRunner {
     this._currentActiveTasks = 0;
     console.log(`Executing a maximum of ${this._parallelism} simultaneous processes...${os.EOL}`);
 
+    this._checkForCyclicDependencies([...this._tasks.values()], []);
+
     // Precalculate the number of dependent packages
     this._tasks.forEach((task: ITask) => {
       this._calculateCriticalPaths(task);
@@ -280,10 +282,27 @@ export default class TaskRunner {
   }
 
   /**
-   * Calculate the number of packages which must be build before we reach
+   * Checks for projects that indirectly depend on themselves.
+   */
+  private _checkForCyclicDependencies(tasks: ReadonlyArray<ITask>, dependencyChain: string[]): void {
+    for (const task of tasks) {
+      if (dependencyChain.indexOf(task.name) >= 0) {
+        throw new Error('A cyclic dependency was encountered:' + os.EOL
+          + '  ' + [...dependencyChain, task.name].reverse().join('\n  -> ') + os.EOL
+          + 'Consider using the cyclicDependencyProjects option for rush.json.');
+      }
+      dependencyChain.push(task.name);
+      this._checkForCyclicDependencies([...task.dependents], dependencyChain);
+      dependencyChain.pop();
+    }
+  }
+
+  /**
+   * Calculate the number of packages which must be built before we reach
    * the furthest away "root" node
    */
   private _calculateCriticalPaths(task: ITask): number {
+
     // Return the memoized value
     if (task.criticalPathLength !== undefined) {
       return task.criticalPathLength;

--- a/apps/rush/src/taskRunner/TaskRunner.ts
+++ b/apps/rush/src/taskRunner/TaskRunner.ts
@@ -101,7 +101,7 @@ export default class TaskRunner {
     this._currentActiveTasks = 0;
     console.log(`Executing a maximum of ${this._parallelism} simultaneous processes...${os.EOL}`);
 
-    this._checkForCyclicDependencies([...this._tasks.values()], []);
+    this._checkForCyclicDependencies(this._tasks.values(), []);
 
     // Precalculate the number of dependent packages
     this._tasks.forEach((task: ITask) => {
@@ -284,7 +284,7 @@ export default class TaskRunner {
   /**
    * Checks for projects that indirectly depend on themselves.
    */
-  private _checkForCyclicDependencies(tasks: ReadonlyArray<ITask>, dependencyChain: string[]): void {
+  private _checkForCyclicDependencies(tasks: Iterable<ITask>, dependencyChain: string[]): void {
     for (const task of tasks) {
       if (dependencyChain.indexOf(task.name) >= 0) {
         throw new Error('A cyclic dependency was encountered:' + os.EOL
@@ -292,7 +292,7 @@ export default class TaskRunner {
           + 'Consider using the cyclicDependencyProjects option for rush.json.');
       }
       dependencyChain.push(task.name);
-      this._checkForCyclicDependencies([...task.dependents], dependencyChain);
+      this._checkForCyclicDependencies(task.dependents, dependencyChain);
       dependencyChain.pop();
     }
   }

--- a/apps/rush/src/taskRunner/TaskRunner.ts
+++ b/apps/rush/src/taskRunner/TaskRunner.ts
@@ -287,9 +287,9 @@ export default class TaskRunner {
   private _checkForCyclicDependencies(tasks: Iterable<ITask>, dependencyChain: string[]): void {
     for (const task of tasks) {
       if (dependencyChain.indexOf(task.name) >= 0) {
-        throw new Error('A cyclic dependency was encountered:' + os.EOL
-          + '  ' + [...dependencyChain, task.name].reverse().join('\n  -> ') + os.EOL
-          + 'Consider using the cyclicDependencyProjects option for rush.json.');
+        throw new Error('A cyclic dependency was encountered:\n'
+          + '  ' + [...dependencyChain, task.name].reverse().join('\n  -> ')
+          + '\nConsider using the cyclicDependencyProjects option for rush.json.');
       }
       dependencyChain.push(task.name);
       this._checkForCyclicDependencies(task.dependents, dependencyChain);


### PR DESCRIPTION
Problem: If a cyclic dependency exists, "rush install" would succeed, but "rush rebuild" would fail with a stack overflow error.

This PR adds an explicit check for such cycles.  If found, it displays the chain of dependencies that's causing the trouble, and recommends to use the "cyclicDependencyProjects" option in rush.json.