### PR TITLE
Upgrade cyclicDependencyProjects and migrate to latest API Extractor

### DIFF
--- a/apps/api-extractor/config/api-extractor.json
+++ b/apps/api-extractor/config/api-extractor.json
@@ -2,5 +2,5 @@
   "enabled": true,
   "apiReviewFolder": "../../common/reviews/api",
   "apiJsonFolder": "./temp",
-  "entry": "src/index.ts"
+  "entry": "lib/index.d.ts"
 }

--- a/apps/api-extractor/package.json
+++ b/apps/api-extractor/package.json
@@ -44,7 +44,7 @@
     "@types/colors": "1.1.3",
     "@types/lodash": "4.14.74",
     "gulp": "~3.9.1",
-    "@microsoft/node-library-build": "4.2.3",
+    "@microsoft/node-library-build": "4.2.16",
     "@types/jest": "~21.1.8"
   }
 }

--- a/apps/api-extractor/src/index.ts
+++ b/apps/api-extractor/src/index.ts
@@ -5,8 +5,9 @@
  * API Extractor helps you build better TypeScript library packages.
  * It helps with validation, documentation, and reviewing of the exported API
  * for a TypeScript library.
+ *
+ * @packagedocumentation
  */
-declare const packageDescription: void; // tslint:disable-line:no-unused-variable
 
 export { default as ExternalApiHelper } from './ExternalApiHelper';
 

--- a/apps/api-extractor/testInputs/example2/src/index.ts
+++ b/apps/api-extractor/testInputs/example2/src/index.ts
@@ -3,10 +3,13 @@
 
 /**
  * Here is some documentation for example2.
- * @remarks These are additional remarks that may be too long for the summary.
+ *
+ * @remarks
+ * These are additional remarks that may be too long for the summary.
  * They should appear in the remarks of the json generated file for this package.
+ *
+ * @packagedocumentation
  */
-declare const packageDescription: void;
 
 export {
     TestMissingCommentStar,

--- a/apps/api-extractor/testInputs/example3/src/index.ts
+++ b/apps/api-extractor/testInputs/example3/src/index.ts
@@ -3,8 +3,9 @@
 
 /**
  * This example folder is used to test the functionality of DocItemLoader and API reference resolution.
+ *
+ * @packagedocumentation
  */
-declare const packageDescription: void;
 
 export {
     inheritLocalOptionOne,

--- a/apps/rush-lib/config/api-extractor.json
+++ b/apps/rush-lib/config/api-extractor.json
@@ -2,5 +2,5 @@
   "enabled": true,
   "apiReviewFolder": "../../common/reviews/api",
   "apiJsonFolder": "./temp",
-  "entry": "src/index.ts"
+  "entry": "lib/index.d.ts"
 }

--- a/common/changes/@microsoft/api-extractor/pgonzal-upgrade-ae_2018-01-09-00-03.json
+++ b/common/changes/@microsoft/api-extractor/pgonzal-upgrade-ae_2018-01-09-00-03.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@microsoft/api-extractor",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/gulp-core-build-karma/pgonzal-upgrade-ae_2018-01-09-00-03.json
+++ b/common/changes/@microsoft/gulp-core-build-karma/pgonzal-upgrade-ae_2018-01-09-00-03.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@microsoft/gulp-core-build-karma",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/gulp-core-build-karma",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/gulp-core-build-mocha/pgonzal-upgrade-ae_2018-01-09-00-03.json
+++ b/common/changes/@microsoft/gulp-core-build-mocha/pgonzal-upgrade-ae_2018-01-09-00-03.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@microsoft/gulp-core-build-mocha",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/gulp-core-build-mocha",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/gulp-core-build-sass/pgonzal-upgrade-ae_2018-01-09-00-03.json
+++ b/common/changes/@microsoft/gulp-core-build-sass/pgonzal-upgrade-ae_2018-01-09-00-03.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@microsoft/gulp-core-build-sass",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/gulp-core-build-sass",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/gulp-core-build-serve/pgonzal-upgrade-ae_2018-01-09-00-03.json
+++ b/common/changes/@microsoft/gulp-core-build-serve/pgonzal-upgrade-ae_2018-01-09-00-03.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@microsoft/gulp-core-build-serve",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/gulp-core-build-serve",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/gulp-core-build-typescript/pgonzal-upgrade-ae_2018-01-09-00-03.json
+++ b/common/changes/@microsoft/gulp-core-build-typescript/pgonzal-upgrade-ae_2018-01-09-00-03.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@microsoft/gulp-core-build-typescript",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/gulp-core-build-typescript",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/gulp-core-build-webpack/pgonzal-upgrade-ae_2018-01-09-00-03.json
+++ b/common/changes/@microsoft/gulp-core-build-webpack/pgonzal-upgrade-ae_2018-01-09-00-03.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@microsoft/gulp-core-build-webpack",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/gulp-core-build-webpack",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/gulp-core-build/pgonzal-upgrade-ae_2018-01-09-00-03.json
+++ b/common/changes/@microsoft/gulp-core-build/pgonzal-upgrade-ae_2018-01-09-00-03.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@microsoft/gulp-core-build",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/gulp-core-build",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/node-core-library/pgonzal-upgrade-ae_2018-01-09-00-03.json
+++ b/common/changes/@microsoft/node-core-library/pgonzal-upgrade-ae_2018-01-09-00-03.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@microsoft/node-core-library",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/node-core-library",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/node-library-build/pgonzal-upgrade-ae_2018-01-09-00-03.json
+++ b/common/changes/@microsoft/node-library-build/pgonzal-upgrade-ae_2018-01-09-00-03.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@microsoft/node-library-build",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/node-library-build",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/package-deps-hash/pgonzal-upgrade-ae_2018-01-09-00-03.json
+++ b/common/changes/@microsoft/package-deps-hash/pgonzal-upgrade-ae_2018-01-09-00-03.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@microsoft/package-deps-hash",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/package-deps-hash",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/set-webpack-public-path-plugin/pgonzal-upgrade-ae_2018-01-09-00-03.json
+++ b/common/changes/@microsoft/set-webpack-public-path-plugin/pgonzal-upgrade-ae_2018-01-09-00-03.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@microsoft/set-webpack-public-path-plugin",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/set-webpack-public-path-plugin",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/ts-command-line/pgonzal-upgrade-ae_2018-01-09-00-03.json
+++ b/common/changes/@microsoft/ts-command-line/pgonzal-upgrade-ae_2018-01-09-00-03.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@microsoft/ts-command-line",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/ts-command-line",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/web-library-build/pgonzal-upgrade-ae_2018-01-09-00-03.json
+++ b/common/changes/@microsoft/web-library-build/pgonzal-upgrade-ae_2018-01-09-00-03.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@microsoft/web-library-build",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/web-library-build",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/config/rush/npm-shrinkwrap.json
+++ b/common/config/rush/npm-shrinkwrap.json
@@ -3,103 +3,39 @@
   "version": "0.0.0",
   "dependencies": {
     "@microsoft/api-extractor": {
-      "version": "4.2.2",
-      "from": "@microsoft/api-extractor@4.2.2",
-      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-4.2.2.tgz"
+      "version": "5.0.0",
+      "from": "@microsoft/api-extractor@5.0.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-5.0.0.tgz"
     },
     "@microsoft/gulp-core-build": {
-      "version": "3.2.3",
-      "from": "@microsoft/gulp-core-build@3.2.3",
-      "resolved": "https://registry.npmjs.org/@microsoft/gulp-core-build/-/gulp-core-build-3.2.3.tgz",
-      "dependencies": {
-        "arr-diff": {
-          "version": "2.0.0",
-          "from": "arr-diff@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz"
-        },
-        "array-unique": {
-          "version": "0.2.1",
-          "from": "array-unique@>=0.2.1 <0.3.0",
-          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz"
-        },
-        "braces": {
-          "version": "1.8.5",
-          "from": "braces@>=1.8.2 <2.0.0",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz"
-        },
-        "expand-brackets": {
-          "version": "0.1.5",
-          "from": "expand-brackets@>=0.1.4 <0.2.0",
-          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz"
-        },
-        "extglob": {
-          "version": "0.3.2",
-          "from": "extglob@>=0.3.1 <0.4.0",
-          "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz"
-        },
-        "is-extglob": {
-          "version": "1.0.0",
-          "from": "is-extglob@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
-        },
-        "is-glob": {
-          "version": "2.0.1",
-          "from": "is-glob@>=2.0.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz"
-        },
-        "jest": {
-          "version": "20.0.4",
-          "from": "jest@>=20.0.4 <20.1.0",
-          "resolved": "https://registry.npmjs.org/jest/-/jest-20.0.4.tgz"
-        },
-        "jest-cli": {
-          "version": "20.0.4",
-          "from": "jest-cli@>=20.0.4 <20.1.0",
-          "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-20.0.4.tgz",
-          "dependencies": {
-            "yargs": {
-              "version": "7.1.0",
-              "from": "yargs@>=7.0.2 <8.0.0",
-              "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz"
-            }
-          }
-        },
-        "kind-of": {
-          "version": "3.2.2",
-          "from": "kind-of@>=3.0.2 <4.0.0",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz"
-        },
-        "micromatch": {
-          "version": "2.3.11",
-          "from": "micromatch@>=2.3.11 <3.0.0",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz"
-        }
-      }
+      "version": "3.3.6",
+      "from": "@microsoft/gulp-core-build@3.3.6",
+      "resolved": "https://registry.npmjs.org/@microsoft/gulp-core-build/-/gulp-core-build-3.3.6.tgz"
     },
     "@microsoft/gulp-core-build-mocha": {
-      "version": "3.2.3",
-      "from": "@microsoft/gulp-core-build-mocha@3.2.3",
-      "resolved": "https://registry.npmjs.org/@microsoft/gulp-core-build-mocha/-/gulp-core-build-mocha-3.2.3.tgz"
+      "version": "3.2.16",
+      "from": "@microsoft/gulp-core-build-mocha@3.2.16",
+      "resolved": "https://registry.npmjs.org/@microsoft/gulp-core-build-mocha/-/gulp-core-build-mocha-3.2.16.tgz"
     },
     "@microsoft/gulp-core-build-typescript": {
-      "version": "4.2.10",
-      "from": "@microsoft/gulp-core-build-typescript@4.2.10",
-      "resolved": "https://registry.npmjs.org/@microsoft/gulp-core-build-typescript/-/gulp-core-build-typescript-4.2.10.tgz"
+      "version": "4.4.0",
+      "from": "@microsoft/gulp-core-build-typescript@4.4.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/gulp-core-build-typescript/-/gulp-core-build-typescript-4.4.0.tgz"
     },
     "@microsoft/node-core-library": {
-      "version": "0.3.22",
-      "from": "@microsoft/node-core-library@>=0.3.12 <0.4.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/node-core-library/-/node-core-library-0.3.22.tgz"
+      "version": "0.3.25",
+      "from": "@microsoft/node-core-library@0.3.25",
+      "resolved": "https://registry.npmjs.org/@microsoft/node-core-library/-/node-core-library-0.3.25.tgz"
     },
     "@microsoft/node-library-build": {
-      "version": "4.2.3",
-      "from": "@microsoft/node-library-build@4.2.3",
-      "resolved": "https://registry.npmjs.org/@microsoft/node-library-build/-/node-library-build-4.2.3.tgz"
+      "version": "4.2.16",
+      "from": "@microsoft/node-library-build@4.2.16",
+      "resolved": "https://registry.npmjs.org/@microsoft/node-library-build/-/node-library-build-4.2.16.tgz"
     },
     "@microsoft/ts-command-line": {
-      "version": "2.2.10",
-      "from": "@microsoft/ts-command-line@>=2.2.0 <2.3.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/ts-command-line/-/ts-command-line-2.2.10.tgz"
+      "version": "2.2.13",
+      "from": "@microsoft/ts-command-line@2.2.13",
+      "resolved": "https://registry.npmjs.org/@microsoft/ts-command-line/-/ts-command-line-2.2.13.tgz"
     },
     "@rush-temp/api-documenter": {
       "version": "0.0.0",
@@ -499,9 +435,9 @@
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
     },
     "ansi-escapes": {
-      "version": "1.4.0",
-      "from": "ansi-escapes@>=1.4.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz"
+      "version": "3.0.0",
+      "from": "ansi-escapes@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.0.0.tgz"
     },
     "ansi-gray": {
       "version": "0.1.1",
@@ -713,9 +649,9 @@
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
     },
     "assertion-error": {
-      "version": "1.0.2",
+      "version": "1.1.0",
       "from": "assertion-error@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz"
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz"
     },
     "assign-symbols": {
       "version": "1.0.0",
@@ -802,9 +738,9 @@
       "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz"
     },
     "babel-jest": {
-      "version": "20.0.3",
-      "from": "babel-jest@>=20.0.3 <21.0.0",
-      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-20.0.3.tgz"
+      "version": "21.2.0",
+      "from": "babel-jest@>=21.2.0 <22.0.0",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-21.2.0.tgz"
     },
     "babel-messages": {
       "version": "6.23.0",
@@ -817,9 +753,9 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.5.tgz"
     },
     "babel-plugin-jest-hoist": {
-      "version": "20.0.3",
-      "from": "babel-plugin-jest-hoist@>=20.0.3 <21.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-20.0.3.tgz"
+      "version": "21.2.0",
+      "from": "babel-plugin-jest-hoist@>=21.2.0 <22.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-21.2.0.tgz"
     },
     "babel-plugin-syntax-object-rest-spread": {
       "version": "6.13.0",
@@ -827,9 +763,9 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz"
     },
     "babel-preset-jest": {
-      "version": "20.0.3",
-      "from": "babel-preset-jest@>=20.0.3 <21.0.0",
-      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-20.0.3.tgz"
+      "version": "21.2.0",
+      "from": "babel-preset-jest@>=21.2.0 <22.0.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-21.2.0.tgz"
     },
     "babel-register": {
       "version": "6.26.0",
@@ -1129,9 +1065,9 @@
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz"
     },
     "camelcase": {
-      "version": "3.0.0",
-      "from": "camelcase@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz"
+      "version": "4.1.0",
+      "from": "camelcase@>=4.1.0 <5.0.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz"
     },
     "camelcase-keys": {
       "version": "2.1.0",
@@ -1146,9 +1082,9 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000787",
+      "version": "1.0.30000789",
       "from": "caniuse-db@>=1.0.30000488 <2.0.0",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000787.tgz"
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000789.tgz"
     },
     "caseless": {
       "version": "0.12.0",
@@ -1174,7 +1110,7 @@
     },
     "chalk": {
       "version": "1.1.3",
-      "from": "chalk@>=1.0.0 <2.0.0",
+      "from": "chalk@>=1.1.3 <1.2.0",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz"
     },
     "charenc": {
@@ -1273,7 +1209,14 @@
     "cliui": {
       "version": "3.2.0",
       "from": "cliui@>=3.2.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz"
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+      "dependencies": {
+        "string-width": {
+          "version": "1.0.2",
+          "from": "string-width@>=1.0.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz"
+        }
+      }
     },
     "clone": {
       "version": "1.0.3",
@@ -1587,6 +1530,11 @@
       "from": "css-modules-loader-core@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/css-modules-loader-core/-/css-modules-loader-core-1.1.0.tgz",
       "dependencies": {
+        "has-flag": {
+          "version": "1.0.0",
+          "from": "has-flag@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
+        },
         "postcss": {
           "version": "6.0.1",
           "from": "postcss@6.0.1",
@@ -2190,100 +2138,10 @@
       "from": "expect@>=21.2.1 <22.0.0",
       "resolved": "https://registry.npmjs.org/expect/-/expect-21.2.1.tgz",
       "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "from": "ansi-regex@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz"
-        },
         "ansi-styles": {
           "version": "3.2.0",
           "from": "ansi-styles@>=3.2.0 <4.0.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz"
-        },
-        "arr-diff": {
-          "version": "2.0.0",
-          "from": "arr-diff@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz"
-        },
-        "array-unique": {
-          "version": "0.2.1",
-          "from": "array-unique@>=0.2.1 <0.3.0",
-          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz"
-        },
-        "braces": {
-          "version": "1.8.5",
-          "from": "braces@>=1.8.2 <2.0.0",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz"
-        },
-        "chalk": {
-          "version": "2.3.0",
-          "from": "chalk@>=2.0.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz"
-        },
-        "expand-brackets": {
-          "version": "0.1.5",
-          "from": "expand-brackets@>=0.1.4 <0.2.0",
-          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz"
-        },
-        "extglob": {
-          "version": "0.3.2",
-          "from": "extglob@>=0.3.1 <0.4.0",
-          "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz"
-        },
-        "has-flag": {
-          "version": "2.0.0",
-          "from": "has-flag@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz"
-        },
-        "is-extglob": {
-          "version": "1.0.0",
-          "from": "is-extglob@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
-        },
-        "is-glob": {
-          "version": "2.0.1",
-          "from": "is-glob@>=2.0.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz"
-        },
-        "jest-diff": {
-          "version": "21.2.1",
-          "from": "jest-diff@>=21.2.1 <22.0.0",
-          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-21.2.1.tgz"
-        },
-        "jest-matcher-utils": {
-          "version": "21.2.1",
-          "from": "jest-matcher-utils@>=21.2.1 <22.0.0",
-          "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-21.2.1.tgz"
-        },
-        "jest-message-util": {
-          "version": "21.2.1",
-          "from": "jest-message-util@>=21.2.1 <22.0.0",
-          "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-21.2.1.tgz"
-        },
-        "jest-regex-util": {
-          "version": "21.2.0",
-          "from": "jest-regex-util@>=21.2.0 <22.0.0",
-          "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-21.2.0.tgz"
-        },
-        "kind-of": {
-          "version": "3.2.2",
-          "from": "kind-of@>=3.0.2 <4.0.0",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz"
-        },
-        "micromatch": {
-          "version": "2.3.11",
-          "from": "micromatch@>=2.3.11 <3.0.0",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz"
-        },
-        "pretty-format": {
-          "version": "21.2.1",
-          "from": "pretty-format@>=21.2.1 <22.0.0",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-21.2.1.tgz"
-        },
-        "supports-color": {
-          "version": "4.5.0",
-          "from": "supports-color@>=4.0.0 <5.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz"
         }
       }
     },
@@ -2575,7 +2433,14 @@
     "gauge": {
       "version": "2.7.4",
       "from": "gauge@>=2.7.3 <2.8.0",
-      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz"
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+      "dependencies": {
+        "string-width": {
+          "version": "1.0.2",
+          "from": "string-width@>=1.0.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz"
+        }
+      }
     },
     "gaze": {
       "version": "0.5.2",
@@ -3558,9 +3423,9 @@
       "resolved": "https://registry.npmjs.org/has-cors/-/has-cors-1.1.0.tgz"
     },
     "has-flag": {
-      "version": "1.0.0",
-      "from": "has-flag@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
+      "version": "2.0.0",
+      "from": "has-flag@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz"
     },
     "has-gulplog": {
       "version": "0.1.0",
@@ -3724,10 +3589,20 @@
       "from": "inquirer@>=1.2.1 <1.3.0",
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-1.2.3.tgz",
       "dependencies": {
+        "ansi-escapes": {
+          "version": "1.4.0",
+          "from": "ansi-escapes@>=1.1.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz"
+        },
         "mute-stream": {
           "version": "0.0.6",
           "from": "mute-stream@0.0.6",
           "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.6.tgz"
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "from": "string-width@>=1.0.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz"
         }
       }
     },
@@ -3915,7 +3790,7 @@
     },
     "is-stream": {
       "version": "1.1.0",
-      "from": "is-stream@>=1.0.1 <2.0.0",
+      "from": "is-stream@>=1.1.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz"
     },
     "is-typedarray": {
@@ -3998,6 +3873,11 @@
           "from": "glob@>=5.0.15 <6.0.0",
           "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz"
         },
+        "has-flag": {
+          "version": "1.0.0",
+          "from": "has-flag@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
+        },
         "resolve": {
           "version": "1.1.7",
           "from": "resolve@>=1.1.0 <1.2.0",
@@ -4040,6 +3920,11 @@
       "from": "istanbul-lib-report@>=1.1.2 <2.0.0",
       "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.2.tgz",
       "dependencies": {
+        "has-flag": {
+          "version": "1.0.0",
+          "from": "has-flag@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
+        },
         "supports-color": {
           "version": "3.2.3",
           "from": "supports-color@>=3.1.2 <4.0.0",
@@ -4116,6 +4001,11 @@
           "from": "glob@>=5.0.0 <6.0.0",
           "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz"
         },
+        "has-flag": {
+          "version": "1.0.0",
+          "from": "has-flag@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
+        },
         "istanbul": {
           "version": "0.3.22",
           "from": "istanbul@>=0.3.0 <0.4.0",
@@ -4188,20 +4078,15 @@
       "resolved": "https://registry.npmjs.org/jest/-/jest-21.2.1.tgz"
     },
     "jest-changed-files": {
-      "version": "20.0.3",
-      "from": "jest-changed-files@>=20.0.3 <21.0.0",
-      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-20.0.3.tgz"
+      "version": "21.2.0",
+      "from": "jest-changed-files@>=21.2.0 <22.0.0",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-21.2.0.tgz"
     },
     "jest-cli": {
       "version": "21.2.1",
       "from": "jest-cli@>=21.2.1 <21.3.0",
       "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-21.2.1.tgz",
       "dependencies": {
-        "ansi-escapes": {
-          "version": "3.0.0",
-          "from": "ansi-escapes@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.0.0.tgz"
-        },
         "ansi-regex": {
           "version": "3.0.0",
           "from": "ansi-regex@>=3.0.0 <4.0.0",
@@ -4222,30 +4107,10 @@
           "from": "array-unique@>=0.2.1 <0.3.0",
           "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz"
         },
-        "babel-jest": {
-          "version": "21.2.0",
-          "from": "babel-jest@>=21.2.0 <22.0.0",
-          "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-21.2.0.tgz"
-        },
-        "babel-plugin-jest-hoist": {
-          "version": "21.2.0",
-          "from": "babel-plugin-jest-hoist@>=21.2.0 <22.0.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-21.2.0.tgz"
-        },
-        "babel-preset-jest": {
-          "version": "21.2.0",
-          "from": "babel-preset-jest@>=21.2.0 <22.0.0",
-          "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-21.2.0.tgz"
-        },
         "braces": {
           "version": "1.8.5",
           "from": "braces@>=1.8.2 <2.0.0",
           "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz"
-        },
-        "camelcase": {
-          "version": "4.1.0",
-          "from": "camelcase@>=4.1.0 <5.0.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz"
         },
         "chalk": {
           "version": "2.3.0",
@@ -4267,115 +4132,15 @@
           "from": "glob@>=7.1.2 <8.0.0",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz"
         },
-        "has-flag": {
-          "version": "2.0.0",
-          "from": "has-flag@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz"
-        },
         "is-extglob": {
           "version": "1.0.0",
           "from": "is-extglob@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
         },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "from": "is-fullwidth-code-point@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz"
-        },
         "is-glob": {
           "version": "2.0.1",
           "from": "is-glob@>=2.0.1 <3.0.0",
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz"
-        },
-        "jest-changed-files": {
-          "version": "21.2.0",
-          "from": "jest-changed-files@>=21.2.0 <22.0.0",
-          "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-21.2.0.tgz"
-        },
-        "jest-config": {
-          "version": "21.2.1",
-          "from": "jest-config@>=21.2.1 <22.0.0",
-          "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-21.2.1.tgz"
-        },
-        "jest-diff": {
-          "version": "21.2.1",
-          "from": "jest-diff@>=21.2.1 <22.0.0",
-          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-21.2.1.tgz"
-        },
-        "jest-docblock": {
-          "version": "21.2.0",
-          "from": "jest-docblock@>=21.2.0 <22.0.0",
-          "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-21.2.0.tgz"
-        },
-        "jest-environment-jsdom": {
-          "version": "21.2.1",
-          "from": "jest-environment-jsdom@>=21.2.1 <22.0.0",
-          "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-21.2.1.tgz"
-        },
-        "jest-environment-node": {
-          "version": "21.2.1",
-          "from": "jest-environment-node@>=21.2.1 <22.0.0",
-          "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-21.2.1.tgz"
-        },
-        "jest-haste-map": {
-          "version": "21.2.0",
-          "from": "jest-haste-map@>=21.2.0 <22.0.0",
-          "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-21.2.0.tgz"
-        },
-        "jest-jasmine2": {
-          "version": "21.2.1",
-          "from": "jest-jasmine2@>=21.2.1 <22.0.0",
-          "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-21.2.1.tgz"
-        },
-        "jest-matcher-utils": {
-          "version": "21.2.1",
-          "from": "jest-matcher-utils@>=21.2.1 <22.0.0",
-          "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-21.2.1.tgz"
-        },
-        "jest-message-util": {
-          "version": "21.2.1",
-          "from": "jest-message-util@>=21.2.1 <22.0.0",
-          "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-21.2.1.tgz"
-        },
-        "jest-mock": {
-          "version": "21.2.0",
-          "from": "jest-mock@>=21.2.0 <22.0.0",
-          "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-21.2.0.tgz"
-        },
-        "jest-regex-util": {
-          "version": "21.2.0",
-          "from": "jest-regex-util@>=21.2.0 <22.0.0",
-          "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-21.2.0.tgz"
-        },
-        "jest-resolve": {
-          "version": "21.2.0",
-          "from": "jest-resolve@>=21.2.0 <22.0.0",
-          "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-21.2.0.tgz"
-        },
-        "jest-resolve-dependencies": {
-          "version": "21.2.0",
-          "from": "jest-resolve-dependencies@>=21.2.0 <22.0.0",
-          "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-21.2.0.tgz"
-        },
-        "jest-runtime": {
-          "version": "21.2.1",
-          "from": "jest-runtime@>=21.2.1 <22.0.0",
-          "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-21.2.1.tgz"
-        },
-        "jest-snapshot": {
-          "version": "21.2.1",
-          "from": "jest-snapshot@>=21.2.1 <22.0.0",
-          "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-21.2.1.tgz"
-        },
-        "jest-util": {
-          "version": "21.2.1",
-          "from": "jest-util@>=21.2.1 <22.0.0",
-          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-21.2.1.tgz"
-        },
-        "jest-validate": {
-          "version": "21.2.1",
-          "from": "jest-validate@>=21.2.1 <22.0.0",
-          "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-21.2.1.tgz"
         },
         "kind-of": {
           "version": "3.2.2",
@@ -4399,11 +4164,6 @@
           "from": "micromatch@>=2.3.11 <3.0.0",
           "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz"
         },
-        "os-locale": {
-          "version": "2.1.0",
-          "from": "os-locale@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz"
-        },
         "path-type": {
           "version": "2.0.0",
           "from": "path-type@>=2.0.0 <3.0.0",
@@ -4421,11 +4181,6 @@
           "from": "pify@>=3.0.0 <4.0.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz"
         },
-        "pretty-format": {
-          "version": "21.2.1",
-          "from": "pretty-format@>=21.2.1 <22.0.0",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-21.2.1.tgz"
-        },
         "read-pkg": {
           "version": "2.0.0",
           "from": "read-pkg@>=2.0.0 <3.0.0",
@@ -4436,21 +4191,6 @@
           "from": "read-pkg-up@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz"
         },
-        "sane": {
-          "version": "2.2.0",
-          "from": "sane@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/sane/-/sane-2.2.0.tgz"
-        },
-        "string-length": {
-          "version": "2.0.0",
-          "from": "string-length@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/string-length/-/string-length-2.0.0.tgz"
-        },
-        "string-width": {
-          "version": "2.1.1",
-          "from": "string-width@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz"
-        },
         "strip-ansi": {
           "version": "4.0.0",
           "from": "strip-ansi@>=4.0.0 <5.0.0",
@@ -4458,7 +4198,7 @@
         },
         "strip-bom": {
           "version": "3.0.0",
-          "from": "strip-bom@3.0.0",
+          "from": "strip-bom@>=3.0.0 <4.0.0",
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz"
         },
         "supports-color": {
@@ -4466,64 +4206,76 @@
           "from": "supports-color@>=4.0.0 <5.0.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz"
         },
-        "throat": {
-          "version": "4.1.0",
-          "from": "throat@>=4.0.0 <5.0.0",
-          "resolved": "https://registry.npmjs.org/throat/-/throat-4.1.0.tgz"
-        },
-        "watch": {
-          "version": "0.18.0",
-          "from": "watch@>=0.18.0 <0.19.0",
-          "resolved": "https://registry.npmjs.org/watch/-/watch-0.18.0.tgz"
-        },
-        "which-module": {
-          "version": "2.0.0",
-          "from": "which-module@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz"
-        },
         "yargs": {
           "version": "9.0.1",
           "from": "yargs@>=9.0.0 <10.0.0",
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-9.0.1.tgz"
-        },
-        "yargs-parser": {
-          "version": "7.0.0",
-          "from": "yargs-parser@>=7.0.0 <8.0.0",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz"
         }
       }
     },
     "jest-config": {
-      "version": "20.0.4",
-      "from": "jest-config@>=20.0.4 <21.0.0",
-      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-20.0.4.tgz",
+      "version": "21.2.1",
+      "from": "jest-config@>=21.2.1 <22.0.0",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-21.2.1.tgz",
       "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "from": "ansi-styles@>=3.1.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz"
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "from": "chalk@>=2.0.1 <3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz"
+        },
         "glob": {
           "version": "7.1.2",
           "from": "glob@>=7.1.1 <8.0.0",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz"
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "from": "supports-color@>=4.0.0 <5.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz"
         }
       }
     },
     "jest-diff": {
-      "version": "20.0.3",
-      "from": "jest-diff@>=20.0.3 <21.0.0",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-20.0.3.tgz"
+      "version": "21.2.1",
+      "from": "jest-diff@>=21.2.1 <22.0.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-21.2.1.tgz",
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "from": "ansi-styles@>=3.1.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz"
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "from": "chalk@>=2.0.1 <3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz"
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "from": "supports-color@>=4.0.0 <5.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz"
+        }
+      }
     },
     "jest-docblock": {
-      "version": "20.0.3",
-      "from": "jest-docblock@>=20.0.3 <21.0.0",
-      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-20.0.3.tgz"
+      "version": "21.2.0",
+      "from": "jest-docblock@>=21.2.0 <22.0.0",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-21.2.0.tgz"
     },
     "jest-environment-jsdom": {
-      "version": "20.0.3",
-      "from": "jest-environment-jsdom@>=20.0.3 <21.0.0",
-      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-20.0.3.tgz"
+      "version": "21.2.1",
+      "from": "jest-environment-jsdom@>=21.2.1 <22.0.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-21.2.1.tgz"
     },
     "jest-environment-node": {
-      "version": "20.0.3",
-      "from": "jest-environment-node@>=20.0.3 <21.0.0",
-      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-20.0.3.tgz"
+      "version": "21.2.1",
+      "from": "jest-environment-node@>=21.2.1 <22.0.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-21.2.1.tgz"
     },
     "jest-get-type": {
       "version": "21.2.0",
@@ -4531,9 +4283,9 @@
       "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-21.2.0.tgz"
     },
     "jest-haste-map": {
-      "version": "20.0.5",
-      "from": "jest-haste-map@>=20.0.4 <21.0.0",
-      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-20.0.5.tgz",
+      "version": "21.2.0",
+      "from": "jest-haste-map@>=21.2.0 <22.0.0",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-21.2.0.tgz",
       "dependencies": {
         "arr-diff": {
           "version": "2.0.0",
@@ -4583,102 +4335,54 @@
       }
     },
     "jest-jasmine2": {
-      "version": "20.0.4",
-      "from": "jest-jasmine2@>=20.0.4 <21.0.0",
-      "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-20.0.4.tgz"
-    },
-    "jest-matcher-utils": {
-      "version": "20.0.3",
-      "from": "jest-matcher-utils@>=20.0.3 <21.0.0",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-20.0.3.tgz"
-    },
-    "jest-matchers": {
-      "version": "20.0.3",
-      "from": "jest-matchers@>=20.0.3 <21.0.0",
-      "resolved": "https://registry.npmjs.org/jest-matchers/-/jest-matchers-20.0.3.tgz"
-    },
-    "jest-message-util": {
-      "version": "20.0.3",
-      "from": "jest-message-util@>=20.0.3 <21.0.0",
-      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-20.0.3.tgz",
+      "version": "21.2.1",
+      "from": "jest-jasmine2@>=21.2.1 <22.0.0",
+      "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-21.2.1.tgz",
       "dependencies": {
-        "arr-diff": {
-          "version": "2.0.0",
-          "from": "arr-diff@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz"
+        "ansi-styles": {
+          "version": "3.2.0",
+          "from": "ansi-styles@>=3.1.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz"
         },
-        "array-unique": {
-          "version": "0.2.1",
-          "from": "array-unique@>=0.2.1 <0.3.0",
-          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz"
+        "chalk": {
+          "version": "2.3.0",
+          "from": "chalk@>=2.0.1 <3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz"
         },
-        "braces": {
-          "version": "1.8.5",
-          "from": "braces@>=1.8.2 <2.0.0",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz"
-        },
-        "expand-brackets": {
-          "version": "0.1.5",
-          "from": "expand-brackets@>=0.1.4 <0.2.0",
-          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz"
-        },
-        "extglob": {
-          "version": "0.3.2",
-          "from": "extglob@>=0.3.1 <0.4.0",
-          "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz"
-        },
-        "is-extglob": {
-          "version": "1.0.0",
-          "from": "is-extglob@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
-        },
-        "is-glob": {
-          "version": "2.0.1",
-          "from": "is-glob@>=2.0.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz"
-        },
-        "kind-of": {
-          "version": "3.2.2",
-          "from": "kind-of@>=3.0.2 <4.0.0",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz"
-        },
-        "micromatch": {
-          "version": "2.3.11",
-          "from": "micromatch@>=2.3.11 <3.0.0",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz"
+        "supports-color": {
+          "version": "4.5.0",
+          "from": "supports-color@>=4.0.0 <5.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz"
         }
       }
     },
-    "jest-mock": {
-      "version": "20.0.3",
-      "from": "jest-mock@>=20.0.3 <21.0.0",
-      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-20.0.3.tgz"
-    },
-    "jest-regex-util": {
-      "version": "20.0.3",
-      "from": "jest-regex-util@>=20.0.3 <21.0.0",
-      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-20.0.3.tgz"
-    },
-    "jest-resolve": {
-      "version": "20.0.4",
-      "from": "jest-resolve@>=20.0.4 <21.0.0",
-      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-20.0.4.tgz"
-    },
-    "jest-resolve-dependencies": {
-      "version": "20.0.3",
-      "from": "jest-resolve-dependencies@>=20.0.3 <21.0.0",
-      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-20.0.3.tgz"
-    },
-    "jest-runner": {
+    "jest-matcher-utils": {
       "version": "21.2.1",
-      "from": "jest-runner@>=21.2.1 <22.0.0",
-      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-21.2.1.tgz",
+      "from": "jest-matcher-utils@>=21.2.1 <22.0.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-21.2.1.tgz",
       "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "from": "ansi-regex@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz"
+        "ansi-styles": {
+          "version": "3.2.0",
+          "from": "ansi-styles@>=3.1.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz"
         },
+        "chalk": {
+          "version": "2.3.0",
+          "from": "chalk@>=2.0.1 <3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz"
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "from": "supports-color@>=4.0.0 <5.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz"
+        }
+      }
+    },
+    "jest-message-util": {
+      "version": "21.2.1",
+      "from": "jest-message-util@>=21.2.1 <22.0.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-21.2.1.tgz",
+      "dependencies": {
         "ansi-styles": {
           "version": "3.2.0",
           "from": "ansi-styles@>=3.1.0 <4.0.0",
@@ -4694,30 +4398,10 @@
           "from": "array-unique@>=0.2.1 <0.3.0",
           "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz"
         },
-        "babel-jest": {
-          "version": "21.2.0",
-          "from": "babel-jest@>=21.2.0 <22.0.0",
-          "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-21.2.0.tgz"
-        },
-        "babel-plugin-jest-hoist": {
-          "version": "21.2.0",
-          "from": "babel-plugin-jest-hoist@>=21.2.0 <22.0.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-21.2.0.tgz"
-        },
-        "babel-preset-jest": {
-          "version": "21.2.0",
-          "from": "babel-preset-jest@>=21.2.0 <22.0.0",
-          "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-21.2.0.tgz"
-        },
         "braces": {
           "version": "1.8.5",
           "from": "braces@>=1.8.2 <2.0.0",
           "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz"
-        },
-        "camelcase": {
-          "version": "4.1.0",
-          "from": "camelcase@>=4.1.0 <5.0.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz"
         },
         "chalk": {
           "version": "2.3.0",
@@ -4734,227 +4418,92 @@
           "from": "extglob@>=0.3.1 <0.4.0",
           "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz"
         },
-        "glob": {
-          "version": "7.1.2",
-          "from": "glob@>=7.1.1 <8.0.0",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz"
-        },
-        "has-flag": {
-          "version": "2.0.0",
-          "from": "has-flag@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz"
-        },
         "is-extglob": {
           "version": "1.0.0",
           "from": "is-extglob@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "from": "is-fullwidth-code-point@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz"
         },
         "is-glob": {
           "version": "2.0.1",
           "from": "is-glob@>=2.0.1 <3.0.0",
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz"
         },
-        "jest-config": {
-          "version": "21.2.1",
-          "from": "jest-config@>=21.2.1 <22.0.0",
-          "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-21.2.1.tgz"
-        },
-        "jest-diff": {
-          "version": "21.2.1",
-          "from": "jest-diff@>=21.2.1 <22.0.0",
-          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-21.2.1.tgz"
-        },
-        "jest-docblock": {
-          "version": "21.2.0",
-          "from": "jest-docblock@>=21.2.0 <22.0.0",
-          "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-21.2.0.tgz"
-        },
-        "jest-environment-jsdom": {
-          "version": "21.2.1",
-          "from": "jest-environment-jsdom@>=21.2.1 <22.0.0",
-          "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-21.2.1.tgz"
-        },
-        "jest-environment-node": {
-          "version": "21.2.1",
-          "from": "jest-environment-node@>=21.2.1 <22.0.0",
-          "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-21.2.1.tgz"
-        },
-        "jest-haste-map": {
-          "version": "21.2.0",
-          "from": "jest-haste-map@>=21.2.0 <22.0.0",
-          "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-21.2.0.tgz"
-        },
-        "jest-jasmine2": {
-          "version": "21.2.1",
-          "from": "jest-jasmine2@>=21.2.1 <22.0.0",
-          "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-21.2.1.tgz"
-        },
-        "jest-matcher-utils": {
-          "version": "21.2.1",
-          "from": "jest-matcher-utils@>=21.2.1 <22.0.0",
-          "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-21.2.1.tgz"
-        },
-        "jest-message-util": {
-          "version": "21.2.1",
-          "from": "jest-message-util@>=21.2.1 <22.0.0",
-          "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-21.2.1.tgz"
-        },
-        "jest-mock": {
-          "version": "21.2.0",
-          "from": "jest-mock@>=21.2.0 <22.0.0",
-          "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-21.2.0.tgz"
-        },
-        "jest-regex-util": {
-          "version": "21.2.0",
-          "from": "jest-regex-util@>=21.2.0 <22.0.0",
-          "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-21.2.0.tgz"
-        },
-        "jest-resolve": {
-          "version": "21.2.0",
-          "from": "jest-resolve@>=21.2.0 <22.0.0",
-          "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-21.2.0.tgz"
-        },
-        "jest-runtime": {
-          "version": "21.2.1",
-          "from": "jest-runtime@>=21.2.1 <22.0.0",
-          "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-21.2.1.tgz"
-        },
-        "jest-snapshot": {
-          "version": "21.2.1",
-          "from": "jest-snapshot@>=21.2.1 <22.0.0",
-          "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-21.2.1.tgz"
-        },
-        "jest-util": {
-          "version": "21.2.1",
-          "from": "jest-util@>=21.2.1 <22.0.0",
-          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-21.2.1.tgz"
-        },
-        "jest-validate": {
-          "version": "21.2.1",
-          "from": "jest-validate@>=21.2.1 <22.0.0",
-          "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-21.2.1.tgz"
-        },
         "kind-of": {
           "version": "3.2.2",
           "from": "kind-of@>=3.0.2 <4.0.0",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz"
-        },
-        "load-json-file": {
-          "version": "2.0.0",
-          "from": "load-json-file@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
-          "dependencies": {
-            "pify": {
-              "version": "2.3.0",
-              "from": "pify@^2.0.0",
-              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
-            }
-          }
         },
         "micromatch": {
           "version": "2.3.11",
           "from": "micromatch@>=2.3.11 <3.0.0",
           "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz"
         },
-        "os-locale": {
-          "version": "2.1.0",
-          "from": "os-locale@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz"
+        "supports-color": {
+          "version": "4.5.0",
+          "from": "supports-color@>=4.0.0 <5.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz"
+        }
+      }
+    },
+    "jest-mock": {
+      "version": "21.2.0",
+      "from": "jest-mock@>=21.2.0 <22.0.0",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-21.2.0.tgz"
+    },
+    "jest-regex-util": {
+      "version": "21.2.0",
+      "from": "jest-regex-util@>=21.2.0 <22.0.0",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-21.2.0.tgz"
+    },
+    "jest-resolve": {
+      "version": "21.2.0",
+      "from": "jest-resolve@>=21.2.0 <22.0.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-21.2.0.tgz",
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "from": "ansi-styles@>=3.1.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz"
         },
-        "path-type": {
-          "version": "2.0.0",
-          "from": "path-type@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
-          "dependencies": {
-            "pify": {
-              "version": "2.3.0",
-              "from": "pify@^2.0.0",
-              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
-            }
-          }
-        },
-        "pify": {
-          "version": "3.0.0",
-          "from": "pify@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz"
-        },
-        "pretty-format": {
-          "version": "21.2.1",
-          "from": "pretty-format@>=21.2.1 <22.0.0",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-21.2.1.tgz"
-        },
-        "read-pkg": {
-          "version": "2.0.0",
-          "from": "read-pkg@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz"
-        },
-        "read-pkg-up": {
-          "version": "2.0.0",
-          "from": "read-pkg-up@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz"
-        },
-        "sane": {
-          "version": "2.2.0",
-          "from": "sane@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/sane/-/sane-2.2.0.tgz"
-        },
-        "string-width": {
-          "version": "2.1.1",
-          "from": "string-width@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz"
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "from": "strip-ansi@>=4.0.0 <5.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz"
-        },
-        "strip-bom": {
-          "version": "3.0.0",
-          "from": "strip-bom@3.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz"
+        "chalk": {
+          "version": "2.3.0",
+          "from": "chalk@>=2.0.1 <3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz"
         },
         "supports-color": {
           "version": "4.5.0",
           "from": "supports-color@>=4.0.0 <5.0.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz"
-        },
-        "throat": {
-          "version": "4.1.0",
-          "from": "throat@>=4.0.0 <5.0.0",
-          "resolved": "https://registry.npmjs.org/throat/-/throat-4.1.0.tgz"
-        },
-        "watch": {
-          "version": "0.18.0",
-          "from": "watch@>=0.18.0 <0.19.0",
-          "resolved": "https://registry.npmjs.org/watch/-/watch-0.18.0.tgz"
-        },
-        "which-module": {
-          "version": "2.0.0",
-          "from": "which-module@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz"
-        },
-        "yargs": {
-          "version": "9.0.1",
-          "from": "yargs@>=9.0.0 <10.0.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-9.0.1.tgz"
-        },
-        "yargs-parser": {
-          "version": "7.0.0",
-          "from": "yargs-parser@>=7.0.0 <8.0.0",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz"
+        }
+      }
+    },
+    "jest-resolve-dependencies": {
+      "version": "21.2.0",
+      "from": "jest-resolve-dependencies@>=21.2.0 <22.0.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-21.2.0.tgz"
+    },
+    "jest-runner": {
+      "version": "21.2.1",
+      "from": "jest-runner@>=21.2.1 <22.0.0",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-21.2.1.tgz",
+      "dependencies": {
+        "pify": {
+          "version": "3.0.0",
+          "from": "pify@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz"
         }
       }
     },
     "jest-runtime": {
-      "version": "20.0.4",
-      "from": "jest-runtime@>=20.0.4 <21.0.0",
-      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-20.0.4.tgz",
+      "version": "21.2.1",
+      "from": "jest-runtime@>=21.2.1 <22.0.0",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-21.2.1.tgz",
       "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "from": "ansi-styles@>=3.1.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz"
+        },
         "arr-diff": {
           "version": "2.0.0",
           "from": "arr-diff@>=2.0.0 <3.0.0",
@@ -4969,6 +4518,11 @@
           "version": "1.8.5",
           "from": "braces@>=1.8.2 <2.0.0",
           "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz"
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "from": "chalk@>=2.0.1 <3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz"
         },
         "expand-brackets": {
           "version": "0.1.5",
@@ -4995,37 +4549,113 @@
           "from": "kind-of@>=3.0.2 <4.0.0",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz"
         },
+        "load-json-file": {
+          "version": "2.0.0",
+          "from": "load-json-file@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz"
+        },
         "micromatch": {
           "version": "2.3.11",
           "from": "micromatch@>=2.3.11 <3.0.0",
           "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz"
+        },
+        "path-type": {
+          "version": "2.0.0",
+          "from": "path-type@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz"
+        },
+        "read-pkg": {
+          "version": "2.0.0",
+          "from": "read-pkg@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz"
+        },
+        "read-pkg-up": {
+          "version": "2.0.0",
+          "from": "read-pkg-up@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz"
         },
         "strip-bom": {
           "version": "3.0.0",
           "from": "strip-bom@3.0.0",
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz"
         },
+        "supports-color": {
+          "version": "4.5.0",
+          "from": "supports-color@>=4.0.0 <5.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz"
+        },
         "yargs": {
-          "version": "7.1.0",
-          "from": "yargs@>=7.0.2 <8.0.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz"
+          "version": "9.0.1",
+          "from": "yargs@>=9.0.0 <10.0.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-9.0.1.tgz"
         }
       }
     },
     "jest-snapshot": {
-      "version": "20.0.3",
-      "from": "jest-snapshot@>=20.0.3 <21.0.0",
-      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-20.0.3.tgz"
+      "version": "21.2.1",
+      "from": "jest-snapshot@>=21.2.1 <22.0.0",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-21.2.1.tgz",
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "from": "ansi-styles@>=3.1.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz"
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "from": "chalk@>=2.0.1 <3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz"
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "from": "supports-color@>=4.0.0 <5.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz"
+        }
+      }
     },
     "jest-util": {
-      "version": "20.0.3",
-      "from": "jest-util@>=20.0.3 <21.0.0",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-20.0.3.tgz"
+      "version": "21.2.1",
+      "from": "jest-util@>=21.2.1 <22.0.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-21.2.1.tgz",
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "from": "ansi-styles@>=3.1.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz"
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "from": "chalk@>=2.0.1 <3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz"
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "from": "supports-color@>=4.0.0 <5.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz"
+        }
+      }
     },
     "jest-validate": {
-      "version": "20.0.3",
-      "from": "jest-validate@>=20.0.3 <21.0.0",
-      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-20.0.3.tgz"
+      "version": "21.2.1",
+      "from": "jest-validate@>=21.2.1 <22.0.0",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-21.2.1.tgz",
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "from": "ansi-styles@>=3.1.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz"
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "from": "chalk@>=2.0.1 <3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz"
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "from": "supports-color@>=4.0.0 <5.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz"
+        }
+      }
     },
     "jju": {
       "version": "1.3.0",
@@ -5701,9 +5331,9 @@
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz"
     },
     "micromatch": {
-      "version": "3.1.4",
+      "version": "3.1.5",
       "from": "micromatch@>=3.0.4 <4.0.0",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.4.tgz"
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.5.tgz"
     },
     "miller-rabin": {
       "version": "4.0.1",
@@ -5816,6 +5446,11 @@
           "from": "glob@7.1.1",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz"
         },
+        "has-flag": {
+          "version": "1.0.0",
+          "from": "has-flag@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
+        },
         "ms": {
           "version": "0.7.2",
           "from": "ms@0.7.2",
@@ -5881,9 +5516,9 @@
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz"
     },
     "nanomatch": {
-      "version": "1.2.6",
+      "version": "1.2.7",
       "from": "nanomatch@>=1.2.5 <2.0.0",
-      "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.6.tgz",
+      "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.7.tgz",
       "dependencies": {
         "kind-of": {
           "version": "5.1.0",
@@ -6301,9 +5936,9 @@
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz"
     },
     "os-locale": {
-      "version": "1.4.0",
-      "from": "os-locale@>=1.4.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz"
+      "version": "2.1.0",
+      "from": "os-locale@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz"
     },
     "os-shim": {
       "version": "0.1.3",
@@ -6339,11 +5974,6 @@
       "version": "2.0.0",
       "from": "p-locate@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz"
-    },
-    "p-map": {
-      "version": "1.2.0",
-      "from": "p-map@>=1.1.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz"
     },
     "p-try": {
       "version": "1.0.0",
@@ -6571,6 +6201,11 @@
       "from": "postcss@>=5.0.21 <6.0.0",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
       "dependencies": {
+        "has-flag": {
+          "version": "1.0.0",
+          "from": "has-flag@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
+        },
         "supports-color": {
           "version": "3.2.3",
           "from": "supports-color@>=3.2.3 <4.0.0",
@@ -6620,15 +6255,10 @@
             }
           }
         },
-        "has-flag": {
-          "version": "2.0.0",
-          "from": "has-flag@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz"
-        },
         "postcss": {
-          "version": "6.0.15",
+          "version": "6.0.16",
           "from": "postcss@>=6.0.1 <7.0.0",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.15.tgz"
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.16.tgz"
         },
         "source-map": {
           "version": "0.6.1",
@@ -6664,15 +6294,10 @@
             }
           }
         },
-        "has-flag": {
-          "version": "2.0.0",
-          "from": "has-flag@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz"
-        },
         "postcss": {
-          "version": "6.0.15",
+          "version": "6.0.16",
           "from": "postcss@>=6.0.1 <7.0.0",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.15.tgz"
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.16.tgz"
         },
         "source-map": {
           "version": "0.6.1",
@@ -6708,15 +6333,10 @@
             }
           }
         },
-        "has-flag": {
-          "version": "2.0.0",
-          "from": "has-flag@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz"
-        },
         "postcss": {
-          "version": "6.0.15",
+          "version": "6.0.16",
           "from": "postcss@>=6.0.1 <7.0.0",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.15.tgz"
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.16.tgz"
         },
         "source-map": {
           "version": "0.6.1",
@@ -6752,15 +6372,10 @@
             }
           }
         },
-        "has-flag": {
-          "version": "2.0.0",
-          "from": "has-flag@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz"
-        },
         "postcss": {
-          "version": "6.0.15",
+          "version": "6.0.16",
           "from": "postcss@>=6.0.1 <7.0.0",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.15.tgz"
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.16.tgz"
         },
         "source-map": {
           "version": "0.6.1",
@@ -6790,13 +6405,18 @@
       "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz"
     },
     "pretty-format": {
-      "version": "20.0.3",
-      "from": "pretty-format@>=20.0.3 <21.0.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-20.0.3.tgz",
+      "version": "21.2.1",
+      "from": "pretty-format@>=21.2.1 <22.0.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-21.2.1.tgz",
       "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "from": "ansi-regex@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz"
+        },
         "ansi-styles": {
           "version": "3.2.0",
-          "from": "ansi-styles@>=3.0.0 <4.0.0",
+          "from": "ansi-styles@>=3.2.0 <4.0.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz"
         }
       }
@@ -7179,31 +6799,44 @@
       "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.1.2.tgz"
     },
     "sane": {
-      "version": "1.6.0",
-      "from": "sane@>=1.6.0 <1.7.0",
-      "resolved": "https://registry.npmjs.org/sane/-/sane-1.6.0.tgz",
-      "dependencies": {
-        "bser": {
-          "version": "1.0.2",
-          "from": "bser@1.0.2",
-          "resolved": "https://registry.npmjs.org/bser/-/bser-1.0.2.tgz"
-        },
-        "fb-watchman": {
-          "version": "1.9.2",
-          "from": "fb-watchman@>=1.8.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-1.9.2.tgz"
-        }
-      }
+      "version": "2.2.0",
+      "from": "sane@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/sane/-/sane-2.2.0.tgz"
     },
     "sass-graph": {
       "version": "2.2.4",
       "from": "sass-graph@>=2.2.4 <3.0.0",
       "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.2.4.tgz",
       "dependencies": {
+        "camelcase": {
+          "version": "3.0.0",
+          "from": "camelcase@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz"
+        },
+        "os-locale": {
+          "version": "1.4.0",
+          "from": "os-locale@>=1.4.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz"
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "from": "string-width@>=1.0.2 <2.0.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz"
+        },
+        "which-module": {
+          "version": "1.0.0",
+          "from": "which-module@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz"
+        },
         "yargs": {
           "version": "7.1.0",
           "from": "yargs@>=7.0.0 <8.0.0",
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz"
+        },
+        "yargs-parser": {
+          "version": "5.0.0",
+          "from": "yargs-parser@>=5.0.0 <6.0.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz"
         }
       }
     },
@@ -7795,14 +7428,43 @@
       "resolved": "https://registry.npmjs.org/string-hash/-/string-hash-1.1.3.tgz"
     },
     "string-length": {
-      "version": "1.0.1",
-      "from": "string-length@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/string-length/-/string-length-1.0.1.tgz"
+      "version": "2.0.0",
+      "from": "string-length@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/string-length/-/string-length-2.0.0.tgz",
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "from": "ansi-regex@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz"
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "from": "strip-ansi@>=4.0.0 <5.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz"
+        }
+      }
     },
     "string-width": {
-      "version": "1.0.2",
-      "from": "string-width@>=1.0.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz"
+      "version": "2.1.1",
+      "from": "string-width@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "from": "ansi-regex@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz"
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "from": "is-fullwidth-code-point@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz"
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "from": "strip-ansi@>=4.0.0 <5.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz"
+        }
+      }
     },
     "stringstream": {
       "version": "0.0.5",
@@ -7953,9 +7615,9 @@
       "resolved": "https://registry.npmjs.org/textextensions/-/textextensions-1.0.2.tgz"
     },
     "throat": {
-      "version": "3.2.0",
-      "from": "throat@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/throat/-/throat-3.2.0.tgz"
+      "version": "4.1.0",
+      "from": "throat@>=4.0.0 <5.0.0",
+      "resolved": "https://registry.npmjs.org/throat/-/throat-4.1.0.tgz"
     },
     "throttleit": {
       "version": "1.0.0",
@@ -8245,9 +7907,9 @@
       "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.5.tgz"
     },
     "tsutils": {
-      "version": "2.15.0",
+      "version": "2.16.0",
       "from": "tsutils@>=2.7.1 <3.0.0",
-      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.15.0.tgz"
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.16.0.tgz"
     },
     "tty-browserify": {
       "version": "0.0.0",
@@ -8604,9 +8266,9 @@
       "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz"
     },
     "watch": {
-      "version": "0.10.0",
-      "from": "watch@>=0.10.0 <0.11.0",
-      "resolved": "https://registry.npmjs.org/watch/-/watch-0.10.0.tgz"
+      "version": "0.18.0",
+      "from": "watch@>=0.18.0 <0.19.0",
+      "resolved": "https://registry.npmjs.org/watch/-/watch-0.18.0.tgz"
     },
     "watchpack": {
       "version": "1.4.0",
@@ -8628,35 +8290,10 @@
           "from": "acorn@>=5.0.0 <6.0.0",
           "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.3.0.tgz"
         },
-        "ansi-regex": {
-          "version": "3.0.0",
-          "from": "ansi-regex@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz"
-        },
-        "camelcase": {
-          "version": "4.1.0",
-          "from": "camelcase@>=4.1.0 <5.0.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz"
-        },
-        "has-flag": {
-          "version": "2.0.0",
-          "from": "has-flag@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz"
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "from": "is-fullwidth-code-point@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz"
-        },
         "load-json-file": {
           "version": "2.0.0",
           "from": "load-json-file@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz"
-        },
-        "os-locale": {
-          "version": "2.1.0",
-          "from": "os-locale@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz"
         },
         "path-type": {
           "version": "2.0.0",
@@ -8673,16 +8310,6 @@
           "from": "read-pkg-up@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz"
         },
-        "string-width": {
-          "version": "2.1.1",
-          "from": "string-width@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz"
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "from": "strip-ansi@>=4.0.0 <5.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz"
-        },
         "strip-bom": {
           "version": "3.0.0",
           "from": "strip-bom@>=3.0.0 <4.0.0",
@@ -8693,20 +8320,10 @@
           "from": "supports-color@>=4.2.1 <5.0.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz"
         },
-        "which-module": {
-          "version": "2.0.0",
-          "from": "which-module@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz"
-        },
         "yargs": {
           "version": "8.0.2",
           "from": "yargs@>=8.0.2 <9.0.0",
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz"
-        },
-        "yargs-parser": {
-          "version": "7.0.0",
-          "from": "yargs-parser@>=7.0.0 <8.0.0",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz"
         }
       }
     },
@@ -8767,14 +8384,21 @@
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz"
     },
     "which-module": {
-      "version": "1.0.0",
-      "from": "which-module@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz"
+      "version": "2.0.0",
+      "from": "which-module@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz"
     },
     "wide-align": {
       "version": "1.1.2",
       "from": "wide-align@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz"
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
+      "dependencies": {
+        "string-width": {
+          "version": "1.0.2",
+          "from": "string-width@>=1.0.2 <2.0.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz"
+        }
+      }
     },
     "window-size": {
       "version": "0.2.0",
@@ -8794,7 +8418,14 @@
     "wrap-ansi": {
       "version": "2.1.0",
       "from": "wrap-ansi@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz"
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "dependencies": {
+        "string-width": {
+          "version": "1.0.2",
+          "from": "string-width@>=1.0.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz"
+        }
+      }
     },
     "wrappy": {
       "version": "1.0.2",
@@ -8851,6 +8482,16 @@
           "from": "camelcase@>=2.0.1 <3.0.0",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz"
         },
+        "os-locale": {
+          "version": "1.4.0",
+          "from": "os-locale@>=1.4.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz"
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "from": "string-width@>=1.0.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz"
+        },
         "yargs-parser": {
           "version": "2.4.1",
           "from": "yargs-parser@>=2.4.0 <3.0.0",
@@ -8858,7 +8499,7 @@
           "dependencies": {
             "camelcase": {
               "version": "3.0.0",
-              "from": "camelcase@^3.0.0",
+              "from": "camelcase@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz"
             }
           }
@@ -8866,9 +8507,9 @@
       }
     },
     "yargs-parser": {
-      "version": "5.0.0",
-      "from": "yargs-parser@>=5.0.0 <6.0.0",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz"
+      "version": "7.0.0",
+      "from": "yargs-parser@>=7.0.0 <8.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz"
     },
     "yauzl": {
       "version": "2.4.1",

--- a/common/reviews/api/api-extractor.api.ts
+++ b/common/reviews/api/api-extractor.api.ts
@@ -1,24 +1,24 @@
 // @public
 class ApiJsonFile {
-  public static jsonSchema: JsonSchema;
-  public static loadFromFile(apiJsonFilePath: string): IApiPackage;
+  static jsonSchema: JsonSchema;
+  static loadFromFile(apiJsonFilePath: string): IApiPackage;
 }
 
 // @beta
 class ExternalApiHelper {
   // (undocumented)
-  public static generateApiJson(rootDir: string, libFolder: string, externalPackageFilePath: string): void;
+  static generateApiJson(rootDir: string, libFolder: string, externalPackageFilePath: string): void;
 }
 
 // @public
 class Extractor {
-  public constructor(config: IExtractorConfig, options?: IExtractorOptions);
-  public readonly actualConfig: IExtractorConfig;
+  constructor(config: IExtractorConfig, options?: IExtractorOptions);
+  readonly actualConfig: IExtractorConfig;
   // @deprecated
-  public analyzeProject(options?: IAnalyzeProjectOptions): void;
-  public static generateFilePathsForAnalysis(inputFilePaths: string[]): string[];
-  public static jsonSchema: JsonSchema;
-  public processProject(options?: IAnalyzeProjectOptions): boolean;
+  analyzeProject(options?: IAnalyzeProjectOptions): void;
+  static generateFilePathsForAnalysis(inputFilePaths: string[]): string[];
+  static jsonSchema: JsonSchema;
+  processProject(options?: IAnalyzeProjectOptions): boolean;
 }
 
 // @public
@@ -107,8 +107,7 @@ interface IApiMethod extends IApiBaseDefinition {
 
 // @alpha
 interface IApiNameMap<T> {
-  // (undocumented)
-  [ name: string ]: T;
+  [name: string]: T;
 }
 
 // @alpha
@@ -339,25 +338,25 @@ interface IMarkupWebLink {
 
 // @public
 class Markup {
-  public static BREAK: IMarkupLineBreak;
-  public static createApiLink(textElements: MarkupLinkTextElement[], target: IApiItemReference): IMarkupApiLink;
-  public static createApiLinkFromText(text: string, target: IApiItemReference): IMarkupApiLink;
-  public static createCode(code: string, highlighter?: MarkupHighlighter): IMarkupHighlightedText;
-  public static createCodeBox(code: string, highlighter: MarkupHighlighter): IMarkupCodeBox;
-  public static createHeading1(text: string): IMarkupHeading1;
-  public static createHeading2(text: string): IMarkupHeading2;
-  public static createNoteBox(textElements: MarkupBasicElement[]): IMarkupNoteBox;
-  public static createNoteBoxFromText(text: string): IMarkupNoteBox;
-  public static createPage(title: string): IMarkupPage;
-  public static createTable(headerCellValues: MarkupBasicElement[][] | undefined = undefined): IMarkupTable;
-  public static createTableRow(cellValues: MarkupBasicElement[][] | undefined = undefined): IMarkupTableRow;
-  public static createTextElements(text: string, options?: IMarkupCreateTextOptions): IMarkupText[];
-  public static createTextParagraphs(text: string, options?: IMarkupCreateTextOptions): MarkupBasicElement[];
-  public static createWebLink(textElements: MarkupLinkTextElement[], targetUrl: string): IMarkupWebLink;
-  public static createWebLinkFromText(text: string, targetUrl: string): IMarkupWebLink;
-  public static extractTextContent(elements: MarkupElement[]): string;
-  public static normalize < T extends MarkupElement >(elements: T[]): void;
-  public static PARAGRAPH: IMarkupParagraph;
+  static BREAK: IMarkupLineBreak;
+  static createApiLink(textElements: MarkupLinkTextElement[], target: IApiItemReference): IMarkupApiLink;
+  static createApiLinkFromText(text: string, target: IApiItemReference): IMarkupApiLink;
+  static createCode(code: string, highlighter?: MarkupHighlighter): IMarkupHighlightedText;
+  static createCodeBox(code: string, highlighter: MarkupHighlighter): IMarkupCodeBox;
+  static createHeading1(text: string): IMarkupHeading1;
+  static createHeading2(text: string): IMarkupHeading2;
+  static createNoteBox(textElements: MarkupBasicElement[]): IMarkupNoteBox;
+  static createNoteBoxFromText(text: string): IMarkupNoteBox;
+  static createPage(title: string): IMarkupPage;
+  static createTable(headerCellValues?: MarkupBasicElement[][] | undefined): IMarkupTable;
+  static createTableRow(cellValues?: MarkupBasicElement[][] | undefined): IMarkupTableRow;
+  static createTextElements(text: string, options?: IMarkupCreateTextOptions): IMarkupText[];
+  static createTextParagraphs(text: string, options?: IMarkupCreateTextOptions): MarkupBasicElement[];
+  static createWebLink(textElements: MarkupLinkTextElement[], targetUrl: string): IMarkupWebLink;
+  static createWebLinkFromText(text: string, targetUrl: string): IMarkupWebLink;
+  static extractTextContent(elements: MarkupElement[]): string;
+  static normalize<T extends MarkupElement>(elements: T[]): void;
+  static PARAGRAPH: IMarkupParagraph;
 }
 
 // WARNING: Unsupported export: ApiAccessModifier

--- a/common/reviews/api/gulp-core-build-karma.api.ts
+++ b/common/reviews/api/gulp-core-build-karma.api.ts
@@ -1,3 +1,3 @@
 // WARNING: Unsupported export: karma
 // WARNING: Unsupported export: default
-// (No packageDescription for this package)
+// (No @packagedocumentation comment for this package)

--- a/common/reviews/api/gulp-core-build-mocha.api.ts
+++ b/common/reviews/api/gulp-core-build-mocha.api.ts
@@ -1,4 +1,4 @@
 // WARNING: Unsupported export: instrument
 // WARNING: Unsupported export: mocha
 // WARNING: Unsupported export: default
-// (No packageDescription for this package)
+// (No @packagedocumentation comment for this package)

--- a/common/reviews/api/gulp-core-build-sass.api.ts
+++ b/common/reviews/api/gulp-core-build-sass.api.ts
@@ -1,3 +1,3 @@
 // WARNING: Unsupported export: sass
 // WARNING: Unsupported export: default
-// (No packageDescription for this package)
+// (No @packagedocumentation comment for this package)

--- a/common/reviews/api/gulp-core-build-serve.api.ts
+++ b/common/reviews/api/gulp-core-build-serve.api.ts
@@ -3,4 +3,4 @@
 // WARNING: Unsupported export: trustDevCert
 // WARNING: Unsupported export: untrustDevCert
 // WARNING: Unsupported export: default
-// (No packageDescription for this package)
+// (No @packagedocumentation comment for this package)

--- a/common/reviews/api/gulp-core-build-typescript.api.ts
+++ b/common/reviews/api/gulp-core-build-typescript.api.ts
@@ -3,9 +3,9 @@
 class ApiExtractorTask extends GulpTask<IApiExtractorTaskConfig> {
   constructor();
   // (undocumented)
-  public executeTask(gulp: typeof Gulp, completeCallback: (error?: string) => void): NodeJS.ReadWriteStream | void;
+  executeTask(gulp: typeof Gulp, completeCallback: (error?: string) => void): NodeJS.ReadWriteStream | void;
   // (undocumented)
-  public loadSchema(): Object;
+  loadSchema(): Object;
 }
 
 // @public (undocumented)
@@ -22,14 +22,12 @@ interface ITsConfigFile<T> {
 
 // @public
 class TypeScriptConfiguration {
-  public static fixupSettings(compilerOptions: ts.Settings,
-      logWarning: (msg: string) => void,
-      options: Partial<IFixupSettingsOptions> = {}): void;
-  public static getGulpTypescriptOptions(buildConfig: IBuildConfig): ITsConfigFile<ts.Settings>;
-  public static getTsConfigFile(config: IBuildConfig): ITsConfigFile<ts.Settings>;
-  public static getTypescriptCompiler(): any;
-  public static setBaseConfig(config: ITsConfigFile<ts.Settings>): void;
-  public static setTypescriptCompiler(typescriptOverride: any): void;
+  static fixupSettings(compilerOptions: ts.Settings, logWarning: (msg: string) => void, options?: Partial<IFixupSettingsOptions>): void;
+  static getGulpTypescriptOptions(buildConfig: IBuildConfig): ITsConfigFile<ts.Settings>;
+  static getTsConfigFile(config: IBuildConfig): ITsConfigFile<ts.Settings>;
+  static getTypescriptCompiler(): any;
+  static setBaseConfig(config: ITsConfigFile<ts.Settings>): void;
+  static setTypescriptCompiler(typescriptOverride: any): void;
 }
 
 // WARNING: The type "ITypeScriptTaskConfig" needs to be exported by the package (e.g. added to index.ts)
@@ -37,14 +35,14 @@ class TypeScriptConfiguration {
 class TypeScriptTask extends GulpTask<ITypeScriptTaskConfig> {
   constructor();
   // (undocumented)
-  public executeTask(gulp: gulpType.Gulp, completeCallback: (error?: string) => void): void;
+  executeTask(gulp: gulpType.Gulp, completeCallback: (error?: string) => void): void;
   // WARNING: The type "ITypeScriptTaskConfig" needs to be exported by the package (e.g. added to index.ts)
   // (undocumented)
-  public getCleanMatch(buildConfig: IBuildConfig, taskConfig: ITypeScriptTaskConfig = this.taskConfig): string[];
+  getCleanMatch(buildConfig: IBuildConfig, taskConfig?: ITypeScriptTaskConfig): string[];
   // (undocumented)
-  public loadSchema(): Object;
+  loadSchema(): Object;
   // WARNING: The type "ITypeScriptTaskConfig" needs to be exported by the package (e.g. added to index.ts)
-  public mergeConfig(config: ITypeScriptTaskConfig): void;
+  mergeConfig(config: ITypeScriptTaskConfig): void;
 }
 
 // WARNING: Unsupported export: apiExtractor
@@ -53,4 +51,4 @@ class TypeScriptTask extends GulpTask<ITypeScriptTaskConfig> {
 // WARNING: Unsupported export: text
 // WARNING: Unsupported export: removeTripleSlash
 // WARNING: Unsupported export: default
-// (No packageDescription for this package)
+// (No @packagedocumentation comment for this package)

--- a/common/reviews/api/gulp-core-build-webpack.api.ts
+++ b/common/reviews/api/gulp-core-build-webpack.api.ts
@@ -17,15 +17,15 @@ interface IWebpackTaskConfig {
 class WebpackTask<TExtendedConfig = {}> extends GulpTask<IWebpackTaskConfig & TExtendedConfig> {
   constructor(extendedName?: string, extendedConfig?: TExtendedConfig);
   // (undocumented)
-  public executeTask(gulp: typeof Gulp, completeCallback: (error?: string) => void): void;
+  executeTask(gulp: typeof Gulp, completeCallback: (error?: string) => void): void;
   // (undocumented)
-  public isEnabled(buildConfig: IBuildConfig): boolean;
+  isEnabled(buildConfig: IBuildConfig): boolean;
   // (undocumented)
-  public loadSchema(): Object;
+  loadSchema(): Object;
   // (undocumented)
-  public readonly resources: IWebpackResources;
+  readonly resources: IWebpackResources;
 }
 
 // WARNING: Unsupported export: webpack
 // WARNING: Unsupported export: default
-// (No packageDescription for this package)
+// (No @packagedocumentation comment for this package)

--- a/common/reviews/api/gulp-core-build.api.ts
+++ b/common/reviews/api/gulp-core-build.api.ts
@@ -8,34 +8,31 @@ export function addSuppression(suppression: string | RegExp): void;
 class CleanFlagTask extends CleanTask {
   constructor();
   // (undocumented)
-  public executeTask(gulp: typeof Gulp,
-      completeCallback: (error?: string | Error) => void): void;
+  executeTask(gulp: typeof Gulp, completeCallback: (error?: string | Error) => void): void;
   // (undocumented)
-  public isEnabled(buildConfig: IBuildConfig): boolean;
+  isEnabled(buildConfig: IBuildConfig): boolean;
 }
 
 // @public
 class CleanTask extends GulpTask<void> {
   constructor();
-  public executeTask(gulp: typeof Gulp,
-      completeCallback: (error?: string | Error) => void): void;
+  executeTask(gulp: typeof Gulp, completeCallback: (error?: string | Error) => void): void;
 }
 
 // @public
 class CopyStaticAssetsTask extends GulpTask<ICopyStaticAssetsTaskConfig> {
   constructor();
   // (undocumented)
-  public executeTask(gulp: typeof Gulp, completeCallback: (error?: string) => void): NodeJS.ReadWriteStream;
+  executeTask(gulp: typeof Gulp, completeCallback: (error?: string) => void): NodeJS.ReadWriteStream;
   // (undocumented)
-  public loadSchema(): Object;
+  loadSchema(): Object;
 }
 
 // @public
 class CopyTask extends GulpTask<ICopyConfig> {
   constructor();
-  public executeTask(gulp: typeof Gulp,
-      completeCallback: (error?: string | Error) => void): Promise<Object> | NodeJS.ReadWriteStream | void;
-  public loadSchema(): Object;
+  executeTask(gulp: typeof Gulp, completeCallback: (error?: string | Error) => void): Promise<Object> | NodeJS.ReadWriteStream | void;
+  loadSchema(): Object;
 }
 
 // @public
@@ -45,29 +42,13 @@ export function coverageData(coverage: number, threshold: number, filePath: stri
 export function error(...args: Array<string | Chalk.ChalkChain>): void;
 
 // @public
-export function fileError(taskName: string,
-  filePath: string,
-  line: number,
-  column: number,
-  errorCode: string,
-  message: string): void;
+export function fileError(taskName: string, filePath: string, line: number, column: number, errorCode: string, message: string): void;
 
 // @public
-export function fileLog(write: (text: string) => void,
-  taskName: string,
-  filePath: string,
-  line: number,
-  column: number,
-  errorCode: string,
-  message: string): void;
+export function fileLog(write: (text: string) => void, taskName: string, filePath: string, line: number, column: number, errorCode: string, message: string): void;
 
 // @public
-export function fileWarning(taskName: string,
-  filePath: string,
-  line: number,
-  column: number,
-  errorCode: string,
-  message: string): void;
+export function fileWarning(taskName: string, filePath: string, line: number, column: number, errorCode: string, message: string): void;
 
 // @public
 export function functionalTestRun(name: string, result: TestResultState, duration: number): void;
@@ -75,8 +56,7 @@ export function functionalTestRun(name: string, result: TestResultState, duratio
 // @public
 class GenerateShrinkwrapTask extends GulpTask<void> {
   constructor();
-  public executeTask(gulp: gulpType.Gulp,
-      completeCallback: (error?: string | Error) => void): NodeJS.ReadWriteStream | void;
+  executeTask(gulp: gulpType.Gulp, completeCallback: (error?: string | Error) => void): NodeJS.ReadWriteStream | void;
 }
 
 // @public
@@ -90,41 +70,40 @@ export function getWarnings(): string[];
 
 // @public
 class GulpTask<TTaskConfig> implements IExecutable {
-  public constructor(name: string, initialTaskConfig: Partial<TTaskConfig> = {});
+  constructor(name: string, initialTaskConfig?: Partial<TTaskConfig>);
   protected _getConfigFilePath(): string;
-  public buildConfig: IBuildConfig;
-  public cleanMatch: string[];
-  public copyFile(localSourcePath: string, localDestPath?: string): void;
-  public enabled: boolean;
-  public execute(config: IBuildConfig): Promise<void>;
+  buildConfig: IBuildConfig;
+  cleanMatch: string[];
+  copyFile(localSourcePath: string, localDestPath?: string): void;
+  enabled: boolean;
+  execute(config: IBuildConfig): Promise<void>;
   // WARNING: The type "GulpProxy" needs to be exported by the package (e.g. added to index.ts)
-  public abstract executeTask(gulp: gulp.Gulp | GulpProxy,
-      completeCallback?: (error?: string | Error) => void): Promise<Object | void> | NodeJS.ReadWriteStream | void;
-  public fileError(filePath: string, line: number, column: number, errorCode: string, message: string): void;
-  public fileExists(localPath: string): boolean;
-  public fileWarning(filePath: string, line: number, column: number, warningCode: string, message: string): void;
-  public getCleanMatch(buildConfig: IBuildConfig, taskConfig: TTaskConfig = this.taskConfig): string[];
-  public isEnabled(buildConfig: IBuildConfig): boolean;
+  abstract executeTask(gulp: gulp.Gulp | GulpProxy, completeCallback?: (error?: string | Error) => void): Promise<Object | void> | NodeJS.ReadWriteStream | void;
+  fileError(filePath: string, line: number, column: number, errorCode: string, message: string): void;
+  fileExists(localPath: string): boolean;
+  fileWarning(filePath: string, line: number, column: number, warningCode: string, message: string): void;
+  getCleanMatch(buildConfig: IBuildConfig, taskConfig?: TTaskConfig): string[];
+  isEnabled(buildConfig: IBuildConfig): boolean;
   protected loadSchema(): Object | undefined;
-  public log(message: string): void;
-  public logError(message: string): void;
-  public logVerbose(message: string): void;
-  public logWarning(message: string): void;
-  public mergeConfig(taskConfig: Partial<TTaskConfig>): void;
-  public name: string;
-  public onRegister(): void;
-  public readJSONSync(localPath: string): Object | undefined;
-  public replaceConfig(taskConfig: TTaskConfig): void;
-  public resolvePath(localPath: string): string;
-  public readonly schema: Object | undefined;
-  public setConfig(taskConfig: Partial<TTaskConfig>): void;
-  public taskConfig: TTaskConfig;
+  log(message: string): void;
+  logError(message: string): void;
+  logVerbose(message: string): void;
+  logWarning(message: string): void;
+  mergeConfig(taskConfig: Partial<TTaskConfig>): void;
+  name: string;
+  onRegister(): void;
+  readJSONSync(localPath: string): Object | undefined;
+  replaceConfig(taskConfig: TTaskConfig): void;
+  resolvePath(localPath: string): string;
+  readonly schema: Object | undefined;
+  setConfig(taskConfig: Partial<TTaskConfig>): void;
+  taskConfig: TTaskConfig;
 }
 
 // @public (undocumented)
 interface IBuildConfig {
   args: {
-    [ name: string ]: string | boolean
+    [name: string]: string | boolean;
   }
   buildErrorIconPath?: string;
   buildSuccessIconPath?: string;
@@ -140,7 +119,7 @@ interface IBuildConfig {
   packageFolder: string;
   production: boolean;
   properties?: {
-    [ key: string ]: any
+    [key: string]: any;
   }
   relogIssues?: boolean;
   rootPath: string;
@@ -155,7 +134,7 @@ interface IBuildConfig {
 // @public
 interface ICopyConfig {
   copyTo: {
-    [ destPath: string ]: string[];
+    [destPath: string]: string[];
   }
   shouldFlatten?: boolean;
 }
@@ -207,11 +186,10 @@ export function initialize(gulp: typeof Gulp): void;
 class JestTask extends GulpTask<IJestConfig> {
   constructor();
   // (undocumented)
-  public executeTask(gulp: typeof Gulp,
-      completeCallback: (error?: string | Error) => void): void;
+  executeTask(gulp: typeof Gulp, completeCallback: (error?: string | Error) => void): void;
   // (undocumented)
-  public isEnabled(buildConfig: IBuildConfig): boolean;
-  public loadSchema(): Object;
+  isEnabled(buildConfig: IBuildConfig): boolean;
+  loadSchema(): Object;
 }
 
 // @public
@@ -247,19 +225,19 @@ export function task(taskName: string, taskExecutable: IExecutable): IExecutable
 // @public
 enum TestResultState {
   // (undocumented)
-  Failed,
+  Failed = 1,
   // (undocumented)
-  FlakyFailed,
+  FlakyFailed = 2,
   // (undocumented)
-  Passed,
+  Passed = 0,
   // (undocumented)
-  Skipped
+  Skipped = 3
 }
 
 // @public
 class ValidateShrinkwrapTask extends GulpTask<void> {
   constructor();
-  public executeTask(gulp: gulpType.Gulp, completeCallback: (error: string) => void): NodeJS.ReadWriteStream | void;
+  executeTask(gulp: gulpType.Gulp, completeCallback: (error: string) => void): NodeJS.ReadWriteStream | void;
 }
 
 // @public
@@ -275,4 +253,4 @@ export function watch(watchMatch: string | string[], taskExecutable: IExecutable
 // WARNING: Unsupported export: clean
 // WARNING: Unsupported export: copyStaticAssets
 // WARNING: Unsupported export: jest
-// (No packageDescription for this package)
+// (No @packagedocumentation comment for this package)

--- a/common/reviews/api/node-core-library.api.ts
+++ b/common/reviews/api/node-core-library.api.ts
@@ -1,8 +1,8 @@
 // @public
 class FileDiffTest {
-  public static assertEqual(actualFilePath: string, expectedFilePath: string): void;
-  public static clearCache(): void;
-  public static prepareFolder(unitTestDirName: string, testModule: string): string;
+  static assertEqual(actualFilePath: string, expectedFilePath: string): void;
+  static clearCache(): void;
+  static prepareFolder(unitTestDirName: string, testModule: string): string;
 }
 
 // @public
@@ -32,32 +32,29 @@ interface IJsonSchemaValidateOptions {
 
 // @public
 class JsonFile {
-  public static load(jsonFilename: string): any;
-  public static loadAndValidate(jsonFilename: string, jsonSchema: JsonSchema,
-      options?: IJsonSchemaValidateOptions): any;
-  public static loadAndValidateWithCallback(jsonFilename: string, jsonSchema: JsonSchema,
-      errorCallback: (errorInfo: IJsonSchemaErrorInfo) => void): any;
-  public static save(jsonObject: Object, jsonFilename: string, options: IJsonFileSaveOptions = {}): boolean;
-  public static stringify(jsonObject: Object, options?: IJsonFileStringifyOptions): string;
-  public static validateNoUndefinedMembers(jsonObject: Object): void;
+  static load(jsonFilename: string): any;
+  static loadAndValidate(jsonFilename: string, jsonSchema: JsonSchema, options?: IJsonSchemaValidateOptions): any;
+  static loadAndValidateWithCallback(jsonFilename: string, jsonSchema: JsonSchema, errorCallback: (errorInfo: IJsonSchemaErrorInfo) => void): any;
+  static save(jsonObject: Object, jsonFilename: string, options?: IJsonFileSaveOptions): boolean;
+  static stringify(jsonObject: Object, options?: IJsonFileStringifyOptions): string;
+  static validateNoUndefinedMembers(jsonObject: Object): void;
 }
 
 // @public
 class JsonSchema {
-  public ensureCompiled(): void;
-  public static fromFile(filename: string, options?: IJsonSchemaFromFileOptions): JsonSchema;
-  public static fromLoadedObject(schemaObject: Object): JsonSchema;
-  public readonly shortName: string;
-  public validateObject(jsonObject: Object, filenameForErrors: string, options?: IJsonSchemaValidateOptions): void;
-  public validateObjectWithCallback(jsonObject: Object,
-      errorCallback: (errorInfo: IJsonSchemaErrorInfo) => void): void;
+  ensureCompiled(): void;
+  static fromFile(filename: string, options?: IJsonSchemaFromFileOptions): JsonSchema;
+  static fromLoadedObject(schemaObject: Object): JsonSchema;
+  readonly shortName: string;
+  validateObject(jsonObject: Object, filenameForErrors: string, options?: IJsonSchemaValidateOptions): void;
+  validateObjectWithCallback(jsonObject: Object, errorCallback: (errorInfo: IJsonSchemaErrorInfo) => void): void;
 }
 
 // @public
 class PackageJsonLookup {
   constructor();
-  public clearCache(): void;
-  public getPackageName(packageJsonPath: string): string;
-  public tryGetPackageFolder(sourceFilePath: string): string | undefined;
+  clearCache(): void;
+  getPackageName(packageJsonPath: string): string;
+  tryGetPackageFolder(sourceFilePath: string): string | undefined;
 }
 

--- a/common/reviews/api/ts-command-line.api.ts
+++ b/common/reviews/api/ts-command-line.api.ts
@@ -1,7 +1,7 @@
 // @internal (undocumented)
 interface _ICommandLineParserData {
   // (undocumented)
-  [ key: string ]: any;
+  [key: string]: any;
   // (undocumented)
   action: string;
 }
@@ -10,13 +10,13 @@ interface _ICommandLineParserData {
 class CommandLineAction extends CommandLineParameterProvider {
   constructor(options: ICommandLineActionOptions);
   // @internal
-  public _buildParser(actionsSubParser: argparse.SubParser): void;
+  _buildParser(actionsSubParser: argparse.SubParser): void;
   // @internal
-  public _execute(): void;
+  _execute(): void;
   // @internal
-  public _processParsedData(data: ICommandLineParserData): void;
+  _processParsedData(data: ICommandLineParserData): void;
   protected abstract onExecute(): void;
-  public options: ICommandLineActionOptions;
+  options: ICommandLineActionOptions;
 }
 
 // @public
@@ -35,10 +35,10 @@ class CommandLineOptionParameter extends CommandLineParameter<string> {
 class CommandLineParameter<T> {
   constructor(key: string, converter?: (data: string) => T);
   // @internal
-  public readonly _key: string;
+  readonly _key: string;
   // @internal
-  public _setValue(data: ICommandLineParserData): void;
-  public readonly value: T;
+  _setValue(data: ICommandLineParserData): void;
+  readonly value: T;
 }
 
 // @public
@@ -59,8 +59,8 @@ class CommandLineParameterProvider {
 // @public
 class CommandLineParser extends CommandLineParameterProvider {
   constructor(options: ICommandListParserOptions);
-  public addAction(command: CommandLineAction): void;
-  public execute(args?: string[]): void;
+  addAction(command: CommandLineAction): void;
+  execute(args?: string[]): void;
   protected onExecute(): void;
   protected selectedAction: CommandLineAction;
 }

--- a/core-build/gulp-core-build-karma/config/api-extractor.json
+++ b/core-build/gulp-core-build-karma/config/api-extractor.json
@@ -2,5 +2,5 @@
   "enabled": true,
   "apiReviewFolder": "../../common/reviews/api",
   "apiJsonFolder": "./temp",
-  "entry": "src/index.ts"
+  "entry": "lib/index.d.ts"
 }

--- a/core-build/gulp-core-build-karma/package.json
+++ b/core-build/gulp-core-build-karma/package.json
@@ -34,7 +34,7 @@
     "webpack": "~3.6.0"
   },
   "devDependencies": {
-    "@microsoft/node-library-build": "4.2.3",
+    "@microsoft/node-library-build": "4.2.16",
     "@types/gulp": "3.8.32",
     "@types/karma": "0.13.33",
     "@types/log4js": "0.0.33",

--- a/core-build/gulp-core-build-mocha/config/api-extractor.json
+++ b/core-build/gulp-core-build-mocha/config/api-extractor.json
@@ -2,5 +2,5 @@
   "enabled": true,
   "apiReviewFolder": "../../common/reviews/api",
   "apiJsonFolder": "./temp",
-  "entry": "src/index.ts"
+  "entry": "lib/index.d.ts"
 }

--- a/core-build/gulp-core-build-mocha/package.json
+++ b/core-build/gulp-core-build-mocha/package.json
@@ -20,7 +20,7 @@
     "gulp-mocha": "~2.2.0"
   },
   "devDependencies": {
-    "@microsoft/node-library-build": "4.2.3",
+    "@microsoft/node-library-build": "4.2.16",
     "@types/gulp": "3.8.32",
     "@types/gulp-istanbul": "0.9.30",
     "@types/gulp-mocha": "0.0.29",

--- a/core-build/gulp-core-build-sass/config/api-extractor.json
+++ b/core-build/gulp-core-build-sass/config/api-extractor.json
@@ -2,5 +2,5 @@
   "enabled": true,
   "apiReviewFolder": "../../common/reviews/api",
   "apiJsonFolder": "./temp",
-  "entry": "src/index.ts"
+  "entry": "lib/index.d.ts"
 }

--- a/core-build/gulp-core-build-sass/package.json
+++ b/core-build/gulp-core-build-sass/package.json
@@ -28,7 +28,7 @@
     "postcss-modules": "~0.6.4"
   },
   "devDependencies": {
-    "@microsoft/node-library-build": "4.2.3",
+    "@microsoft/node-library-build": "4.2.16",
     "@types/express": "4.0.35",
     "@types/express-serve-static-core": "4.0.41",
     "@types/gulp": "3.8.32",

--- a/core-build/gulp-core-build-serve/config/api-extractor.json
+++ b/core-build/gulp-core-build-serve/config/api-extractor.json
@@ -2,5 +2,5 @@
   "enabled": true,
   "apiReviewFolder": "../../common/reviews/api",
   "apiJsonFolder": "./temp",
-  "entry": "src/index.ts"
+  "entry": "lib/index.d.ts"
 }

--- a/core-build/gulp-core-build-serve/package.json
+++ b/core-build/gulp-core-build-serve/package.json
@@ -25,7 +25,7 @@
     "sudo": "~1.0.3"
   },
   "devDependencies": {
-    "@microsoft/node-library-build": "4.2.3",
+    "@microsoft/node-library-build": "4.2.16",
     "@types/express": "4.0.35",
     "@types/express-serve-static-core": "4.0.41",
     "@types/gulp": "3.8.32",

--- a/core-build/gulp-core-build-typescript/config/api-extractor.json
+++ b/core-build/gulp-core-build-typescript/config/api-extractor.json
@@ -2,5 +2,5 @@
   "enabled": true,
   "apiReviewFolder": "../../common/reviews/api",
   "apiJsonFolder": "./temp",
-  "entry": "src/index.ts"
+  "entry": "lib/index.d.ts"
 }

--- a/core-build/gulp-core-build-typescript/package.json
+++ b/core-build/gulp-core-build-typescript/package.json
@@ -39,7 +39,7 @@
     "typescript": "~2.4.1"
   },
   "devDependencies": {
-    "@microsoft/node-library-build": "4.2.3",
+    "@microsoft/node-library-build": "4.2.16",
     "@types/gulp-util": "3.0.30",
     "@types/orchestrator": "0.0.30",
     "@types/q": "0.0.32",

--- a/core-build/gulp-core-build-webpack/config/api-extractor.json
+++ b/core-build/gulp-core-build-webpack/config/api-extractor.json
@@ -2,5 +2,5 @@
   "enabled": true,
   "apiReviewFolder": "../../common/reviews/api",
   "apiJsonFolder": "./temp",
-  "entry": "src/index.ts"
+  "entry": "lib/index.d.ts"
 }

--- a/core-build/gulp-core-build-webpack/package.json
+++ b/core-build/gulp-core-build-webpack/package.json
@@ -21,7 +21,7 @@
     "webpack": "~3.6.0"
   },
   "devDependencies": {
-    "@microsoft/node-library-build": "4.2.3",
+    "@microsoft/node-library-build": "4.2.16",
     "@types/orchestrator": "0.0.30",
     "@types/q": "0.0.32",
     "@types/source-map": "0.5.0",

--- a/core-build/gulp-core-build/config/api-extractor.json
+++ b/core-build/gulp-core-build/config/api-extractor.json
@@ -2,5 +2,5 @@
   "enabled": true,
   "apiReviewFolder": "../../common/reviews/api",
   "apiJsonFolder": "./temp",
-  "entry": "src/index.ts"
+  "entry": "lib/index.d.ts"
 }

--- a/core-build/gulp-core-build/package.json
+++ b/core-build/gulp-core-build/package.json
@@ -56,7 +56,7 @@
   },
   "devDependencies": {
     "@types/z-schema": "3.16.31",
-    "@microsoft/node-library-build": "4.2.3",
+    "@microsoft/node-library-build": "4.2.16",
     "chai": "~3.5.0"
   }
 }

--- a/core-build/node-library-build/config/api-extractor.json
+++ b/core-build/node-library-build/config/api-extractor.json
@@ -2,5 +2,5 @@
   "enabled": true,
   "apiReviewFolder": "../../common/reviews/api",
   "apiJsonFolder": "./temp",
-  "entry": "src/index.ts"
+  "entry": "lib/index.d.ts"
 }

--- a/core-build/web-library-build/config/api-extractor.json
+++ b/core-build/web-library-build/config/api-extractor.json
@@ -2,5 +2,5 @@
   "enabled": true,
   "apiReviewFolder": "../../common/reviews/api",
   "apiJsonFolder": "./temp",
-  "entry": "src/index.ts"
+  "entry": "lib/index.d.ts"
 }

--- a/libraries/decorators/config/api-extractor.json
+++ b/libraries/decorators/config/api-extractor.json
@@ -2,5 +2,5 @@
   "enabled": true,
   "apiReviewFolder": "../../common/reviews/api",
   "apiJsonFolder": "./temp",
-  "entry": "src/index.ts"
+  "entry": "lib/index.d.ts"
 }

--- a/libraries/node-core-library/config/api-extractor.json
+++ b/libraries/node-core-library/config/api-extractor.json
@@ -2,5 +2,5 @@
   "enabled": true,
   "apiReviewFolder": "../../common/reviews/api",
   "apiJsonFolder": "./temp",
-  "entry": "src/index.ts"
+  "entry": "lib/index.d.ts"
 }

--- a/libraries/node-core-library/package.json
+++ b/libraries/node-core-library/package.json
@@ -22,6 +22,6 @@
     "chai": "~3.5.0",
     "gulp": "~3.9.1",
     "mocha": "~3.4.2",
-    "@microsoft/node-library-build": "4.2.3"
+    "@microsoft/node-library-build": "4.2.16"
   }
 }

--- a/libraries/node-core-library/src/index.ts
+++ b/libraries/node-core-library/src/index.ts
@@ -3,8 +3,9 @@
 
 /**
  * Core libraries that every NodeJS toolchain project should use.
+ *
+ * @packagedocumentation
  */
-declare const packageDescription: void; // tslint:disable-line:no-unused-variable
 
 export { FileDiffTest } from './FileDiffTest';
 export {

--- a/libraries/package-deps-hash/config/api-extractor.json
+++ b/libraries/package-deps-hash/config/api-extractor.json
@@ -2,5 +2,5 @@
   "enabled": true,
   "apiReviewFolder": "../../common/reviews/api",
   "apiJsonFolder": "./temp",
-  "entry": "src/index.ts"
+  "entry": "lib/index.d.ts"
 }

--- a/libraries/ts-command-line/config/api-extractor.json
+++ b/libraries/ts-command-line/config/api-extractor.json
@@ -2,5 +2,5 @@
   "enabled": true,
   "apiReviewFolder": "../../common/reviews/api",
   "apiJsonFolder": "./temp",
-  "entry": "src/index.ts"
+  "entry": "lib/index.d.ts"
 }

--- a/libraries/ts-command-line/package.json
+++ b/libraries/ts-command-line/package.json
@@ -23,6 +23,6 @@
     "chai": "~3.5.0",
     "gulp": "~3.9.1",
     "mocha": "~3.4.2",
-    "@microsoft/node-library-build": "4.2.3"
+    "@microsoft/node-library-build": "4.2.16"
   }
 }

--- a/libraries/ts-command-line/src/index.ts
+++ b/libraries/ts-command-line/src/index.ts
@@ -3,8 +3,9 @@
 
 /**
  * An object-oriented command-line parser for TypeScript projects.
+ *
+ * @packagedocumentation
  */
-declare const packageDescription: void; // tslint:disable-line:no-unused-variable
 
 export {
   default as CommandLineAction,

--- a/webpack/set-webpack-public-path-plugin/config/api-extractor.json
+++ b/webpack/set-webpack-public-path-plugin/config/api-extractor.json
@@ -2,5 +2,5 @@
   "enabled": true,
   "apiReviewFolder": "../../common/reviews/api",
   "apiJsonFolder": "./temp",
-  "entry": "src/index.ts"
+  "entry": "lib/index.d.ts"
 }


### PR DESCRIPTION
This PR bumps the **node-library-build** version, which is not automatically incremented because it is part of  `cyclicDependencyProjects`.

It also migrates some config files / definitions to work with the new API Extractor 5.0.0.