### PR TITLE
Fix issue with "git commit" not having any files added to index 

### DIFF
--- a/apps/rush-lib/src/cli/actions/VersionAction.ts
+++ b/apps/rush-lib/src/cli/actions/VersionAction.ts
@@ -158,8 +158,15 @@ export default class VersionAction extends BaseRushAction {
     }
 
     // Commit the package.json and change files updates.
-    git.addChanges();
-    git.commit();
+    const packageJsonUpdated: boolean = VersionControl.getUncommittedChanges().some((changePath) => {
+      return changePath.indexOf('package.json') > 0;
+    });
+
+    if (packageJsonUpdated) {
+      git.addChanges();
+      git.commit();
+    }
+
     git.push(tempBranch);
 
     // Now merge to target branch.

--- a/apps/rush-lib/src/cli/actions/VersionAction.ts
+++ b/apps/rush-lib/src/cli/actions/VersionAction.ts
@@ -144,9 +144,11 @@ export default class VersionAction extends BaseRushAction {
     // Make changes in temp branch.
     git.checkout(tempBranch, true);
 
+    const uncommittedChanges: ReadonlyArray<string> = VersionControl.getUncommittedChanges();
+
     // Stage, commit, and push the changes to remote temp branch.
     // Need to commit the change log updates in its own commit
-    const changeLogUpdated: boolean = VersionControl.getUncommittedChanges().some((changePath) => {
+    const changeLogUpdated: boolean = uncommittedChanges.some((changePath) => {
       return changePath.indexOf('CHANGELOG.json') > 0;
     });
 
@@ -158,7 +160,7 @@ export default class VersionAction extends BaseRushAction {
     }
 
     // Commit the package.json and change files updates.
-    const packageJsonUpdated: boolean = VersionControl.getUncommittedChanges().some((changePath) => {
+    const packageJsonUpdated: boolean = uncommittedChanges.some((changePath) => {
       return changePath.indexOf('package.json') > 0;
     });
 


### PR DESCRIPTION
We should only need to do the second commit if there are changes to `package.json` files.