### PR TITLE
Fix issues with file locks during tarball creation

### DIFF
--- a/apps/rush-lib/src/cli/actions/GenerateAction.ts
+++ b/apps/rush-lib/src/cli/actions/GenerateAction.ts
@@ -86,7 +86,7 @@ export default class GenerateAction extends BaseRushAction {
 
     installManager.ensureLocalNpmTool(false);
 
-    installManager.createTempModules();
+    installManager.createTempModules(true);
 
     // Delete both copies of the shrinkwrap file
     if (fsx.existsSync(this.rushConfiguration.committedShrinkwrapFilename)) {

--- a/apps/rush-lib/src/cli/actions/GenerateAction.ts
+++ b/apps/rush-lib/src/cli/actions/GenerateAction.ts
@@ -71,7 +71,7 @@ export default class GenerateAction extends BaseRushAction {
 
       if (shrinkwrapFile
         && !this._forceParameter.value
-        && installManager.createTempModulesAndCheckShrinkwrap(shrinkwrapFile)) {
+        && installManager.createTempModulesAndCheckShrinkwrap(shrinkwrapFile, false)) {
         console.log();
         console.log(colors.yellow('Skipping generate, since all project dependencies are already satisfied.'));
         console.log();

--- a/apps/rush-lib/src/cli/actions/InstallAction.ts
+++ b/apps/rush-lib/src/cli/actions/InstallAction.ts
@@ -93,18 +93,18 @@ export default class InstallAction extends BaseRushAction {
         return;
       }
 
-      if (!installManager.createTempModulesAndCheckShrinkwrap(shrinkwrapFile)) {
-        console.log('');
-        console.log(colors.red('You need to run "rush generate" to update your NPM shrinkwrap file.'));
-        process.exit(1);
-        return;
-      }
-
       let installType: InstallType = InstallType.Normal;
       if (this._cleanInstallFull.value) {
         installType = InstallType.UnsafePurge;
       } else if (this._cleanInstall.value) {
         installType = InstallType.ForceClean;
+      }
+
+      if (!installManager.createTempModulesAndCheckShrinkwrap(shrinkwrapFile, installType !== InstallType.Normal)) {
+        console.log('');
+        console.log(colors.red('You need to run "rush generate" to update your NPM shrinkwrap file.'));
+        process.exit(1);
+        return;
       }
 
       installManager.installCommonModules(installType);

--- a/apps/rush-lib/src/cli/utilities/InstallManager.ts
+++ b/apps/rush-lib/src/cli/utilities/InstallManager.ts
@@ -440,6 +440,8 @@ export default class InstallManager {
       }
     }
 
+    process.exit();
+
     // Example: "C:\MyRepo\common\temp\package.json"
     const commonPackageJsonFilename: string = path.join(this._rushConfiguration.commonTempFolder,
       RushConstants.packageJsonFilename);

--- a/apps/rush-lib/src/cli/utilities/InstallManager.ts
+++ b/apps/rush-lib/src/cli/utilities/InstallManager.ts
@@ -440,8 +440,6 @@ export default class InstallManager {
       }
     }
 
-    process.exit();
-
     // Example: "C:\MyRepo\common\temp\package.json"
     const commonPackageJsonFilename: string = path.join(this._rushConfiguration.commonTempFolder,
       RushConstants.packageJsonFilename);

--- a/apps/rush-lib/src/cli/utilities/InstallManager.ts
+++ b/apps/rush-lib/src/cli/utilities/InstallManager.ts
@@ -195,8 +195,8 @@ export default class InstallManager {
   /**
    * Regenerates the common/package.json and all temp_modules projects.
    */
-  public createTempModules(): void {
-    this.createTempModulesAndCheckShrinkwrap(undefined);
+  public createTempModules(forceCreate: boolean = false): void {
+    this.createTempModulesAndCheckShrinkwrap(undefined, forceCreate);
   }
 
   /**
@@ -205,7 +205,9 @@ export default class InstallManager {
    * everything we need to install and returns true if so; in all other cases,
    * the return value is false.
    */
-  public createTempModulesAndCheckShrinkwrap(shrinkwrapFile: ShrinkwrapFile | undefined): boolean {
+  public createTempModulesAndCheckShrinkwrap(
+    shrinkwrapFile: ShrinkwrapFile | undefined,
+    forceCreate: boolean = false): boolean {
     const stopwatch: Stopwatch = Stopwatch.start();
 
     // Example: "C:\MyRepo\common\temp\projects"
@@ -391,7 +393,7 @@ export default class InstallManager {
       // we only want to overwrite the package if the existing tarball's package.json is different from tempPackageJson
       let shouldOverwrite: boolean = true;
       try {
-        // if the tarball and the temp folder still exist, then compare the contents
+        // if the tarball and the temp file still exist, then compare the contents
         if (fsx.existsSync(tarballFile) && fsx.existsSync(tempPackageJsonFilename)) {
 
           // compare the extracted package.json with the one we are about to write
@@ -406,7 +408,7 @@ export default class InstallManager {
         // ignore the error, we will go ahead and create a new tarball
       }
 
-      if (shouldOverwrite) {
+      if (shouldOverwrite || forceCreate) {
         try {
           // ensure the folder we are about to zip exists
           Utilities.createFolderWithRetry(tempProjectFolder);

--- a/apps/rush-lib/src/cli/utilities/InstallManager.ts
+++ b/apps/rush-lib/src/cli/utilities/InstallManager.ts
@@ -195,7 +195,7 @@ export default class InstallManager {
   /**
    * Regenerates the common/package.json and all temp_modules projects.
    */
-  public createTempModules(forceCreate: boolean = false): void {
+  public createTempModules(forceCreate: boolean): void {
     this.createTempModulesAndCheckShrinkwrap(undefined, forceCreate);
   }
 
@@ -207,7 +207,7 @@ export default class InstallManager {
    */
   public createTempModulesAndCheckShrinkwrap(
     shrinkwrapFile: ShrinkwrapFile | undefined,
-    forceCreate: boolean = false): boolean {
+    forceCreate: boolean): boolean {
     const stopwatch: Stopwatch = Stopwatch.start();
 
     // Example: "C:\MyRepo\common\temp\projects"


### PR DESCRIPTION
We used to extract the tarball and compare the package.json to see if we need to generate a new one. Then we would create a new directory, use it to create a new tarball, then delete the temp directory. This led to situations where locks were still being held on various files.

Instead, we now leave the temp folder in place, and check A) that the tarball exists, B) that the temp file exists, and C) that the temp package.json matches. In case of error during tarball creation, we delete the temp folder.

This is much more straightforward and removes the .old and .new folder distinction. It is also much faster as we don't have to extract every tarball during every rush install.