### PR TITLE
Decrease default Rush parallelism

### DIFF
--- a/apps/rush-lib/src/cli/actions/CustomCommandFactory.ts
+++ b/apps/rush-lib/src/cli/actions/CustomCommandFactory.ts
@@ -22,7 +22,7 @@ export class CustomCommandFactory {
       + ' project contains scripts for "npm run clean" and "npm run test".  It invokes'
       + ' these commands to build each project.  Projects are built in parallel where'
       + ' possible, but always respecting the dependency graph for locally linked projects.'
-      + ' The number of simultaneous processes will be equal to the number of machine cores.'
+      + ' The number of simultaneous processes will be based on the number of machine cores'
       + ' unless overridden by the --parallelism flag.';
 
     // always create a build and a rebuild command

--- a/apps/rush-lib/src/cli/actions/CustomRushAction.ts
+++ b/apps/rush-lib/src/cli/actions/CustomRushAction.ts
@@ -127,7 +127,8 @@ export class CustomRushAction extends BaseRushAction {
         parameterLongName: '--parallelism',
         parameterShortName: '-p',
         key: 'COUNT',
-        description: 'Limit the number of simultaneous executions. This value defaults to the number of CPU cores.'
+        description: 'Specify the number of concurrent build processes.'
+          + ' If omitted, the parallelism will be based on the number of CPU cores.'
       });
     }
     this._toFlag = this.defineStringListParameter({


### PR DESCRIPTION
Some people reported that "rush rebuild" would  make their desktop computers slow because the `--parallelism` flag defaults to using all CPU cores.  This only affects a minority of people, but it's a bad experience.  This PR decreases the default by 1, which was reported to fix the problem.