### PR TITLE
Add an api-documenter switch for use with Office add-ins

### DIFF
--- a/libraries/api-documenter/src/cli/YamlAction.ts
+++ b/libraries/api-documenter/src/cli/YamlAction.ts
@@ -1,12 +1,20 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
+import {
+  CommandLineFlagParameter
+} from '@microsoft/ts-command-line';
+
 import { ApiDocumenterCommandLine } from './ApiDocumenterCommandLine';
 import { BaseAction } from './BaseAction';
 import { DocItemSet } from '../utils/DocItemSet';
+
 import { YamlDocumenter } from '../yaml/YamlDocumenter';
+import { OfficeYamlDocumenter } from '../yaml/OfficeYamlDocumenter';
 
 export class YamlAction extends BaseAction {
+  private _officeParameter: CommandLineFlagParameter;
+
   constructor(parser: ApiDocumenterCommandLine) {
     super({
       actionVerb: 'yaml',
@@ -15,9 +23,22 @@ export class YamlAction extends BaseAction {
     });
   }
 
+  protected onDefineParameters(): void { // override
+    super.onDefineParameters();
+
+    this._officeParameter = this.defineFlagParameter({
+      parameterLongName: '--office',
+      description: `Enables some additional features specific to Office Add-ins`
+    });
+  }
+
   protected onExecute(): void { // override
     const docItemSet: DocItemSet = this.buildDocItemSet();
-    const yamlDocumenter: YamlDocumenter = new YamlDocumenter(docItemSet);
+
+    const yamlDocumenter: YamlDocumenter = this._officeParameter.value
+       ? new OfficeYamlDocumenter(docItemSet, this.inputFolder)
+       : new YamlDocumenter(docItemSet);
+
     yamlDocumenter.generateFiles(this.outputFolder);
   }
 }

--- a/libraries/api-documenter/src/utils/DocItemSet.ts
+++ b/libraries/api-documenter/src/utils/DocItemSet.ts
@@ -12,6 +12,7 @@ import { Utilities } from './Utilities';
 
 export enum DocItemKind {
   Package,
+  Namespace,
   Class,
   Interface,
   Method,
@@ -58,7 +59,8 @@ export class DocItem {
 
     switch (this.apiItem.kind) {
       case 'package':
-        this.kind = DocItemKind.Package;
+      case 'namespace':
+        this.kind = this.apiItem.kind === 'package' ? DocItemKind.Package : DocItemKind.Namespace;
         for (const exportName of Object.keys(this.apiItem.exports)) {
           const child: ApiItem = this.apiItem.exports[exportName];
           this.children.push(new DocItem(child, exportName, this.docItemSet, this));

--- a/libraries/api-documenter/src/utils/DocItemSet.ts
+++ b/libraries/api-documenter/src/utils/DocItemSet.ts
@@ -155,16 +155,6 @@ export class DocItem {
     }
     return undefined;
   }
-
-  /**
-   * Returns true if this is a package, and it has been classified as "external",
-   * i.e. a system library that is maintained by an external party, but included in the
-   * documentation for informational purposes.
-   */
-  public get isExternalPackage(): boolean {
-    // We should define a better criteria for this
-    return this.apiItem.kind === 'package' && this.apiItem.name.substr(0, 1) === '@';
-  }
 }
 
 /**

--- a/libraries/api-documenter/src/yaml/OfficeYamlDocumenter.ts
+++ b/libraries/api-documenter/src/yaml/OfficeYamlDocumenter.ts
@@ -1,0 +1,86 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import * as fsx from 'fs-extra';
+import * as path from 'path';
+import yaml = require('js-yaml');
+
+import { DocItemSet } from '../utils/DocItemSet';
+import { IYamlTocItem } from './IYamlTocFile';
+import { IYamlItem } from './IYamlApiFile';
+import { YamlDocumenter } from './YamlDocumenter';
+
+interface ISnippetsFile {
+  /**
+   * The keys are API names like "Excel.Range.clear".
+   * The values are TypeScript source code excerpts.
+   */
+  [apiName: string]: string[];
+}
+
+/**
+ * Extends YamlDocumenter with some custom logic that is specific to Office Add-ins.
+ */
+export class OfficeYamlDocumenter extends YamlDocumenter {
+  private _snippets: ISnippetsFile;
+
+  public constructor(docItemSet: DocItemSet, inputFolder: string) {
+    super(docItemSet);
+
+    const snippetsFilePath: string = path.join(inputFolder, 'snippets.yaml');
+
+    console.log('Loading snippets from ' + snippetsFilePath);
+    const snippetsContent: string = fsx.readFileSync(snippetsFilePath).toString();
+    this._snippets = yaml.load(snippetsContent, { filename: snippetsFilePath });
+  }
+
+  public generateFiles(outputFolder: string): void { // override
+    super.generateFiles(outputFolder);
+
+    // After we generate everything, check for any unused snippets
+    for (const apiName of Object.keys(this._snippets)) {
+      console.error('UNUSED SNIPPET: ' + apiName);
+    }
+  }
+
+  protected onGetTocRoot(): IYamlTocItem { // override
+    return {
+      name: 'Office Add-ins',
+      items: [ ]
+    };
+  }
+
+  protected onCustomizeYamlItem(yamlItem: IYamlItem): void { // override
+    const nameWithoutPackage: string = yamlItem.uid.replace(/^[^.]+\./, '');
+
+    const snippets: string[] | undefined = this._snippets[nameWithoutPackage];
+    if (snippets) {
+      delete this._snippets[nameWithoutPackage];
+
+      if (!yamlItem.remarks) {
+        yamlItem.remarks = '';
+      }
+
+      yamlItem.remarks += '\n\n## Snippets\n';
+      for (const snippet of snippets) {
+        yamlItem.remarks += '\n```typescript\n' + snippet + '\n```\n';
+      }
+    }
+
+    if (yamlItem.summary) {
+      yamlItem.summary = this._fixupApiSet(yamlItem.summary);
+    }
+    if (yamlItem.remarks) {
+      yamlItem.remarks = this._fixupApiSet(yamlItem.remarks);
+    }
+  }
+
+  private _fixupApiSet(markup: string): string {
+    // Search for a pattern such as this:
+    // \[Api set: ExcelApi 1.1\]
+    //
+    // Hyperlink it like this:
+    // \[ [Api set: ExcelApi 1.1](http://bing.com) \]
+    return markup.replace(/\\\[(Api set:[^\]]+)\\\]/, `\\[ [$1](http://bing.com) \\]`);
+  }
+}

--- a/libraries/api-documenter/src/yaml/YamlDocumenter.ts
+++ b/libraries/api-documenter/src/yaml/YamlDocumenter.ts
@@ -118,26 +118,10 @@ export class YamlDocumenter {
 
     tocFile.items.push({
       name: 'SharePoint Framework', // TODO: parameterize this
-      items: [
-        {
-          name: 'Overview',
-          href: './index.md'
-        } as IYamlTocItem
-      ].concat(this._buildTocItems(docItems.filter(x => x.isExternalPackage)))
+      href: '~/overview/sharepoint.md',
+      items: this._buildTocItems(docItems)
     });
 
-    const externalPackages: DocItem[] = docItems.filter(x => !x.isExternalPackage);
-    if (externalPackages.length) {
-      tocFile.items.push({
-        name: '─────────────'
-      });
-      tocFile.items.push({
-        name: 'External Packages',
-        items: this._buildTocItems(externalPackages)
-      });
-    }
-
-    this._buildTocItems(docItems);
     const tocFilePath: string = path.join(this._outputFolder, 'toc.yml');
     console.log('Writing ' + tocFilePath);
     this._writeYamlFile(tocFile, tocFilePath, '', undefined);

--- a/libraries/api-documenter/src/yaml/YamlDocumenter.ts
+++ b/libraries/api-documenter/src/yaml/YamlDocumenter.ts
@@ -45,7 +45,7 @@ export class YamlDocumenter {
     this._docItemSet = docItemSet;
   }
 
-  public generateFiles(outputFolder: string): void {
+  public generateFiles(outputFolder: string): void { // virtual
     this._outputFolder = outputFolder;
 
     console.log();
@@ -58,11 +58,25 @@ export class YamlDocumenter {
     this._writeTocFile(this._docItemSet.docPackages);
   }
 
+  protected onGetTocRoot(): IYamlTocItem {  // virtual
+    return {
+      name: 'SharePoint Framework',
+      href: '~/overview/sharepoint.md',
+      items: [ ]
+    };
+  }
+
+  protected onCustomizeYamlItem(yamlItem: IYamlItem): void { // virtual
+    // (overridden by child class)
+  }
+
   private _visitDocItems(docItem: DocItem, parentYamlFile: IYamlApiFile | undefined): boolean {
     const yamlItem: IYamlItem | undefined = this._generateYamlItem(docItem);
     if (!yamlItem) {
       return false;
     }
+
+    this.onCustomizeYamlItem(yamlItem);
 
     if (this._shouldEmbed(docItem.kind)) {
       if (!parentYamlFile) {
@@ -132,11 +146,10 @@ export class YamlDocumenter {
       items: [ ]
     };
 
-    tocFile.items.push({
-      name: 'SharePoint Framework', // TODO: parameterize this
-      href: '~/overview/sharepoint.md',
-      items: this._buildTocItems(docItems)
-    });
+    const rootItem: IYamlTocItem = this.onGetTocRoot();
+    tocFile.items.push(rootItem);
+
+    rootItem.items!.push(...this._buildTocItems(docItems));
 
     const tocFilePath: string = path.join(this._outputFolder, 'toc.yml');
     console.log('Writing ' + tocFilePath);


### PR DESCRIPTION
Office add-ins had two minor additional requirements beyond the normal api-documenter feature set:

- Ability to mix code snippets into the "Remarks" section for a class
- Ability to hyperlink the "Api Set" tags

This is a prototype that shows how the YamlDocumenter.ts class can be extended; going forward the OfficeYamlDocumenter.ts subclass would be owned by the Office group.