### PR TITLE
Enable publishing for api-documenter tool

### DIFF
--- a/common/changes/@microsoft/api-documenter/pgonzal-publish-api-documenter_2017-10-20-23-51.json
+++ b/common/changes/@microsoft/api-documenter/pgonzal-publish-api-documenter_2017-10-20-23-51.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@microsoft/api-documenter",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/api-documenter",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/api-extractor/pgonzal-publish-api-documenter_2017-10-21-02-18.json
+++ b/common/changes/@microsoft/api-extractor/pgonzal-publish-api-documenter_2017-10-21-02-18.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@microsoft/api-extractor",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/libraries/api-documenter/LICENSE
+++ b/libraries/api-documenter/LICENSE
@@ -1,0 +1,24 @@
+@microsoft/api-extractor
+
+Copyright (c) Microsoft Corporation. All rights reserved.
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/libraries/api-documenter/LICENSE
+++ b/libraries/api-documenter/LICENSE
@@ -1,4 +1,4 @@
-@microsoft/api-extractor
+@microsoft/api-documenter
 
 Copyright (c) Microsoft Corporation. All rights reserved.
 

--- a/libraries/api-documenter/README.md
+++ b/libraries/api-documenter/README.md
@@ -4,3 +4,11 @@ This is a code sample for [API Extractor](http://aka.ms/extractor), which create
 online API reference manual for your TypeScript library.  It reads *.api.json data files
 produced by API Extractor, and creates web pages using the
 [Markdown](https://en.wikipedia.org/wiki/Markdown) file format.
+
+This tool is part of Microsoft's production documentation pipeline.  It is provided
+as a code sample to illustrate how to load and process the API JSON file format.  For simple
+use cases, you can use this tool directly.  For more advanced needs, the tool does not
+include an elaborate templating system.  Instead, developers are encouraged to fork the
+project and modify the source code directly.  The implementation is intentionally kept
+simple and easy to modify.  This is possible because most of processing is already
+performed upstream by the API Extractor tool.

--- a/libraries/api-documenter/README.md
+++ b/libraries/api-documenter/README.md
@@ -1,14 +1,18 @@
 # @microsoft/api-documenter
 
-This is a code sample for [API Extractor](http://aka.ms/extractor), which creates a simple
-online API reference manual for your TypeScript library.  It reads *.api.json data files
-produced by API Extractor, and creates web pages using the
-[Markdown](https://en.wikipedia.org/wiki/Markdown) file format.
+This tool can be used to generate an online API reference manual for your TypeScript library.
+It reads the *.api.json data files produced by [API Extractor](http://aka.ms/extractor),
+and then generates web pages using the [Markdown](https://en.wikipedia.org/wiki/Markdown)
+file format.
 
-This tool is part of Microsoft's production documentation pipeline.  It is provided
-as a code sample to illustrate how to load and process the API JSON file format.  For simple
-use cases, you can use this tool directly.  For more advanced needs, the tool does not
-include an elaborate templating system.  Instead, developers are encouraged to fork the
-project and modify the source code directly.  The implementation is intentionally kept
-simple and easy to modify.  This is possible because most of processing is already
-performed upstream by the API Extractor tool.
+The **api-documenter** tool is part of Microsoft's production documentation pipeline.
+It is provided as a code sample to illustrate how to load and process the
+API JSON file format.  If your requirements are simple, you can use this tool directly.
+For more advanced scenarios, developers are encouraged to fork the project and modify
+the source code.  The implementation is intentionally kept simple and easy
+to understand.  This is possible because most of processing is already performed upstream
+by API Extractor.
+
+For more information, see the
+[Rendering API docs](https://github.com/Microsoft/web-build-tools/wiki/API-Extractor-~-Rendering-API-docs)
+wiki article.

--- a/libraries/api-documenter/package.json
+++ b/libraries/api-documenter/package.json
@@ -1,12 +1,12 @@
 {
   "name": "@microsoft/api-documenter",
-  "version": "0.1.6",
-  "private": true,
+  "version": "1.0.0",
   "description": "Read JSON files from api-extractor, generate documentation pages",
   "repository": {
     "type": "git",
     "url": "https://github.com/microsoft/web-build-tools"
   },
+  "homepage": "http://aka.ms/extractor",
   "license": "MIT",
   "scripts": {
     "build": "gulp",

--- a/libraries/api-documenter/src/cli/ApiDocumenterCommandLine.ts
+++ b/libraries/api-documenter/src/cli/ApiDocumenterCommandLine.ts
@@ -10,7 +10,7 @@ export class ApiDocumenterCommandLine extends CommandLineParser {
     super({
       toolFilename: 'api-documenter',
       toolDescription: 'Reads *.api.json files produced by api-extractor, '
-        + ' and generates API documentation in various output formats'
+        + ' and generates API documentation in various output formats.'
     });
     this._populateActions();
   }

--- a/libraries/api-documenter/src/cli/MarkdownAction.ts
+++ b/libraries/api-documenter/src/cli/MarkdownAction.ts
@@ -11,7 +11,8 @@ export class MarkdownAction extends BaseAction {
     super({
       actionVerb: 'markdown',
       summary: 'Generate documentation as Markdown files (*.md)',
-      documentation: 'Generate documentation as Markdown files (*.md)'
+      documentation: 'Generates API documentation as a collection of files in'
+        + ' Markdown format, suitable for example for publishing on a GitHub site.'
     });
   }
 

--- a/libraries/api-documenter/src/cli/YamlAction.ts
+++ b/libraries/api-documenter/src/cli/YamlAction.ts
@@ -11,7 +11,9 @@ export class YamlAction extends BaseAction {
     super({
       actionVerb: 'yaml',
       summary: 'Generate documentation as universal reference YAML files (*.yml)',
-      documentation: 'Generate documentation as YAML files (*.yml)'
+      documentation: 'Generates API documentation as a collection of files conforming'
+        + ' to the universal reference YAML format, which is used by the docs.microsoft.com'
+        + ' pipeline.'
     });
   }
 

--- a/libraries/api-extractor/README.md
+++ b/libraries/api-extractor/README.md
@@ -21,7 +21,7 @@
 
 - **Alpha/Beta graduation:**  You want to release previews of new APIs that are not ready for prime time yet.  If you did a major SemVer bump every time you change these definitions, the villagers would be after you with torches and pitchforks.  A better approach is to designate certain classes/members as "**alpha**" quality, then promote them to "**beta**" and finally to "**public**" when they're mature.  But how to indicate this to your consumers?  (And how to detect scoping mistakes?  A "public" function should never return a "beta" result.)
 
-- **Online documentation:**  You have faithfully annotated each TypeScript member with nice [JSDoc](http://usejsdoc.org/) descriptions.  Now that your library is published, you should probably set up [a nicely formatted](https://dev.office.com/sharepoint/reference/spfx/sp-page-context/cultureinfo) API reference.  Which tool should we use to generate that?  (What!?  There aren't any good ones!?)
+- **Online documentation:**  You have faithfully annotated each TypeScript member with nice [JSDoc](http://usejsdoc.org/) descriptions.  Now that your library is published, you should probably set up [a nicely formatted](https://docs.microsoft.com/en-us/javascript/api/sp-http) API reference.  Which tool should we use to generate that?  (What!?  There aren't any good ones!?)
 
 **API Extractor** provides an integrated, professional-quality solution for all these problems.  It is invoked at build time by your toolchain and leverages the TypeScript compiler engine to:
 

--- a/libraries/api-extractor/src/cli/RunAction.ts
+++ b/libraries/api-extractor/src/cli/RunAction.ts
@@ -46,7 +46,7 @@ export class RunAction extends CommandLineAction {
       description: 'Indicates that API Extractor is running as part of a local build,'
         + ' e.g. on a developer\'s machine. This disables certain validation that would'
         + ' normally be performed for a ship/production build. For example, the *.api.ts'
-        + ' signature file is automatically copied in a local build.'
+        + ' review file is automatically copied in a local build.'
     });
   }
 

--- a/libraries/api-extractor/src/extractor/Extractor.ts
+++ b/libraries/api-extractor/src/extractor/Extractor.ts
@@ -50,7 +50,7 @@ export interface IExtractorOptions {
   /**
    * Indicates that API Extractor is running as part of a local build, e.g. on developer's
    * machine. This disables certain validation that would normally be performed
-   * for a ship/production build. For example, the *.api.ts signature file is
+   * for a ship/production build. For example, the *.api.ts review file is
    * automatically local in a debug build.
    *
    * The default value is false.

--- a/rush.json
+++ b/rush.json
@@ -141,7 +141,7 @@
       "packageName": "@microsoft/api-documenter",
       "projectFolder": "libraries/api-documenter",
       "reviewCategory": "libraries",
-      "shouldPublish": false
+      "shouldPublish": true
     },
     {
       "packageName": "@microsoft/decorators",


### PR DESCRIPTION
Since this tool has a command line, we are publishing the NPM package so that people can now use it without having to enlist and build the web-build-tools repo.  It should still be considered a "code sample" level of support.