### PR TITLE
Update handlebars in package.json samples so GitHub does not show a warning message

### DIFF
--- a/apps/rush-lib/src/cli/utilities/test/packages/c/package.json
+++ b/apps/rush-lib/src/cli/utilities/test/packages/c/package.json
@@ -4,6 +4,6 @@
   "description": "Test package c",
   "dependencies": {
     "b": ">=1.0.0 <2.0.0",
-    "handlebars": "3.0.0"
+    "handlebars": "~4.0.11"
   }
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/17131271/32917203-4aed6012-cad3-11e7-8058-388ff7173bec.png)

GitHub is detecting a security vulnerability in an old version of handlebars, which is being referenced by a sample `package.json` file. We simply need to update this version to remove the warning, which should have no side effects, since this file isn't really used by anything except for some unit tests which read the `rush.json` and `package.json` files.