### PR TITLE
Improve api-extractor invocation so it's easier to determine failure

### DIFF
--- a/apps/api-extractor/src/DebugRun.ts
+++ b/apps/api-extractor/src/DebugRun.ts
@@ -26,6 +26,10 @@ const extractor: Extractor = new Extractor(
   }
 );
 
-extractor.analyzeProject();
+if (!extractor.processProject()) {
+  console.log('processProject() failed the build');
+} else {
+  console.log('processProject() succeeded');
+}
 
 console.log('DebugRun completed.');

--- a/apps/api-extractor/src/ExternalApiHelper.ts
+++ b/apps/api-extractor/src/ExternalApiHelper.ts
@@ -69,6 +69,8 @@ export default class ExternalApiHelper {
       }
     });
 
-    extractor.analyzeProject();
+    if (!extractor.processProject()) {
+      throw new Error('API Extractor failed to process the input: ' + externalPackageFilePath);
+    }
   }
 }

--- a/apps/api-extractor/src/cli/ApiExtractorCommandLine.ts
+++ b/apps/api-extractor/src/cli/ApiExtractorCommandLine.ts
@@ -1,6 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
+import * as os from 'os';
+import * as colors from 'colors';
+
 import { CommandLineParser } from '@microsoft/ts-command-line';
 import { RunAction } from './RunAction';
 
@@ -14,6 +17,15 @@ export class ApiExtractorCommandLine extends CommandLineParser {
   }
 
   protected onDefineParameters(): void { // override
+  }
+
+  protected onExecute(): void { // override
+    try {
+      super.onExecute();
+    } catch (error) {
+      console.error(os.EOL + colors.red('ERROR: ' + error.message.trim()));
+      process.exitCode = 1;
+    }
   }
 
   private _populateActions(): void {

--- a/apps/api-extractor/src/cli/RunAction.ts
+++ b/apps/api-extractor/src/cli/RunAction.ts
@@ -82,6 +82,9 @@ export class RunAction extends CommandLineAction {
     const extractor: Extractor = new Extractor(config, {
       localBuild: this._localParameter.value
     });
-    extractor.analyzeProject();
+
+    if (!extractor.processProject()) {
+      throw new Error('The build failed');
+    }
   }
 }

--- a/apps/api-extractor/src/cli/RunAction.ts
+++ b/apps/api-extractor/src/cli/RunAction.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
+import * as colors from 'colors';
 import * as fsx from 'fs-extra';
 import * as os from 'os';
 import * as path from 'path';
@@ -84,7 +85,8 @@ export class RunAction extends CommandLineAction {
     });
 
     if (!extractor.processProject()) {
-      throw new Error('The build failed');
+      console.log(os.EOL + colors.yellow('API Extractor completed with errors or warnings'));
+      process.exitCode = 1;
     }
   }
 }

--- a/apps/api-extractor/src/extractor/Extractor.ts
+++ b/apps/api-extractor/src/extractor/Extractor.ts
@@ -17,6 +17,7 @@ import { ExtractorContext } from '../ExtractorContext';
 import { ILogger } from './ILogger';
 import ApiJsonGenerator from '../generators/ApiJsonGenerator';
 import ApiFileGenerator from '../generators/ApiFileGenerator';
+import { MonitoredLogger } from './MonitoredLogger';
 
 /**
  * Options for {@link Extractor.analyzeProject}.
@@ -79,11 +80,11 @@ export class Extractor {
     logError: (message: string) => console.error(colors.red(message))
   };
 
-  private _config: IExtractorConfig;
-  private _program: ts.Program;
-  private _localBuild: boolean;
-  private _logger: ILogger;
-  private _absoluteRootFolder: string;
+  private readonly _config: IExtractorConfig;
+  private readonly _program: ts.Program;
+  private readonly _localBuild: boolean;
+  private readonly _monitoredLogger: MonitoredLogger;
+  private readonly _absoluteRootFolder: string;
 
   private static _applyConfigDefaults(config: IExtractorConfig): IExtractorConfig {
     // Use the provided config to override the defaults
@@ -93,17 +94,19 @@ export class Extractor {
     return normalized;
   }
 
-  public constructor (config: IExtractorConfig, options?: IExtractorOptions) {
+  public constructor(config: IExtractorConfig, options?: IExtractorOptions) {
+    let mergedLogger: ILogger;
     if (options && options.customLogger) {
-      this._logger = lodash.merge(lodash.cloneDeep(Extractor._defaultLogger),
+      mergedLogger = lodash.merge(lodash.cloneDeep(Extractor._defaultLogger),
         options.customLogger);
     } else {
-      this._logger = Extractor._defaultLogger;
+      mergedLogger = Extractor._defaultLogger;
     }
+    this._monitoredLogger = new MonitoredLogger(mergedLogger);
 
     this._config = Extractor._applyConfigDefaults(config);
 
-    this._logger.logVerbose('API Extractor Config: ' + JSON.stringify(this._config));
+    this._monitoredLogger.logVerbose('API Extractor Config: ' + JSON.stringify(this._config));
 
     if (!options) {
       options = { };
@@ -160,6 +163,9 @@ export class Extractor {
 
   /**
    * Invokes the API Extractor engine, using the configuration that was passed to the constructor.
+   * @param options - provides additional runtime state that is NOT part of the API Extractor
+   *     config file.
+   * @returns true if there were no errors; false if the tool chain should fail the build
    */
   public analyzeProject(options?: IAnalyzeProjectOptions): void {
     if (!options) {
@@ -178,7 +184,7 @@ export class Extractor {
     const context: ExtractorContext = new ExtractorContext({
       program: this._program,
       entryPointFile: path.resolve(this._absoluteRootFolder, projectConfig.entryPointSourceFile),
-      logger: this._logger,
+      logger: this._monitoredLogger,
       policies: this._config.policies
     });
 
@@ -199,7 +205,7 @@ export class Extractor {
       const jsonGenerator: ApiJsonGenerator = new ApiJsonGenerator();
       const apiJsonFilename: string = path.join(outputFolder, packageBaseName + '.api.json');
 
-      this._logger.logVerbose('Writing: ' + apiJsonFilename);
+      this._monitoredLogger.logVerbose('Writing: ' + apiJsonFilename);
       jsonGenerator.writeJsonFile(apiJsonFilename, context);
     }
 
@@ -228,7 +234,7 @@ export class Extractor {
         if (!ApiFileGenerator.areEquivalentApiFileContents(actualApiReviewContent, expectedApiReviewContent)) {
           if (!this._localBuild) {
             // For production, issue a warning that will break the CI build.
-            this._logger.logWarning('You have changed the public API signature for this project.'
+            this._monitoredLogger.logWarning('You have changed the public API signature for this project.'
               // @microsoft/gulp-core-build seems to run JSON.stringify() on the error messages for some reason,
               // so try to avoid escaped characters:
               + ` Please overwrite ${expectedApiReviewShortPath} with a`
@@ -236,19 +242,20 @@ export class Extractor {
               + ' and then request an API review. See the Git repository README.md for more info.');
           } else {
             // For a local build, just copy the file automatically.
-            this._logger.logWarning('You have changed the public API signature for this project.'
+            this._monitoredLogger.logWarning('You have changed the public API signature for this project.'
               + ` Updating ${expectedApiReviewShortPath}`);
 
             fsx.writeFileSync(expectedApiReviewPath, actualApiReviewContent);
           }
         } else {
-          this._logger.logVerbose(`The API signature is up to date: ${actualApiReviewShortPath}`);
+          this._monitoredLogger.logVerbose(`The API signature is up to date: ${actualApiReviewShortPath}`);
         }
       } else {
         // NOTE: This warning seems like a nuisance, but it has caught genuine mistakes.
         // For example, when projects were moved into category folders, the relative path for
         // the API review files ended up in the wrong place.
-        this._logger.logError(`The API review file has not been set up. Do this by copying ${actualApiReviewShortPath}`
+        this._monitoredLogger.logError(`The API review file has not been set up.`
+          + ` Do this by copying ${actualApiReviewShortPath}`
           + ` to ${expectedApiReviewShortPath} and committing it.`);
       }
     }

--- a/apps/api-extractor/src/extractor/Extractor.ts
+++ b/apps/api-extractor/src/extractor/Extractor.ts
@@ -97,8 +97,7 @@ export class Extractor {
   public constructor(config: IExtractorConfig, options?: IExtractorOptions) {
     let mergedLogger: ILogger;
     if (options && options.customLogger) {
-      mergedLogger = lodash.merge(lodash.cloneDeep(Extractor._defaultLogger),
-        options.customLogger);
+      mergedLogger = lodash.merge(lodash.clone(Extractor._defaultLogger), options.customLogger);
     } else {
       mergedLogger = Extractor._defaultLogger;
     }

--- a/apps/api-extractor/src/extractor/Extractor.ts
+++ b/apps/api-extractor/src/extractor/Extractor.ts
@@ -20,7 +20,7 @@ import ApiFileGenerator from '../generators/ApiFileGenerator';
 import { MonitoredLogger } from './MonitoredLogger';
 
 /**
- * Options for {@link Extractor.analyzeProject}.
+ * Options for {@link Extractor.processProject}.
  * @public
  */
 export interface IAnalyzeProjectOptions {
@@ -163,11 +163,21 @@ export class Extractor {
 
   /**
    * Invokes the API Extractor engine, using the configuration that was passed to the constructor.
-   * @param options - provides additional runtime state that is NOT part of the API Extractor
-   *     config file.
-   * @returns true if there were no errors; false if the tool chain should fail the build
+   * @deprecated Use {@link Extractor.processProject} instead.
    */
   public analyzeProject(options?: IAnalyzeProjectOptions): void {
+    this.processProject(options);
+  }
+
+  /**
+   * Invokes the API Extractor engine, using the configuration that was passed to the constructor.
+   * @param options - provides additional runtime state that is NOT part of the API Extractor
+   *     config file.
+   * @returns true if there were no errors or warnings; false if the tool chain should fail the build
+   */
+  public processProject(options?: IAnalyzeProjectOptions): boolean {
+    this._monitoredLogger.resetCounters();
+
     if (!options) {
       options = { };
     }
@@ -259,6 +269,9 @@ export class Extractor {
           + ` to ${expectedApiReviewShortPath} and committing it.`);
       }
     }
+
+    // If there were any errors or warnings, then fail the build
+    return (this._monitoredLogger.errorCount + this._monitoredLogger.warningCount) === 0;
   }
 
   private _getShortFilePath(absolutePath: string): string {

--- a/apps/api-extractor/src/extractor/MonitoredLogger.ts
+++ b/apps/api-extractor/src/extractor/MonitoredLogger.ts
@@ -1,0 +1,52 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import { ILogger } from './ILogger';
+
+/**
+ * Used to collect statistics for an ILogger implementation.
+ */
+export class MonitoredLogger implements ILogger {
+  /**
+   * Number of calls to logError()
+   */
+  public errorCount: number = 0;
+
+  /**
+   * Number of calls to logWarning()
+   */
+  public warningCount: number = 0;
+
+  /**
+   * Number of calls to any logging method.
+   */
+  public messageCount: number = 0;
+
+  private _innerLogger: ILogger;
+
+  constructor(logger: ILogger) {
+    this._innerLogger = logger;
+  }
+
+  public logVerbose(message: string): void {
+    ++this.messageCount;
+    this._innerLogger.logVerbose(message);
+  }
+
+  public logInfo(message: string): void {
+    ++this.messageCount;
+    this._innerLogger.logVerbose(message);
+  }
+
+  public logWarning(message: string): void {
+    ++this.messageCount;
+    ++this.warningCount;
+    this._innerLogger.logVerbose(message);
+  }
+
+  public logError(message: string): void {
+    ++this.messageCount;
+    ++this.errorCount;
+    this._innerLogger.logVerbose(message);
+  }
+}

--- a/apps/api-extractor/src/extractor/MonitoredLogger.ts
+++ b/apps/api-extractor/src/extractor/MonitoredLogger.ts
@@ -10,22 +10,23 @@ export class MonitoredLogger implements ILogger {
   /**
    * Number of calls to logError()
    */
-  public errorCount: number = 0;
+  public errorCount: number;
 
   /**
    * Number of calls to logWarning()
    */
-  public warningCount: number = 0;
+  public warningCount: number;
 
   /**
    * Number of calls to any logging method.
    */
-  public messageCount: number = 0;
+  public messageCount: number;
 
   private _innerLogger: ILogger;
 
   constructor(logger: ILogger) {
     this._innerLogger = logger;
+    this.resetCounters();
   }
 
   public logVerbose(message: string): void {
@@ -48,5 +49,11 @@ export class MonitoredLogger implements ILogger {
     ++this.messageCount;
     ++this.errorCount;
     this._innerLogger.logVerbose(message);
+  }
+
+  public resetCounters(): void {
+    this.errorCount = 0;
+    this.warningCount = 0;
+    this.messageCount = 0;
   }
 }

--- a/apps/api-extractor/src/extractor/MonitoredLogger.ts
+++ b/apps/api-extractor/src/extractor/MonitoredLogger.ts
@@ -36,19 +36,19 @@ export class MonitoredLogger implements ILogger {
 
   public logInfo(message: string): void {
     ++this.messageCount;
-    this._innerLogger.logVerbose(message);
+    this._innerLogger.logInfo(message);
   }
 
   public logWarning(message: string): void {
     ++this.messageCount;
     ++this.warningCount;
-    this._innerLogger.logVerbose(message);
+    this._innerLogger.logWarning(message);
   }
 
   public logError(message: string): void {
     ++this.messageCount;
     ++this.errorCount;
-    this._innerLogger.logVerbose(message);
+    this._innerLogger.logError(message);
   }
 
   public resetCounters(): void {

--- a/common/changes/@microsoft/api-extractor/pgonzal-extractor-error-detection_2017-11-23-01-11.json
+++ b/common/changes/@microsoft/api-extractor/pgonzal-extractor-error-detection_2017-11-23-01-11.json
@@ -1,0 +1,16 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor",
+      "comment": "Add Extractor.processProject() whose return value indicates success",
+      "type": "minor"
+    },
+    {
+      "packageName": "@microsoft/api-extractor",
+      "comment": "Deprecate Extractor.analyzeProject() API",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/gulp-core-build-typescript/pgonzal-extractor-error-detection_2017-11-23-01-11.json
+++ b/common/changes/@microsoft/gulp-core-build-typescript/pgonzal-extractor-error-detection_2017-11-23-01-11.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@microsoft/gulp-core-build-typescript",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/gulp-core-build-typescript",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/reviews/api/api-extractor.api.ts
+++ b/common/reviews/api/api-extractor.api.ts
@@ -13,8 +13,10 @@ class ExternalApiHelper {
 // @public
 class Extractor {
   public constructor(config: IExtractorConfig, options?: IExtractorOptions);
+  // @deprecated
   public analyzeProject(options?: IAnalyzeProjectOptions): void;
   public static jsonSchema: JsonSchema;
+  public processProject(options?: IAnalyzeProjectOptions): boolean;
 }
 
 // @public

--- a/core-build/gulp-core-build-typescript/src/ApiExtractorTask.ts
+++ b/core-build/gulp-core-build-typescript/src/ApiExtractorTask.ts
@@ -146,7 +146,10 @@ export class ApiExtractorTask extends GulpTask<IApiExtractorTaskConfig>  {
       };
 
       const extractor: Extractor = new Extractor(extractorConfig, extractorOptions);
-      extractor.analyzeProject();
+
+      // NOTE: processProject() returns false if errors or warnings occurred, however we
+      // already handle this above via our customLogger
+      extractor.processProject();
     } catch (e) {
       completeCallback(e.message);
       return;


### PR DESCRIPTION
If API Extractor reports warnings or errors, the build should fail.  However, since `Extractor.analyzeProject()` doesn't return a value, the only way to determine failure is by providing a customLogger.  (This is what **gulp-core-build** does.)  This PR adds a boolean return value to avoid this limitation.

Based on feedback, we're also renaming `Extractor.analyzeProject()` to `Extractor.processProject()`.

This PR also updates the api-extractor command-line tool to return a nonzero exit code if an error occurs.