### PR TITLE
api-extractor now processes the *.d.ts compiler output, instead of source file inputs

### DIFF
--- a/apps/api-extractor/src/aedoc/ApiDocumentation.ts
+++ b/apps/api-extractor/src/aedoc/ApiDocumentation.ts
@@ -72,7 +72,7 @@ export default class ApiDocumentation {
   ];
 
   /**
-   * The original AEDoc comment.
+   * The original AEDoc comment, with the "/**" characters already removed.
    *
    * Example: "This is a summary. \{\@link a\} \@remarks These are remarks."
    */
@@ -169,7 +169,7 @@ export default class ApiDocumentation {
 
   public readonly reportError: (message: string) => void;
 
-  constructor(docComment: string,
+  constructor(originalAedoc: string,
     referenceResolver: IReferenceResolver,
     context: ExtractorContext,
     errorLogger: (message: string) => void,
@@ -180,7 +180,7 @@ export default class ApiDocumentation {
       this.failedToParse = true;
     };
 
-    this.originalAedoc = docComment;
+    this.originalAedoc = originalAedoc;
     this.referenceResolver = referenceResolver;
     this.context = context;
     this.reportError = errorLogger;

--- a/apps/api-extractor/src/aedoc/ApiDocumentation.ts
+++ b/apps/api-extractor/src/aedoc/ApiDocumentation.ts
@@ -56,6 +56,7 @@ export default class ApiDocumentation {
     '@betadocumentation',
     '@internal',
     '@internalremarks',
+    '@packagedocumentation',
     '@param',
     '@preapproved',
     '@public',
@@ -127,10 +128,16 @@ export default class ApiDocumentation {
   public releaseTag: ReleaseTag;
 
   /**
-   * True if the "@preapproved" tag was specified.
+   * True if the "\@preapproved" tag was specified.
    * Indicates that this internal API is exempt from further reviews.
    */
   public preapproved?: boolean;
+
+  /**
+   * True if the "\@packagedocumentation" tag was specified.
+   */
+  public isPackageDocumentation?: boolean;
+
   public deprecated?: string;
   public internalremarks?: string;
   public paramDocs?: Map<string, string>;
@@ -283,6 +290,10 @@ export default class ApiDocumentation {
           case '@preapproved':
             tokenizer.getToken();
             this.preapproved = true;
+            break;
+          case '@packagedocumentation':
+            tokenizer.getToken();
+            this.isPackageDocumentation = true;
             break;
           case '@readonly':
             tokenizer.getToken();

--- a/apps/api-extractor/src/ast/AstEnum.ts
+++ b/apps/api-extractor/src/ast/AstEnum.ts
@@ -23,8 +23,7 @@ export default class AstEnum extends AstItemContainer {
       const memberOptions: IAstItemOptions = {
         context: this.context,
         declaration: memberDeclaration,
-        declarationSymbol: memberSymbol,
-        jsdocNode: memberDeclaration
+        declarationSymbol: memberSymbol
       };
 
       this.addMemberItem(new AstEnumValue(memberOptions));

--- a/apps/api-extractor/src/ast/AstFunction.ts
+++ b/apps/api-extractor/src/ast/AstFunction.ts
@@ -31,8 +31,7 @@ class AstFunction extends AstItem {
         const astParameter: AstParameter = new AstParameter({
           context: this.context,
           declaration: param,
-          declarationSymbol: declarationSymbol,
-          jsdocNode: param
+          declarationSymbol: declarationSymbol
         });
         this.innerItems.push(astParameter);
         this.params.push(astParameter);

--- a/apps/api-extractor/src/ast/AstItem.ts
+++ b/apps/api-extractor/src/ast/AstItem.ts
@@ -294,7 +294,7 @@ abstract class AstItem {
 
     let aedocCommentRange: ts.TextRange | undefined;
 
-    if (options.aedocCommentRange) {
+    if (options.aedocCommentRange) { // but might be ""
       // This is e.g. for the special @packagedocumentation comment, which is pulled
       // from elsewhere in the AST.
       aedocCommentRange = options.aedocCommentRange;
@@ -312,9 +312,11 @@ abstract class AstItem {
     // This will be the AEDoc content, excluding the "/**" characters
     let aedoc: string = '';
     if (aedocCommentRange) {
-      // This is the raw comment including the "/**" characters
+      // This is the raw comment including the "/**" characters, or "" if there was no comment
       const rawComment: string = sourceFileText.substring(aedocCommentRange.pos, aedocCommentRange.end);
-      aedoc = TypeScriptHelpers.extractJSDocContent(rawComment, this.reportError);
+      if (rawComment) {
+        aedoc = TypeScriptHelpers.extractJSDocContent(rawComment, this.reportError);
+      }
     }
 
     this.documentation = new ApiDocumentation(

--- a/apps/api-extractor/src/ast/AstItem.ts
+++ b/apps/api-extractor/src/ast/AstItem.ts
@@ -111,12 +111,15 @@ export interface IAstItemOptions {
    * The semantic information for the declaration.
    */
   declarationSymbol: ts.Symbol;
+
   /**
-   * The declaration node that contains the JSDoc comments for this AstItem.
-   * In most cases this is the same as `declaration`, but for AstPackage it will be
-   * a separate node under the root.
+   * The JSDoc-style comment range (including the "/**" characters), which is assumed
+   * to be in the same source file as the IAstItemOptions.declaration node.
+   * If this is undefined, then the comment will be obtained from the
+   * IAstItemOptions.declaration node.
    */
-  jsdocNode: ts.Node | undefined;
+  aedocCommentRange?: ts.TextRange;
+
   /**
    * The symbol used to export this AstItem from the AstPackage.
    */
@@ -200,13 +203,6 @@ abstract class AstItem {
   public warnings: string[];
 
   /**
-   * The declaration node that contains the JSDoc comments for this AstItem.
-   * In most cases this is the same as `declaration`, but for AstPackage it will be
-   * a separate node under the root.
-   */
-  public jsdocNode: ts.Node | undefined;
-
-  /**
    * The parsed AEDoc comment for this item.
    */
   public documentation: ApiDocumentation;
@@ -282,7 +278,6 @@ abstract class AstItem {
   constructor(options: IAstItemOptions) {
     this.reportError = this.reportError.bind(this);
 
-    this.jsdocNode = options.jsdocNode;
     this.declaration = options.declaration;
     this._errorNode = options.declaration;
     this._state = InitializationState.Incomplete;
@@ -295,13 +290,35 @@ abstract class AstItem {
 
     this.name = this.exportSymbol.name || '???';
 
-    let originalJsdoc: string = '';
-    if (this.jsdocNode) {
-      originalJsdoc = TypeScriptHelpers.getJsdocComments(this.jsdocNode, this.reportError);
+    const sourceFileText: string = this.declaration.getSourceFile().text;
+
+    let aedocCommentRange: ts.TextRange | undefined;
+
+    if (options.aedocCommentRange) {
+      // This is e.g. for the special @packagedocumentation comment, which is pulled
+      // from elsewhere in the AST.
+      aedocCommentRange = options.aedocCommentRange;
+    } else {
+      // This is the typical case
+      const ranges: ts.CommentRange[] = TypeScriptHelpers.getJSDocCommentRanges(
+        this.declaration, sourceFileText) || [];
+      if (ranges.length > 0) {
+        // We use the JSDoc comment block that is closest to the definition, i.e.
+        // the last one preceding it
+        aedocCommentRange = ranges[ranges.length - 1];
+      }
+    }
+
+    // This will be the AEDoc content, excluding the "/**" characters
+    let aedoc: string = '';
+    if (aedocCommentRange) {
+      // This is the raw comment including the "/**" characters
+      const rawComment: string = sourceFileText.substring(aedocCommentRange.pos, aedocCommentRange.end);
+      aedoc = TypeScriptHelpers.extractJSDocContent(rawComment, this.reportError);
     }
 
     this.documentation = new ApiDocumentation(
-      originalJsdoc,
+      aedoc,
       this.context.docItemLoader,
       this.context,
       this.reportError,

--- a/apps/api-extractor/src/ast/AstItem.ts
+++ b/apps/api-extractor/src/ast/AstItem.ts
@@ -477,16 +477,26 @@ abstract class AstItem {
       this.documentation.summary).replace(/\s\s/g, ' ');
     this.needsDocumentation = this.shouldHaveDocumentation() && summaryTextCondensed.length <= 10;
 
-    this.supportedName =  (this.kind === AstItemKind.Package) || AstItem._allowedNameRegex.test(this.name);
+    this.supportedName = (this.kind === AstItemKind.Package) || AstItem._allowedNameRegex.test(this.name);
     if (!this.supportedName) {
       this.warnings.push(`The name "${this.name}" contains unsupported characters; ` +
         'API names should use only letters, numbers, and underscores');
     }
 
     if (this.kind === AstItemKind.Package) {
+      if (this.documentation.originalAedoc.trim().length > 0) {
+        if (!this.documentation.isPackageDocumentation) {
+          this.reportError('A package comment was found, but it is missing the @packagedocumentation tag');
+        }
+      }
+
       if (this.documentation.releaseTag !== ReleaseTag.None) {
         const tag: string = '@' + ReleaseTag[this.documentation.releaseTag].toLowerCase();
         this.reportError(`The ${tag} tag is not allowed on the package, which is always considered to be @public`);
+      }
+    } else {
+      if (this.documentation.isPackageDocumentation) {
+        this.reportError(`The @packagedocumentation tag cannot be used for an item of type ${AstItemKind[this.kind]}`);
       }
     }
 

--- a/apps/api-extractor/src/ast/AstMember.ts
+++ b/apps/api-extractor/src/ast/AstMember.ts
@@ -25,10 +25,10 @@ export enum ApiAccessModifier {
  * AstMember is used to represent members of classes, interfaces, and nested type literal expressions.
  */
 export default class AstMember extends AstItem {
+  public accessModifier: ApiAccessModifier;
   /**
    * True if the member is an optional field value, indicated by a question mark ("?") after the name
    */
-  public accessModifier: ApiAccessModifier;
   public isOptional: boolean;
   public isStatic: boolean;
 

--- a/apps/api-extractor/src/ast/AstMember.ts
+++ b/apps/api-extractor/src/ast/AstMember.ts
@@ -69,8 +69,7 @@ export default class AstMember extends AstItem {
       const typeLiteralOptions: IAstItemOptions = {
         context: this.context,
         declaration: propertyTypeDeclaration,
-        declarationSymbol: propertyTypeSymbol,
-        jsdocNode: propertyTypeDeclaration
+        declarationSymbol: propertyTypeSymbol
       };
 
       this.typeLiteral = new AstStructuredType(typeLiteralOptions);

--- a/apps/api-extractor/src/ast/AstMethod.ts
+++ b/apps/api-extractor/src/ast/AstMethod.ts
@@ -40,8 +40,7 @@ export default class AstMethod extends AstMember {
         const astParameter: AstParameter = new AstParameter({
           context: this.context,
           declaration: param,
-          declarationSymbol: declarationSymbol,
-          jsdocNode: param
+          declarationSymbol: declarationSymbol
         });
 
         this.innerItems.push(astParameter);

--- a/apps/api-extractor/src/ast/AstModule.ts
+++ b/apps/api-extractor/src/ast/AstModule.ts
@@ -32,7 +32,6 @@ abstract class AstModule extends AstItemContainer {
         context: this.context,
         declaration,
         declarationSymbol: followedSymbol,
-        jsdocNode: declaration,
         exportSymbol
       };
 

--- a/apps/api-extractor/src/ast/AstNamespace.ts
+++ b/apps/api-extractor/src/ast/AstNamespace.ts
@@ -109,7 +109,6 @@ export default class AstNamespace extends AstModule {
         context: this.context,
         declaration,
         declarationSymbol: followedSymbol,
-        jsdocNode: jsdocNode,
         exportSymbol
       };
 

--- a/apps/api-extractor/src/ast/AstStructuredType.ts
+++ b/apps/api-extractor/src/ast/AstStructuredType.ts
@@ -204,8 +204,7 @@ export default class AstStructuredType extends AstItemContainer {
     const memberOptions: IAstItemOptions = {
       context: this.context,
       declaration: memberDeclaration,
-      declarationSymbol: memberSymbol,
-      jsdocNode: memberDeclaration
+      declarationSymbol: memberSymbol
     };
 
     if (memberSymbol.flags & (

--- a/apps/api-extractor/src/extractor/Extractor.ts
+++ b/apps/api-extractor/src/extractor/Extractor.ts
@@ -74,6 +74,8 @@ export class Extractor {
   private static _defaultConfig: Partial<IExtractorConfig> = JsonFile.load(path.join(__dirname,
     './api-extractor-defaults.json'));
 
+  private static _outputFileExtensionRegExp: RegExp = /\.d\.ts$/i;
+
   private static _defaultLogger: ILogger = {
     logVerbose: (message: string) => console.log('(Verbose) ' + message),
     logInfo: (message: string) => console.log(message),
@@ -86,6 +88,45 @@ export class Extractor {
   private readonly _localBuild: boolean;
   private readonly _monitoredLogger: MonitoredLogger;
   private readonly _absoluteRootFolder: string;
+
+  /**
+   * Given a list of absolute file paths, return a list containing only the declaration
+   * files.  Duplicates are also eliminated.
+   *
+   * @remarks
+   * The tsconfig.json settings specify the compiler's input (a set of *.ts source files,
+   * plus some *.d.ts declaration files used for legacy typings).  However API Extractor
+   * analyzes the compiler's output (a set of *.d.ts entry point files, plus any legacy
+   * typings).  This requires API Extractor to generate a special file list when it invokes
+   * the compiler.
+   *
+   * For configType=tsconfig this happens automatically, but for configType=runtime it is
+   * the responsibility of the custom tooling.  The generateFilePathsForAnalysis() function
+   * is provided to facilitate that.  Duplicates are removed so that entry points can be
+   * appended without worrying whether they may already appear in the tsconfig.json file list.
+   */
+  public static generateFilePathsForAnalysis(inputFilePaths: string[]): string[] {
+    const analysisFilePaths: string[] = [];
+
+    const seenFiles: Set<string> = new Set<string>();
+
+    for (const inputFilePath of inputFilePaths) {
+      const inputFileToUpper: string = inputFilePath.toUpperCase();
+      if (!seenFiles.has(inputFileToUpper)) {
+        seenFiles.add(inputFileToUpper);
+
+        if (!path.isAbsolute(inputFilePath)) {
+          throw new Error('Input file is not an absolute path: ' + inputFilePath);
+        }
+
+        if (Extractor._outputFileExtensionRegExp.test(inputFilePath)) {
+          analysisFilePaths.push(inputFilePath);
+        }
+      }
+    }
+
+    return analysisFilePaths;
+  }
 
   private static _applyConfigDefaults(config: IExtractorConfig): IExtractorConfig {
     // Use the provided config to override the defaults
@@ -129,7 +170,15 @@ export class Extractor {
 
         const commandLine: ts.ParsedCommandLine = ts.parseJsonConfigFileContent(tsconfig,
           ts.sys, this._absoluteRootFolder);
-        this._program = ts.createProgram(commandLine.fileNames, commandLine.options);
+
+        const normalizedEntryPointFile: string = path.normalize(
+          path.resolve(this._absoluteRootFolder, this._actualConfig.project.entryPointSourceFile));
+
+        // Append the normalizedEntryPointFile and remove any source files from the list
+        const analysisFilePaths: string[] = Extractor.generateFilePathsForAnalysis(commandLine.fileNames
+          .concat(normalizedEntryPointFile));
+
+        this._program = ts.createProgram(analysisFilePaths, commandLine.options);
 
         if (commandLine.errors.length > 0) {
           throw new Error('Error parsing tsconfig.json content: ' + commandLine.errors[0].messageText);
@@ -206,6 +255,10 @@ export class Extractor {
     if (!(this._actualConfig.policies && this._actualConfig.apiJsonFile && this._actualConfig.apiReviewFile
       && this._actualConfig.packageTypings)) {
       throw new Error('The configuration object wasn\'t normalized properly');
+    }
+
+    if (!Extractor._outputFileExtensionRegExp.test(projectConfig.entryPointSourceFile)) {
+      throw new Error('The entry point is not a declaration file: ' + projectConfig.entryPointSourceFile);
     }
 
     const context: ExtractorContext = new ExtractorContext({

--- a/apps/api-extractor/src/extractor/IExtractorConfig.ts
+++ b/apps/api-extractor/src/extractor/IExtractorConfig.ts
@@ -51,10 +51,16 @@ export interface IExtractorRuntimeCompilerConfig {
  */
 export interface IExtractorProjectConfig {
   /**
-   * Specifies the TypeScript source file that will be treated as the entry point
-   * for compilation.  This cannot always be inferred automatically.  (The package.json
-   * "main" and "typings" field point to the compiler output files, but this does not
-   * guarantee a specific location for the source files.)
+   * Specifies the TypeScript *.d.ts file that will be treated as the entry point
+   * for compilation.  Typically this corresponds to the "typings" or "types" field
+   * from package.json, but secondary entry points are also possible.
+   *
+   * @remarks
+   * The file extension must not be *.ts.  API Extractor does NOT process TypeScript
+   * source code, but instead the output of the compiler.  This is needed for compatibility
+   * with preprocessors and also custom tooling that produces TypeScript-compatible outputs
+   * without using the real compiler.  It also speeds up the analysis by avoiding the
+   * need to parse implementation code.
    */
   entryPointSourceFile: string;
 

--- a/apps/api-extractor/src/generators/ApiFileGenerator.ts
+++ b/apps/api-extractor/src/generators/ApiFileGenerator.ts
@@ -187,7 +187,7 @@ export default class ApiFileGenerator extends AstItemVisitor {
     const lines: string[] = [];
 
     if (astItem instanceof AstPackage && !astItem.documentation.summary.length) {
-      lines.push('(No packageDescription for this package)');
+      lines.push('(No @packagedocumentation comment for this package)');
     } else {
       let footer: string = '';
       switch (astItem.documentation.releaseTag) {

--- a/apps/api-extractor/src/test/TypeScriptHelpers.test.ts
+++ b/apps/api-extractor/src/test/TypeScriptHelpers.test.ts
@@ -20,19 +20,13 @@ describe('TypeScriptHelpers tests', () => {
 
   describe('extractCommentContent()', () => {
     it('multi-line comment', () => {
-      expect(TypeScriptHelpers.extractCommentContent('/**\n * this is\n * a test\n */\n'))
+      expect(TypeScriptHelpers.extractJSDocContent('/**\n * this is\n * a test\n */\n', console.error))
         .toBe('this is\na test');
     });
 
     it('single-line comment', () => {
-      expect(TypeScriptHelpers.extractCommentContent('/** single line comment */'))
+      expect(TypeScriptHelpers.extractJSDocContent('/** single line comment */', console.error))
         .toBe('single line comment');
-    });
-
-    it('degenerate comment', () => {
-      expect(TypeScriptHelpers.removeJsdocSequences(
-        ['/**', '* degenerate comment', 'star missing here', '* end of comment', '*/']))
-        .toBe('degenerate comment\nstar missing here\nend of comment');
     });
   });
 

--- a/apps/api-extractor/src/test/TypeScriptHelpers.test.ts
+++ b/apps/api-extractor/src/test/TypeScriptHelpers.test.ts
@@ -3,6 +3,11 @@
 
 import TypeScriptHelpers from '../TypeScriptHelpers';
 
+interface ITestCase {
+  input: string;
+  output: string;
+}
+
 describe('TypeScriptHelpers tests', () => {
 
   describe('splitStringWithRegEx()', () => {
@@ -19,15 +24,102 @@ describe('TypeScriptHelpers tests', () => {
   });
 
   describe('extractCommentContent()', () => {
-    it('multi-line comment', () => {
-      expect(TypeScriptHelpers.extractJSDocContent('/**\n * this is\n * a test\n */\n', console.error))
-        .toBe('this is\na test');
-    });
 
-    it('single-line comment', () => {
-      expect(TypeScriptHelpers.extractJSDocContent('/** single line comment */', console.error))
-        .toBe('single line comment');
-    });
+    const testCases: ITestCase[] = [
+      { // 0
+        input: '/*A*/',
+        output: '' // error
+      },
+      { // 1
+        input: '/****A****/',
+        output: 'A'
+      },
+      { // 2
+        input: '/**A */',
+        output: 'A'
+      },
+      { // 3
+        input: '/** A */',
+        output: 'A'
+      },
+      { // 4
+        input: '/**   A */',
+        output: 'A'
+      },
+      { // 5
+        input: '/**\n' +
+               'A */',
+        output: 'A'
+      },
+      { // 6
+        input: '/**\n' +
+               ' A */',
+        output: ' A'
+      },
+      { // 7
+        input: '/**\n' +
+               ' *A */',
+        output: 'A'
+      },
+      { // 8
+        input: '/**\n' +
+               ' * A */',
+        output: 'A'
+      },
+      { // 9
+        input: '/**\n' +
+               ' *   A*/',
+        output: '  A'
+      },
+      { // 10
+        input: '/**\n' +
+               ' *   A\n' +
+               ' */',
+        output: '  A\n'
+      },
+      { // 11
+        input: '/*****\n' +
+               '*A\n' +
+               '******/',
+        output: 'A\n'
+      },
+      { // 12
+        input: '/******\n' +
+               ' ***A**\n' +
+               ' ******/',
+        output: '**A**\n'
+      },
+      { // 13
+        input: '/** A\n' +
+               ' * B\n' +
+               'C */',
+        output: 'A\nB\nC'
+      },
+      { // 14
+        input: '/** A\n' +
+               ' *  B\n' +
+               ' *  C */',
+        output: 'A\n B\n C'
+      },
+      { // 15
+        input: '/**\n' +
+               ' * A\n' +
+               ' *   \t \n' +
+               ' * B\n' +
+               '    \n' +
+               ' * C\n' +
+               ' */',
+        output: 'A\n\nB\n\nC\n'
+      }
+    ];
+
+    for (let i: number = 0; i < testCases.length; ++i) {
+      it(`JSDoc test case ${i}`, () => {
+        expect(TypeScriptHelpers.extractJSDocContent(testCases[i].input, console.log))
+        .toBe(testCases[i].output);
+      });
+    }
+
   });
 
 });

--- a/apps/rush-lib/src/index.ts
+++ b/apps/rush-lib/src/index.ts
@@ -3,8 +3,8 @@
 
 /**
  * A library for writing scripts that interact with the Rush tool.
+ * @packagedocumentation
  */
-declare const packageDescription: void; // tslint:disable-line:no-unused-variable
 
 export {
   ApprovedPackagesPolicy

--- a/build-tests/api-extractor-test-01/api-extractor.json
+++ b/build-tests/api-extractor-test-01/api-extractor.json
@@ -2,37 +2,7 @@
   "$schema": "https://dev.office.com/json-schemas/api-extractor/api-extractor.schema.json",
   "compiler" : {
     "configType": "tsconfig",
-    "rootFolder": ".",
-
-    "overrideTsconfig": {
-      "compilerOptions": {
-        "target": "es6",
-        "forceConsistentCasingInFileNames": true,
-        "module": "commonjs",
-        "declaration": true,
-        "sourceMap": true,
-        "experimentalDecorators": true,
-        "strictNullChecks": true,
-        "types": [
-          "node",
-          "jest"
-        ],
-        "lib": [
-          "es5",
-          "scripthost",
-          "es2015.collection",
-          "es2015.promise",
-          "es2015.iterable",
-          "dom"
-        ]
-      },
-      "include": [
-        // TODO: Automatically generate this from the real tsconfig.json
-        "lib/index.d.ts",
-        "typings/tsd.d.ts"
-      ]
-    }
-
+    "rootFolder": "."
   },
 
   "packageTypings": {

--- a/build-tests/api-extractor-test-01/etc/api-extractor-test-01.api.ts
+++ b/build-tests/api-extractor-test-01/etc/api-extractor-test-01.api.ts
@@ -15,4 +15,4 @@ interface ISimpleInterface {
 class ReexportedClass {
 }
 
-// (No packageDescription for this package)
+// (No @packagedocumentation comment for this package)

--- a/build-tests/api-extractor-test-01/etc/api-extractor-test-01.api.ts
+++ b/build-tests/api-extractor-test-01/etc/api-extractor-test-01.api.ts
@@ -8,6 +8,11 @@ class AmbientConsumer {
 }
 
 // @public
+class DecoratorTest {
+  test(): void;
+}
+
+// @public
 interface ISimpleInterface {
 }
 
@@ -15,4 +20,6 @@ interface ISimpleInterface {
 class ReexportedClass {
 }
 
-// (No @packagedocumentation comment for this package)
+// @public
+export function virtual(target: Object, propertyKey: string | symbol, descriptor: TypedPropertyDescriptor<any>): void;
+

--- a/build-tests/api-extractor-test-01/src/index.ts
+++ b/build-tests/api-extractor-test-01/src/index.ts
@@ -2,9 +2,13 @@
 // See LICENSE in the project root for license information.
 
 /**
- * Example package docs.
+ * Example documentation for the package.
+ *
+ * @remarks
+ * Additional remarks
+ *
+ * @packagedocumentation
  */
-declare const packageDescription: void; // tslint:disable-line:no-unused-variable
 
 /**
  * Test the alias-following logic:  This class gets aliased twice before being
@@ -53,5 +57,29 @@ export class AmbientConsumer {
    */
   public localTypings(): IAmbientInterfaceExample {
     return {} as IAmbientInterfaceExample;
+  }
+}
+
+/**
+ * Example decorator
+ * @public
+ */
+export function virtual(target: Object, propertyKey: string | symbol,
+  descriptor: TypedPropertyDescriptor<any>): void {
+  // Eventually we may implement runtime validation (e.g. in DEBUG builds)
+  // but currently this decorator is only used by the build tools.
+}
+
+/**
+ * Tests a decorator
+ * @public
+ */
+export class DecoratorTest {
+  /**
+   * Function with a decorator
+   */
+  @virtual
+  public test(): void {
+    console.log('');
   }
 }

--- a/common/changes/@microsoft/api-extractor/pgonzal-ae-reads-dts_2018-01-05-22-40.json
+++ b/common/changes/@microsoft/api-extractor/pgonzal-ae-reads-dts_2018-01-05-22-40.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor",
+      "comment": "API Extractor now processes *.d.ts files instead of *.ts files",
+      "type": "major"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/api-extractor/pgonzal-ae-reads-dts_2018-01-05-22-42.json
+++ b/common/changes/@microsoft/api-extractor/pgonzal-ae-reads-dts_2018-01-05-22-42.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor",
+      "comment": "Introduced new tag @packagedocumentation which replaces the earlier approach that used a \"packageDescription\" variable",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/gulp-core-build-typescript/pgonzal-ae-reads-dts_2018-01-05-22-40.json
+++ b/common/changes/@microsoft/gulp-core-build-typescript/pgonzal-ae-reads-dts_2018-01-05-22-40.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/gulp-core-build-typescript",
+      "comment": "The ApiExtractor task now expects *.d.ts files instead of *.ts, but includes a compatibility workaround for the common case of src/index.ts",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@microsoft/gulp-core-build-typescript",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/gulp-core-build-typescript/pgonzal-ae-reads-dts_2018-01-05-22-42.json
+++ b/common/changes/@microsoft/gulp-core-build-typescript/pgonzal-ae-reads-dts_2018-01-05-22-42.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@microsoft/gulp-core-build-typescript",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/gulp-core-build-typescript",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/loader-load-themed-styles/pgonzal-ae-reads-dts_2018-01-05-22-40.json
+++ b/common/changes/@microsoft/loader-load-themed-styles/pgonzal-ae-reads-dts_2018-01-05-22-40.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@microsoft/loader-load-themed-styles",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/loader-load-themed-styles",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/loader-load-themed-styles/pgonzal-ae-reads-dts_2018-01-05-22-42.json
+++ b/common/changes/@microsoft/loader-load-themed-styles/pgonzal-ae-reads-dts_2018-01-05-22-42.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@microsoft/loader-load-themed-styles",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/loader-load-themed-styles",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/resolve-chunk-plugin/pgonzal-ae-reads-dts_2018-01-05-22-40.json
+++ b/common/changes/@microsoft/resolve-chunk-plugin/pgonzal-ae-reads-dts_2018-01-05-22-40.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/resolve-chunk-plugin",
+      "comment": "Minor updates for compatibility with new api-extractor",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/resolve-chunk-plugin",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/resolve-chunk-plugin/pgonzal-ae-reads-dts_2018-01-05-22-42.json
+++ b/common/changes/@microsoft/resolve-chunk-plugin/pgonzal-ae-reads-dts_2018-01-05-22-42.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@microsoft/resolve-chunk-plugin",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/resolve-chunk-plugin",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/set-webpack-public-path-plugin/pgonzal-ae-reads-dts_2018-01-05-22-40.json
+++ b/common/changes/@microsoft/set-webpack-public-path-plugin/pgonzal-ae-reads-dts_2018-01-05-22-40.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@microsoft/set-webpack-public-path-plugin",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/set-webpack-public-path-plugin",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/set-webpack-public-path-plugin/pgonzal-ae-reads-dts_2018-01-05-22-42.json
+++ b/common/changes/@microsoft/set-webpack-public-path-plugin/pgonzal-ae-reads-dts_2018-01-05-22-42.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@microsoft/set-webpack-public-path-plugin",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/set-webpack-public-path-plugin",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/web-library-build/pgonzal-ae-reads-dts_2018-01-05-22-40.json
+++ b/common/changes/@microsoft/web-library-build/pgonzal-ae-reads-dts_2018-01-05-22-40.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/web-library-build",
+      "comment": "api-extractor now runs after tsc rather than in parallel, and is excluded from \"gulp serve\"",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@microsoft/web-library-build",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/web-library-build/pgonzal-ae-reads-dts_2018-01-05-22-42.json
+++ b/common/changes/@microsoft/web-library-build/pgonzal-ae-reads-dts_2018-01-05-22-42.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@microsoft/web-library-build",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/web-library-build",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/reviews/api/api-extractor.api.ts
+++ b/common/reviews/api/api-extractor.api.ts
@@ -16,6 +16,7 @@ class Extractor {
   public readonly actualConfig: IExtractorConfig;
   // @deprecated
   public analyzeProject(options?: IAnalyzeProjectOptions): void;
+  public static generateFilePathsForAnalysis(inputFilePaths: string[]): string[];
   public static jsonSchema: JsonSchema;
   public processProject(options?: IAnalyzeProjectOptions): boolean;
 }

--- a/common/reviews/api/loader-load-themed-styles.api.ts
+++ b/common/reviews/api/loader-load-themed-styles.api.ts
@@ -4,12 +4,12 @@ interface ILoadThemedStylesLoaderOptions {
   namedExport?: string;
 }
 
-// WARNING: loadedThemedStylesPath has incomplete type information
 // @public
 class LoadThemedStylesLoader {
   constructor();
+  static loadedThemedStylesPath: string;
   // (undocumented)
-  public static pitch(this: loader.LoaderContext, remainingRequest: string): string;
-  public static resetLoadedThemedStylesPath(): void;
+  static pitch(this: loader.LoaderContext, remainingRequest: string): string;
+  static resetLoadedThemedStylesPath(): void;
 }
 

--- a/common/reviews/api/node-library-build.api.ts
+++ b/common/reviews/api/node-library-build.api.ts
@@ -1,8 +1,8 @@
 // @internal
-export declare function _isJestEnabled(rootFolder: string): boolean;
+export function _isJestEnabled(rootFolder: string): boolean;
 
 // @public
-export declare function addSuppression(suppression: string | RegExp): void;
+export function addSuppression(suppression: string | RegExp): void;
 
 // @public
 class ApiExtractorTask extends GulpTask<IApiExtractorTaskConfig> {
@@ -45,22 +45,22 @@ class CopyTask extends GulpTask<ICopyConfig> {
 }
 
 // @public
-export declare function coverageData(coverage: number, threshold: number, filePath: string): void;
+export function coverageData(coverage: number, threshold: number, filePath: string): void;
 
 // @public
-export declare function error(...args: Array<string | Chalk.ChalkChain>): void;
+export function error(...args: Array<string | Chalk.ChalkChain>): void;
 
 // @public
-export declare function fileError(taskName: string, filePath: string, line: number, column: number, errorCode: string, message: string): void;
+export function fileError(taskName: string, filePath: string, line: number, column: number, errorCode: string, message: string): void;
 
 // @public
-export declare function fileLog(write: (text: string) => void, taskName: string, filePath: string, line: number, column: number, errorCode: string, message: string): void;
+export function fileLog(write: (text: string) => void, taskName: string, filePath: string, line: number, column: number, errorCode: string, message: string): void;
 
 // @public
-export declare function fileWarning(taskName: string, filePath: string, line: number, column: number, errorCode: string, message: string): void;
+export function fileWarning(taskName: string, filePath: string, line: number, column: number, errorCode: string, message: string): void;
 
 // @public
-export declare function functionalTestRun(name: string, result: TestResultState, duration: number): void;
+export function functionalTestRun(name: string, result: TestResultState, duration: number): void;
 
 // @public
 class GenerateShrinkwrapTask extends GulpTask<void> {
@@ -69,13 +69,13 @@ class GenerateShrinkwrapTask extends GulpTask<void> {
 }
 
 // @public
-export declare function getConfig(): IBuildConfig;
+export function getConfig(): IBuildConfig;
 
 // @public
-export declare function getErrors(): string[];
+export function getErrors(): string[];
 
 // @public
-export declare function getWarnings(): string[];
+export function getWarnings(): string[];
 
 // @public
 class GulpTask<TTaskConfig> implements IExecutable {
@@ -111,7 +111,7 @@ class GulpTask<TTaskConfig> implements IExecutable {
 // @public (undocumented)
 interface IBuildConfig {
   args: {
-    [ name: string ]: string | boolean;
+    [name: string]: string | boolean;
   }
   buildErrorIconPath?: string;
   buildSuccessIconPath?: string;
@@ -127,7 +127,7 @@ interface IBuildConfig {
   packageFolder: string;
   production: boolean;
   properties?: {
-    [ key: string ]: any;
+    [key: string]: any;
   }
   relogIssues?: boolean;
   rootPath: string;
@@ -142,7 +142,7 @@ interface IBuildConfig {
 // @public
 interface ICopyConfig {
   copyTo: {
-    [ destPath: string ]: string[];
+    [destPath: string]: string[];
   }
   shouldFlatten?: boolean;
 }
@@ -193,7 +193,7 @@ interface IJestConfig {
 }
 
 // @public
-export declare function initialize(gulp: typeof Gulp): void;
+export function initialize(gulp: typeof Gulp): void;
 
 // @public (undocumented)
 interface ITsConfigFile<T> {
@@ -212,34 +212,34 @@ class JestTask extends GulpTask<IJestConfig> {
 }
 
 // @public
-export declare function log(...args: Array<string | Chalk.ChalkChain>): void;
+export function log(...args: Array<string | Chalk.ChalkChain>): void;
 
 // @public
-export declare function logSummary(value: string): void;
+export function logSummary(value: string): void;
 
 // @public
-export declare function mergeConfig(config: Partial<IBuildConfig>): void;
+export function mergeConfig(config: Partial<IBuildConfig>): void;
 
 // @public
-export declare function parallel(...tasks: Array<IExecutable[] | IExecutable>): IExecutable;
+export function parallel(...tasks: Array<IExecutable[] | IExecutable>): IExecutable;
 
 // @public
-export declare function replaceConfig(config: IBuildConfig): void;
+export function replaceConfig(config: IBuildConfig): void;
 
 // @public
-export declare function reset(): void;
+export function reset(): void;
 
 // @public
-export declare function serial(...tasks: Array<IExecutable[] | IExecutable>): IExecutable;
+export function serial(...tasks: Array<IExecutable[] | IExecutable>): IExecutable;
 
 // @public
-export declare function setConfig(config: Partial<IBuildConfig>): void;
+export function setConfig(config: Partial<IBuildConfig>): void;
 
 // @public
-export declare function subTask(taskName: string, fn: ICustomGulpTask): IExecutable;
+export function subTask(taskName: string, fn: ICustomGulpTask): IExecutable;
 
 // @public
-export declare function task(taskName: string, taskExecutable: IExecutable): IExecutable;
+export function task(taskName: string, taskExecutable: IExecutable): IExecutable;
 
 // @public
 enum TestResultState {
@@ -282,13 +282,13 @@ class ValidateShrinkwrapTask extends GulpTask<void> {
 }
 
 // @public
-export declare function verbose(...args: Array<string | Chalk.ChalkChain>): void;
+export function verbose(...args: Array<string | Chalk.ChalkChain>): void;
 
 // @public
-export declare function warn(...args: Array<string | Chalk.ChalkChain>): void;
+export function warn(...args: Array<string | Chalk.ChalkChain>): void;
 
 // @public
-export declare function watch(watchMatch: string | string[], taskExecutable: IExecutable): IExecutable;
+export function watch(watchMatch: string | string[], taskExecutable: IExecutable): IExecutable;
 
 // WARNING: Unsupported export: preCopy
 // WARNING: Unsupported export: postCopy
@@ -306,4 +306,4 @@ export declare function watch(watchMatch: string | string[], taskExecutable: IEx
 // WARNING: Unsupported export: removeTripleSlash
 // WARNING: Unsupported export: instrument
 // WARNING: Unsupported export: mocha
-// (No packageDescription for this package)
+// (No @packagedocumentation comment for this package)

--- a/common/reviews/api/package-deps-hash.api.ts
+++ b/common/reviews/api/package-deps-hash.api.ts
@@ -1,12 +1,12 @@
 // @public
-export function getPackageDeps(packagePath: string = process.cwd(), excludedPaths?: string[]): IPackageDeps;
+export function getPackageDeps(packagePath?: string, excludedPaths?: string[]): IPackageDeps;
 
 // @public (undocumented)
 interface IPackageDeps {
   // (undocumented)
   files: {
-    [ key: string ]: string
+    [key: string]: string;
   }
 }
 
-// (No packageDescription for this package)
+// (No @packagedocumentation comment for this package)

--- a/common/reviews/api/resolve-chunk-plugin.api.ts
+++ b/common/reviews/api/resolve-chunk-plugin.api.ts
@@ -1,5 +1,5 @@
 // @public
 class ResolveChunkPlugin implements Webpack.Plugin {
-  public apply(compiler: Webpack.Compiler): void;
+  apply(compiler: Webpack.Compiler): void;
 }
 

--- a/common/reviews/api/rush-lib.api.ts
+++ b/common/reviews/api/rush-lib.api.ts
@@ -1,62 +1,61 @@
 // @public
 class ApprovedPackagesConfiguration {
-  public constructor(jsonFilename: string);
+  constructor(jsonFilename: string);
   // (undocumented)
-  public addOrUpdatePackage(packageName: string, reviewCategory: string): void;
-  public clear(): void;
+  addOrUpdatePackage(packageName: string, reviewCategory: string): void;
+  clear(): void;
   // (undocumented)
-  public getItemByName(packageName: string): ApprovedPackagesItem | undefined;
+  getItemByName(packageName: string): ApprovedPackagesItem | undefined;
   // (undocumented)
-  public items: ApprovedPackagesItem[];
-  public loadFromFile(): void;
-  public saveToFile(): void;
-  public tryLoadFromFile(approvedPackagesPolicyEnabled: boolean): boolean;
+  items: ApprovedPackagesItem[];
+  loadFromFile(): void;
+  saveToFile(): void;
+  tryLoadFromFile(approvedPackagesPolicyEnabled: boolean): boolean;
 }
 
 // @public
 class ApprovedPackagesItem {
-  public allowedCategories: Set<string>;
-  public packageName: string;
+  allowedCategories: Set<string>;
+  packageName: string;
 }
 
 // @public
 class ApprovedPackagesPolicy {
   // WARNING: The type "IRushConfigurationJson" needs to be exported by the package (e.g. added to index.ts)
   // @internal
-  public constructor(rushConfiguration: RushConfiguration, rushConfigurationJson: IRushConfigurationJson);
-  public readonly browserApprovedPackages: ApprovedPackagesConfiguration;
-  public readonly enabled: boolean;
-  public readonly ignoredNpmScopes: Set<string>;
-  public readonly nonbrowserApprovedPackages: ApprovedPackagesConfiguration;
-  public readonly reviewCategories: Set<string>;
+  constructor(rushConfiguration: RushConfiguration, rushConfigurationJson: IRushConfigurationJson);
+  readonly browserApprovedPackages: ApprovedPackagesConfiguration;
+  readonly enabled: boolean;
+  readonly ignoredNpmScopes: Set<string>;
+  readonly nonbrowserApprovedPackages: ApprovedPackagesConfiguration;
+  readonly reviewCategories: Set<string>;
 }
 
 // @beta
 enum BumpType {
   // (undocumented)
-  'major',
+  'major' = 5,
   // (undocumented)
-  'minor',
+  'minor' = 4,
   // (undocumented)
-  'none',
+  'none' = 0,
   // (undocumented)
-  'patch',
+  'patch' = 2,
   // (undocumented)
-  'preminor',
+  'preminor' = 3,
   // (undocumented)
-  'prerelease'
+  'prerelease' = 1
 }
 
 // @public
 class ChangeFile {
   // WARNING: The type "IChangeFile" needs to be exported by the package (e.g. added to index.ts)
   // @internal
-  public constructor(private _changeFileData: IChangeFile,
-      private _rushConfiguration: RushConfiguration);
-  public addChange(data: IChangeInfo): void;
-  public generatePath(): string;
-  public getChanges(packageName: string): IChangeInfo[];
-  public writeSync(): void;
+  constructor(_changeFileData: IChangeFile, _rushConfiguration: RushConfiguration);
+  addChange(data: IChangeInfo): void;
+  generatePath(): string;
+  getChanges(packageName: string): IChangeInfo[];
+  writeSync(): void;
 }
 
 // @public
@@ -87,8 +86,8 @@ enum Event {
 class EventHooks {
   // WARNING: The type "IEventHooksJson" needs to be exported by the package (e.g. added to index.ts)
   // @internal
-  public constructor(eventHooksJson: IEventHooksJson);
-  public get(event: Event): string[];
+  constructor(eventHooksJson: IEventHooksJson);
+  get(event: Event): string[];
 }
 
 // @public
@@ -112,31 +111,30 @@ class IndividualVersionPolicy extends VersionPolicy {
   constructor(versionPolicyJson: IIndividualVersionJson);
   // WARNING: The type "IIndividualVersionJson" needs to be exported by the package (e.g. added to index.ts)
   // @internal
-  public readonly _json: IIndividualVersionJson;
-  public bump(bumpType?: BumpType, identifier?: string): void;
-  public ensure(project: IPackageJson): IPackageJson | undefined;
-  public readonly lockedMajor: number | undefined;
-  public validate(versionString: string, packageName: string): void;
+  readonly _json: IIndividualVersionJson;
+  bump(bumpType?: BumpType, identifier?: string): void;
+  ensure(project: IPackageJson): IPackageJson | undefined;
+  readonly lockedMajor: number | undefined;
+  validate(versionString: string, packageName: string): void;
 }
 
 // @public
 interface IPackageJson {
-  // (undocumented)
-  [ key: string ]: any;
+  [key: string]: any;
   dependencies?: {
-    [ key: string ]: string
+    [key: string]: string;
   }
   description?: string;
   devDependencies?: {
-    [ key: string ]: string
+    [key: string]: string;
   }
   name: string;
   optionalDependencies?: {
-    [ key: string ]: string
+    [key: string]: string;
   }
   private?: boolean;
   scripts?: {
-    [ key: string ]: string
+    [key: string]: string;
   }
   version: string;
 }
@@ -148,108 +146,106 @@ class LockStepVersionPolicy extends VersionPolicy {
   constructor(versionPolicyJson: ILockStepVersionJson);
   // WARNING: The type "ILockStepVersionJson" needs to be exported by the package (e.g. added to index.ts)
   // @internal
-  public readonly _json: ILockStepVersionJson;
-  public bump(bumpType?: BumpType, identifier?: string): void;
-  public ensure(project: IPackageJson): IPackageJson | undefined;
-  public readonly nextBump: BumpType;
-  public validate(versionString: string, packageName: string): void;
-  public readonly version: semver.SemVer;
+  readonly _json: ILockStepVersionJson;
+  bump(bumpType?: BumpType, identifier?: string): void;
+  ensure(project: IPackageJson): IPackageJson | undefined;
+  readonly nextBump: BumpType;
+  validate(versionString: string, packageName: string): void;
+  readonly version: semver.SemVer;
 }
 
 // @public
 class PinnedVersionsConfiguration {
   // (undocumented)
-  public clear(): this;
+  clear(): this;
   // (undocumented)
-  public delete(dependency: string): boolean;
+  delete(dependency: string): boolean;
   // (undocumented)
-  public forEach(cb: (version: string, dependency: string) => void): this;
+  forEach(cb: (version: string, dependency: string) => void): this;
   // (undocumented)
-  public get(dependency: string): string | undefined;
+  get(dependency: string): string | undefined;
   // (undocumented)
-  public has(dependency: string): boolean;
+  has(dependency: string): boolean;
   // (undocumented)
-  public save(): this;
-  public set(dependency: string, version: string): this;
+  save(): this;
+  set(dependency: string, version: string): this;
   // (undocumented)
-  public readonly size: number;
-  public static tryLoadFromFile(jsonFilename: string): PinnedVersionsConfiguration;
+  readonly size: number;
+  static tryLoadFromFile(jsonFilename: string): PinnedVersionsConfiguration;
 }
 
 // @public
 class Rush {
-  public static launch(launcherVersion: string, isManaged: boolean): void;
+  static launch(launcherVersion: string, isManaged: boolean): void;
   // @public
-  public static readonly version: string;
+  static readonly version: string;
 }
 
 // @public
 class RushConfiguration {
-  public readonly approvedPackagesPolicy: ApprovedPackagesPolicy;
-  public readonly changesFolder: string;
-  public readonly committedShrinkwrapFilename: string;
-  public readonly commonFolder: string;
-  public readonly commonRushConfigFolder: string;
-  public readonly commonTempFolder: string;
+  readonly approvedPackagesPolicy: ApprovedPackagesPolicy;
+  readonly changesFolder: string;
+  readonly committedShrinkwrapFilename: string;
+  readonly commonFolder: string;
+  readonly commonRushConfigFolder: string;
+  readonly commonTempFolder: string;
   // @beta
-  public readonly eventHooks: EventHooks;
-  public findProjectByShorthandName(shorthandProjectName: string): RushConfigurationProject | undefined;
-  public findProjectByTempName(tempProjectName: string): RushConfigurationProject | undefined;
-  public static getHomeDirectory(): string;
-  public getProjectByName(projectName: string): RushConfigurationProject | undefined;
-  public readonly gitAllowedEmailRegExps: string[];
-  public readonly gitSampleEmail: string;
-  public readonly homeFolder: string;
-  public readonly hotfixChangeEnabled: boolean;
-  public static loadFromConfigurationFile(rushJsonFilename: string): RushConfiguration;
+  readonly eventHooks: EventHooks;
+  findProjectByShorthandName(shorthandProjectName: string): RushConfigurationProject | undefined;
+  findProjectByTempName(tempProjectName: string): RushConfigurationProject | undefined;
+  static getHomeDirectory(): string;
+  getProjectByName(projectName: string): RushConfigurationProject | undefined;
+  readonly gitAllowedEmailRegExps: string[];
+  readonly gitSampleEmail: string;
+  readonly homeFolder: string;
+  readonly hotfixChangeEnabled: boolean;
+  static loadFromConfigurationFile(rushJsonFilename: string): RushConfiguration;
   // (undocumented)
-  public static loadFromDefaultLocation(): RushConfiguration;
-  public readonly npmCacheFolder: string;
-  public readonly npmTmpFolder: string;
-  public readonly packageManager: PackageManager;
-  public readonly packageManagerToolFilename: string;
-  public readonly packageManagerToolVersion: string;
-  public readonly pinnedVersions: PinnedVersionsConfiguration;
-  public readonly pnpmStoreFolder: string;
-  public readonly projectFolderMaxDepth: number;
-  public readonly projectFolderMinDepth: number;
+  static loadFromDefaultLocation(): RushConfiguration;
+  readonly npmCacheFolder: string;
+  readonly npmTmpFolder: string;
+  readonly packageManager: PackageManager;
+  readonly packageManagerToolFilename: string;
+  readonly packageManagerToolVersion: string;
+  readonly pinnedVersions: PinnedVersionsConfiguration;
+  readonly pnpmStoreFolder: string;
+  readonly projectFolderMaxDepth: number;
+  readonly projectFolderMinDepth: number;
   // (undocumented)
-  public readonly projects: RushConfigurationProject[];
+  readonly projects: RushConfigurationProject[];
   // (undocumented)
-  public readonly projectsByName: Map<string, RushConfigurationProject>;
-  public readonly repositoryUrl: string;
-  public readonly rushJsonFile: string;
-  public readonly rushJsonFolder: string;
-  public readonly rushLinkJsonFilename: string;
+  readonly projectsByName: Map<string, RushConfigurationProject>;
+  readonly repositoryUrl: string;
+  readonly rushJsonFile: string;
+  readonly rushJsonFolder: string;
+  readonly rushLinkJsonFilename: string;
   // @beta
-  public readonly telemetryEnabled: boolean;
-  public readonly tempShrinkwrapFilename: string;
-  public static tryFindRushJsonLocation(verbose: boolean = true): string | undefined;
+  readonly telemetryEnabled: boolean;
+  readonly tempShrinkwrapFilename: string;
+  static tryFindRushJsonLocation(verbose?: boolean): string | undefined;
   // @beta (undocumented)
-  public readonly versionPolicyConfiguration: VersionPolicyConfiguration;
+  readonly versionPolicyConfiguration: VersionPolicyConfiguration;
 }
 
 // @public
 class RushConfigurationProject {
   // WARNING: The type "IRushConfigurationProjectJson" needs to be exported by the package (e.g. added to index.ts)
   // @internal
-  constructor(projectJson: IRushConfigurationProjectJson,
-                rushConfiguration: RushConfiguration,
-                tempProjectName: string);
-  public readonly cyclicDependencyProjects: Set<string>;
-  public readonly downstreamDependencyProjects: string[];
-  public readonly packageJson: IPackageJson;
-  public readonly packageName: string;
-  public readonly projectFolder: string;
-  public readonly projectRelativeFolder: string;
-  public readonly reviewCategory: string;
-  public readonly shouldPublish: boolean;
-  public readonly tempProjectName: string;
-  public readonly unscopedTempProjectName: string;
+  constructor(projectJson: IRushConfigurationProjectJson, rushConfiguration: RushConfiguration, tempProjectName: string);
+  readonly cyclicDependencyProjects: Set<string>;
+  readonly downstreamDependencyProjects: string[];
+  readonly packageJson: IPackageJson;
+  readonly packageName: string;
+  readonly projectFolder: string;
+  readonly projectRelativeFolder: string;
+  readonly reviewCategory: string;
+  readonly shouldPublish: boolean;
+  readonly tempProjectName: string;
+  readonly unscopedTempProjectName: string;
   // @beta
-  public readonly versionPolicy: VersionPolicy | undefined;
+  readonly versionPolicy: VersionPolicy | undefined;
   // @beta
-  public readonly versionPolicyName: string | undefined;
+  readonly versionPolicyName: string | undefined;
 }
 
 // @beta
@@ -259,36 +255,33 @@ class VersionPolicy {
   constructor(versionPolicyJson: IVersionPolicyJson);
   // WARNING: The type "IVersionPolicyJson" needs to be exported by the package (e.g. added to index.ts)
   // @internal
-  public readonly _json: IVersionPolicyJson;
-  public abstract bump(bumpType?: BumpType, identifier?: string): void;
-  public readonly definitionName: VersionPolicyDefinitionName;
-  public abstract ensure(project: IPackageJson): IPackageJson | undefined;
+  readonly _json: IVersionPolicyJson;
+  abstract bump(bumpType?: BumpType, identifier?: string): void;
+  readonly definitionName: VersionPolicyDefinitionName;
+  abstract ensure(project: IPackageJson): IPackageJson | undefined;
   // WARNING: Because this definition is explicitly marked as @internal, an underscore prefix ("_") should be added to its name
   // WARNING: The type "IVersionPolicyJson" needs to be exported by the package (e.g. added to index.ts)
   // @internal
-  public static load(versionPolicyJson: IVersionPolicyJson): VersionPolicy | undefined;
-  public readonly policyName: string;
-  public abstract validate(versionString: string, packageName: string): void;
+  static load(versionPolicyJson: IVersionPolicyJson): VersionPolicy | undefined;
+  readonly policyName: string;
+  abstract validate(versionString: string, packageName: string): void;
 }
 
 // @beta (undocumented)
 class VersionPolicyConfiguration {
   // @internal
-  public constructor(private _jsonFileName: string);
-  public bump(versionPolicyName?: string,
-      bumpType?: BumpType,
-      identifier?: string,
-      shouldCommit?: boolean): void;
-  public getVersionPolicy(policyName: string): VersionPolicy;
-  public readonly versionPolicies: Map<string, VersionPolicy>;
+  constructor(_jsonFileName: string);
+  bump(versionPolicyName?: string, bumpType?: BumpType, identifier?: string, shouldCommit?: boolean): void;
+  getVersionPolicy(policyName: string): VersionPolicy;
+  readonly versionPolicies: Map<string, VersionPolicy>;
 }
 
 // @beta
 enum VersionPolicyDefinitionName {
   // (undocumented)
-  'individualVersion',
+  'individualVersion' = 1,
   // (undocumented)
-  'lockStepVersion'
+  'lockStepVersion' = 0
 }
 
 // WARNING: Unsupported export: PackageManager

--- a/common/reviews/api/set-webpack-public-path-plugin.api.ts
+++ b/common/reviews/api/set-webpack-public-path-plugin.api.ts
@@ -1,5 +1,5 @@
 // @public
-export function getGlobalRegisterCode(debug: boolean = false): string;
+export function getGlobalRegisterCode(debug?: boolean): string;
 
 // @public
 interface ISetWebpackPublicPathOptions {
@@ -22,9 +22,9 @@ interface ISetWebpackPublicPathPluginOptions extends ISetWebpackPublicPathOption
 class SetPublicPathPlugin implements Webpack.Plugin {
   constructor(options: ISetWebpackPublicPathPluginOptions);
   // (undocumented)
-  public apply(compiler: Webpack.Compiler): void;
+  apply(compiler: Webpack.Compiler): void;
   // (undocumented)
-  public options: ISetWebpackPublicPathPluginOptions;
+  options: ISetWebpackPublicPathPluginOptions;
 }
 
 // WARNING: Unsupported export: registryVariableName

--- a/common/reviews/api/test-web-library-build.api.ts
+++ b/common/reviews/api/test-web-library-build.api.ts
@@ -7,4 +7,4 @@ export function log(message: string): void;
 // @public (undocumented)
 export function logClass(): void;
 
-// (No packageDescription for this package)
+// (No @packagedocumentation comment for this package)

--- a/common/reviews/api/web-library-build.api.ts
+++ b/common/reviews/api/web-library-build.api.ts
@@ -1,8 +1,8 @@
 // @internal
-export declare function _isJestEnabled(rootFolder: string): boolean;
+export function _isJestEnabled(rootFolder: string): boolean;
 
 // @public
-export declare function addSuppression(suppression: string | RegExp): void;
+export function addSuppression(suppression: string | RegExp): void;
 
 // @public
 class ApiExtractorTask extends GulpTask<IApiExtractorTaskConfig> {
@@ -45,22 +45,22 @@ class CopyTask extends GulpTask<ICopyConfig> {
 }
 
 // @public
-export declare function coverageData(coverage: number, threshold: number, filePath: string): void;
+export function coverageData(coverage: number, threshold: number, filePath: string): void;
 
 // @public
-export declare function error(...args: Array<string | Chalk.ChalkChain>): void;
+export function error(...args: Array<string | Chalk.ChalkChain>): void;
 
 // @public
-export declare function fileError(taskName: string, filePath: string, line: number, column: number, errorCode: string, message: string): void;
+export function fileError(taskName: string, filePath: string, line: number, column: number, errorCode: string, message: string): void;
 
 // @public
-export declare function fileLog(write: (text: string) => void, taskName: string, filePath: string, line: number, column: number, errorCode: string, message: string): void;
+export function fileLog(write: (text: string) => void, taskName: string, filePath: string, line: number, column: number, errorCode: string, message: string): void;
 
 // @public
-export declare function fileWarning(taskName: string, filePath: string, line: number, column: number, errorCode: string, message: string): void;
+export function fileWarning(taskName: string, filePath: string, line: number, column: number, errorCode: string, message: string): void;
 
 // @public
-export declare function functionalTestRun(name: string, result: TestResultState, duration: number): void;
+export function functionalTestRun(name: string, result: TestResultState, duration: number): void;
 
 // @public
 class GenerateShrinkwrapTask extends GulpTask<void> {
@@ -69,13 +69,13 @@ class GenerateShrinkwrapTask extends GulpTask<void> {
 }
 
 // @public
-export declare function getConfig(): IBuildConfig;
+export function getConfig(): IBuildConfig;
 
 // @public
-export declare function getErrors(): string[];
+export function getErrors(): string[];
 
 // @public
-export declare function getWarnings(): string[];
+export function getWarnings(): string[];
 
 // @public
 class GulpTask<TTaskConfig> implements IExecutable {
@@ -111,7 +111,7 @@ class GulpTask<TTaskConfig> implements IExecutable {
 // @public (undocumented)
 interface IBuildConfig {
   args: {
-    [ name: string ]: string | boolean;
+    [name: string]: string | boolean;
   }
   buildErrorIconPath?: string;
   buildSuccessIconPath?: string;
@@ -127,7 +127,7 @@ interface IBuildConfig {
   packageFolder: string;
   production: boolean;
   properties?: {
-    [ key: string ]: any;
+    [key: string]: any;
   }
   relogIssues?: boolean;
   rootPath: string;
@@ -142,7 +142,7 @@ interface IBuildConfig {
 // @public
 interface ICopyConfig {
   copyTo: {
-    [ destPath: string ]: string[];
+    [destPath: string]: string[];
   }
   shouldFlatten?: boolean;
 }
@@ -193,7 +193,7 @@ interface IJestConfig {
 }
 
 // @public
-export declare function initialize(gulp: typeof Gulp): void;
+export function initialize(gulp: typeof Gulp): void;
 
 // @public (undocumented)
 interface ITsConfigFile<T> {
@@ -227,34 +227,34 @@ class JestTask extends GulpTask<IJestConfig> {
 }
 
 // @public
-export declare function log(...args: Array<string | Chalk.ChalkChain>): void;
+export function log(...args: Array<string | Chalk.ChalkChain>): void;
 
 // @public
-export declare function logSummary(value: string): void;
+export function logSummary(value: string): void;
 
 // @public
-export declare function mergeConfig(config: Partial<IBuildConfig>): void;
+export function mergeConfig(config: Partial<IBuildConfig>): void;
 
 // @public
-export declare function parallel(...tasks: Array<IExecutable[] | IExecutable>): IExecutable;
+export function parallel(...tasks: Array<IExecutable[] | IExecutable>): IExecutable;
 
 // @public
-export declare function replaceConfig(config: IBuildConfig): void;
+export function replaceConfig(config: IBuildConfig): void;
 
 // @public
-export declare function reset(): void;
+export function reset(): void;
 
 // @public
-export declare function serial(...tasks: Array<IExecutable[] | IExecutable>): IExecutable;
+export function serial(...tasks: Array<IExecutable[] | IExecutable>): IExecutable;
 
 // @public
-export declare function setConfig(config: Partial<IBuildConfig>): void;
+export function setConfig(config: Partial<IBuildConfig>): void;
 
 // @public
-export declare function subTask(taskName: string, fn: ICustomGulpTask): IExecutable;
+export function subTask(taskName: string, fn: ICustomGulpTask): IExecutable;
 
 // @public
-export declare function task(taskName: string, taskExecutable: IExecutable): IExecutable;
+export function task(taskName: string, taskExecutable: IExecutable): IExecutable;
 
 // @public
 enum TestResultState {
@@ -297,13 +297,13 @@ class ValidateShrinkwrapTask extends GulpTask<void> {
 }
 
 // @public
-export declare function verbose(...args: Array<string | Chalk.ChalkChain>): void;
+export function verbose(...args: Array<string | Chalk.ChalkChain>): void;
 
 // @public
-export declare function warn(...args: Array<string | Chalk.ChalkChain>): void;
+export function warn(...args: Array<string | Chalk.ChalkChain>): void;
 
 // @public
-export declare function watch(watchMatch: string | string[], taskExecutable: IExecutable): IExecutable;
+export function watch(watchMatch: string | string[], taskExecutable: IExecutable): IExecutable;
 
 // @public (undocumented)
 class WebpackTask<TExtendedConfig = {}> extends GulpTask<IWebpackTaskConfig & TExtendedConfig> {
@@ -344,4 +344,4 @@ class WebpackTask<TExtendedConfig = {}> extends GulpTask<IWebpackTaskConfig & TE
 // WARNING: Unsupported export: reload
 // WARNING: Unsupported export: trustDevCert
 // WARNING: Unsupported export: untrustDevCert
-// (No packageDescription for this package)
+// (No @packagedocumentation comment for this package)

--- a/core-build/test-web-library-build/config/api-extractor.json
+++ b/core-build/test-web-library-build/config/api-extractor.json
@@ -2,5 +2,5 @@
   "enabled": true,
   "apiReviewFolder": "../../common/reviews/api",
   "apiJsonFolder": "./temp",
-  "entry": "src/test.ts"
+  "entry": "lib/test.d.ts"
 }

--- a/core-build/web-library-build/src/index.ts
+++ b/core-build/web-library-build/src/index.ts
@@ -52,8 +52,8 @@ tslint.mergeConfig({
 });
 
 // Define default task groups.
-export const compileTsTasks: IExecutable = parallel(typescript, text, apiExtractor);
-export const buildTasks: IExecutable = task('build', serial(preCopy, sass, parallel(tslint, compileTsTasks), postCopy));
+export const compileTsTasks: IExecutable = parallel(typescript, text);
+export const buildTasks: IExecutable = task('build', serial(preCopy, sass, parallel(tslint, compileTsTasks), apiExtractor, postCopy));
 export const bundleTasks: IExecutable = task('bundle', serial(buildTasks, webpack));
 export const testTasks: IExecutable = task('test', serial(buildTasks, karma, jest));
 export const defaultTasks: IExecutable = serial(bundleTasks, karma, jest);

--- a/libraries/decorators/src/index.ts
+++ b/libraries/decorators/src/index.ts
@@ -8,8 +8,8 @@
  * of API contracts when using the TypeScript language.  The intent is to better document
  * expected behaviors and catch common mistakes.  This package is not intended to be a
  * general toolkit of language extensions or helpful macros.
+ * @packagedocumentation
  */
-declare const packageDescription: void; // tslint:disable-line:no-unused-variable
 
 export { virtual } from './virtual';
 export { sealed } from './sealed';

--- a/webpack/loader-load-themed-styles/config/api-extractor.json
+++ b/webpack/loader-load-themed-styles/config/api-extractor.json
@@ -2,5 +2,5 @@
   "enabled": true,
   "apiReviewFolder": "../../common/reviews/api",
   "apiJsonFolder": "./temp",
-  "entry": "src/LoadThemedStylesLoader.ts"
+  "entry": "lib/LoadThemedStylesLoader.d.ts"
 }

--- a/webpack/loader-load-themed-styles/src/LoadThemedStylesLoader.ts
+++ b/webpack/loader-load-themed-styles/src/LoadThemedStylesLoader.ts
@@ -1,16 +1,14 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
- * See LICENSE in the project root for license information.
- */
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
 
 /**
  * This simple loader wraps the loading of CSS in script equivalent to
  *  require("load-themed-styles").loadStyles('... css text ...').
+ * @packagedocumentation
  */
-declare const packageDescription: void; // tslint:disable-line:no-unused-variable
 
-import loaderUtils = require('loader-utils');
 import { loader } from 'webpack';
+import loaderUtils = require('loader-utils');
 
 const loadedThemedStylesPath: string = require.resolve('@microsoft/load-themed-styles');
 

--- a/webpack/resolve-chunk-plugin/config/api-extractor.json
+++ b/webpack/resolve-chunk-plugin/config/api-extractor.json
@@ -2,5 +2,5 @@
   "enabled": true,
   "apiReviewFolder": "../../common/reviews/api",
   "apiJsonFolder": "./temp",
-  "entry": "src/index.ts"
+  "entry": "lib/index.d.ts"
 }

--- a/webpack/resolve-chunk-plugin/src/ResolveChunkPlugin.ts
+++ b/webpack/resolve-chunk-plugin/src/ResolveChunkPlugin.ts
@@ -1,5 +1,3 @@
-/// <reference path="./custom-typings/webpackTypes.d.ts" />
-
 import * as Webpack from 'webpack';
 
 // tslint:disable-next-line:variable-name

--- a/webpack/resolve-chunk-plugin/src/index.ts
+++ b/webpack/resolve-chunk-plugin/src/index.ts
@@ -1,12 +1,10 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
- * See LICENSE in the project root for license information.
- */
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
 
 /**
  * This is a webpack plugin that looks for calls to `resolveChunk` with a chunk name, and returns the
- *  chunk ID. It's useful for referencing a chunk without making webpack coalesce two chunks.
+ * chunk ID. It's useful for referencing a chunk without making webpack coalesce two chunks.
+ * @packagedocumentation
  */
-declare const packageDescription: void; // tslint:disable-line:no-unused-variable
 
 export * from './ResolveChunkPlugin';

--- a/webpack/resolve-chunk-plugin/typings/tsd.d.ts
+++ b/webpack/resolve-chunk-plugin/typings/tsd.d.ts
@@ -1,0 +1,4 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+/// <reference path="webpack-plugin-types.d.ts" />

--- a/webpack/resolve-chunk-plugin/typings/webpack-plugin-types.d.ts
+++ b/webpack/resolve-chunk-plugin/typings/webpack-plugin-types.d.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
 interface IRange { }
 interface ILoc { }
 

--- a/webpack/set-webpack-public-path-plugin/src/index.ts
+++ b/webpack/set-webpack-public-path-plugin/src/index.ts
@@ -1,14 +1,12 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
- * See LICENSE in the project root for license information.
- */
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
 
 /**
  * This simple plugin sets the `__webpack_public_path__` variable to
  *  a value specified in the arguments, optionally appended to the SystemJs baseURL
  *  property.
+ * @packagedocumentation
  */
-declare const packageDescription: void; // tslint:disable-line:no-unused-variable
 
 export * from './SetPublicPathPlugin';
 export {


### PR DESCRIPTION
This is a significant architectural change for API Extractor.  In the past, it processed the TypeScript source files using the same configuration as the compiler, and could theoretically run in parallel with the compiler (although that was rarely useful, since we don't want to run API Extractor unless the code compiles).  After this PR, API Extractor runs against the lib/*.d.ts outputs from the compiler. This has a number of benefits:

- It is significantly faster
- It allows us to handle situations where the source files don't exist, because people hand-author or machine-generate their *.d.ts files
- It makes the packageTypings generator significantly simpler, by allowing us to rely on the compiler to normalize a lot of things

This PR had to solve two interesting technical problems:

1. **Construct a valid compiler configuration.**  The tsconfig.json file describes how to compile source code, and is not exactly correct for handling *.d.ts files.  API Extractor and GCB's ApiExtractorTask both need some extra logic to fix up the compiler configuration.

2. **Parse the package documentation comment.** In the past this was attached to a private void-typed definition called `packageDescription`, however this does not get emitted in the *.d.ts file. I needed to introduce a new `@packagedocumentation` tag to identify the JSDoc comment, and figure out how to fish it out of the *.d.ts file. (It typically precedes an `export` statement, which the compiler doesn't consider a definition, so the comment ends up in the "trivia" tokens that are not part of the regular AST.)

  