### PR TITLE
Additional jest task arguments; ability to choose between default and passed args

### DIFF
--- a/common/changes/@microsoft/gulp-core-build/olfilato-optional-overrides-jest_2017-11-30-22-33.json
+++ b/common/changes/@microsoft/gulp-core-build/olfilato-optional-overrides-jest_2017-11-30-22-33.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/gulp-core-build",
+      "comment": "Added optional args moduleDirectories and rootDir to JestTask",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@microsoft/gulp-core-build",
+  "email": "olfilato@users.noreply.github.com"
+}

--- a/common/reviews/api/gulp-core-build.api.ts
+++ b/common/reviews/api/gulp-core-build.api.ts
@@ -196,6 +196,8 @@ interface IJestConfig {
   coverage?: boolean;
   coverageReporters?: string[];
   isEnabled?: boolean;
+  moduleDirectories?: string[];
+  rootDir?: string;
   testPathIgnorePatterns?: string[];
 }
 

--- a/common/reviews/api/node-library-build.api.ts
+++ b/common/reviews/api/node-library-build.api.ts
@@ -188,6 +188,8 @@ interface IJestConfig {
   coverage?: boolean;
   coverageReporters?: string[];
   isEnabled?: boolean;
+  moduleDirectories?: string[];
+  rootDir?: string;
   testPathIgnorePatterns?: string[];
 }
 

--- a/common/reviews/api/web-library-build.api.ts
+++ b/common/reviews/api/web-library-build.api.ts
@@ -188,6 +188,8 @@ interface IJestConfig {
   coverage?: boolean;
   coverageReporters?: string[];
   isEnabled?: boolean;
+  moduleDirectories?: string[];
+  rootDir?: string;
   testPathIgnorePatterns?: string[];
 }
 

--- a/core-build/gulp-core-build/src/tasks/JestTask.ts
+++ b/core-build/gulp-core-build/src/tasks/JestTask.ts
@@ -47,6 +47,16 @@ export interface IJestConfig {
    * Same as Jest CLI option testPathIgnorePatterns
    */
   testPathIgnorePatterns?: string[];
+
+  /**
+   * Same as Jest CLI option moduleDirectories
+   */
+  moduleDirectories?: string[];
+
+  /**
+   * Same as Jest CLI option rootDir
+   */
+  rootDir?: string;
 }
 
 const DEFAULT_JEST_CONFIG_FILE_NAME: string = 'jest.config.json';
@@ -113,9 +123,12 @@ export class JestTask extends GulpTask<IJestConfig> {
       coverageReporters: this.taskConfig.coverageReporters,
       coverageDirectory: path.join(this.buildConfig.tempFolder, 'coverage'),
       maxWorkers: 1,
-      moduleDirectories: ['node_modules', this.buildConfig.libFolder],
+      moduleDirectories: !!this.taskConfig.moduleDirectories ?
+        this.taskConfig.moduleDirectories :
+        ['node_modules', this.buildConfig.libFolder],
       reporters: [path.join(__dirname, 'JestReporter.js')],
-      rootDir: this.buildConfig.rootPath,
+      rootDir: !!this.taskConfig.rootDir ?
+        this.taskConfig.rootDir : this.buildConfig.rootPath,
       runInBand: true,
       testMatch: ['**/*.test.js?(x)'],
       testPathIgnorePatterns: this.taskConfig.testPathIgnorePatterns,

--- a/core-build/gulp-core-build/src/tasks/jest.schema.json
+++ b/core-build/gulp-core-build/src/tasks/jest.schema.json
@@ -46,6 +46,17 @@
       "items": {
         "type": "string"
       }
+    },
+    "moduleDirectories": {
+      "description": "Same as Jest CLI option moduleDirectories",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "rootDir": {
+      "description": "Same as Jest CLI option rootDir",
+      "type": "string"
     }
   },
   "additionalProperties": false


### PR DESCRIPTION
Two new optional arguments for Jest task: moduleDirectories and rootDir (directly corresponding to their Jest CLI counterparts). Added logic to the task, so that it automatically picks the default values for those two arguments if they were not provided, otherwise it uses the provided ones.