### PR TITLE
Improve wording of Rush change log notice

### DIFF
--- a/apps/rush-lib/src/cli/utilities/ChangelogGenerator.ts
+++ b/apps/rush-lib/src/cli/utilities/ChangelogGenerator.ts
@@ -206,7 +206,7 @@ export default class ChangelogGenerator {
       if (!comments) {
         markdown += ((changelog.entries.length === index + 1) ?
           '*Initial release*' :
-          '*Changes not tracked*') +
+          '*Version update only*') +
           EOL + EOL;
       } else {
         markdown += comments;


### PR DESCRIPTION
When a release is published without any change log entries (e.g. because of a version bump), we currently show a "changes not tracked" notice, for example:

> ## 3.2.2
> Mon, 31 Jul 2017 21:18:26 GMT
> 
> *Changes not tracked*
>
> ## 3.2.1
> Thu, 27 Jul 2017 01:04:48 GMT
>
> ### Patches
> 
> - Upgrade to the TS2.4 version of the build tools and restrict the dependency version requirements.
>

This notice suggests that we made a mistake or did something secret.  Maybe our tooling is broken? 
 Maybe the change tracking was disabled for that time period?

We want the message to indicate that there were no significant changes (other than the version bump). 
 I'm proposing to change the message to this:

> ## 3.2.2
> Mon, 31 Jul 2017 21:18:26 GMT
> 
> *Version update only*
>

(Feel free to suggest an alternative wording.)