### PR TITLE
'rush change' should respect previously entered comments for the change.

### DIFF
--- a/apps/rush-lib/src/cli/actions/ChangeAction.ts
+++ b/apps/rush-lib/src/cli/actions/ChangeAction.ts
@@ -222,7 +222,7 @@ export default class ChangeAction extends BaseRushAction {
         name: 'appendComment',
         type: 'list',
         default: 'skip',
-        message: 'Append to existing comments or skip:',
+        message: 'Append to existing comments or skip?',
         choices: [
           {
             'name': 'Skip',
@@ -234,7 +234,7 @@ export default class ChangeAction extends BaseRushAction {
           }
         ]
       })
-      .then(({ appendComment }: { appendComment: string }) => {
+      .then(({ appendComment }: { appendComment: 'skip' | 'append' }) => {
         if (appendComment === 'skip') {
           return undefined;
         } else {

--- a/apps/rush-lib/src/cli/utilities/ChangeFiles.ts
+++ b/apps/rush-lib/src/cli/utilities/ChangeFiles.ts
@@ -31,9 +31,13 @@ export default class ChangeFiles {
     newChangeFilePaths.forEach((filePath) => {
       console.log(`Found change file: ${filePath}`);
       const changeRequest: IChangeInfo = JSON.parse(fsx.readFileSync(filePath, 'utf8'));
-      changeRequest.changes!.forEach(change => {
-        changedSet.add(change.packageName);
-      });
+      if (changeRequest && changeRequest.changes) {
+        changeRequest.changes!.forEach(change => {
+          changedSet.add(change.packageName);
+        });
+      } else {
+        throw new Error(`Invalid change file: ${filePath}`);
+      }
     });
 
     const requiredSet: Set<string> = new Set(changedPackages);
@@ -58,14 +62,18 @@ export default class ChangeFiles {
     newChangeFilePaths.forEach((filePath) => {
       console.log(`Found change file: ${filePath}`);
       const changeRequest: IChangeInfo = JSON.parse(fsx.readFileSync(filePath, 'utf8'));
-      changeRequest.changes!.forEach(change => {
-        if (!changes.get(change.packageName)) {
-          changes.set(change.packageName, []);
-        }
-        if (change.comment && change.comment.length) {
-          changes.get(change.packageName)!.push(change.comment);
-        }
-      });
+      if (changeRequest && changeRequest.changes) {
+        changeRequest.changes!.forEach(change => {
+          if (!changes.get(change.packageName)) {
+            changes.set(change.packageName, []);
+          }
+          if (change.comment && change.comment.length) {
+            changes.get(change.packageName)!.push(change.comment);
+          }
+        });
+      } else {
+        throw new Error(`Invalid change file: ${filePath}`);
+      }
     });
     return changes;
   }

--- a/apps/rush-lib/src/cli/utilities/ChangeFiles.ts
+++ b/apps/rush-lib/src/cli/utilities/ChangeFiles.ts
@@ -32,11 +32,6 @@ export default class ChangeFiles {
       console.log(`Found change file: ${filePath}`);
       const changeRequest: IChangeInfo = JSON.parse(fsx.readFileSync(filePath, 'utf8'));
       changeRequest.changes!.forEach(change => {
-        if (changedSet.has(change.packageName)) {
-          const duplicateError: string = `Project ${change.packageName} has more than one entries. ` +
-            `Delete the duplicate change file and commit.`;
-          throw new Error(duplicateError);
-        }
         changedSet.add(change.packageName);
       });
     });
@@ -52,6 +47,27 @@ export default class ChangeFiles {
       });
       throw new Error(`Change file does not contain ${missingProjects.join(',')}.`);
     }
+  }
+
+  public static getChangeComments(
+    newChangeFilePaths: string[],
+    changedPackages: string[]
+  ): Map<string, string[]> {
+    const changes: Map<string, string[]> = new Map<string, string[]>();
+
+    newChangeFilePaths.forEach((filePath) => {
+      console.log(`Found change file: ${filePath}`);
+      const changeRequest: IChangeInfo = JSON.parse(fsx.readFileSync(filePath, 'utf8'));
+      changeRequest.changes!.forEach(change => {
+        if (!changes.get(change.packageName)) {
+          changes.set(change.packageName, []);
+        }
+        if (change.comment && change.comment.length) {
+          changes.get(change.packageName)!.push(change.comment);
+        }
+      });
+    });
+    return changes;
   }
 
   constructor(private _changesPath: string) {


### PR DESCRIPTION
If 'rush change' finds previously entered comments about current change, it will list those out and provide one option to skip adding more comments, and the other to append more comments.

Examples interactions (Package one has existing comments, and package two does not):

PackageOneName 
Found existing comments:
    > blah blah
    > I have more to say
? Append to existing comments or skip: Skip

PackageTwoName
? Describe changes, or ENTER if no changes: I have something to say


