### PR TITLE
Fix bug where api-documenter was incorrectly escaping certain special characters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ app
 app-min
 bower_components
 coverage
+local
 dist
 jspm_packages
 lib

--- a/common/changes/@microsoft/node-core-library/pgonzal-escape-bug_2017-10-13-18-28.json
+++ b/common/changes/@microsoft/node-core-library/pgonzal-escape-bug_2017-10-13-18-28.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/node-core-library",
+      "comment": "When FileDiffTest creates a copy of the expected output for comparison, it is now marked as read-only to avoid confusion",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/node-core-library",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/libraries/api-documenter/.gitignore
+++ b/libraries/api-documenter/.gitignore
@@ -1,7 +1,0 @@
-# For now, the api-documenter tool operates on files in a local folder:
-#
-# ./files/input      - the *.api.json files to process
-# ./files/markdown   - the generated *.md output files
-#
-# (In the future, we will introduce a command-line to make this more configurable.)
-files

--- a/libraries/api-documenter/src/MarkdownRenderer.ts
+++ b/libraries/api-documenter/src/MarkdownRenderer.ts
@@ -116,11 +116,12 @@ export class MarkdownRenderer {
   private static _getEscapedText(text: string): string {
     const textWithBackslashes: string = text
       .replace(/\\/g, '\\\\')  // first replace the escape character
-      .replace(/[*#[\]_|]/g, (x) => '\\' + x); // then escape any special characters
-    return textWithBackslashes
+      .replace(/[*#[\]_|`~]/g, (x) => '\\' + x) // then escape any special characters
+      .replace(/---/g, '\\-\\-\\-') // hyphens only if it's 3 or more
       .replace(/&/g, '&amp;')
       .replace(/</g, '&lt;')
       .replace(/>/g, '&gt;');
+    return textWithBackslashes
   }
 
   /**

--- a/libraries/api-documenter/src/MarkdownRenderer.ts
+++ b/libraries/api-documenter/src/MarkdownRenderer.ts
@@ -115,12 +115,12 @@ export class MarkdownRenderer {
 
   private static _getEscapedText(text: string): string {
     const textWithBackslashes: string = text
-      .replace('\\', '\\\\')  // first replace the escape character
-      .replace(/[\*\#\[\]\_\|]/g, (x) => '\\' + x); // then escape any special characters
+      .replace(/\\/g, '\\\\')  // first replace the escape character
+      .replace(/[*#[\]_|]/g, (x) => '\\' + x); // then escape any special characters
     return textWithBackslashes
-      .replace('&', '&amp;')
-      .replace('<', '&lt;')
-      .replace('>', '&gt;');
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;');
   }
 
   /**

--- a/libraries/api-documenter/src/MarkdownRenderer.ts
+++ b/libraries/api-documenter/src/MarkdownRenderer.ts
@@ -121,7 +121,7 @@ export class MarkdownRenderer {
       .replace(/&/g, '&amp;')
       .replace(/</g, '&lt;')
       .replace(/>/g, '&gt;');
-    return textWithBackslashes
+    return textWithBackslashes;
   }
 
   /**

--- a/libraries/api-documenter/src/index.ts
+++ b/libraries/api-documenter/src/index.ts
@@ -18,7 +18,7 @@ console.log(os.EOL + colors.bold(`api-documenter ${myPackageJson.version}` + os.
 
 const docItemSet: DocItemSet = new DocItemSet();
 
-const dataFolder: string = path.join(__dirname, '../files');
+const dataFolder: string = path.join(__dirname, '../local');
 
 const inputFolder: string = path.join(dataFolder, 'input');
 for (const filename of fsx.readdirSync(inputFolder)) {

--- a/libraries/api-documenter/src/test/ExpectedOutput.md
+++ b/libraries/api-documenter/src/test/ExpectedOutput.md
@@ -30,3 +30,14 @@ This is a **bold** word.
 ## Bad characters
 
 **\*one\*two\*three\*four**
+
+## Characters that should be escaped
+
+Double-encoded JSON: "{ \\"A\\": 123}"
+
+HTML chars: &lt;script&gt;alert("\[You\] are \#1!");&lt;/script&gt;
+
+HTML escape: &amp;quot;
+
+3 or more hyphens: - -- \-\-\- \-\-\-- \-\-\--- \-\-\-\-\-\-
+

--- a/libraries/api-documenter/src/test/MarkdownPageRenderer.test.ts
+++ b/libraries/api-documenter/src/test/MarkdownPageRenderer.test.ts
@@ -53,6 +53,16 @@ describe('MarkdownPageRenderer', () => {
     markupPage.elements.push(...MarkupBuilder.createTextElements('*one*two*', { bold: true }));
     markupPage.elements.push(...MarkupBuilder.createTextElements('three*four', { bold: true }));
 
+    markupPage.elements.push(MarkupBuilder.createHeading1('Characters that should be escaped'));
+    markupPage.elements.push(...MarkupBuilder.createTextElements(
+      'Double-encoded JSON: "{ \\"A\\": 123}"\n\n'));
+    markupPage.elements.push(...MarkupBuilder.createTextElements(
+      'HTML chars: <script>alert("[You] are #1!");</script>\n\n'));
+    markupPage.elements.push(...MarkupBuilder.createTextElements(
+      'HTML escape: &quot;\n\n'));
+    markupPage.elements.push(...MarkupBuilder.createTextElements(
+      '3 or more hyphens: - -- --- ---- ----- ------\n\n'));
+
     const outputFilename: string = path.join(outputFolder, 'ActualOutput.md');
     fsx.writeFileSync(outputFilename, MarkdownRenderer.renderElements([markupPage], { }));
 

--- a/libraries/node-core-library/src/FileDiffTest.ts
+++ b/libraries/node-core-library/src/FileDiffTest.ts
@@ -76,6 +76,7 @@ export class FileDiffTest {
           + ' the file already exists:\n' + expectedCopyFilename);
       }
       fsx.copySync(expectedFilePath, expectedCopyFilename);
+      fsx.chmodSync(expectedCopyFilename, 292); // 292 = 444 octal = "rrr"
 
       throw new Error('The test output file does not match the expected input:\n'
         + actualFilePath);


### PR DESCRIPTION
string.replace("x", "y") only replaces the first match.