### PR TITLE
Force change log name to be the same as package name.

### DIFF
--- a/apps/rush-lib/src/cli/utilities/ChangelogGenerator.ts
+++ b/apps/rush-lib/src/cli/utilities/ChangelogGenerator.ts
@@ -167,6 +167,10 @@ export default class ChangelogGenerator {
         name: packageName,
         entries: []
       };
+    } else {
+      // Force the changelog name to be same as package name.
+      // In case the package has been renamed but change log name is not updated.
+      changelog.name = packageName;
     }
 
     return changelog;


### PR DESCRIPTION
Force change log name to be the same as package name to handle the error case when package is renamed but change log is not.