### PR TITLE
Fix @types/chalk error and upgrade cyclic dependencies

### DIFF
--- a/apps/api-extractor/package.json
+++ b/apps/api-extractor/package.json
@@ -50,6 +50,6 @@
     "chai": "~3.5.0",
     "gulp": "~3.9.1",
     "mocha": "~3.4.2",
-    "@microsoft/node-library-build": "~4.1.5"
+    "@microsoft/node-library-build": "~4.2.3"
   }
 }

--- a/common/changes/@microsoft/api-extractor/pgonzal-upgrade-cyclic-deps_2017-11-01-05-28.json
+++ b/common/changes/@microsoft/api-extractor/pgonzal-upgrade-cyclic-deps_2017-11-01-05-28.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor",
+      "comment": "Upgrade cyclic dependencies",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/gulp-core-build-karma/pgonzal-upgrade-cyclic-deps_2017-11-01-05-28.json
+++ b/common/changes/@microsoft/gulp-core-build-karma/pgonzal-upgrade-cyclic-deps_2017-11-01-05-28.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/gulp-core-build-karma",
+      "comment": "Upgrade cyclic dependencies",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/gulp-core-build-karma",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/gulp-core-build-mocha/pgonzal-upgrade-cyclic-deps_2017-11-01-05-28.json
+++ b/common/changes/@microsoft/gulp-core-build-mocha/pgonzal-upgrade-cyclic-deps_2017-11-01-05-28.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/gulp-core-build-mocha",
+      "comment": "Upgrade cyclic dependencies",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/gulp-core-build-mocha",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/gulp-core-build-sass/pgonzal-upgrade-cyclic-deps_2017-11-01-05-28.json
+++ b/common/changes/@microsoft/gulp-core-build-sass/pgonzal-upgrade-cyclic-deps_2017-11-01-05-28.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/gulp-core-build-sass",
+      "comment": "Upgrade cyclic dependencies",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/gulp-core-build-sass",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/gulp-core-build-serve/pgonzal-upgrade-cyclic-deps_2017-11-01-05-28.json
+++ b/common/changes/@microsoft/gulp-core-build-serve/pgonzal-upgrade-cyclic-deps_2017-11-01-05-28.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/gulp-core-build-serve",
+      "comment": "Upgrade cyclic dependencies",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/gulp-core-build-serve",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/gulp-core-build-typescript/pgonzal-upgrade-cyclic-deps_2017-11-01-05-28.json
+++ b/common/changes/@microsoft/gulp-core-build-typescript/pgonzal-upgrade-cyclic-deps_2017-11-01-05-28.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/gulp-core-build-typescript",
+      "comment": "Upgrade cyclic dependencies",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/gulp-core-build-typescript",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/gulp-core-build-webpack/pgonzal-upgrade-cyclic-deps_2017-11-01-05-28.json
+++ b/common/changes/@microsoft/gulp-core-build-webpack/pgonzal-upgrade-cyclic-deps_2017-11-01-05-28.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/gulp-core-build-webpack",
+      "comment": "Upgrade cyclic dependencies",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/gulp-core-build-webpack",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/gulp-core-build/pgonzal-upgrade-cyclic-deps_2017-11-01-05-28.json
+++ b/common/changes/@microsoft/gulp-core-build/pgonzal-upgrade-cyclic-deps_2017-11-01-05-28.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/gulp-core-build",
+      "comment": "Upgrade cyclic dependencies",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/gulp-core-build",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/node-core-library/pgonzal-upgrade-cyclic-deps_2017-11-01-05-28.json
+++ b/common/changes/@microsoft/node-core-library/pgonzal-upgrade-cyclic-deps_2017-11-01-05-28.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/node-core-library",
+      "comment": "Upgrade cyclic dependencies",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/node-core-library",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/ts-command-line/pgonzal-upgrade-cyclic-deps_2017-11-01-05-28.json
+++ b/common/changes/@microsoft/ts-command-line/pgonzal-upgrade-cyclic-deps_2017-11-01-05-28.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/ts-command-line",
+      "comment": "Upgrade cyclic dependencies",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/ts-command-line",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/config/rush/npm-shrinkwrap.json
+++ b/common/config/rush/npm-shrinkwrap.json
@@ -3,39 +3,39 @@
   "version": "0.0.0",
   "dependencies": {
     "@microsoft/api-extractor": {
-      "version": "4.1.1",
-      "from": "@microsoft/api-extractor@4.1.1",
-      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-4.1.1.tgz"
+      "version": "4.2.2",
+      "from": "@microsoft/api-extractor@4.2.2",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-4.2.2.tgz"
     },
     "@microsoft/gulp-core-build": {
-      "version": "3.1.6",
-      "from": "@microsoft/gulp-core-build@3.1.6",
-      "resolved": "https://registry.npmjs.org/@microsoft/gulp-core-build/-/gulp-core-build-3.1.6.tgz"
+      "version": "3.2.3",
+      "from": "@microsoft/gulp-core-build@3.2.3",
+      "resolved": "https://registry.npmjs.org/@microsoft/gulp-core-build/-/gulp-core-build-3.2.3.tgz"
     },
     "@microsoft/gulp-core-build-mocha": {
-      "version": "3.1.6",
-      "from": "@microsoft/gulp-core-build-mocha@3.1.6",
-      "resolved": "https://registry.npmjs.org/@microsoft/gulp-core-build-mocha/-/gulp-core-build-mocha-3.1.6.tgz"
+      "version": "3.2.3",
+      "from": "@microsoft/gulp-core-build-mocha@3.2.3",
+      "resolved": "https://registry.npmjs.org/@microsoft/gulp-core-build-mocha/-/gulp-core-build-mocha-3.2.3.tgz"
     },
     "@microsoft/gulp-core-build-typescript": {
-      "version": "4.2.6",
-      "from": "@microsoft/gulp-core-build-typescript@4.2.6",
-      "resolved": "https://registry.npmjs.org/@microsoft/gulp-core-build-typescript/-/gulp-core-build-typescript-4.2.6.tgz"
+      "version": "4.2.10",
+      "from": "@microsoft/gulp-core-build-typescript@4.2.10",
+      "resolved": "https://registry.npmjs.org/@microsoft/gulp-core-build-typescript/-/gulp-core-build-typescript-4.2.10.tgz"
     },
     "@microsoft/node-core-library": {
-      "version": "0.3.9",
-      "from": "@microsoft/node-core-library@>=0.3.8 <0.4.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/node-core-library/-/node-core-library-0.3.9.tgz"
+      "version": "0.3.12",
+      "from": "@microsoft/node-core-library@>=0.3.12 <0.4.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/node-core-library/-/node-core-library-0.3.12.tgz"
     },
     "@microsoft/node-library-build": {
-      "version": "4.1.6",
-      "from": "@microsoft/node-library-build@>=4.1.5 <4.2.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/node-library-build/-/node-library-build-4.1.6.tgz"
+      "version": "4.2.3",
+      "from": "@microsoft/node-library-build@>=4.2.3 <4.3.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/node-library-build/-/node-library-build-4.2.3.tgz"
     },
     "@microsoft/ts-command-line": {
-      "version": "2.1.2",
-      "from": "@microsoft/ts-command-line@>=2.1.1 <2.2.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/ts-command-line/-/ts-command-line-2.1.2.tgz"
+      "version": "2.2.0",
+      "from": "@microsoft/ts-command-line@>=2.2.0 <2.3.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/ts-command-line/-/ts-command-line-2.2.0.tgz"
     },
     "@rush-temp/api-documenter": {
       "version": "0.0.0",
@@ -184,7 +184,7 @@
     },
     "@types/chalk": {
       "version": "0.4.31",
-      "from": "@types/chalk@*",
+      "from": "@types/chalk@0.4.31",
       "resolved": "https://registry.npmjs.org/@types/chalk/-/chalk-0.4.31.tgz"
     },
     "@types/colors": {
@@ -408,9 +408,9 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.2.tgz"
     },
     "ajv-keywords": {
-      "version": "2.1.0",
+      "version": "2.1.1",
       "from": "ajv-keywords@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.0.tgz"
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz"
     },
     "align-text": {
       "version": "0.1.4",
@@ -560,9 +560,9 @@
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
     },
     "asn1.js": {
-      "version": "4.9.1",
+      "version": "4.9.2",
       "from": "asn1.js@>=4.0.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.1.tgz"
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.2.tgz"
     },
     "assert": {
       "version": "1.4.1",
@@ -580,9 +580,9 @@
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz"
     },
     "async": {
-      "version": "1.5.2",
-      "from": "async@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
+      "version": "2.5.0",
+      "from": "async@>=2.1.4 <3.0.0",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz"
     },
     "async-each": {
       "version": "1.0.1",
@@ -616,7 +616,7 @@
     },
     "babel-code-frame": {
       "version": "6.26.0",
-      "from": "babel-code-frame@>=6.22.0 <7.0.0",
+      "from": "babel-code-frame@>=6.26.0 <7.0.0",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz"
     },
     "babel-core": {
@@ -624,25 +624,10 @@
       "from": "babel-core@>=6.0.0 <7.0.0",
       "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.0.tgz",
       "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "from": "debug@>=2.6.8 <3.0.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz"
-        },
         "lodash": {
           "version": "4.17.4",
           "from": "lodash@>=4.17.4 <5.0.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
-        },
-        "ms": {
-          "version": "2.0.0",
-          "from": "ms@2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "from": "source-map@>=0.5.6 <0.6.0",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz"
         }
       }
     },
@@ -655,11 +640,6 @@
           "version": "4.17.4",
           "from": "lodash@>=4.17.4 <5.0.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "from": "source-map@>=0.5.6 <0.6.0",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz"
         }
       }
     },
@@ -681,14 +661,7 @@
     "babel-plugin-istanbul": {
       "version": "4.1.5",
       "from": "babel-plugin-istanbul@>=4.0.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.5.tgz",
-      "dependencies": {
-        "find-up": {
-          "version": "2.1.0",
-          "from": "find-up@>=2.1.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz"
-        }
-      }
+      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.5.tgz"
     },
     "babel-plugin-jest-hoist": {
       "version": "20.0.3",
@@ -734,20 +707,10 @@
       "from": "babel-traverse@>=6.18.0 <7.0.0",
       "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
       "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "from": "debug@>=2.6.8 <3.0.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz"
-        },
         "lodash": {
           "version": "4.17.4",
           "from": "lodash@>=4.17.4 <5.0.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
-        },
-        "ms": {
-          "version": "2.0.0",
-          "from": "ms@2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
         }
       }
     },
@@ -866,24 +829,7 @@
     "body-parser": {
       "version": "1.18.2",
       "from": "body-parser@>=1.12.4 <2.0.0",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz",
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "from": "debug@2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz"
-        },
-        "iconv-lite": {
-          "version": "0.4.19",
-          "from": "iconv-lite@0.4.19",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz"
-        },
-        "ms": {
-          "version": "2.0.0",
-          "from": "ms@2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
-        }
-      }
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz"
     },
     "boom": {
       "version": "4.3.1",
@@ -1015,19 +961,26 @@
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz"
     },
     "camelcase": {
-      "version": "2.1.1",
-      "from": "camelcase@>=2.0.1 <3.0.0",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz"
+      "version": "3.0.0",
+      "from": "camelcase@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz"
     },
     "camelcase-keys": {
       "version": "2.1.0",
       "from": "camelcase-keys@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz"
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+      "dependencies": {
+        "camelcase": {
+          "version": "2.1.1",
+          "from": "camelcase@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz"
+        }
+      }
     },
     "caniuse-db": {
-      "version": "1.0.30000745",
+      "version": "1.0.30000756",
       "from": "caniuse-db@>=1.0.30000488 <2.0.0",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000745.tgz"
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000756.tgz"
     },
     "caseless": {
       "version": "0.12.0",
@@ -1072,14 +1025,7 @@
     "clean-css": {
       "version": "4.1.9",
       "from": "clean-css@>=4.0.9 <5.0.0",
-      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.1.9.tgz",
-      "dependencies": {
-        "source-map": {
-          "version": "0.5.7",
-          "from": "source-map@>=0.5.0 <0.6.0",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz"
-        }
-      }
+      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.1.9.tgz"
     },
     "cli-cursor": {
       "version": "1.0.2",
@@ -1176,6 +1122,16 @@
           "from": "bytes@2.1.0",
           "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.1.0.tgz"
         },
+        "debug": {
+          "version": "2.2.0",
+          "from": "debug@>=2.2.0 <2.3.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
+        },
+        "ms": {
+          "version": "0.7.1",
+          "from": "ms@0.7.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+        },
         "negotiator": {
           "version": "0.5.3",
           "from": "negotiator@0.5.3",
@@ -1218,19 +1174,7 @@
     "connect": {
       "version": "3.6.5",
       "from": "connect@>=3.3.5 <4.0.0",
-      "resolved": "https://registry.npmjs.org/connect/-/connect-3.6.5.tgz",
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "from": "debug@2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz"
-        },
-        "ms": {
-          "version": "2.0.0",
-          "from": "ms@2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
-        }
-      }
+      "resolved": "https://registry.npmjs.org/connect/-/connect-3.6.5.tgz"
     },
     "connect-livereload": {
       "version": "0.5.4",
@@ -1242,10 +1186,20 @@
       "from": "connect-timeout@>=1.6.2 <1.7.0",
       "resolved": "https://registry.npmjs.org/connect-timeout/-/connect-timeout-1.6.2.tgz",
       "dependencies": {
+        "debug": {
+          "version": "2.2.0",
+          "from": "debug@>=2.2.0 <2.3.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
+        },
         "http-errors": {
           "version": "1.3.1",
           "from": "http-errors@>=1.3.1 <1.4.0",
           "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz"
+        },
+        "ms": {
+          "version": "0.7.1",
+          "from": "ms@0.7.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
         }
       }
     },
@@ -1281,7 +1235,7 @@
     },
     "convert-source-map": {
       "version": "1.5.0",
-      "from": "convert-source-map@>=1.1.1 <2.0.0",
+      "from": "convert-source-map@>=1.4.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz"
     },
     "cookie": {
@@ -1390,11 +1344,6 @@
           "from": "postcss@6.0.1",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.1.tgz"
         },
-        "source-map": {
-          "version": "0.5.7",
-          "from": "source-map@>=0.5.6 <0.6.0",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz"
-        },
         "supports-color": {
           "version": "3.2.3",
           "from": "supports-color@>=3.2.3 <4.0.0",
@@ -1475,9 +1424,9 @@
       "resolved": "https://registry.npmjs.org/deasync/-/deasync-0.1.10.tgz"
     },
     "debug": {
-      "version": "2.2.0",
-      "from": "debug@2.2.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
+      "version": "2.6.9",
+      "from": "debug@>=2.6.8 <3.0.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz"
     },
     "debuglog": {
       "version": "1.0.1",
@@ -1492,14 +1441,7 @@
     "decomment": {
       "version": "0.8.8",
       "from": "decomment@>=0.8.2 <0.9.0",
-      "resolved": "https://registry.npmjs.org/decomment/-/decomment-0.8.8.tgz",
-      "dependencies": {
-        "esprima": {
-          "version": "4.0.0",
-          "from": "esprima@>=4.0.0 <5.0.0",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz"
-        }
-      }
+      "resolved": "https://registry.npmjs.org/decomment/-/decomment-0.8.8.tgz"
     },
     "deep-eql": {
       "version": "0.1.3",
@@ -1591,9 +1533,9 @@
       "resolved": "https://registry.npmjs.org/di/-/di-0.0.1.tgz"
     },
     "diff": {
-      "version": "1.4.0",
-      "from": "diff@1.4.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz"
+      "version": "3.4.0",
+      "from": "diff@>=3.2.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.4.0.tgz"
     },
     "diffie-hellman": {
       "version": "5.0.2",
@@ -1749,9 +1691,9 @@
       "resolved": "https://registry.npmjs.org/errorhandler/-/errorhandler-1.4.3.tgz"
     },
     "es5-ext": {
-      "version": "0.10.31",
+      "version": "0.10.35",
       "from": "es5-ext@>=0.10.14 <0.11.0",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.31.tgz"
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.35.tgz"
     },
     "es6-iterator": {
       "version": "2.0.3",
@@ -1794,43 +1736,36 @@
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
     },
     "escodegen": {
-      "version": "1.8.1",
-      "from": "escodegen@>=1.8.0 <1.9.0",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz"
+      "version": "1.9.0",
+      "from": "escodegen@>=1.6.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.0.tgz",
+      "dependencies": {
+        "esprima": {
+          "version": "3.1.3",
+          "from": "esprima@>=3.1.3 <4.0.0",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz"
+        }
+      }
     },
     "escope": {
       "version": "3.6.0",
       "from": "escope@>=3.6.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
-      "dependencies": {
-        "estraverse": {
-          "version": "4.2.0",
-          "from": "estraverse@>=4.1.1 <5.0.0",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz"
-        }
-      }
+      "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz"
     },
     "esprima": {
-      "version": "2.7.3",
-      "from": "esprima@>=2.7.0 <2.8.0",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz"
+      "version": "4.0.0",
+      "from": "esprima@>=4.0.0 <5.0.0",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz"
     },
     "esrecurse": {
       "version": "4.2.0",
       "from": "esrecurse@>=4.1.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.0.tgz",
-      "dependencies": {
-        "estraverse": {
-          "version": "4.2.0",
-          "from": "estraverse@>=4.1.0 <5.0.0",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz"
-        }
-      }
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.0.tgz"
     },
     "estraverse": {
-      "version": "1.9.3",
-      "from": "estraverse@>=1.9.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz"
+      "version": "4.2.0",
+      "from": "estraverse@>=4.2.0 <5.0.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz"
     },
     "esutils": {
       "version": "2.0.2",
@@ -1934,10 +1869,20 @@
       "from": "express@>=4.14.0 <4.15.0",
       "resolved": "https://registry.npmjs.org/express/-/express-4.14.1.tgz",
       "dependencies": {
+        "debug": {
+          "version": "2.2.0",
+          "from": "debug@>=2.2.0 <2.3.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
+        },
         "finalhandler": {
           "version": "0.5.1",
           "from": "finalhandler@0.5.1",
           "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.5.1.tgz"
+        },
+        "ms": {
+          "version": "0.7.1",
+          "from": "ms@0.7.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
         },
         "qs": {
           "version": "6.2.0",
@@ -1966,10 +1911,20 @@
           "from": "cookie@0.1.3",
           "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.3.tgz"
         },
+        "debug": {
+          "version": "2.2.0",
+          "from": "debug@>=2.2.0 <2.3.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
+        },
         "depd": {
           "version": "1.0.1",
           "from": "depd@>=1.0.1 <1.1.0",
           "resolved": "https://registry.npmjs.org/depd/-/depd-1.0.1.tgz"
+        },
+        "ms": {
+          "version": "0.7.1",
+          "from": "ms@0.7.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
         },
         "uid-safe": {
           "version": "2.0.0",
@@ -2011,9 +1966,9 @@
       "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz"
     },
     "extract-zip": {
-      "version": "1.6.5",
+      "version": "1.6.6",
       "from": "extract-zip@>=1.6.5 <1.7.0",
-      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.5.tgz",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.6.tgz",
       "dependencies": {
         "minimist": {
           "version": "0.0.8",
@@ -2078,21 +2033,9 @@
       "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz"
     },
     "fileset": {
-      "version": "0.2.1",
-      "from": "fileset@>=0.2.0 <0.3.0",
-      "resolved": "https://registry.npmjs.org/fileset/-/fileset-0.2.1.tgz",
-      "dependencies": {
-        "glob": {
-          "version": "5.0.15",
-          "from": "glob@>=5.0.0 <6.0.0",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz"
-        },
-        "minimatch": {
-          "version": "2.0.10",
-          "from": "minimatch@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz"
-        }
-      }
+      "version": "2.0.3",
+      "from": "fileset@>=2.0.2 <3.0.0",
+      "resolved": "https://registry.npmjs.org/fileset/-/fileset-2.0.3.tgz"
     },
     "fill-range": {
       "version": "2.2.3",
@@ -2104,16 +2047,6 @@
       "from": "finalhandler@1.0.6",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.6.tgz",
       "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "from": "debug@2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz"
-        },
-        "ms": {
-          "version": "2.0.0",
-          "from": "ms@2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
-        },
         "statuses": {
           "version": "1.3.1",
           "from": "statuses@>=1.3.1 <1.4.0",
@@ -2127,9 +2060,9 @@
       "resolved": "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz"
     },
     "find-up": {
-      "version": "1.1.2",
-      "from": "find-up@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz"
+      "version": "2.1.0",
+      "from": "find-up@>=2.1.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz"
     },
     "findup-sync": {
       "version": "0.4.3",
@@ -2234,9 +2167,9 @@
       "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz"
     },
     "generic-names": {
-      "version": "1.0.2",
+      "version": "1.0.3",
       "from": "generic-names@>=1.0.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/generic-names/-/generic-names-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/generic-names/-/generic-names-1.0.3.tgz",
       "dependencies": {
         "loader-utils": {
           "version": "0.2.17",
@@ -2594,6 +2527,11 @@
           "from": "cookie@0.1.3",
           "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.3.tgz"
         },
+        "debug": {
+          "version": "2.2.0",
+          "from": "debug@>=2.2.0 <2.3.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
+        },
         "depd": {
           "version": "1.0.1",
           "from": "depd@>=1.0.1 <1.1.0",
@@ -2633,6 +2571,11 @@
           "version": "1.3.4",
           "from": "mime@1.3.4",
           "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
+        },
+        "ms": {
+          "version": "0.7.1",
+          "from": "ms@0.7.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
         },
         "qs": {
           "version": "4.0.0",
@@ -2841,6 +2784,16 @@
       "from": "gulp-mocha@>=2.2.0 <2.3.0",
       "resolved": "https://registry.npmjs.org/gulp-mocha/-/gulp-mocha-2.2.0.tgz",
       "dependencies": {
+        "debug": {
+          "version": "2.2.0",
+          "from": "debug@2.2.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
+        },
+        "diff": {
+          "version": "1.4.0",
+          "from": "diff@1.4.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz"
+        },
         "escape-string-regexp": {
           "version": "1.0.2",
           "from": "escape-string-regexp@1.0.2",
@@ -2860,6 +2813,11 @@
           "version": "2.5.3",
           "from": "mocha@>=2.0.1 <3.0.0",
           "resolved": "https://registry.npmjs.org/mocha/-/mocha-2.5.3.tgz"
+        },
+        "ms": {
+          "version": "0.7.1",
+          "from": "ms@0.7.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
         },
         "supports-color": {
           "version": "1.2.0",
@@ -3021,11 +2979,6 @@
           "from": "readable-stream@>=2.0.4 <3.0.0",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz"
         },
-        "source-map": {
-          "version": "0.5.7",
-          "from": "source-map@>=0.5.3 <0.6.0",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz"
-        },
         "string_decoder": {
           "version": "1.0.3",
           "from": "string_decoder@>=1.0.3 <1.1.0",
@@ -3072,8 +3025,20 @@
     },
     "handlebars": {
       "version": "4.0.11",
-      "from": "handlebars@>=4.0.1 <5.0.0",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz"
+      "from": "handlebars@>=4.0.3 <5.0.0",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
+      "dependencies": {
+        "async": {
+          "version": "1.5.2",
+          "from": "async@>=1.4.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
+        },
+        "source-map": {
+          "version": "0.4.4",
+          "from": "source-map@>=0.4.4 <0.5.0",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz"
+        }
+      }
     },
     "har-schema": {
       "version": "2.0.0",
@@ -3191,9 +3156,9 @@
       "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.1.tgz"
     },
     "iconv-lite": {
-      "version": "0.4.13",
-      "from": "iconv-lite@0.4.13",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
+      "version": "0.4.19",
+      "from": "iconv-lite@0.4.19",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz"
     },
     "icss-replace-symbols": {
       "version": "1.1.0",
@@ -3298,9 +3263,9 @@
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz"
     },
     "is-buffer": {
-      "version": "1.1.5",
+      "version": "1.1.6",
       "from": "is-buffer@>=1.1.5 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz"
     },
     "is-builtin-module": {
       "version": "1.0.0",
@@ -3471,6 +3436,26 @@
       "from": "istanbul@>=0.4.0 <0.5.0",
       "resolved": "https://registry.npmjs.org/istanbul/-/istanbul-0.4.5.tgz",
       "dependencies": {
+        "async": {
+          "version": "1.5.2",
+          "from": "async@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
+        },
+        "escodegen": {
+          "version": "1.8.1",
+          "from": "escodegen@>=1.8.0 <1.9.0",
+          "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz"
+        },
+        "esprima": {
+          "version": "2.7.3",
+          "from": "esprima@>=2.7.0 <2.8.0",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz"
+        },
+        "estraverse": {
+          "version": "1.9.3",
+          "from": "estraverse@>=1.9.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz"
+        },
         "glob": {
           "version": "5.0.15",
           "from": "glob@>=5.0.15 <6.0.0",
@@ -3491,19 +3476,7 @@
     "istanbul-api": {
       "version": "1.2.1",
       "from": "istanbul-api@>=1.1.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/istanbul-api/-/istanbul-api-1.2.1.tgz",
-      "dependencies": {
-        "async": {
-          "version": "2.5.0",
-          "from": "async@>=2.1.4 <3.0.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz"
-        },
-        "fileset": {
-          "version": "2.0.3",
-          "from": "fileset@>=2.0.2 <3.0.0",
-          "resolved": "https://registry.npmjs.org/fileset/-/fileset-2.0.3.tgz"
-        }
-      }
+      "resolved": "https://registry.npmjs.org/istanbul-api/-/istanbul-api-1.2.1.tgz"
     },
     "istanbul-instrumenter-loader": {
       "version": "3.0.0",
@@ -3547,20 +3520,10 @@
           "from": "debug@>=3.1.0 <4.0.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz"
         },
-        "ms": {
-          "version": "2.0.0",
-          "from": "ms@2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
-        },
         "rimraf": {
           "version": "2.6.2",
           "from": "rimraf@>=2.6.1 <3.0.0",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz"
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "from": "source-map@>=0.5.3 <0.6.0",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz"
         }
       }
     },
@@ -3574,6 +3537,11 @@
       "from": "istanbul-threshold-checker@>=0.1.0 <0.2.0",
       "resolved": "https://registry.npmjs.org/istanbul-threshold-checker/-/istanbul-threshold-checker-0.1.0.tgz",
       "dependencies": {
+        "async": {
+          "version": "1.5.2",
+          "from": "async@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
+        },
         "escodegen": {
           "version": "1.7.1",
           "from": "escodegen@>=1.7.0 <1.8.0",
@@ -3591,10 +3559,25 @@
           "from": "esprima@>=2.5.0 <2.6.0",
           "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.5.0.tgz"
         },
+        "estraverse": {
+          "version": "1.9.3",
+          "from": "estraverse@>=1.9.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz"
+        },
         "fast-levenshtein": {
           "version": "1.0.7",
           "from": "fast-levenshtein@>=1.0.0 <1.1.0",
           "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.7.tgz"
+        },
+        "fileset": {
+          "version": "0.2.1",
+          "from": "fileset@>=0.2.0 <0.3.0",
+          "resolved": "https://registry.npmjs.org/fileset/-/fileset-0.2.1.tgz"
+        },
+        "glob": {
+          "version": "5.0.15",
+          "from": "glob@>=5.0.0 <6.0.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz"
         },
         "istanbul": {
           "version": "0.3.22",
@@ -3610,6 +3593,11 @@
           "version": "3.6.0",
           "from": "lodash@>=3.6.0 <3.7.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.6.0.tgz"
+        },
+        "minimatch": {
+          "version": "2.0.10",
+          "from": "minimatch@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz"
         },
         "optionator": {
           "version": "0.5.0",
@@ -3672,20 +3660,10 @@
       "from": "jest-cli@>=20.0.4 <20.1.0",
       "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-20.0.4.tgz",
       "dependencies": {
-        "camelcase": {
-          "version": "3.0.0",
-          "from": "camelcase@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz"
-        },
         "yargs": {
           "version": "7.1.0",
           "from": "yargs@>=7.0.2 <8.0.0",
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz"
-        },
-        "yargs-parser": {
-          "version": "5.0.0",
-          "from": "yargs-parser@>=5.0.0 <6.0.0",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz"
         }
       }
     },
@@ -3704,14 +3682,7 @@
     "jest-diff": {
       "version": "20.0.3",
       "from": "jest-diff@>=20.0.3 <21.0.0",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-20.0.3.tgz",
-      "dependencies": {
-        "diff": {
-          "version": "3.4.0",
-          "from": "diff@>=3.2.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-3.4.0.tgz"
-        }
-      }
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-20.0.3.tgz"
     },
     "jest-docblock": {
       "version": "20.0.3",
@@ -3778,11 +3749,6 @@
       "from": "jest-runtime@>=20.0.4 <21.0.0",
       "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-20.0.4.tgz",
       "dependencies": {
-        "camelcase": {
-          "version": "3.0.0",
-          "from": "camelcase@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz"
-        },
         "strip-bom": {
           "version": "3.0.0",
           "from": "strip-bom@3.0.0",
@@ -3792,11 +3758,6 @@
           "version": "7.1.0",
           "from": "yargs@>=7.0.2 <8.0.0",
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz"
-        },
-        "yargs-parser": {
-          "version": "5.0.0",
-          "from": "yargs-parser@>=5.0.0 <6.0.0",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz"
         }
       }
     },
@@ -3833,14 +3794,7 @@
     "js-yaml": {
       "version": "3.9.1",
       "from": "js-yaml@>=3.9.1 <3.10.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.9.1.tgz",
-      "dependencies": {
-        "esprima": {
-          "version": "4.0.0",
-          "from": "esprima@>=4.0.0 <5.0.0",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz"
-        }
-      }
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.9.1.tgz"
     },
     "jsdom": {
       "version": "9.12.0",
@@ -3874,7 +3828,7 @@
     },
     "json-stable-stringify": {
       "version": "1.0.1",
-      "from": "json-stable-stringify@>=1.0.0 <2.0.0",
+      "from": "json-stable-stringify@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz"
     },
     "json-stringify-safe": {
@@ -3921,11 +3875,6 @@
           "version": "3.10.1",
           "from": "lodash@>=3.8.0 <4.0.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "from": "source-map@>=0.5.3 <0.6.0",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz"
         }
       }
     },
@@ -3938,11 +3887,6 @@
           "version": "1.0.12",
           "from": "dateformat@>=1.0.6 <2.0.0",
           "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz"
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "from": "source-map@>=0.5.1 <0.6.0",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz"
         }
       }
     },
@@ -4069,7 +4013,7 @@
     },
     "load-json-file": {
       "version": "1.1.0",
-      "from": "load-json-file@>=1.1.0 <2.0.0",
+      "from": "load-json-file@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
       "dependencies": {
         "strip-bom": {
@@ -4092,14 +4036,7 @@
     "locate-path": {
       "version": "2.0.0",
       "from": "locate-path@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-      "dependencies": {
-        "path-exists": {
-          "version": "3.0.0",
-          "from": "path-exists@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz"
-        }
-      }
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz"
     },
     "lodash": {
       "version": "4.15.0",
@@ -4498,19 +4435,7 @@
     "method-override": {
       "version": "2.3.10",
       "from": "method-override@>=2.3.5 <2.4.0",
-      "resolved": "https://registry.npmjs.org/method-override/-/method-override-2.3.10.tgz",
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "from": "debug@2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz"
-        },
-        "ms": {
-          "version": "2.0.0",
-          "from": "ms@2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
-        }
-      }
+      "resolved": "https://registry.npmjs.org/method-override/-/method-override-2.3.10.tgz"
     },
     "methods": {
       "version": "1.1.2",
@@ -4643,17 +4568,27 @@
       "from": "morgan@>=1.6.1 <1.7.0",
       "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.6.1.tgz",
       "dependencies": {
+        "debug": {
+          "version": "2.2.0",
+          "from": "debug@>=2.2.0 <2.3.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
+        },
         "depd": {
           "version": "1.0.1",
           "from": "depd@>=1.0.1 <1.1.0",
           "resolved": "https://registry.npmjs.org/depd/-/depd-1.0.1.tgz"
+        },
+        "ms": {
+          "version": "0.7.1",
+          "from": "ms@0.7.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
         }
       }
     },
     "ms": {
-      "version": "0.7.1",
-      "from": "ms@0.7.1",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+      "version": "2.0.0",
+      "from": "ms@2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
     },
     "multiparty": {
       "version": "3.3.2",
@@ -4985,7 +4920,7 @@
     },
     "os-tmpdir": {
       "version": "1.0.2",
-      "from": "os-tmpdir@>=1.0.0 <2.0.0",
+      "from": "os-tmpdir@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz"
     },
     "osenv": {
@@ -5079,9 +5014,9 @@
       "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz"
     },
     "path-exists": {
-      "version": "2.1.0",
-      "from": "path-exists@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz"
+      "version": "3.0.0",
+      "from": "path-exists@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz"
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -5268,7 +5203,19 @@
     "pkg-conf": {
       "version": "1.1.3",
       "from": "pkg-conf@>=1.1.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-1.1.3.tgz"
+      "resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-1.1.3.tgz",
+      "dependencies": {
+        "find-up": {
+          "version": "1.1.2",
+          "from": "find-up@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz"
+        },
+        "path-exists": {
+          "version": "2.1.0",
+          "from": "path-exists@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz"
+        }
+      }
     },
     "plur": {
       "version": "2.1.2",
@@ -5280,11 +5227,6 @@
       "from": "postcss@>=5.0.21 <6.0.0",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
       "dependencies": {
-        "source-map": {
-          "version": "0.5.7",
-          "from": "source-map@>=0.5.6 <0.6.0",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz"
-        },
         "supports-color": {
           "version": "3.2.3",
           "from": "supports-color@>=3.2.3 <4.0.0",
@@ -5594,14 +5536,7 @@
     "raw-body": {
       "version": "2.3.2",
       "from": "raw-body@2.3.2",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz",
-      "dependencies": {
-        "iconv-lite": {
-          "version": "0.4.19",
-          "from": "iconv-lite@0.4.19",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz"
-        }
-      }
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz"
     },
     "read": {
       "version": "1.0.7",
@@ -5633,7 +5568,19 @@
     "read-pkg-up": {
       "version": "1.0.1",
       "from": "read-pkg-up@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz"
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+      "dependencies": {
+        "find-up": {
+          "version": "1.1.2",
+          "from": "find-up@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz"
+        },
+        "path-exists": {
+          "version": "2.1.0",
+          "from": "path-exists@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz"
+        }
+      }
     },
     "readable-stream": {
       "version": "1.1.14",
@@ -5792,9 +5739,9 @@
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz"
     },
     "resolve": {
-      "version": "1.4.0",
+      "version": "1.5.0",
       "from": "resolve@>=1.1.7 <2.0.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz"
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz"
     },
     "resolve-dir": {
       "version": "0.1.1",
@@ -5878,20 +5825,10 @@
       "from": "sass-graph@>=2.1.1 <3.0.0",
       "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.2.4.tgz",
       "dependencies": {
-        "camelcase": {
-          "version": "3.0.0",
-          "from": "camelcase@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz"
-        },
         "yargs": {
           "version": "7.1.0",
           "from": "yargs@>=7.0.0 <8.0.0",
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz"
-        },
-        "yargs-parser": {
-          "version": "5.0.0",
-          "from": "yargs-parser@>=5.0.0 <6.0.0",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz"
         }
       }
     },
@@ -5908,7 +5845,14 @@
     "scss-tokenizer": {
       "version": "0.2.3",
       "from": "scss-tokenizer@>=0.2.3 <0.3.0",
-      "resolved": "https://registry.npmjs.org/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz"
+      "resolved": "https://registry.npmjs.org/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz",
+      "dependencies": {
+        "source-map": {
+          "version": "0.4.4",
+          "from": "source-map@>=0.4.2 <0.5.0",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz"
+        }
+      }
     },
     "semver": {
       "version": "5.3.0",
@@ -5920,6 +5864,18 @@
       "from": "send@0.14.2",
       "resolved": "https://registry.npmjs.org/send/-/send-0.14.2.tgz",
       "dependencies": {
+        "debug": {
+          "version": "2.2.0",
+          "from": "debug@>=2.2.0 <2.3.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+          "dependencies": {
+            "ms": {
+              "version": "0.7.1",
+              "from": "ms@0.7.1",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+            }
+          }
+        },
         "http-errors": {
           "version": "1.5.1",
           "from": "http-errors@>=1.5.1 <1.6.0",
@@ -5974,10 +5930,20 @@
           "from": "accepts@>=1.2.13 <1.3.0",
           "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.2.13.tgz"
         },
+        "debug": {
+          "version": "2.2.0",
+          "from": "debug@>=2.2.0 <2.3.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
+        },
         "http-errors": {
           "version": "1.3.1",
           "from": "http-errors@>=1.3.1 <1.4.0",
           "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz"
+        },
+        "ms": {
+          "version": "0.7.1",
+          "from": "ms@0.7.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
         },
         "negotiator": {
           "version": "0.5.3",
@@ -6064,9 +6030,9 @@
       "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz"
     },
     "sntp": {
-      "version": "2.0.2",
+      "version": "2.1.0",
       "from": "sntp@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.0.2.tgz"
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz"
     },
     "socket.io": {
       "version": "1.7.4",
@@ -6132,7 +6098,19 @@
     "socket.io-parser": {
       "version": "2.3.1",
       "from": "socket.io-parser@2.3.1",
-      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.3.1.tgz"
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.3.1.tgz",
+      "dependencies": {
+        "debug": {
+          "version": "2.2.0",
+          "from": "debug@2.2.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
+        },
+        "ms": {
+          "version": "0.7.1",
+          "from": "ms@0.7.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+        }
+      }
     },
     "source-list-map": {
       "version": "2.0.0",
@@ -6140,21 +6118,14 @@
       "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.0.tgz"
     },
     "source-map": {
-      "version": "0.4.4",
-      "from": "source-map@>=0.4.4 <0.5.0",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz"
+      "version": "0.5.7",
+      "from": "source-map@>=0.5.6 <0.6.0",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz"
     },
     "source-map-support": {
       "version": "0.4.18",
       "from": "source-map-support@>=0.4.15 <0.5.0",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
-      "dependencies": {
-        "source-map": {
-          "version": "0.5.7",
-          "from": "source-map@>=0.5.6 <0.6.0",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz"
-        }
-      }
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz"
     },
     "sparkles": {
       "version": "1.0.0",
@@ -6304,7 +6275,7 @@
     },
     "string-width": {
       "version": "1.0.2",
-      "from": "string-width@>=1.0.1 <2.0.0",
+      "from": "string-width@>=1.0.2 <2.0.0",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz"
     },
     "stringstream": {
@@ -6487,10 +6458,25 @@
           "from": "bytes@2.2.0",
           "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.2.0.tgz"
         },
+        "debug": {
+          "version": "2.2.0",
+          "from": "debug@>=2.2.0 <2.3.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
+        },
         "http-errors": {
           "version": "1.3.1",
           "from": "http-errors@>=1.3.1 <1.4.0",
           "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz"
+        },
+        "iconv-lite": {
+          "version": "0.4.13",
+          "from": "iconv-lite@0.4.13",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
+        },
+        "ms": {
+          "version": "0.7.1",
+          "from": "ms@0.7.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
         },
         "qs": {
           "version": "5.1.0",
@@ -6586,11 +6572,6 @@
           "from": "commander@>=2.9.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz"
         },
-        "diff": {
-          "version": "3.4.0",
-          "from": "diff@>=3.2.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-3.4.0.tgz"
-        },
         "glob": {
           "version": "7.1.2",
           "from": "glob@>=7.1.1 <8.0.0",
@@ -6617,7 +6598,7 @@
     },
     "tsutils": {
       "version": "2.12.1",
-      "from": "tsutils@>=2.5.1 <3.0.0",
+      "from": "tsutils@>=2.7.1 <3.0.0",
       "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.12.1.tgz"
     },
     "tty-browserify": {
@@ -6664,11 +6645,6 @@
           "version": "2.11.0",
           "from": "commander@>=2.11.0 <2.12.0",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz"
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "from": "source-map@>=0.5.1 <0.6.0",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz"
         }
       }
     },
@@ -6686,11 +6662,6 @@
           "version": "2.1.0",
           "from": "cliui@>=2.1.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz"
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "from": "source-map@>=0.5.6 <0.6.0",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz"
         },
         "uglify-js": {
           "version": "2.8.29",
@@ -6875,14 +6846,7 @@
     "vinyl-sourcemaps-apply": {
       "version": "0.2.1",
       "from": "vinyl-sourcemaps-apply@>=0.2.1 <0.3.0",
-      "resolved": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.1.tgz",
-      "dependencies": {
-        "source-map": {
-          "version": "0.5.7",
-          "from": "source-map@>=0.5.1 <0.6.0",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz"
-        }
-      }
+      "resolved": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.1.tgz"
     },
     "vm-browserify": {
       "version": "0.0.4",
@@ -6907,14 +6871,7 @@
     "watchpack": {
       "version": "1.4.0",
       "from": "watchpack@>=1.4.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.4.0.tgz",
-      "dependencies": {
-        "async": {
-          "version": "2.5.0",
-          "from": "async@>=2.1.2 <3.0.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz"
-        }
-      }
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.4.0.tgz"
     },
     "webidl-conversions": {
       "version": "4.0.2",
@@ -6927,29 +6884,19 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-3.6.0.tgz",
       "dependencies": {
         "acorn": {
-          "version": "5.1.2",
+          "version": "5.2.1",
           "from": "acorn@>=5.0.0 <6.0.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.1.2.tgz"
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.2.1.tgz"
         },
         "ansi-regex": {
           "version": "3.0.0",
           "from": "ansi-regex@>=3.0.0 <4.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz"
         },
-        "async": {
-          "version": "2.5.0",
-          "from": "async@>=2.1.2 <3.0.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz"
-        },
         "camelcase": {
           "version": "4.1.0",
           "from": "camelcase@>=4.1.0 <5.0.0",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz"
-        },
-        "find-up": {
-          "version": "2.1.0",
-          "from": "find-up@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz"
         },
         "has-flag": {
           "version": "2.0.0",
@@ -6985,11 +6932,6 @@
           "version": "2.0.0",
           "from": "read-pkg-up@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz"
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "from": "source-map@>=0.5.3 <0.6.0",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz"
         },
         "string-width": {
           "version": "2.1.1",
@@ -7043,14 +6985,7 @@
     "webpack-sources": {
       "version": "1.0.1",
       "from": "webpack-sources@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.0.1.tgz",
-      "dependencies": {
-        "source-map": {
-          "version": "0.5.7",
-          "from": "source-map@>=0.5.3 <0.6.0",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz"
-        }
-      }
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.0.1.tgz"
     },
     "websocket-driver": {
       "version": "0.7.0",
@@ -7063,9 +6998,9 @@
       "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.2.tgz"
     },
     "whatwg-encoding": {
-      "version": "1.0.2",
+      "version": "1.0.3",
       "from": "whatwg-encoding@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.2.tgz"
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.3.tgz"
     },
     "whatwg-url": {
       "version": "4.8.0",
@@ -7105,9 +7040,9 @@
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz"
     },
     "worker-farm": {
-      "version": "1.5.0",
+      "version": "1.5.1",
       "from": "worker-farm@>=1.3.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.5.0.tgz"
+      "resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.5.1.tgz"
     },
     "wrap-ansi": {
       "version": "2.1.0",
@@ -7157,19 +7092,31 @@
     "yargs": {
       "version": "4.6.0",
       "from": "yargs@>=4.6.0 <4.7.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-4.6.0.tgz"
-    },
-    "yargs-parser": {
-      "version": "2.4.1",
-      "from": "yargs-parser@>=2.4.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-4.6.0.tgz",
       "dependencies": {
         "camelcase": {
-          "version": "3.0.0",
-          "from": "camelcase@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz"
+          "version": "2.1.1",
+          "from": "camelcase@>=2.0.1 <3.0.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz"
+        },
+        "yargs-parser": {
+          "version": "2.4.1",
+          "from": "yargs-parser@>=2.4.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
+          "dependencies": {
+            "camelcase": {
+              "version": "3.0.0",
+              "from": "camelcase@^3.0.0",
+              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz"
+            }
+          }
         }
       }
+    },
+    "yargs-parser": {
+      "version": "5.0.0",
+      "from": "yargs-parser@>=5.0.0 <6.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz"
     },
     "yauzl": {
       "version": "2.4.1",

--- a/core-build/gulp-core-build-karma/package.json
+++ b/core-build/gulp-core-build-karma/package.json
@@ -36,7 +36,7 @@
     "webpack": "~3.6.0"
   },
   "devDependencies": {
-    "@microsoft/node-library-build": "~4.1.5",
+    "@microsoft/node-library-build": "~4.2.3",
     "@types/gulp": "3.8.32",
     "@types/karma": "0.13.33",
     "@types/log4js": "0.0.33",

--- a/core-build/gulp-core-build-mocha/package.json
+++ b/core-build/gulp-core-build-mocha/package.json
@@ -22,7 +22,7 @@
     "gulp-mocha": "~2.2.0"
   },
   "devDependencies": {
-    "@microsoft/node-library-build": "~4.1.5",
+    "@microsoft/node-library-build": "~4.2.3",
     "@types/gulp": "3.8.32",
     "@types/gulp-istanbul": "0.9.30",
     "@types/gulp-mocha": "0.0.29",

--- a/core-build/gulp-core-build-sass/package.json
+++ b/core-build/gulp-core-build-sass/package.json
@@ -30,7 +30,7 @@
     "postcss-modules": "~0.6.4"
   },
   "devDependencies": {
-    "@microsoft/node-library-build": "~4.1.5",
+    "@microsoft/node-library-build": "~4.2.3",
     "@types/express": "4.0.35",
     "@types/express-serve-static-core": "4.0.41",
     "@types/gulp": "3.8.32",

--- a/core-build/gulp-core-build-serve/package.json
+++ b/core-build/gulp-core-build-serve/package.json
@@ -27,7 +27,7 @@
     "sudo": "~1.0.3"
   },
   "devDependencies": {
-    "@microsoft/node-library-build": "~4.1.5",
+    "@microsoft/node-library-build": "~4.2.3",
     "@types/express": "4.0.35",
     "@types/express-serve-static-core": "4.0.41",
     "@types/gulp": "3.8.32",

--- a/core-build/gulp-core-build-typescript/package.json
+++ b/core-build/gulp-core-build-typescript/package.json
@@ -41,7 +41,7 @@
     "typescript": "~2.4.1"
   },
   "devDependencies": {
-    "@microsoft/node-library-build": "~4.1.5",
+    "@microsoft/node-library-build": "~4.2.3",
     "@types/gulp-util": "3.0.30",
     "@types/orchestrator": "0.0.30",
     "@types/q": "0.0.32",

--- a/core-build/gulp-core-build-webpack/package.json
+++ b/core-build/gulp-core-build-webpack/package.json
@@ -23,7 +23,7 @@
     "webpack": "~3.6.0"
   },
   "devDependencies": {
-    "@microsoft/node-library-build": "~4.1.5",
+    "@microsoft/node-library-build": "~4.2.3",
     "@types/orchestrator": "0.0.30",
     "@types/q": "0.0.32",
     "@types/source-map": "0.5.0",

--- a/core-build/gulp-core-build/package.json
+++ b/core-build/gulp-core-build/package.json
@@ -56,7 +56,7 @@
   },
   "devDependencies": {
     "@types/z-schema": "3.16.31",
-    "@microsoft/node-library-build": "~4.1.5",
+    "@microsoft/node-library-build": "~4.2.3",
     "chai": "~3.5.0"
   }
 }

--- a/core-build/gulp-core-build/package.json
+++ b/core-build/gulp-core-build/package.json
@@ -18,6 +18,7 @@
     "@microsoft/node-core-library": "~0.3.12",
     "@types/assertion-error": "1.0.30",
     "@types/chai": "3.4.34",
+    "@types/chalk": "0.4.31",
     "@types/gulp": "3.8.32",
     "@types/gulp-util": "3.0.30",
     "@types/mocha": "2.2.38",

--- a/libraries/node-core-library/package.json
+++ b/libraries/node-core-library/package.json
@@ -24,6 +24,6 @@
     "chai": "~3.5.0",
     "gulp": "~3.9.1",
     "mocha": "~3.4.2",
-    "@microsoft/node-library-build": "~4.1.5"
+    "@microsoft/node-library-build": "~4.2.3"
   }
 }

--- a/libraries/ts-command-line/package.json
+++ b/libraries/ts-command-line/package.json
@@ -25,6 +25,6 @@
     "chai": "~3.5.0",
     "gulp": "~3.9.1",
     "mocha": "~3.4.2",
-    "@microsoft/node-library-build": "~4.1.5"
+    "@microsoft/node-library-build": "~4.2.3"
   }
 }


### PR DESCRIPTION
Some people reported build failures because **gulp-core-builds** has an indirect dependency on @types/chalk, and DefinitelyTyped doesn't lock these versions.  This PR fixes that.

It also upgrades the cyclic dependencies, so that our *.api.json files are using the latest file format.