### PR TITLE
Two minor fixes for API Extractor

### DIFF
--- a/common/changes/@microsoft/api-extractor/pgonzal-ae-fixes_2017-10-20-19-24.json
+++ b/common/changes/@microsoft/api-extractor/pgonzal-ae-fixes_2017-10-20-19-24.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor",
+      "comment": "Fixed an issue where properties were sometimes marked as readonly; a remark is automatically generated for classes with internal constructors",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/libraries/api-extractor/src/DocElementParser.ts
+++ b/libraries/api-extractor/src/DocElementParser.ts
@@ -329,6 +329,7 @@ export default class DocElementParser {
         documentation.returnsMessage = resolvedAstItem.returnsMessage;
         break;
       case AstItemKind.Method:
+      case AstItemKind.Constructor:
         documentation.parameters = resolvedAstItem.params;
         documentation.returnsMessage = resolvedAstItem.returnsMessage;
         break;

--- a/libraries/api-extractor/src/ast/AstMethod.ts
+++ b/libraries/api-extractor/src/ast/AstMethod.ts
@@ -19,11 +19,16 @@ import ApiDefinitionReference, { IScopedPackageName } from '../ApiDefinitionRefe
 export default class AstMethod extends AstMember {
   public readonly returnType: string;
   public readonly params: AstParameter[];
-  private readonly _isConstructor: boolean;
 
   constructor(options: IAstItemOptions) {
     super(options);
-    this.kind = AstItemKind.Method;
+
+    // tslint:disable-next-line:no-bitwise
+    if ((options.declarationSymbol.flags & ts.SymbolFlags.Constructor) !== 0) {
+      this.kind = AstItemKind.Constructor;
+    } else {
+      this.kind = AstItemKind.Method;
+    }
 
     const methodDeclaration: ts.MethodDeclaration = options.declaration as ts.MethodDeclaration;
 
@@ -44,11 +49,8 @@ export default class AstMethod extends AstMember {
       }
     }
 
-    // tslint:disable-next-line:no-bitwise
-    this._isConstructor = (options.declarationSymbol.flags & ts.SymbolFlags.Constructor) !== 0;
-
     // Return type
-    if (!this.isConstructor) {
+    if (this.kind !== AstItemKind.Constructor) {
       if (methodDeclaration.type) {
         this.returnType = methodDeclaration.type.getText();
       } else {
@@ -58,20 +60,13 @@ export default class AstMethod extends AstMember {
     }
   }
 
-  /**
-   * Returns true if this member represents a class constructor.
-   */
-  public get isConstructor(): boolean {
-    return this._isConstructor;
-  }
-
   protected onCompleteInitialization(): void {
     super.onCompleteInitialization();
 
     // If this is a class constructor, and if the documentation summary was omitted, then
     // we fill in a default summary versus flagging it as "undocumented".
     // Generally class constructors have uninteresting documentation.
-    if (this.isConstructor) {
+    if (this.kind === AstItemKind.Constructor) {
       if (this.documentation.summary.length === 0) {
         this.documentation.summary.push({
           kind: 'textDocElement',

--- a/libraries/api-extractor/src/ast/AstProperty.ts
+++ b/libraries/api-extractor/src/ast/AstProperty.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
+import * as ts from 'typescript';
+
 import { AstItemKind, IAstItemOptions } from './AstItem';
 import AstMember from './AstMember';
 
@@ -17,16 +19,23 @@ class AstProperty extends AstMember {
     super(options);
     this.kind = AstItemKind.Property;
 
-    if (this.documentation.hasReadOnlyTag) {
-      this.isReadOnly = true;
-    }
-
-    const declaration: any = options.declaration as any; /* tslint:disable-line:no-any */
+    const declaration: ts.PropertyDeclaration = options.declaration as ts.PropertyDeclaration;
     if (declaration.type) {
       this.type = declaration.type.getText();
     } else {
       this.hasIncompleteTypes = true;
       this.type = 'any';
+    }
+
+    if (this.documentation.hasReadOnlyTag) {
+      this.isReadOnly = true;
+    } else {
+      // Check for a readonly modifier
+      for (const modifier of declaration.modifiers || []) {
+        if (modifier.kind === ts.SyntaxKind.ReadonlyKeyword) {
+          this.isReadOnly = true;
+        }
+      }
     }
   }
 

--- a/libraries/api-extractor/src/ast/AstStructuredType.ts
+++ b/libraries/api-extractor/src/ast/AstStructuredType.ts
@@ -4,6 +4,8 @@
 /* tslint:disable:no-bitwise */
 
 import * as ts from 'typescript';
+import { ReleaseTag } from '../aedoc/ReleaseTag';
+import { ITextElement, IParagraphElement } from '../markup/OldMarkup';
 import AstMethod from './AstMethod';
 import AstProperty from './AstProperty';
 import AstItem, { AstItemKind, IAstItemOptions } from './AstItem';
@@ -153,6 +155,29 @@ export default class AstStructuredType extends AstItemContainer {
       }
     }
     return result;
+  }
+
+  protected onCompleteInitialization(): void {
+    super.onCompleteInitialization();
+
+    // Is the constructor internal?
+    for (const member of this.getSortedMemberItems()) {
+      if (member.kind === AstItemKind.Constructor) {
+        if (member.documentation.releaseTag === ReleaseTag.Internal) {
+          // Add a boilerplate notice for classes with internal constructors
+          this.documentation.remarks.unshift(
+            {
+              kind: 'textDocElement',
+              value: `The constructor for this class is marked as internal. Third-party code`
+                + ` should not extend subclasses of the ${this.name} class or instantiate it directly.`
+            } as ITextElement,
+            {
+              kind: 'paragraphDocElement'
+            } as IParagraphElement
+          );
+        }
+      }
+    }
   }
 
   private _processMember(memberSymbol: ts.Symbol, memberDeclaration: ts.Declaration): void {

--- a/libraries/api-extractor/testInputs/example1/index.ts
+++ b/libraries/api-extractor/testInputs/example1/index.ts
@@ -23,37 +23,3 @@ export function publicFunction(param: number): string {
 }
 
 export { AlphaTaggedClass, BetaTaggedClass, PublicTaggedClass } from './folder/ReleaseTagTests';
-
-
-/** 
-  * Summary text
-  * @remarks
-  * Remarks text
-  * @public 
-  */
-export class Blarg {
-  /** 
-   * @internal 
-   */
-  public constructor(x: number) {
-  }
-  
-  doSomething(): void {
-  }
-}
-
-/** 
-  * Summary text
-  * @remarks
-  * Remarks text
-  * @public 
-  */
-export class Blorg {
-  /** @beta */
-  public constructor(x: number) {
-  }
-  
-  doSomething(): void {
-  }
-}
-

--- a/libraries/api-extractor/testInputs/example1/index.ts
+++ b/libraries/api-extractor/testInputs/example1/index.ts
@@ -23,3 +23,37 @@ export function publicFunction(param: number): string {
 }
 
 export { AlphaTaggedClass, BetaTaggedClass, PublicTaggedClass } from './folder/ReleaseTagTests';
+
+
+/** 
+  * Summary text
+  * @remarks
+  * Remarks text
+  * @public 
+  */
+export class Blarg {
+  /** 
+   * @internal 
+   */
+  public constructor(x: number) {
+  }
+  
+  doSomething(): void {
+  }
+}
+
+/** 
+  * Summary text
+  * @remarks
+  * Remarks text
+  * @public 
+  */
+export class Blorg {
+  /** @beta */
+  public constructor(x: number) {
+  }
+  
+  doSomething(): void {
+  }
+}
+


### PR DESCRIPTION
This PR takes care of two longstanding backlog issues:

- For class properties such as `public readonly x: Y;`, the `readonly` modifier is now handled correctly

- If a class's constructor is marked as internal, API Extractor generates this boilerplate in the Remarks documentation:

> The constructor for this class is marked as internal. Third-party code should not extend subclasses of the ${this.name} class or instantiate it directly.
