### PR TITLE
Fix the regression where "rush -h" didn't work outside a repo

### DIFF
--- a/apps/rush-lib/src/cli/actions/CustomRushAction.ts
+++ b/apps/rush-lib/src/cli/actions/CustomRushAction.ts
@@ -190,11 +190,13 @@ export class CustomRushAction extends BaseRushAction {
       }
     });
 
-    this._parser.telemetry.log({
-      name: this.options.actionVerb,
-      duration: stopwatch.duration,
-      result: success ? 'Succeeded' : 'Failed',
-      extraData
-    });
+    if (this._parser.telemetry) {
+      this._parser.telemetry.log({
+        name: this.options.actionVerb,
+        duration: stopwatch.duration,
+        result: success ? 'Succeeded' : 'Failed',
+        extraData
+      });
+    }
   }
 }

--- a/apps/rush-lib/src/cli/actions/InstallAction.ts
+++ b/apps/rush-lib/src/cli/actions/InstallAction.ts
@@ -130,14 +130,16 @@ export default class InstallAction extends BaseRushAction {
   }
 
   private _collectTelemetry(stopwatch: Stopwatch, success: boolean): void {
-    this._parser.telemetry.log({
-      name: 'install',
-      duration: stopwatch.duration,
-      result: success ? 'Succeeded' : 'Failed',
-      extraData: {
-        clean: (!!this._cleanInstall.value).toString(),
-        fullClean: (!!this._cleanInstallFull.value).toString()
-      }
-    });
+    if (this._parser.telemetry) {
+      this._parser.telemetry.log({
+        name: 'install',
+        duration: stopwatch.duration,
+        result: success ? 'Succeeded' : 'Failed',
+        extraData: {
+          clean: (!!this._cleanInstall.value).toString(),
+          fullClean: (!!this._cleanInstallFull.value).toString()
+        }
+      });
+    }
   }
 }

--- a/apps/rush-lib/src/cli/actions/RushCommandLineParser.ts
+++ b/apps/rush-lib/src/cli/actions/RushCommandLineParser.ts
@@ -26,7 +26,7 @@ import { CustomRushAction } from './CustomRushAction';
 import Telemetry from '../utilities/Telemetry';
 
 export default class RushCommandLineParser extends CommandLineParser {
-  public telemetry: Telemetry;
+  public telemetry: Telemetry | undefined;
   public rushConfig: RushConfiguration;
 
   private _debugParameter: CommandLineFlagParameter;
@@ -90,9 +90,15 @@ export default class RushCommandLineParser extends CommandLineParser {
   }
 
   private _execute(): void {
-    this.telemetry = new Telemetry(this.rushConfig);
+    if (this.rushConfig) {
+      this.telemetry = new Telemetry(this.rushConfig);
+    }
+
     super.onExecute();
-    this.flushTelemetry();
+
+    if (this.telemetry) {
+      this.flushTelemetry();
+    }
   }
 
   private _populateActions(): void {

--- a/apps/rush-lib/src/cli/actions/RushCommandLineParser.ts
+++ b/apps/rush-lib/src/cli/actions/RushCommandLineParser.ts
@@ -97,13 +97,16 @@ export default class RushCommandLineParser extends CommandLineParser {
 
   private _populateActions(): void {
     try {
-      this.rushConfig = RushConfiguration.loadFromDefaultLocation();
+      let  commandLineConfig: CommandLineConfiguration | undefined = undefined;
 
-      const commandLineConfigFile: string = path.join(
-        this.rushConfig.commonRushConfigFolder, RushConstants.commandLineFilename);
+      if (RushConfiguration.tryFindRushJsonLocation()) {
+        this.rushConfig = RushConfiguration.loadFromDefaultLocation();
 
-      const commandLineConfig: CommandLineConfiguration =
-        CommandLineConfiguration.tryLoadFromFile(commandLineConfigFile);
+        const commandLineConfigFile: string = path.join(
+          this.rushConfig.commonRushConfigFolder, RushConstants.commandLineFilename);
+
+        commandLineConfig = CommandLineConfiguration.tryLoadFromFile(commandLineConfigFile);
+      }
 
       this.addAction(new ChangeAction(this));
       this.addAction(new CheckAction(this));
@@ -119,6 +122,7 @@ export default class RushCommandLineParser extends CommandLineParser {
         .forEach((customAction: CustomRushAction) => {
           this.addAction(customAction);
         });
+
     } catch (error) {
       this._exitAndReportError(error);
     }

--- a/apps/rush-lib/src/cli/actions/RushCommandLineParser.ts
+++ b/apps/rush-lib/src/cli/actions/RushCommandLineParser.ts
@@ -105,8 +105,9 @@ export default class RushCommandLineParser extends CommandLineParser {
     try {
       let  commandLineConfig: CommandLineConfiguration | undefined = undefined;
 
-      if (RushConfiguration.tryFindRushJsonLocation()) {
-        this.rushConfig = RushConfiguration.loadFromDefaultLocation();
+      const rushJsonFilename: string | undefined = RushConfiguration.tryFindRushJsonLocation();
+      if (rushJsonFilename) {
+        this.rushConfig = RushConfiguration.loadFromConfigurationFile(rushJsonFilename);
 
         const commandLineConfigFile: string = path.join(
           this.rushConfig.commonRushConfigFolder, RushConstants.commandLineFilename);

--- a/apps/rush-lib/src/cli/test/Cli.test.ts
+++ b/apps/rush-lib/src/cli/test/Cli.test.ts
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+/// <reference types='mocha' />
+
+import * as path from 'path';
+import { assert } from 'chai';
+
+import Utilities from '../../utilities/Utilities';
+
+describe('CLI', () => {
+  it('should not fail when there is no rush.json', () => {
+    const workingDir: string = '/';
+    const startPath: string = path.resolve(path.join(__dirname, '../../start.js'));
+
+    assert.doesNotThrow(() => {
+      Utilities.executeCommand('node', [ startPath ], workingDir, true);
+    }, 'rush -h is broken');
+  });
+});


### PR DESCRIPTION
The `rush -h` command was failing when you ran it outside a repo, because code had crept in that assumes there is a RushConfiguration object.

This broke our [3 Minute Demo](https://github.com/Microsoft/web-build-tools/wiki/Rush#3-minute-demo).