### PR TITLE
Fix some issues in rush version handling logic

### DIFF
--- a/apps/rush-lib/src/data/RushConfiguration.ts
+++ b/apps/rush-lib/src/data/RushConfiguration.ts
@@ -154,7 +154,7 @@ export default class RushConfiguration {
     const expectedRushVersion: string = rushConfigurationJson.rushVersion;
     // If the version is missing or malformed, fall through and let the schema handle it.
     if (expectedRushVersion && semver.valid(expectedRushVersion)) {
-      if (semver.eq(rushVersion, expectedRushVersion)) {
+      if (semver.lt(rushVersion, expectedRushVersion)) {
         throw new Error(`Your rush tool is version ${rushVersion}, but rush.json`
           + ` requires version ${rushConfigurationJson.rushVersion}. To upgrade,`
           + ` run "npm install @microsoft/rush -g".`);

--- a/apps/rush-lib/src/run.ts
+++ b/apps/rush-lib/src/run.ts
@@ -1,0 +1,3 @@
+import { start } from './start';
+
+start(false);

--- a/apps/rush-lib/src/start.ts
+++ b/apps/rush-lib/src/start.ts
@@ -16,7 +16,7 @@ import RushCommandLineParser from './cli/actions/RushCommandLineParser';
  *  consider a project without a rush.json to be "unmanaged" and we'll print that to the command line when
  *  the tool is executed. This is mainly used for debugging purposes.
  */
-export function start(launcherVersion: string, isManaged: boolean): void {
+export function start(isManaged: boolean): void {
   console.log(
     EOL +
     colors.bold(`Rush Multi-Package Build Tool ${rushVersion}` + colors.yellow(isManaged ? '' : ' (unmanaged)')) +

--- a/apps/rush/src/RushVersionManager.ts
+++ b/apps/rush/src/RushVersionManager.ts
@@ -19,11 +19,9 @@ const MAX_INSTALL_ATTEMPTS: number = 3;
 
 export default class RushVersionManager {
   private _rushDirectory: string;
-  private _currentPackageVersion: string;
 
-  constructor(homeDirectory: string, currentPackageVersion: string) {
+  constructor(homeDirectory: string) {
     this._rushDirectory = path.join(homeDirectory, '.rush');
-    this._currentPackageVersion = currentPackageVersion;
   }
 
   public ensureRushVersionInstalled(version: string): RushWrapper {
@@ -62,7 +60,7 @@ export default class RushVersionManager {
           'lib',
           'start'
         ));
-        rushCliEntrypoint.start(this._currentPackageVersion, true);
+        rushCliEntrypoint.start(true);
       });
     }
   }

--- a/apps/rush/src/start.ts
+++ b/apps/rush/src/start.ts
@@ -2,10 +2,8 @@
 // See LICENSE in the project root for license information.
 
 import * as path from 'path';
-import { JsonFile } from '@microsoft/node-core-library';
 
 import {
-  IPackageJson,
   RushConfiguration,
   Utilities
 } from '@microsoft/rush-lib';
@@ -25,16 +23,14 @@ if (process.argv[2] === RUSH_PURGE_OPTION_NAME) {
 } else {
   // Load the configuration
   const configuration: MinimalRushConfiguration | undefined = MinimalRushConfiguration.loadFromDefaultLocation();
-  const currentPackageJson: IPackageJson = JsonFile.load(path.join(__dirname, '..', 'package.json'));
 
   if (configuration) {
     const versionManager: RushVersionManager = new RushVersionManager(
-      configuration.homeFolder,
-      currentPackageJson.version
+      configuration.homeFolder
     );
     const rushWrapper: RushWrapper = versionManager.ensureRushVersionInstalled(configuration.rushVersion);
     rushWrapper.invokeRush();
   } else {
-    start(currentPackageJson.version, false);
+    start(false);
   }
 }


### PR DESCRIPTION
1. Fix a version comparison bug
2. Let rush-lib be able to run directly.
3. Remove unused parameter.