### PR TITLE
Enable strict-null-checks for api-extractor

### DIFF
--- a/apps/api-extractor/src/ApiDefinitionReference.ts
+++ b/apps/api-extractor/src/ApiDefinitionReference.ts
@@ -121,7 +121,7 @@ export default class ApiDefinitionReference {
     };
 
     // E.g. @microsoft/sp-core-library:Guid.equals
-    let parts: string[] = apiReferenceExpr.match(ApiDefinitionReference._packageRegEx);
+    let parts: string[] | null = apiReferenceExpr.match(ApiDefinitionReference._packageRegEx);
     if (parts) {
       // parts[1] is of the form ‘@microsoft/sp-core-library’ or ‘sp-core-library’
       const scopePackageName: IScopedPackageName = ApiDefinitionReference.parseScopedPackageName(parts[1]);

--- a/apps/api-extractor/src/ResolvedApiItem.ts
+++ b/apps/api-extractor/src/ResolvedApiItem.ts
@@ -16,15 +16,15 @@ export default class ResolvedApiItem {
   public kind: AstItemKind;
   public summary: MarkupElement[];
   public remarks: MarkupElement[];
-  public deprecatedMessage: MarkupBasicElement[];
+  public deprecatedMessage: MarkupBasicElement[] | undefined;
   public releaseTag: ReleaseTag;
   public isBeta: boolean;
-  public params: {[name: string]: IAedocParameter};
-  public returnsMessage: MarkupBasicElement[];
+  public params: { [name: string]: IAedocParameter } | undefined;
+  public returnsMessage: MarkupBasicElement[] | undefined;
   /**
    * This property will either be an AstItem or undefined.
    */
-  public astItem: AstItem;
+  public astItem: AstItem | undefined;
 
   /**
    * A function to abstract the construction of a ResolvedApiItem instance
@@ -49,8 +49,8 @@ export default class ResolvedApiItem {
    * from a JSON object that symbolizes an ApiItem.
    */
   public static createFromJson(docItem: ApiItem): ResolvedApiItem {
-    let parameters: {[name: string]: IAedocParameter} = undefined;
-    let returnsMessage: MarkupBasicElement[] = undefined;
+    let parameters: { [name: string]: IAedocParameter } | undefined = undefined;
+    let returnsMessage: MarkupBasicElement[] | undefined = undefined;
     switch (docItem.kind) {
       case 'function':
         parameters = docItem.parameters;
@@ -81,12 +81,12 @@ export default class ResolvedApiItem {
     kind: AstItemKind,
     summary: MarkupElement[],
     remarks: MarkupElement[],
-    deprecatedMessage: MarkupBasicElement[],
+    deprecatedMessage: MarkupBasicElement[] | undefined,
     isBeta: boolean,
-    params:  {[name: string]: IAedocParameter},
-    returnsMessage: MarkupBasicElement[],
+    params: { [name: string]: IAedocParameter } | undefined,
+    returnsMessage: MarkupBasicElement[] | undefined,
     releaseTag: ReleaseTag,
-    astItem: AstItem) {
+    astItem: AstItem | undefined) {
     this.kind = kind;
     this.summary = summary;
     this.remarks = remarks;

--- a/apps/api-extractor/src/TypeScriptHelpers.ts
+++ b/apps/api-extractor/src/TypeScriptHelpers.ts
@@ -140,7 +140,7 @@ export default class TypeScriptHelpers {
 
     const result: string[] = [];
     let index: number = 0;
-    let match: RegExpExecArray;
+    let match: RegExpExecArray | null;
 
     do {
       match = regExp.exec(text);

--- a/apps/api-extractor/src/aedoc/test/Tokenizer.test.ts
+++ b/apps/api-extractor/src/aedoc/test/Tokenizer.test.ts
@@ -24,7 +24,7 @@ class TestTokenizer extends Tokenizer {
     return this._tokenizeDocs(docs);
   }
 
-  public tokenizeInline(docs: string): Token {
+  public tokenizeInline(docs: string): Token | undefined {
     return this._tokenizeInline(docs);
   }
 }
@@ -59,10 +59,10 @@ describe('Tokenizer tests', function (): void {
     it('tokenizeInline()', function (): void {
       const token: string = '{    @link   https://bing.com  |  Bing  }';
       const expectedToken: Token = new Token(TokenType.InlineTag, '@link', 'https://bing.com | Bing');
-      const actualToken: Token = testTokenizer.tokenizeInline(token);
-      assert.equal(expectedToken.type, actualToken.type);
-      assert.equal(expectedToken.tag, actualToken.tag);
-      assert.equal(expectedToken.text, actualToken.text);
+      const actualToken: Token | undefined = testTokenizer.tokenizeInline(token);
+      assert.equal(expectedToken.type, actualToken!.type);
+      assert.equal(expectedToken.tag, actualToken!.tag);
+      assert.equal(expectedToken.text, actualToken!.text);
     });
   });
 });

--- a/apps/api-extractor/src/ast/AstItem.ts
+++ b/apps/api-extractor/src/ast/AstItem.ts
@@ -116,7 +116,7 @@ export interface IAstItemOptions {
    * In most cases this is the same as `declaration`, but for AstPackage it will be
    * a separate node under the root.
    */
-  jsdocNode: ts.Node;
+  jsdocNode: ts.Node | undefined;
   /**
    * The symbol used to export this AstItem from the AstPackage.
    */
@@ -204,7 +204,7 @@ abstract class AstItem {
    * In most cases this is the same as `declaration`, but for AstPackage it will be
    * a separate node under the root.
    */
-  public jsdocNode: ts.Node;
+  public jsdocNode: ts.Node | undefined;
 
   /**
    * The parsed AEDoc comment for this item.
@@ -568,7 +568,7 @@ abstract class AstItem {
    * This is a helper for visitTypeReferencesForNode().  It analyzes a single TypeReferenceNode.
    */
   private _analyzeTypeReference(typeReferenceNode: ts.TypeReferenceNode): void {
-    const symbol: ts.Symbol = this.context.typeChecker.getSymbolAtLocation(typeReferenceNode.typeName);
+    const symbol: ts.Symbol | undefined = this.context.typeChecker.getSymbolAtLocation(typeReferenceNode.typeName);
     if (!symbol) {
       // Is this bad?
       return;
@@ -591,7 +591,7 @@ abstract class AstItem {
     // Walk upwards from that directory until you find a directory containing package.json,
     // this is where the referenced type is located.
     // Example: "c:\users\<username>\sp-client\spfx-core\sp-core-library"
-    const typeReferencePackagePath: string = this.context.packageJsonLookup
+    const typeReferencePackagePath: string | undefined = this.context.packageJsonLookup
       .tryGetPackageFolder(sourceFile.fileName);
     // Example: "@microsoft/sp-core-library"
     let typeReferencePackageName: string = '';
@@ -610,6 +610,7 @@ abstract class AstItem {
           // returning true breaks the every loop
           return true;
         }
+        return false;
       });
     }
 
@@ -620,7 +621,7 @@ abstract class AstItem {
     const typeName: string = typeReferenceNode.typeName.getText();
     if (!typeReferencePackagePath || typeReferencePackageName === currentPackageName) {
       // The type is defined in this project.  Did the person remember to export it?
-      const exportedLocalName: string = this.context.package.tryGetExportedSymbolName(currentSymbol);
+      const exportedLocalName: string | undefined = this.context.package.tryGetExportedSymbolName(currentSymbol);
       if (exportedLocalName) {
         // [CASE 1] Local/Exported
         // Yes; the type is properly exported.
@@ -652,8 +653,8 @@ abstract class AstItem {
     // after the period is the member name
     if (currentSymbol.name.indexOf('.') > -1) {
       const exportMemberName: string[] = currentSymbol.name.split('.');
-      apiDefinitionRefParts.exportName = exportMemberName.pop();
-      apiDefinitionRefParts.memberName = exportMemberName.pop();
+      apiDefinitionRefParts.exportName = exportMemberName.pop() || '';
+      apiDefinitionRefParts.memberName = exportMemberName.pop() || '';
     } else {
       apiDefinitionRefParts.exportName = currentSymbol.name;
     }
@@ -664,7 +665,7 @@ abstract class AstItem {
 
     // Attempt to resolve the type by checking the node modules
     const referenceResolutionWarnings: string[] = [];
-    const resolvedAstItem: ResolvedApiItem = this.context.docItemLoader.resolveJsonReferences(
+    const resolvedAstItem: ResolvedApiItem | undefined = this.context.docItemLoader.resolveJsonReferences(
       apiDefinitionRef,
       referenceResolutionWarnings
     );

--- a/apps/api-extractor/src/ast/AstItemContainer.ts
+++ b/apps/api-extractor/src/ast/AstItemContainer.ts
@@ -19,7 +19,7 @@ abstract class AstItemContainer extends AstItem {
    *
    * @param memberName - the name of the exported AstItem
    */
-  public getMemberItem(memberName: string): AstItem {
+  public getMemberItem(memberName: string): AstItem | undefined {
     return this._memberItems.get(memberName);
   }
 

--- a/apps/api-extractor/src/ast/AstMember.ts
+++ b/apps/api-extractor/src/ast/AstMember.ts
@@ -36,7 +36,7 @@ export default class AstMember extends AstItem {
    * The type of the member item, if specified as a type literal expression.  Otherwise,
    * this field is undefined.
    */
-  public typeLiteral: AstStructuredType;
+  public typeLiteral: AstStructuredType | undefined;
 
   constructor(options: IAstItemOptions) {
     super(options);
@@ -95,7 +95,7 @@ export default class AstMember extends AstItem {
    */
   public getDeclarationLine(property?: {type: string; readonly: boolean}): string {
     if (this.typeLiteral || !!property) {
-      const accessModifier: string =
+      const accessModifier: string | undefined =
         this.accessModifier ? ApiAccessModifier[this.accessModifier].toLowerCase() : undefined;
 
       let result: string = accessModifier ? `${accessModifier} ` : '';

--- a/apps/api-extractor/src/ast/AstMethod.ts
+++ b/apps/api-extractor/src/ast/AstMethod.ts
@@ -75,10 +75,10 @@ export default class AstMethod extends AstMember {
           .parseScopedPackageName(this.context.package.name);
 
         this.documentation.summary.push(
-          Markup.createApiLinkFromText(this.parentContainer.name, {
+          Markup.createApiLinkFromText(this.parentContainer!.name, {
               scopeName: scopedPackageName.scope,
               packageName: scopedPackageName.package,
-              exportName: this.parentContainer.name,
+              exportName: this.parentContainer!.name,
               memberName: ''
             }
           )

--- a/apps/api-extractor/src/ast/AstModuleVariable.ts
+++ b/apps/api-extractor/src/ast/AstModuleVariable.ts
@@ -21,9 +21,19 @@ class AstModuleVariable extends AstMember {
     this.kind = AstItemKind.ModuleVariable;
 
     const propertySignature: ts.PropertySignature = options.declaration as ts.PropertySignature;
-    this.type = propertySignature.type.getText();
+    if (propertySignature.type) {
+      this.type = propertySignature.type.getText();
+    } else {
+      this.type = '';
+    }
+
     this.name = propertySignature.name.getText();
-    this.value = propertySignature.initializer.getText(); // value of the export
+
+    if (propertySignature.initializer) {
+      this.value = propertySignature.initializer.getText(); // value of the export
+    } else {
+      this.value = '';
+    }
   }
 }
 

--- a/apps/api-extractor/src/ast/AstNamespace.ts
+++ b/apps/api-extractor/src/ast/AstNamespace.ts
@@ -65,9 +65,14 @@ export default class AstNamespace extends AstModule {
       // const properties we are only taking the first declaration.
       // If we decide to add support for other types within a namespace
       // we will have for evaluate each declaration.
-      const declaration: ts.Declaration = followedSymbol.getDeclarations()[0];
+      const declarations: ts.Declaration[] | undefined = followedSymbol.getDeclarations();
+      if (!declarations) {
+        throw new Error('Missing declaration');
+      }
 
-      if (declaration.parent.flags !== ts.NodeFlags.Const) {
+      const declaration: ts.Declaration = declarations[0];
+
+      if (declaration.parent && declaration.parent.flags !== ts.NodeFlags.Const) {
         this.reportWarning(`Export "${exportSymbol.name}" is missing the "const" ` +
           'modifier. Currently the "namespace" block only supports constant variables.');
         continue;
@@ -90,7 +95,7 @@ export default class AstNamespace extends AstModule {
       // the JSDoc comment Node can be found.
       // If there is no parent or grandparent of this VariableDeclaration then
       // we do not know how to obtain the JSDoc comment.
-      let jsdocNode: ts.Node;
+      let jsdocNode: ts.Node | undefined = undefined;
       if (!declaration.parent || !declaration.parent.parent ||
         declaration.parent.parent.kind !== ts.SyntaxKind.VariableStatement) {
         this.reportWarning(`Unable to locate the documentation node for "${exportSymbol.name}"; `

--- a/apps/api-extractor/src/ast/AstPackage.ts
+++ b/apps/api-extractor/src/ast/AstPackage.ts
@@ -20,7 +20,7 @@ export default class AstPackage extends AstModule {
   private static _getOptions(context: ExtractorContext, rootFile: ts.SourceFile): IAstItemOptions {
     const rootFileSymbol: ts.Symbol = TypeScriptHelpers.getSymbolForDeclaration(rootFile);
     let statement: ts.VariableStatement;
-    let foundDescription: ts.Node = undefined;
+    let foundDescription: ts.Node | undefined = undefined;
 
     for (const statementNode of rootFile.statements) {
       if (statementNode.kind === ts.SyntaxKind.VariableStatement) {
@@ -31,6 +31,10 @@ export default class AstPackage extends AstModule {
           }
         }
       }
+    }
+
+    if (!rootFileSymbol.declarations) {
+      throw new Error('Unable to find a root declaration for this package');
     }
 
     return {
@@ -72,7 +76,7 @@ export default class AstPackage extends AstModule {
    * In this example, given the symbol for _MyClass, getExportedSymbolName() will return
    * the string "MyClass".
    */
-  public tryGetExportedSymbolName(symbol: ts.Symbol): string {
+  public tryGetExportedSymbolName(symbol: ts.Symbol): string | undefined {
     const followedSymbol: ts.Symbol = this.followAliases(symbol);
     for (const exportedSymbol of this._exportedNormalizedSymbols) {
       if (exportedSymbol.followedSymbol === followedSymbol) {

--- a/apps/api-extractor/src/ast/AstStructuredType.ts
+++ b/apps/api-extractor/src/ast/AstStructuredType.ts
@@ -78,8 +78,11 @@ export default class AstStructuredType extends AstItemContainer {
     // Check for heritage clauses (implements and extends)
     if (this._classLikeDeclaration.heritageClauses) {
       for (const heritage of this._classLikeDeclaration.heritageClauses) {
-        const typeText: string = heritage.types && heritage.types.length && heritage.types[0].expression ?
-          heritage.types[0].expression.getText() : undefined;
+
+        const typeText: string | undefined = heritage.types && heritage.types.length
+          && heritage.types[0].expression
+          ? heritage.types[0].expression.getText() : undefined;
+
         if (heritage.token === ts.SyntaxKind.ExtendsKeyword) {
           this.extends = typeText;
         } else if (heritage.token === ts.SyntaxKind.ImplementsKeyword) {

--- a/apps/api-extractor/src/generators/ApiJsonGenerator.ts
+++ b/apps/api-extractor/src/generators/ApiJsonGenerator.ts
@@ -95,7 +95,7 @@ export default class ApiJsonGenerator extends AstItemVisitor {
       remarks: astStructuredType.documentation.remarks || [],
       isBeta: astStructuredType.inheritedReleaseTag === ReleaseTag.Beta
     };
-    refObject[astStructuredType.name] = structureNode;
+    refObject![astStructuredType.name] = structureNode;
 
     ApiJsonGenerator._methodCounter = 0;
 
@@ -125,7 +125,7 @@ export default class ApiJsonGenerator extends AstItemVisitor {
       remarks: astEnum.documentation.remarks || [],
       isBeta: astEnum.inheritedReleaseTag === ReleaseTag.Beta
     };
-    refObject[astEnum.name] = enumNode;
+    refObject![astEnum.name] = enumNode;
 
     for (const astItem of astEnum.getSortedMemberItems()) {
       this.visit(astItem, valuesNode);
@@ -138,12 +138,12 @@ export default class ApiJsonGenerator extends AstItemVisitor {
     }
 
     const declaration: ts.Declaration = astEnumValue.getDeclaration();
-    const firstToken: ts.Node = declaration ? declaration.getFirstToken() : undefined;
-    const lastToken: ts.Node = declaration ? declaration.getLastToken() : undefined;
+    const firstToken: ts.Node | undefined = declaration ? declaration.getFirstToken() : undefined;
+    const lastToken: ts.Node | undefined = declaration ? declaration.getLastToken() : undefined;
 
     const value: string = lastToken && lastToken !== firstToken ? lastToken.getText() : '';
 
-    refObject[astEnumValue.name] = {
+    refObject![astEnumValue.name] = {
       kind: ApiJsonConverter.convertKindToJson(astEnumValue.kind),
       value: value,
       deprecatedMessage: astEnumValue.inheritedDeprecatedMessage || [],
@@ -174,19 +174,19 @@ export default class ApiJsonGenerator extends AstItemVisitor {
       isBeta: astFunction.inheritedReleaseTag === ReleaseTag.Beta
     };
 
-    refObject[astFunction.name] = newNode;
+    refObject![astFunction.name] = newNode;
   }
 
   protected visitAstPackage(astPackage: AstPackage, refObject?: Object): void {
     /* tslint:disable:no-string-literal */
-    refObject['kind'] = ApiJsonConverter.convertKindToJson(astPackage.kind);
-    refObject['name'] = astPackage.name;
-    refObject['summary'] = astPackage.documentation.summary;
-    refObject['remarks'] = astPackage.documentation.remarks;
+    refObject!['kind'] = ApiJsonConverter.convertKindToJson(astPackage.kind);
+    refObject!['name'] = astPackage.name;
+    refObject!['summary'] = astPackage.documentation.summary;
+    refObject!['remarks'] = astPackage.documentation.remarks;
     /* tslint:enable:no-string-literal */
 
     const membersNode: Object = {};
-    refObject[ApiJsonGenerator._EXPORTS_KEY] = membersNode;
+    refObject![ApiJsonGenerator._EXPORTS_KEY] = membersNode;
 
     for (const astItem of astPackage.getSortedMemberItems()) {
       this.visit(astItem, membersNode);
@@ -212,7 +212,7 @@ export default class ApiJsonGenerator extends AstItemVisitor {
       exports: membersNode
     };
 
-    refObject[astNamespace.name] = newNode;
+    refObject![astNamespace.name] = newNode;
   }
 
   protected visitAstMember(astMember: AstMember, refObject?: Object): void {
@@ -220,7 +220,7 @@ export default class ApiJsonGenerator extends AstItemVisitor {
       return;
     }
 
-    refObject[astMember.name] = 'astMember-' + astMember.getDeclaration().kind;
+    refObject![astMember.name] = 'astMember-' + astMember.getDeclaration().kind;
   }
 
   protected visitAstProperty(astProperty: AstProperty, refObject?: Object): void {
@@ -245,7 +245,7 @@ export default class ApiJsonGenerator extends AstItemVisitor {
       isBeta: astProperty.inheritedReleaseTag === ReleaseTag.Beta
     };
 
-    refObject[astProperty.name] = newNode;
+    refObject![astProperty.name] = newNode;
   }
 
   protected visitAstModuleVariable(astModuleVariable: AstModuleVariable, refObject?: Object): void {
@@ -260,7 +260,7 @@ export default class ApiJsonGenerator extends AstItemVisitor {
       isBeta: astModuleVariable.inheritedReleaseTag === ReleaseTag.Beta
     };
 
-    refObject[astModuleVariable.name] = newNode;
+    refObject![astModuleVariable.name] = newNode;
   }
 
   protected visitAstMethod(astMethod: AstMethod, refObject?: Object): void {
@@ -299,7 +299,7 @@ export default class ApiJsonGenerator extends AstItemVisitor {
       };
     }
 
-    refObject[astMethod.name] = newNode;
+    refObject![astMethod.name] = newNode;
   }
 
   private _createParameters(astFunction: AstMethod | AstFunction): IApiNameMap<IApiParameter> {

--- a/apps/api-extractor/src/generators/Span.ts
+++ b/apps/api-extractor/src/generators/Span.ts
@@ -129,7 +129,7 @@ export class Span {
     this.children = [];
     this.modification = new SpanModification(this);
 
-    let previousChildSpan: Span = undefined;
+    let previousChildSpan: Span | undefined = undefined;
 
     for (const childNode of this.node.getChildren() || []) {
       const childSpan: Span = new Span(childNode);

--- a/apps/api-extractor/src/markup/Markup.ts
+++ b/apps/api-extractor/src/markup/Markup.ts
@@ -333,8 +333,8 @@ export class Markup {
       const previousElement: T | undefined = i - 1 >= 0 ? elements[i - 1] : undefined;
       const nextElement: T | undefined = i + 1 < elements.length ? elements[i + 1] : undefined;
 
-      const paragraphBefore: boolean = previousElement && previousElement.kind === 'paragraph';
-      const paragraphAfter: boolean = nextElement && nextElement.kind === 'paragraph';
+      const paragraphBefore: boolean = !!(previousElement && previousElement.kind === 'paragraph');
+      const paragraphAfter: boolean = !!(nextElement && nextElement.kind === 'paragraph');
 
       if (element.kind === 'paragraph') {
         if (i === 0 || i === elements.length - 1 || paragraphBefore) {
@@ -385,8 +385,10 @@ export class Markup {
           buffer.text += '\n\n';
           break;
         case 'table':
-          buffer.text += Markup.extractTextContent([element.header])
-            + Markup.extractTextContent(element.rows);
+          if (element.header) {
+            buffer.text += Markup.extractTextContent([element.header]);
+          }
+          buffer.text += Markup.extractTextContent(element.rows);
           break;
         case 'table-cell':
           buffer.text += Markup.extractTextContent(element.elements);

--- a/apps/api-extractor/src/test/ApiDefinitionReference.test.ts
+++ b/apps/api-extractor/src/test/ApiDefinitionReference.test.ts
@@ -27,36 +27,36 @@ describe('ApiDocumentation tests', function (): void {
 
   describe('ApiDocumentation internal methods', function (): void {
     let apiReferenceExpr: string;
-    let actual: ApiDefinitionReference;
+    let actual: ApiDefinitionReference | undefined;
 
     it('_parseApiReferenceExpression() with scope name', function (): void {
       apiReferenceExpr = '@microsoft/sp-core-library:Guid';
 
       actual = ApiDefinitionReference.createFromString(apiReferenceExpr, console.log);
-      assert.equal('@microsoft', actual.scopeName);
-      assert.equal('sp-core-library', actual.packageName);
-      assert.equal('Guid', actual.exportName);
-      assert.equal('', actual.memberName);
+      assert.equal('@microsoft', actual!.scopeName);
+      assert.equal('sp-core-library', actual!.packageName);
+      assert.equal('Guid', actual!.exportName);
+      assert.equal('', actual!.memberName);
     });
 
     it('_parseApiReferenceExpression() without scope name', function (): void {
       apiReferenceExpr = 'sp-core-library:Guid';
 
       actual = ApiDefinitionReference.createFromString(apiReferenceExpr, console.log);
-      assert.equal('', actual.scopeName);
-      assert.equal('sp-core-library', actual.packageName);
-      assert.equal('Guid', actual.exportName);
-      assert.equal('', actual.memberName);
+      assert.equal('', actual!.scopeName);
+      assert.equal('sp-core-library', actual!.packageName);
+      assert.equal('Guid', actual!.exportName);
+      assert.equal('', actual!.memberName);
     });
 
     it('_parseApiReferenceExpression() without scope name and with member name', function (): void {
       apiReferenceExpr = 'sp-core-library:Guid.equals';
 
       actual = ApiDefinitionReference.createFromString(apiReferenceExpr, console.log);
-      assert.equal('', actual.scopeName);
-      assert.equal('sp-core-library', actual.packageName);
-      assert.equal('Guid', actual.exportName);
-      assert.equal('equals', actual.memberName);
+      assert.equal('', actual!.scopeName);
+      assert.equal('sp-core-library', actual!.packageName);
+      assert.equal('Guid', actual!.exportName);
+      assert.equal('equals', actual!.memberName);
     });
 
     it('_parseApiReferenceExpression() without scope name and invalid memberName', function (): void {

--- a/apps/api-extractor/tsconfig.json
+++ b/apps/api-extractor/tsconfig.json
@@ -6,6 +6,7 @@
     "declaration": true,
     "sourceMap": true,
     "experimentalDecorators": true,
+    "strictNullChecks": true,
     "types": [
       "node"
     ],

--- a/common/changes/@microsoft/api-extractor/pgonzal-ae-strict-null-checks_2017-11-15-02-10.json
+++ b/common/changes/@microsoft/api-extractor/pgonzal-ae-strict-null-checks_2017-11-15-02-10.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@microsoft/api-extractor",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor",
+  "email": "pgonzal@users.noreply.github.com"
+}


### PR DESCRIPTION
Turn on the **strict-null-checks** setting in tsconfig.json.