### PR TITLE
Enabled hotfix changes for rush

### DIFF
--- a/apps/rush-lib/src/cli/actions/ChangeAction.ts
+++ b/apps/rush-lib/src/cli/actions/ChangeAction.ts
@@ -42,29 +42,37 @@ export default class ChangeAction extends BaseRushAction {
   private _prompt: inquirer.PromptModule;
 
   constructor(parser: RushCommandLineParser) {
+    const documentation: string[] = [
+      'Asks a series of questions and then generates a <branchname>-<timstamp>.json file ' +
+      'in the common folder. The `publish` command will consume these files and perform the proper ' +
+      'version bumps. Note these changes will eventually be published in a changelog.md file in each package.',
+      '',
+      'The possible types of changes are: ',
+      '',
+      'MAJOR - these are breaking changes that are not backwards compatible. ' +
+      'Examples are: renaming a public class, adding/removing a non-optional ' +
+      'parameter from a public API, or renaming an variable or function that ' +
+      'is exported.',
+      '',
+      'MINOR - these are changes that are backwards compatible (but not ' +
+      'forwards compatible). Examples are: adding a new public API or adding an ' +
+      'optional parameter to a public API',
+      '',
+      'PATCH - these are changes that are backwards and forwards compatible. ' +
+      'Examples are: Modifying a private API or fixing a bug in the logic ' +
+      'of how an existing API works.',
+      '',
+      'HOTFIX (EXPERIMENTAL) - these are changes that are hotfixes targeting a ' +
+      'specific older version of the package. When a hotfix change is added, ' +
+      'other changes will not be able to increment the version number.' +
+      'Enable this feature by setting \'hotfixChangeEnabled\' in your rush.json.',
+      ''
+    ];
     super({
       actionVerb: 'change',
       summary: 'Records changes made to projects, indicating how the package version number should be bumped ' +
         'for the next publish.',
-      documentation: ['Asks a series of questions and then generates a <branchname>-<timstamp>.json file ' +
-        'in the common folder. The `publish` command will consume these files and perform the proper ' +
-        'version bumps. Note these changes will eventually be published in a changelog.md file in each package.',
-        '',
-        'The possible types of changes are: ',
-        '',
-        'MAJOR - these are breaking changes that are not backwards compatible. ' +
-        'Examples are: renaming a public class, adding/removing a non-optional ' +
-        'parameter from a public API, or renaming an variable or function that ' +
-        'is exported.',
-        '',
-        'MINOR - these are changes that are backwards compatible (but not ' +
-        'forwards compatible). Examples are: adding a new public API or adding an ' +
-        'optional parameter to a public API',
-        '',
-        'PATCH - these are changes that are backwards and forwards compatible. ' +
-        'Examples are: Modifying a private API or fixing a bug in the logic ' +
-        'of how an existing API works.',
-        ''].join(os.EOL)
+      documentation: documentation.join(os.EOL)
     });
     this._parser = parser;
   }
@@ -291,6 +299,11 @@ export default class ChangeAction extends BaseRushAction {
       'minor': 'minor - for backwards compatible changes, e.g. adding a new API',
       'patch': 'patch - for changes that do not affect compatibility, e.g. fixing a bug'
     };
+
+    if (this.rushConfiguration.hotfixChangeEnabled) {
+      // tslint:disable-next-line:no-string-literal
+      bumpOptions['hotfix'] = 'hotfix - for changes that need to be published in a separate hotfix package';
+    }
 
     if (versionPolicy) {
       if (versionPolicy.definitionName === VersionPolicyDefinitionName.lockStepVersion) {

--- a/apps/rush-lib/src/cli/utilities/PublishUtilities.ts
+++ b/apps/rush-lib/src/cli/utilities/PublishUtilities.ts
@@ -17,6 +17,7 @@ import {
   ChangeType
 } from '../../data/ChangeManagement';
 import RushConfigurationProject from '../../data/RushConfigurationProject';
+import RushConfiguration from '../../data/RushConfiguration';
 import Utilities from '../../utilities/Utilities';
 import { execSync } from 'child_process';
 import PrereleaseToken from './PrereleaseToken';
@@ -27,6 +28,19 @@ export interface IChangeInfoHash {
 }
 
 export default class PublishUtilities {
+  private static _rushConfiguration: RushConfiguration;
+
+  public static get rushConfiguration(): RushConfiguration {
+    if (!PublishUtilities._rushConfiguration) {
+      PublishUtilities._rushConfiguration = RushConfiguration.loadFromDefaultLocation();
+    }
+    return PublishUtilities._rushConfiguration;
+  }
+
+  public static set rushConfiguration(newConfiguration: RushConfiguration) {
+    PublishUtilities._rushConfiguration = newConfiguration;
+  }
+
   /**
    * Finds change requests in the given folder.
    * @param changesPath Path to the changes folder.
@@ -85,9 +99,10 @@ export default class PublishUtilities {
         if (skipVersionBump) {
           change.newVersion = pkg.version;
         } else {
+          // For hotfix changes, do not re-write new version
           change.newVersion = (change.changeType! >= ChangeType.patch) ?
             semver.inc(pkg.version, PublishUtilities._getReleaseType(change.changeType!)) :
-            pkg.version;
+            (change.changeType === ChangeType.hotfix ? change.newVersion : pkg.version);
         }
 
         if (deps) {
@@ -205,7 +220,6 @@ export default class PublishUtilities {
   ): string {
     const currentDependencyVersion: string = dependencies[dependencyName];
     let newDependencyVersion: string;
-
     if (PublishUtilities.isRangeDependency(currentDependencyVersion)) {
       newDependencyVersion = PublishUtilities._getNewRangeDependency(newProjectVersion);
     } else if (currentDependencyVersion.lastIndexOf('~', 0) === 0) {
@@ -226,6 +240,8 @@ export default class PublishUtilities {
         return 'minor';
       case ChangeType.patch:
         return 'patch';
+      case ChangeType.hotfix:
+        return 'prerelease';
       default:
         throw new Error(`Wrong change type ${changeType}`);
     }
@@ -353,7 +369,7 @@ export default class PublishUtilities {
             // For prelease, the newVersion needs to be appended with prerelease name.
             // And dependency should specify the specific prerelease version.
             dependencies[depName] = PublishUtilities._getChangeInfoNewVersion(depChange, prereleaseToken);
-          } else if (depChange && depChange.changeType! >= ChangeType.patch) {
+          } else if (depChange && depChange.changeType! >= ChangeType.hotfix) {
             PublishUtilities._updateDependencyVersion(
               packageName,
               dependencies,
@@ -431,6 +447,13 @@ export default class PublishUtilities {
 
       const oldChangeType: ChangeType = currentChange.changeType!;
 
+      if (oldChangeType === ChangeType.hotfix && change.changeType! > oldChangeType) {
+        throw new Error(`Cannot apply ${this._getReleaseType(change.changeType!)} change after hotfix on same package`);
+      }
+      if (change.changeType! === ChangeType.hotfix && oldChangeType > change.changeType!) {
+        throw new Error(`Cannot apply hotfix alongside ${this._getReleaseType(oldChangeType!)} change on same package`);
+      }
+
       currentChange.changeType = Math.max(currentChange.changeType!, change.changeType!);
       currentChange.changes!.push(change);
 
@@ -444,10 +467,27 @@ export default class PublishUtilities {
       hasChanged = false;
       currentChange.changeType = ChangeType.none;
     } else {
-      currentChange.newVersion = change.changeType! >= ChangeType.patch ?
-        semver.inc(pkg.version, PublishUtilities._getReleaseType(currentChange.changeType!)) :
-        pkg.version;
-      currentChange.newRangeDependency = PublishUtilities._getNewRangeDependency(currentChange.newVersion);
+      if (change.changeType === ChangeType.hotfix) {
+        const prereleaseComponents: string[] = semver.prerelease(pkg.version);
+        if (!this.rushConfiguration.hotfixChangeEnabled) {
+          throw new Error(`Cannot add hotfix change; hotfixChangeEnabled is false in configuration.`);
+        }
+
+        currentChange.newVersion = pkg.version;
+        if (!prereleaseComponents) {
+          currentChange.newVersion += '-hotfix';
+        }
+        currentChange.newVersion = semver.inc(currentChange.newVersion, 'prerelease');
+      } else {
+        currentChange.newVersion = change.changeType! >= ChangeType.patch ?
+          semver.inc(pkg.version, PublishUtilities._getReleaseType(currentChange.changeType!)) :
+          pkg.version;
+      }
+
+      // If hotfix change, force new range dependency to be the exact new version
+      currentChange.newRangeDependency = change.changeType === ChangeType.hotfix ?
+        currentChange.newVersion :
+        PublishUtilities._getNewRangeDependency(currentChange.newVersion);
     }
     return hasChanged;
   }
@@ -465,7 +505,7 @@ export default class PublishUtilities {
 
     // Iterate through all downstream dependencies for the package.
     if (downstreamNames) {
-      if ((change.changeType! >= ChangeType.patch) ||
+      if ((change.changeType! >= ChangeType.hotfix) ||
         (prereleaseToken && prereleaseToken.hasValue)) {
         for (const depName of downstreamNames) {
           const pkg: IPackageJson = allPackages.get(depName)!.packageJson;
@@ -497,11 +537,17 @@ export default class PublishUtilities {
       // If the version range exists and has not yet been updated to this version, update it.
       if (requiredVersion !== change.newRangeDependency || alwaysUpdate) {
 
-        // Either it already satisfies the new version, or doesn't.
-        // If not, the downstream dep needs to be republished.
-        const changeType: ChangeType = semver.satisfies(change.newVersion!, requiredVersion) ?
-          ChangeType.dependency :
-          ChangeType.patch;
+        let changeType: ChangeType;
+        // Propagate hotfix changes to dependencies
+        if (change.changeType === ChangeType.hotfix) {
+          changeType = ChangeType.hotfix;
+        } else {
+          // Either it already satisfies the new version, or doesn't.
+          // If not, the downstream dep needs to be republished.
+          changeType = semver.satisfies(change.newVersion!, requiredVersion) ?
+            ChangeType.dependency :
+            ChangeType.patch;
+        }
 
         const hasChanged: boolean = PublishUtilities._addChange({
           packageName: parentPackageName,
@@ -545,8 +591,8 @@ export default class PublishUtilities {
         packageName: packageName,
         changeType: ChangeType.dependency,
         comment:
-        `Updating dependency "${dependencyName}" from \`${currentDependencyVersion}\`` +
-        ` to \`${dependencies[dependencyName]}\``
+          `Updating dependency "${dependencyName}" from \`${currentDependencyVersion}\`` +
+          ` to \`${dependencies[dependencyName]}\``
       },
       allChanges,
       allPackages

--- a/apps/rush-lib/src/cli/utilities/test/ChangeFiles.test.ts
+++ b/apps/rush-lib/src/cli/utilities/test/ChangeFiles.test.ts
@@ -97,5 +97,11 @@ describe('ChangeFiles', () => {
       expect(changeFiles.deleteAll(false, updatedChangelogs)).equals(2,
         'Changes files for a and b should be deleted.');
     });
+
+    it('delete all files when there are hotfixes', () => {
+      const changesPath: string = path.join(__dirname, 'multipleHotfixChanges');
+      const changeFiles: ChangeFiles = new ChangeFiles(changesPath);
+      expect(changeFiles.deleteAll(false)).equals(3);
+    });
   });
 });

--- a/apps/rush-lib/src/cli/utilities/test/ChangelogGenerator.test.ts
+++ b/apps/rush-lib/src/cli/utilities/test/ChangelogGenerator.test.ts
@@ -245,5 +245,32 @@ describe('updateChangelogs', () => {
     expect(updatedChangeLogs.length).eqls(1);
     expect(updatedChangeLogs[0].name).eqls('b');
   });
+
+  it('writes changelog for hotfix changes', () => {
+    const changeHash: IChangeInfoHash = {};
+    // Package a is a hotfix
+    changeHash['a'] = {
+      packageName: 'a',
+      changeType: ChangeType.hotfix,
+      newVersion: '1.0.1-hotfix.1',
+      changes: []
+    };
+    // Package b is not a hotfix
+    changeHash['b'] = {
+      packageName: 'b',
+      changeType: ChangeType.patch,
+      newVersion: '1.0.1',
+      changes: []
+    };
+    // Makes package 'a' hotfix package.
+    const rushProjectA: RushConfigurationProject = rushConfiguration.projectsByName.get('a')!;
+    rushProjectA.packageJson.version = '1.0.1-hotfix.1';
+
+    const updatedChangeLogs: IChangelog[] = ChangelogGenerator.updateChangelogs(
+      changeHash, rushConfiguration.projectsByName, false);
+    expect(updatedChangeLogs.length).eqls(2);
+    expect(updatedChangeLogs[0].name).eqls('a');
+    expect(updatedChangeLogs[1].name).eqls('b');
+  });
   /* tslint:enable:no-string-literal */
 });

--- a/apps/rush-lib/src/cli/utilities/test/hotfixWithPatchChanges/change1.json
+++ b/apps/rush-lib/src/cli/utilities/test/hotfixWithPatchChanges/change1.json
@@ -1,0 +1,7 @@
+{
+  "changes": [{
+    "packageName": "a",
+    "type": "patch",
+    "comment": "Patch change to a"
+  }]
+}

--- a/apps/rush-lib/src/cli/utilities/test/hotfixWithPatchChanges/change2.json
+++ b/apps/rush-lib/src/cli/utilities/test/hotfixWithPatchChanges/change2.json
@@ -1,0 +1,7 @@
+{
+  "changes": [{
+    "packageName": "a",
+    "type": "hotfix",
+    "comment": "Hotfix change to a"
+  }]
+}

--- a/apps/rush-lib/src/cli/utilities/test/hotfixWithPatchChanges/change3.json
+++ b/apps/rush-lib/src/cli/utilities/test/hotfixWithPatchChanges/change3.json
@@ -1,0 +1,7 @@
+{
+  "changes": [{
+    "packageName": "a",
+    "type": "patch",
+    "comment": "Patch change to a"
+  }]
+}

--- a/apps/rush-lib/src/cli/utilities/test/multipleHotfixChanges/change1.json
+++ b/apps/rush-lib/src/cli/utilities/test/multipleHotfixChanges/change1.json
@@ -1,0 +1,7 @@
+{
+  "changes": [{
+    "packageName": "a",
+    "type": "hotfix",
+    "comment": "Hotfix change to a"
+  }]
+}

--- a/apps/rush-lib/src/cli/utilities/test/multipleHotfixChanges/change2.json
+++ b/apps/rush-lib/src/cli/utilities/test/multipleHotfixChanges/change2.json
@@ -1,0 +1,7 @@
+{
+  "changes": [{
+    "packageName": "b",
+    "type": "hotfix",
+    "comment": "Hotfix change to b"
+  }]
+}

--- a/apps/rush-lib/src/cli/utilities/test/multipleHotfixChanges/change3.json
+++ b/apps/rush-lib/src/cli/utilities/test/multipleHotfixChanges/change3.json
@@ -1,0 +1,7 @@
+{
+  "changes": [{
+    "packageName": "a",
+    "type": "hotfix",
+    "comment": "Hotfix change to a"
+  }]
+}

--- a/apps/rush-lib/src/cli/utilities/test/packages/rush.json
+++ b/apps/rush-lib/src/cli/utilities/test/packages/rush.json
@@ -3,6 +3,7 @@
   "rushVersion": "1.0.5",
   "nodeSupportedVersionRange": ">=4.3.0 <7.0.0",
   "projectFolderMinDepth": 1,
+  "hotfixChangeEnabled": true,
   "approvedPackagesPolicy": {
     "reviewCategories": [ "first-party", "third-party", "prototype" ],
     "ignoredNpmScopes": [ "@types", "@internal" ]

--- a/apps/rush-lib/src/cli/utilities/test/rootHotfixChange/change1.json
+++ b/apps/rush-lib/src/cli/utilities/test/rootHotfixChange/change1.json
@@ -1,0 +1,8 @@
+{
+  "changes": [{
+    "packageName": "a",
+    "type": "hotfix",
+    "comment": "Hotfixing a"
+  }]
+}
+

--- a/apps/rush-lib/src/data/ChangeManagement.ts
+++ b/apps/rush-lib/src/data/ChangeManagement.ts
@@ -18,9 +18,10 @@ export interface IChangeFile {
 export enum ChangeType {
   none = 0,
   dependency = 1,
-  patch = 2,
-  minor = 3,
-  major = 4
+  hotfix = 2,
+  patch = 3,
+  minor = 4,
+  major = 5
 }
 
 /**

--- a/apps/rush-lib/src/data/RushConfiguration.ts
+++ b/apps/rush-lib/src/data/RushConfiguration.ts
@@ -85,6 +85,7 @@ export interface IRushConfigurationJson {
   telemetryEnabled?: boolean;
   projects: IRushConfigurationProjectJson[];
   eventHooks?: IEventHooksJson;
+  hotfixChangeEnabled?: boolean;
 }
 
 /**
@@ -135,6 +136,9 @@ export default class RushConfiguration {
   // "gitPolicy" feature
   private _gitAllowedEmailRegExps: string[];
   private _gitSampleEmail: string;
+
+  // "hotfixChangeEnabled" feature
+  private _hotfixChangeEnabled: boolean;
 
   // Repository info
   private _repositoryUrl: string;
@@ -492,6 +496,14 @@ export default class RushConfiguration {
   }
 
   /**
+   * [Part of the "hotfixChange" feature.]
+   * Enables creating hotfix changes
+   */
+  public get hotfixChangeEnabled(): boolean {
+    return this._hotfixChangeEnabled;
+  }
+
+  /**
    * The remote url of the repository. It helps 'Rush change' finds the right remote to compare against.
    */
   public get repositoryUrl(): string {
@@ -657,6 +669,11 @@ export default class RushConfiguration {
             'which is required when using "allowedEmailRegExps"');
         }
       }
+    }
+
+    this._hotfixChangeEnabled = false;
+    if (rushConfigurationJson.hotfixChangeEnabled) {
+      this._hotfixChangeEnabled = rushConfigurationJson.hotfixChangeEnabled;
     }
 
     if (rushConfigurationJson.repository) {

--- a/apps/rush-lib/src/data/test/RushConfiguration.test.ts
+++ b/apps/rush-lib/src/data/test/RushConfiguration.test.ts
@@ -51,6 +51,7 @@ describe('RushConfiguration', () => {
     assert.equal(rushConfiguration.repositoryUrl, 'someFakeUrl', 'Failed to get repository url');
     assert.equal(rushConfiguration.projectFolderMaxDepth, 99, 'Failed to validate projectFolderMaxDepth');
     assert.equal(rushConfiguration.projectFolderMinDepth, 1, 'Failed to validate projectFolderMinDepth');
+    assert.equal(rushConfiguration.hotfixChangeEnabled, true, 'Failed to validate hotfixChangeEnabled');
 
     assert.equal(rushConfiguration.projects.length, 3);
 

--- a/apps/rush-lib/src/data/test/repo/rush-npm.json
+++ b/apps/rush-lib/src/data/test/repo/rush-npm.json
@@ -4,6 +4,7 @@
   "nodeSupportedVersionRange": ">=6.9.0 <7.0.0",
   "projectFolderMinDepth": 1,
   "projectFolderMaxDepth": 99,
+  "hotfixChangeEnabled": true,
 
   "approvedPackagesPolicy": {
     "reviewCategories": [ "first-party", "third-party", "prototype" ],

--- a/apps/rush-lib/src/schemas/rush.schema.json
+++ b/apps/rush-lib/src/schemas/rush.schema.json
@@ -2,7 +2,6 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "title": "Rush Configuration",
   "description": "Configuration file for the Rush multi-package build tool",
-
   "type": "object",
 
   "properties": {
@@ -30,6 +29,10 @@
     "projectFolderMinDepth": {
       "description": "The minimum folder depth for the projectFolder field.  The default value is 1, i.e. no slashes in the path name.",
       "type": "number"
+    },
+    "hotfixChangeEnabled": {
+      "description": "Allows creation of hotfix changes. This feature is experimental so it is disabled by default.",
+      "type": "boolean"
     },
     "projectFolderMaxDepth": {
       "description": "The maximum folder depth for the projectFolder field.  The default value is 2, i.e. a single slash in the path name.",
@@ -125,7 +128,10 @@
           }
         },
         "additionalProperties": false,
-        "required": [ "packageName", "projectFolder" ]
+        "required": [
+          "packageName",
+          "projectFolder"
+        ]
       }
     },
     "eventHooks": {
@@ -165,5 +171,9 @@
     }
   },
   "additionalProperties": false,
-  "required": [ "npmVersion", "rushVersion", "projects" ]
+  "required": [
+    "npmVersion",
+    "rushVersion",
+    "projects"
+  ]
 }

--- a/common/reviews/api/rush-lib.api.ts
+++ b/common/reviews/api/rush-lib.api.ts
@@ -64,13 +64,15 @@ enum ChangeType {
   // (undocumented)
   dependency = 1,
   // (undocumented)
-  major = 4,
+  hotfix = 2,
   // (undocumented)
-  minor = 3,
+  major = 5,
+  // (undocumented)
+  minor = 4,
   // (undocumented)
   none = 0,
   // (undocumented)
-  patch = 2
+  patch = 3
 }
 
 // @beta
@@ -198,6 +200,7 @@ class RushConfiguration {
   public readonly gitAllowedEmailRegExps: string[];
   public readonly gitSampleEmail: string;
   public readonly homeFolder: string;
+  public readonly hotfixChangeEnabled: boolean;
   public static loadFromConfigurationFile(rushJsonFilename: string): RushConfiguration;
   // (undocumented)
   public static loadFromDefaultLocation(): RushConfiguration;

--- a/rush.json
+++ b/rush.json
@@ -1,6 +1,6 @@
 {
   "npmVersion": "4.5.0",
-  "rushVersion": "4.0.0",
+  "rushVersion": "4.0.1",
   "nodeSupportedVersionRange": ">=6.9.0 <7.0.0",
   "projectFolderMinDepth": 1,
 


### PR DESCRIPTION
Added a 'hotfix' bump option for `rush change`

It will append -hotfix.1 to the version number or increment the hotfix version if already on a hotfix branch. 