### PR TITLE
Bump Jest

### DIFF
--- a/apps/api-documenter/package.json
+++ b/apps/api-documenter/package.json
@@ -31,6 +31,6 @@
     "@types/js-yaml": "3.9.1",
     "@types/node": "6.0.88",
     "gulp": "~3.9.1",
-    "@types/jest": "~20.0.4"
+    "@types/jest": "~21.1.5"
   }
 }

--- a/common/changes/@microsoft/api-documenter/nickpape-jest_2017-11-03-22-53.json
+++ b/common/changes/@microsoft/api-documenter/nickpape-jest_2017-11-03-22-53.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-documenter",
+      "comment": "Bump jest and @types/jest",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/api-documenter",
+  "email": "nickpape@microsoft.com"
+}

--- a/common/changes/@microsoft/gulp-core-build/nickpape-jest_2017-11-03-22-53.json
+++ b/common/changes/@microsoft/gulp-core-build/nickpape-jest_2017-11-03-22-53.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/gulp-core-build",
+      "comment": "Bump jest and @types/jest",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/gulp-core-build",
+  "email": "nickpape@microsoft.com"
+}

--- a/common/config/rush/npm-shrinkwrap.json
+++ b/common/config/rush/npm-shrinkwrap.json
@@ -10,7 +10,26 @@
     "@microsoft/gulp-core-build": {
       "version": "3.2.3",
       "from": "@microsoft/gulp-core-build@3.2.3",
-      "resolved": "https://registry.npmjs.org/@microsoft/gulp-core-build/-/gulp-core-build-3.2.3.tgz"
+      "resolved": "https://registry.npmjs.org/@microsoft/gulp-core-build/-/gulp-core-build-3.2.3.tgz",
+      "dependencies": {
+        "jest": {
+          "version": "20.0.4",
+          "from": "jest@>=20.0.4 <20.1.0",
+          "resolved": "https://registry.npmjs.org/jest/-/jest-20.0.4.tgz"
+        },
+        "jest-cli": {
+          "version": "20.0.4",
+          "from": "jest-cli@>=20.0.4 <20.1.0",
+          "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-20.0.4.tgz",
+          "dependencies": {
+            "yargs": {
+              "version": "7.1.0",
+              "from": "yargs@>=7.0.2 <8.0.0",
+              "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz"
+            }
+          }
+        }
+      }
     },
     "@microsoft/gulp-core-build-mocha": {
       "version": "3.2.3",
@@ -23,19 +42,19 @@
       "resolved": "https://registry.npmjs.org/@microsoft/gulp-core-build-typescript/-/gulp-core-build-typescript-4.2.10.tgz"
     },
     "@microsoft/node-core-library": {
-      "version": "0.3.12",
+      "version": "0.3.14",
       "from": "@microsoft/node-core-library@>=0.3.12 <0.4.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/node-core-library/-/node-core-library-0.3.12.tgz"
+      "resolved": "https://registry.npmjs.org/@microsoft/node-core-library/-/node-core-library-0.3.14.tgz"
     },
     "@microsoft/node-library-build": {
       "version": "4.2.3",
-      "from": "@microsoft/node-library-build@>=4.2.3 <4.3.0",
+      "from": "@microsoft/node-library-build@4.2.3",
       "resolved": "https://registry.npmjs.org/@microsoft/node-library-build/-/node-library-build-4.2.3.tgz"
     },
     "@microsoft/ts-command-line": {
-      "version": "2.2.0",
+      "version": "2.2.2",
       "from": "@microsoft/ts-command-line@>=2.2.0 <2.3.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/ts-command-line/-/ts-command-line-2.2.0.tgz"
+      "resolved": "https://registry.npmjs.org/@microsoft/ts-command-line/-/ts-command-line-2.2.2.tgz"
     },
     "@rush-temp/api-documenter": {
       "version": "0.0.0",
@@ -233,9 +252,9 @@
       "resolved": "https://registry.npmjs.org/@types/gulp-util/-/gulp-util-3.0.30.tgz"
     },
     "@types/jest": {
-      "version": "20.0.8",
-      "from": "@types/jest@>=20.0.4 <20.1.0",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-20.0.8.tgz"
+      "version": "21.1.5",
+      "from": "@types/jest@>=21.1.5 <21.2.0",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-21.1.5.tgz"
     },
     "@types/js-yaml": {
       "version": "3.9.1",
@@ -579,6 +598,11 @@
       "from": "assertion-error@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz"
     },
+    "astral-regex": {
+      "version": "1.0.0",
+      "from": "astral-regex@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz"
+    },
     "async": {
       "version": "2.5.0",
       "from": "async@>=2.1.4 <3.0.0",
@@ -667,6 +691,11 @@
       "version": "20.0.3",
       "from": "babel-plugin-jest-hoist@>=20.0.3 <21.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-20.0.3.tgz"
+    },
+    "babel-plugin-syntax-object-rest-spread": {
+      "version": "6.13.0",
+      "from": "babel-plugin-syntax-object-rest-spread@>=6.13.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz"
     },
     "babel-preset-jest": {
       "version": "20.0.3",
@@ -978,9 +1007,9 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000756",
+      "version": "1.0.30000758",
       "from": "caniuse-db@>=1.0.30000488 <2.0.0",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000756.tgz"
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000758.tgz"
     },
     "caseless": {
       "version": "0.12.0",
@@ -1325,9 +1354,9 @@
       }
     },
     "crypto-browserify": {
-      "version": "3.11.1",
+      "version": "3.12.0",
       "from": "crypto-browserify@>=3.11.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.11.1.tgz"
+      "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz"
     },
     "csrf": {
       "version": "3.0.6",
@@ -1706,9 +1735,9 @@
       "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz"
     },
     "es6-promise": {
-      "version": "4.0.5",
-      "from": "es6-promise@>=4.0.3 <4.1.0",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.0.5.tgz"
+      "version": "4.1.1",
+      "from": "es6-promise@>=4.0.3 <5.0.0",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.1.1.tgz"
     },
     "es6-set": {
       "version": "0.1.5",
@@ -1864,6 +1893,63 @@
       "from": "expand-tilde@>=1.2.2 <2.0.0",
       "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz"
     },
+    "expect": {
+      "version": "21.2.1",
+      "from": "expect@>=21.2.1 <22.0.0",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-21.2.1.tgz",
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "from": "ansi-regex@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz"
+        },
+        "ansi-styles": {
+          "version": "3.2.0",
+          "from": "ansi-styles@>=3.2.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz"
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "from": "chalk@>=2.0.1 <3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz"
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "from": "has-flag@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz"
+        },
+        "jest-diff": {
+          "version": "21.2.1",
+          "from": "jest-diff@>=21.2.1 <22.0.0",
+          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-21.2.1.tgz"
+        },
+        "jest-matcher-utils": {
+          "version": "21.2.1",
+          "from": "jest-matcher-utils@>=21.2.1 <22.0.0",
+          "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-21.2.1.tgz"
+        },
+        "jest-message-util": {
+          "version": "21.2.1",
+          "from": "jest-message-util@>=21.2.1 <22.0.0",
+          "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-21.2.1.tgz"
+        },
+        "jest-regex-util": {
+          "version": "21.2.0",
+          "from": "jest-regex-util@>=21.2.0 <22.0.0",
+          "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-21.2.0.tgz"
+        },
+        "pretty-format": {
+          "version": "21.2.1",
+          "from": "pretty-format@>=21.2.1 <22.0.0",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-21.2.1.tgz"
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "from": "supports-color@>=4.0.0 <5.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz"
+        }
+      }
+    },
     "express": {
       "version": "4.14.1",
       "from": "express@>=4.14.0 <4.15.0",
@@ -1967,7 +2053,7 @@
     },
     "extract-zip": {
       "version": "1.6.6",
-      "from": "extract-zip@>=1.6.5 <1.7.0",
+      "from": "extract-zip@>=1.6.5 <2.0.0",
       "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.6.tgz",
       "dependencies": {
         "minimist": {
@@ -3092,7 +3178,7 @@
     },
     "hasha": {
       "version": "2.2.0",
-      "from": "hasha@>=2.2.0 <2.3.0",
+      "from": "hasha@>=2.2.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/hasha/-/hasha-2.2.0.tgz"
     },
     "hawk": {
@@ -3169,6 +3255,11 @@
       "version": "1.1.8",
       "from": "ieee754@>=1.1.4 <2.0.0",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz"
+    },
+    "imurmurhash": {
+      "version": "0.1.4",
+      "from": "imurmurhash@>=0.1.4 <0.2.0",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz"
     },
     "in-publish": {
       "version": "2.0.0",
@@ -3646,9 +3737,9 @@
       }
     },
     "jest": {
-      "version": "20.0.4",
-      "from": "jest@>=20.0.4 <20.1.0",
-      "resolved": "https://registry.npmjs.org/jest/-/jest-20.0.4.tgz"
+      "version": "21.2.1",
+      "from": "jest@>=21.2.1 <21.3.0",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-21.2.1.tgz"
     },
     "jest-changed-files": {
       "version": "20.0.3",
@@ -3656,14 +3747,258 @@
       "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-20.0.3.tgz"
     },
     "jest-cli": {
-      "version": "20.0.4",
-      "from": "jest-cli@>=20.0.4 <20.1.0",
-      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-20.0.4.tgz",
+      "version": "21.2.1",
+      "from": "jest-cli@>=21.2.1 <21.3.0",
+      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-21.2.1.tgz",
       "dependencies": {
+        "ansi-escapes": {
+          "version": "3.0.0",
+          "from": "ansi-escapes@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.0.0.tgz"
+        },
+        "ansi-regex": {
+          "version": "3.0.0",
+          "from": "ansi-regex@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz"
+        },
+        "ansi-styles": {
+          "version": "3.2.0",
+          "from": "ansi-styles@>=3.1.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz"
+        },
+        "babel-jest": {
+          "version": "21.2.0",
+          "from": "babel-jest@>=21.2.0 <22.0.0",
+          "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-21.2.0.tgz"
+        },
+        "babel-plugin-jest-hoist": {
+          "version": "21.2.0",
+          "from": "babel-plugin-jest-hoist@>=21.2.0 <22.0.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-21.2.0.tgz"
+        },
+        "babel-preset-jest": {
+          "version": "21.2.0",
+          "from": "babel-preset-jest@>=21.2.0 <22.0.0",
+          "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-21.2.0.tgz"
+        },
+        "camelcase": {
+          "version": "4.1.0",
+          "from": "camelcase@>=4.1.0 <5.0.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz"
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "from": "chalk@>=2.0.1 <3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz"
+        },
+        "glob": {
+          "version": "7.1.2",
+          "from": "glob@>=7.1.2 <8.0.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz"
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "from": "has-flag@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz"
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "from": "is-fullwidth-code-point@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz"
+        },
+        "jest-changed-files": {
+          "version": "21.2.0",
+          "from": "jest-changed-files@>=21.2.0 <22.0.0",
+          "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-21.2.0.tgz"
+        },
+        "jest-config": {
+          "version": "21.2.1",
+          "from": "jest-config@>=21.2.1 <22.0.0",
+          "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-21.2.1.tgz"
+        },
+        "jest-diff": {
+          "version": "21.2.1",
+          "from": "jest-diff@>=21.2.1 <22.0.0",
+          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-21.2.1.tgz"
+        },
+        "jest-docblock": {
+          "version": "21.2.0",
+          "from": "jest-docblock@>=21.2.0 <22.0.0",
+          "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-21.2.0.tgz"
+        },
+        "jest-environment-jsdom": {
+          "version": "21.2.1",
+          "from": "jest-environment-jsdom@>=21.2.1 <22.0.0",
+          "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-21.2.1.tgz"
+        },
+        "jest-environment-node": {
+          "version": "21.2.1",
+          "from": "jest-environment-node@>=21.2.1 <22.0.0",
+          "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-21.2.1.tgz"
+        },
+        "jest-haste-map": {
+          "version": "21.2.0",
+          "from": "jest-haste-map@>=21.2.0 <22.0.0",
+          "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-21.2.0.tgz"
+        },
+        "jest-jasmine2": {
+          "version": "21.2.1",
+          "from": "jest-jasmine2@>=21.2.1 <22.0.0",
+          "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-21.2.1.tgz"
+        },
+        "jest-matcher-utils": {
+          "version": "21.2.1",
+          "from": "jest-matcher-utils@>=21.2.1 <22.0.0",
+          "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-21.2.1.tgz"
+        },
+        "jest-message-util": {
+          "version": "21.2.1",
+          "from": "jest-message-util@>=21.2.1 <22.0.0",
+          "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-21.2.1.tgz"
+        },
+        "jest-mock": {
+          "version": "21.2.0",
+          "from": "jest-mock@>=21.2.0 <22.0.0",
+          "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-21.2.0.tgz"
+        },
+        "jest-regex-util": {
+          "version": "21.2.0",
+          "from": "jest-regex-util@>=21.2.0 <22.0.0",
+          "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-21.2.0.tgz"
+        },
+        "jest-resolve": {
+          "version": "21.2.0",
+          "from": "jest-resolve@>=21.2.0 <22.0.0",
+          "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-21.2.0.tgz"
+        },
+        "jest-resolve-dependencies": {
+          "version": "21.2.0",
+          "from": "jest-resolve-dependencies@>=21.2.0 <22.0.0",
+          "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-21.2.0.tgz"
+        },
+        "jest-runtime": {
+          "version": "21.2.1",
+          "from": "jest-runtime@>=21.2.1 <22.0.0",
+          "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-21.2.1.tgz"
+        },
+        "jest-snapshot": {
+          "version": "21.2.1",
+          "from": "jest-snapshot@>=21.2.1 <22.0.0",
+          "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-21.2.1.tgz"
+        },
+        "jest-util": {
+          "version": "21.2.1",
+          "from": "jest-util@>=21.2.1 <22.0.0",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-21.2.1.tgz"
+        },
+        "jest-validate": {
+          "version": "21.2.1",
+          "from": "jest-validate@>=21.2.1 <22.0.0",
+          "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-21.2.1.tgz"
+        },
+        "load-json-file": {
+          "version": "2.0.0",
+          "from": "load-json-file@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+          "dependencies": {
+            "pify": {
+              "version": "2.3.0",
+              "from": "pify@^2.0.0",
+              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
+            }
+          }
+        },
+        "os-locale": {
+          "version": "2.1.0",
+          "from": "os-locale@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz"
+        },
+        "path-type": {
+          "version": "2.0.0",
+          "from": "path-type@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+          "dependencies": {
+            "pify": {
+              "version": "2.3.0",
+              "from": "pify@^2.0.0",
+              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
+            }
+          }
+        },
+        "pify": {
+          "version": "3.0.0",
+          "from": "pify@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz"
+        },
+        "pretty-format": {
+          "version": "21.2.1",
+          "from": "pretty-format@>=21.2.1 <22.0.0",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-21.2.1.tgz"
+        },
+        "read-pkg": {
+          "version": "2.0.0",
+          "from": "read-pkg@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz"
+        },
+        "read-pkg-up": {
+          "version": "2.0.0",
+          "from": "read-pkg-up@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz"
+        },
+        "sane": {
+          "version": "2.2.0",
+          "from": "sane@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/sane/-/sane-2.2.0.tgz"
+        },
+        "string-length": {
+          "version": "2.0.0",
+          "from": "string-length@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/string-length/-/string-length-2.0.0.tgz"
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "from": "string-width@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz"
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "from": "strip-ansi@>=4.0.0 <5.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz"
+        },
+        "strip-bom": {
+          "version": "3.0.0",
+          "from": "strip-bom@3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz"
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "from": "supports-color@>=4.0.0 <5.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz"
+        },
+        "throat": {
+          "version": "4.1.0",
+          "from": "throat@>=4.0.0 <5.0.0",
+          "resolved": "https://registry.npmjs.org/throat/-/throat-4.1.0.tgz"
+        },
+        "watch": {
+          "version": "0.18.0",
+          "from": "watch@>=0.18.0 <0.19.0",
+          "resolved": "https://registry.npmjs.org/watch/-/watch-0.18.0.tgz"
+        },
+        "which-module": {
+          "version": "2.0.0",
+          "from": "which-module@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz"
+        },
         "yargs": {
-          "version": "7.1.0",
-          "from": "yargs@>=7.0.2 <8.0.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz"
+          "version": "9.0.1",
+          "from": "yargs@>=9.0.0 <10.0.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-9.0.1.tgz"
+        },
+        "yargs-parser": {
+          "version": "7.0.0",
+          "from": "yargs-parser@>=7.0.0 <8.0.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz"
         }
       }
     },
@@ -3698,6 +4033,11 @@
       "version": "20.0.3",
       "from": "jest-environment-node@>=20.0.3 <21.0.0",
       "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-20.0.3.tgz"
+    },
+    "jest-get-type": {
+      "version": "21.2.0",
+      "from": "jest-get-type@>=21.2.0 <22.0.0",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-21.2.0.tgz"
     },
     "jest-haste-map": {
       "version": "20.0.5",
@@ -3743,6 +4083,242 @@
       "version": "20.0.3",
       "from": "jest-resolve-dependencies@>=20.0.3 <21.0.0",
       "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-20.0.3.tgz"
+    },
+    "jest-runner": {
+      "version": "21.2.1",
+      "from": "jest-runner@>=21.2.1 <22.0.0",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-21.2.1.tgz",
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "from": "ansi-regex@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz"
+        },
+        "ansi-styles": {
+          "version": "3.2.0",
+          "from": "ansi-styles@>=3.1.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz"
+        },
+        "babel-jest": {
+          "version": "21.2.0",
+          "from": "babel-jest@>=21.2.0 <22.0.0",
+          "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-21.2.0.tgz"
+        },
+        "babel-plugin-jest-hoist": {
+          "version": "21.2.0",
+          "from": "babel-plugin-jest-hoist@>=21.2.0 <22.0.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-21.2.0.tgz"
+        },
+        "babel-preset-jest": {
+          "version": "21.2.0",
+          "from": "babel-preset-jest@>=21.2.0 <22.0.0",
+          "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-21.2.0.tgz"
+        },
+        "camelcase": {
+          "version": "4.1.0",
+          "from": "camelcase@>=4.1.0 <5.0.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz"
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "from": "chalk@>=2.0.1 <3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz"
+        },
+        "glob": {
+          "version": "7.1.2",
+          "from": "glob@>=7.1.1 <8.0.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz"
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "from": "has-flag@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz"
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "from": "is-fullwidth-code-point@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz"
+        },
+        "jest-config": {
+          "version": "21.2.1",
+          "from": "jest-config@>=21.2.1 <22.0.0",
+          "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-21.2.1.tgz"
+        },
+        "jest-diff": {
+          "version": "21.2.1",
+          "from": "jest-diff@>=21.2.1 <22.0.0",
+          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-21.2.1.tgz"
+        },
+        "jest-docblock": {
+          "version": "21.2.0",
+          "from": "jest-docblock@>=21.2.0 <22.0.0",
+          "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-21.2.0.tgz"
+        },
+        "jest-environment-jsdom": {
+          "version": "21.2.1",
+          "from": "jest-environment-jsdom@>=21.2.1 <22.0.0",
+          "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-21.2.1.tgz"
+        },
+        "jest-environment-node": {
+          "version": "21.2.1",
+          "from": "jest-environment-node@>=21.2.1 <22.0.0",
+          "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-21.2.1.tgz"
+        },
+        "jest-haste-map": {
+          "version": "21.2.0",
+          "from": "jest-haste-map@>=21.2.0 <22.0.0",
+          "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-21.2.0.tgz"
+        },
+        "jest-jasmine2": {
+          "version": "21.2.1",
+          "from": "jest-jasmine2@>=21.2.1 <22.0.0",
+          "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-21.2.1.tgz"
+        },
+        "jest-matcher-utils": {
+          "version": "21.2.1",
+          "from": "jest-matcher-utils@>=21.2.1 <22.0.0",
+          "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-21.2.1.tgz"
+        },
+        "jest-message-util": {
+          "version": "21.2.1",
+          "from": "jest-message-util@>=21.2.1 <22.0.0",
+          "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-21.2.1.tgz"
+        },
+        "jest-mock": {
+          "version": "21.2.0",
+          "from": "jest-mock@>=21.2.0 <22.0.0",
+          "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-21.2.0.tgz"
+        },
+        "jest-regex-util": {
+          "version": "21.2.0",
+          "from": "jest-regex-util@>=21.2.0 <22.0.0",
+          "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-21.2.0.tgz"
+        },
+        "jest-resolve": {
+          "version": "21.2.0",
+          "from": "jest-resolve@>=21.2.0 <22.0.0",
+          "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-21.2.0.tgz"
+        },
+        "jest-runtime": {
+          "version": "21.2.1",
+          "from": "jest-runtime@>=21.2.1 <22.0.0",
+          "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-21.2.1.tgz"
+        },
+        "jest-snapshot": {
+          "version": "21.2.1",
+          "from": "jest-snapshot@>=21.2.1 <22.0.0",
+          "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-21.2.1.tgz"
+        },
+        "jest-util": {
+          "version": "21.2.1",
+          "from": "jest-util@>=21.2.1 <22.0.0",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-21.2.1.tgz"
+        },
+        "jest-validate": {
+          "version": "21.2.1",
+          "from": "jest-validate@>=21.2.1 <22.0.0",
+          "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-21.2.1.tgz"
+        },
+        "load-json-file": {
+          "version": "2.0.0",
+          "from": "load-json-file@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+          "dependencies": {
+            "pify": {
+              "version": "2.3.0",
+              "from": "pify@^2.0.0",
+              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
+            }
+          }
+        },
+        "os-locale": {
+          "version": "2.1.0",
+          "from": "os-locale@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz"
+        },
+        "path-type": {
+          "version": "2.0.0",
+          "from": "path-type@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+          "dependencies": {
+            "pify": {
+              "version": "2.3.0",
+              "from": "pify@^2.0.0",
+              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
+            }
+          }
+        },
+        "pify": {
+          "version": "3.0.0",
+          "from": "pify@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz"
+        },
+        "pretty-format": {
+          "version": "21.2.1",
+          "from": "pretty-format@>=21.2.1 <22.0.0",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-21.2.1.tgz"
+        },
+        "read-pkg": {
+          "version": "2.0.0",
+          "from": "read-pkg@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz"
+        },
+        "read-pkg-up": {
+          "version": "2.0.0",
+          "from": "read-pkg-up@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz"
+        },
+        "sane": {
+          "version": "2.2.0",
+          "from": "sane@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/sane/-/sane-2.2.0.tgz"
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "from": "string-width@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz"
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "from": "strip-ansi@>=4.0.0 <5.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz"
+        },
+        "strip-bom": {
+          "version": "3.0.0",
+          "from": "strip-bom@3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz"
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "from": "supports-color@>=4.0.0 <5.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz"
+        },
+        "throat": {
+          "version": "4.1.0",
+          "from": "throat@>=4.0.0 <5.0.0",
+          "resolved": "https://registry.npmjs.org/throat/-/throat-4.1.0.tgz"
+        },
+        "watch": {
+          "version": "0.18.0",
+          "from": "watch@>=0.18.0 <0.19.0",
+          "resolved": "https://registry.npmjs.org/watch/-/watch-0.18.0.tgz"
+        },
+        "which-module": {
+          "version": "2.0.0",
+          "from": "which-module@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz"
+        },
+        "yargs": {
+          "version": "9.0.1",
+          "from": "yargs@>=9.0.0 <10.0.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-9.0.1.tgz"
+        },
+        "yargs-parser": {
+          "version": "7.0.0",
+          "from": "yargs-parser@>=7.0.0 <8.0.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz"
+        }
+      }
     },
     "jest-runtime": {
       "version": "20.0.4",
@@ -4928,6 +5504,11 @@
       "from": "osenv@>=0.0.0 <1.0.0",
       "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz"
     },
+    "p-cancelable": {
+      "version": "0.3.0",
+      "from": "p-cancelable@>=0.3.0 <0.4.0",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.3.0.tgz"
+    },
     "p-finally": {
       "version": "1.0.0",
       "from": "p-finally@>=1.0.0 <2.0.0",
@@ -5089,94 +5670,14 @@
       "resolved": "https://registry.npmjs.org/phantomjs-polyfill/-/phantomjs-polyfill-0.0.2.tgz"
     },
     "phantomjs-prebuilt": {
-      "version": "2.1.15",
+      "version": "2.1.16",
       "from": "phantomjs-prebuilt@>=2.1.6 <2.2.0",
-      "resolved": "https://registry.npmjs.org/phantomjs-prebuilt/-/phantomjs-prebuilt-2.1.15.tgz",
+      "resolved": "https://registry.npmjs.org/phantomjs-prebuilt/-/phantomjs-prebuilt-2.1.16.tgz",
       "dependencies": {
-        "ajv": {
-          "version": "4.11.8",
-          "from": "ajv@>=4.9.1 <5.0.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz"
-        },
-        "assert-plus": {
-          "version": "0.2.0",
-          "from": "assert-plus@>=0.2.0 <0.3.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
-        },
-        "aws-sign2": {
-          "version": "0.6.0",
-          "from": "aws-sign2@>=0.6.0 <0.7.0",
-          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
-        },
-        "boom": {
-          "version": "2.10.1",
-          "from": "boom@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
-        },
-        "cryptiles": {
-          "version": "2.0.5",
-          "from": "cryptiles@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
-        },
-        "form-data": {
-          "version": "2.1.4",
-          "from": "form-data@>=2.1.1 <2.2.0",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz"
-        },
         "fs-extra": {
           "version": "1.0.0",
-          "from": "fs-extra@>=1.0.0 <1.1.0",
+          "from": "fs-extra@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz"
-        },
-        "har-schema": {
-          "version": "1.0.5",
-          "from": "har-schema@>=1.0.5 <2.0.0",
-          "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz"
-        },
-        "har-validator": {
-          "version": "4.2.1",
-          "from": "har-validator@>=4.2.1 <4.3.0",
-          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz"
-        },
-        "hawk": {
-          "version": "3.1.3",
-          "from": "hawk@>=3.1.3 <3.2.0",
-          "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz"
-        },
-        "hoek": {
-          "version": "2.16.3",
-          "from": "hoek@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
-        },
-        "http-signature": {
-          "version": "1.1.1",
-          "from": "http-signature@>=1.1.0 <1.2.0",
-          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz"
-        },
-        "performance-now": {
-          "version": "0.2.0",
-          "from": "performance-now@>=0.2.0 <0.3.0",
-          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz"
-        },
-        "qs": {
-          "version": "6.4.0",
-          "from": "qs@>=6.4.0 <6.5.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz"
-        },
-        "request": {
-          "version": "2.81.0",
-          "from": "request@>=2.81.0 <2.82.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz"
-        },
-        "sntp": {
-          "version": "1.0.9",
-          "from": "sntp@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
-        },
-        "which": {
-          "version": "1.2.14",
-          "from": "which@>=1.2.10 <1.3.0",
-          "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz"
         }
       }
     },
@@ -5266,7 +5767,7 @@
         },
         "chalk": {
           "version": "2.3.0",
-          "from": "chalk@>=2.1.0 <3.0.0",
+          "from": "chalk@>=2.3.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz"
         },
         "has-flag": {
@@ -5275,9 +5776,9 @@
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz"
         },
         "postcss": {
-          "version": "6.0.13",
+          "version": "6.0.14",
           "from": "postcss@>=6.0.1 <7.0.0",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.13.tgz"
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.14.tgz"
         },
         "source-map": {
           "version": "0.6.1",
@@ -5303,7 +5804,7 @@
         },
         "chalk": {
           "version": "2.3.0",
-          "from": "chalk@>=2.1.0 <3.0.0",
+          "from": "chalk@>=2.3.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz"
         },
         "has-flag": {
@@ -5312,9 +5813,9 @@
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz"
         },
         "postcss": {
-          "version": "6.0.13",
+          "version": "6.0.14",
           "from": "postcss@>=6.0.1 <7.0.0",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.13.tgz"
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.14.tgz"
         },
         "source-map": {
           "version": "0.6.1",
@@ -5340,7 +5841,7 @@
         },
         "chalk": {
           "version": "2.3.0",
-          "from": "chalk@>=2.1.0 <3.0.0",
+          "from": "chalk@>=2.3.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz"
         },
         "has-flag": {
@@ -5349,9 +5850,9 @@
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz"
         },
         "postcss": {
-          "version": "6.0.13",
+          "version": "6.0.14",
           "from": "postcss@>=6.0.1 <7.0.0",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.13.tgz"
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.14.tgz"
         },
         "source-map": {
           "version": "0.6.1",
@@ -5377,7 +5878,7 @@
         },
         "chalk": {
           "version": "2.3.0",
-          "from": "chalk@>=2.1.0 <3.0.0",
+          "from": "chalk@>=2.3.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz"
         },
         "has-flag": {
@@ -5386,9 +5887,9 @@
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz"
         },
         "postcss": {
-          "version": "6.0.13",
+          "version": "6.0.14",
           "from": "postcss@>=6.0.1 <7.0.0",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.13.tgz"
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.14.tgz"
         },
         "source-map": {
           "version": "0.6.1",
@@ -5451,7 +5952,7 @@
     },
     "progress": {
       "version": "1.1.8",
-      "from": "progress@>=1.1.8 <1.2.0",
+      "from": "progress@>=1.1.8 <2.0.0",
       "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz"
     },
     "proxy-addr": {
@@ -5527,6 +6028,11 @@
       "version": "2.0.5",
       "from": "randombytes@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.5.tgz"
+    },
+    "randomfill": {
+      "version": "1.0.3",
+      "from": "randomfill@>=1.0.3 <2.0.0",
+      "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.3.tgz"
     },
     "range-parser": {
       "version": "1.2.0",
@@ -5715,7 +6221,7 @@
     },
     "request-progress": {
       "version": "2.0.1",
-      "from": "request-progress@>=2.0.1 <2.1.0",
+      "from": "request-progress@>=2.0.1 <3.0.0",
       "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-2.0.1.tgz"
     },
     "require-directory": {
@@ -6004,7 +6510,7 @@
     },
     "signal-exit": {
       "version": "3.0.2",
-      "from": "signal-exit@>=3.0.0 <4.0.0",
+      "from": "signal-exit@>=3.0.2 <4.0.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz"
     },
     "sinon": {
@@ -6597,9 +7103,9 @@
       "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.5.tgz"
     },
     "tsutils": {
-      "version": "2.12.1",
+      "version": "2.12.2",
       "from": "tsutils@>=2.7.1 <3.0.0",
-      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.12.1.tgz"
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.12.2.tgz"
     },
     "tty-browserify": {
       "version": "0.0.0",
@@ -7053,6 +7559,11 @@
       "version": "1.0.2",
       "from": "wrappy@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+    },
+    "write-file-atomic": {
+      "version": "2.3.0",
+      "from": "write-file-atomic@>=2.1.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz"
     },
     "ws": {
       "version": "1.1.4",

--- a/core-build/gulp-core-build/package.json
+++ b/core-build/gulp-core-build/package.json
@@ -52,8 +52,8 @@
     "through2": "~2.0.1",
     "yargs": "~4.6.0",
     "z-schema": "~3.18.3",
-    "jest-cli": "~20.0.4",
-    "jest": "~20.0.4"
+    "jest-cli": "~21.2.1",
+    "jest": "~21.2.1"
   },
   "devDependencies": {
     "@types/z-schema": "3.16.31",

--- a/core-build/test-web-library-build/package.json
+++ b/core-build/test-web-library-build/package.json
@@ -13,7 +13,7 @@
   "devDependencies": {
     "@types/chai": "3.4.34",
     "chai": "~3.5.0",
-    "@types/jest": "~20.0.4",
+    "@types/jest": "~21.1.5",
     "@types/node": "6.0.88"
   },
   "dependencies": {


### PR DESCRIPTION
Older versions of Jest were missing a dependency in package.json, which was making it impossible to build the repo using pnpm