### PR TITLE
Fix the way pnpm shrinkwrap file checks for special dependency

### DIFF
--- a/apps/rush-lib/src/cli/utilities/pnpm/PnpmShrinkwrapFile.ts
+++ b/apps/rush-lib/src/cli/utilities/pnpm/PnpmShrinkwrapFile.ts
@@ -129,12 +129,16 @@ export class PnpmShrinkwrapFile extends BaseShrinkwrapFile {
     // e.g.:  "/gulp-karma/0.0.5/karma@0.13.22"
     // split it by forward slashes, then grab the second group
     // if the second group doesn't exist, return the version directly
-    const versionParts: string[] = version.split('/');
-    if (versionParts.length !== 1 && versionParts.length !== 4) {
-      throw new Error(`Cannot parse pnpm shrinkwrap version specifier: `
-        + `"${version}" for "${dependencyName}"`);
+    if (version) {
+      const versionParts: string[] = version.split('/');
+      if (versionParts.length !== 1 && versionParts.length !== 4) {
+        throw new Error(`Cannot parse pnpm shrinkwrap version specifier: `
+          + `"${version}" for "${dependencyName}"`);
+      }
+      return versionParts[2] || version;
+    } else {
+      return undefined;
     }
-    return version ? (versionParts[2] || version) : undefined;
   }
 
   private constructor(shrinkwrapJson: IShrinkwrapYaml) {

--- a/apps/rush-lib/src/cli/utilities/pnpm/PnpmShrinkwrapFile.ts
+++ b/apps/rush-lib/src/cli/utilities/pnpm/PnpmShrinkwrapFile.ts
@@ -129,7 +129,12 @@ export class PnpmShrinkwrapFile extends BaseShrinkwrapFile {
     // e.g.:  "/gulp-karma/0.0.5/karma@0.13.22"
     // split it by forward slashes, then grab the second group
     // if the second group doesn't exist, return the version directly
-    return version ? (version.split('/')[2] || version) : undefined;
+    const versionParts: string[] = version.split('/');
+    if (versionParts.length !== 1 && versionParts.length !== 4) {
+      throw new Error(`Cannot parse pnpm shrinkwrap version specifier: `
+        + `"${version}" for "${dependencyName}"`);
+    }
+    return version ? (versionParts[2] || version) : undefined;
   }
 
   private constructor(shrinkwrapJson: IShrinkwrapYaml) {

--- a/apps/rush-lib/src/cli/utilities/pnpm/PnpmShrinkwrapFile.ts
+++ b/apps/rush-lib/src/cli/utilities/pnpm/PnpmShrinkwrapFile.ts
@@ -115,7 +115,18 @@ export class PnpmShrinkwrapFile extends BaseShrinkwrapFile {
       return undefined;
     }
 
-    return packageDescription.dependencies[dependencyName];
+    const version: string = packageDescription.dependencies[dependencyName];
+    if (version) {
+      // e.g.:  "/gulp-karma/0.0.5/karma@0.13.22"
+      // capture 0: "/gulp-karma/0.0.5/"
+      // capture 1: "0.0.5"
+      const specialVersionCase: RegExp = /\/[a-z\-]+\/(.*)\//;
+      const match: RegExpMatchArray | null = version.match(specialVersionCase);
+      if (match) {
+        return match[1];
+      }
+    }
+    return version;
   }
 
   private constructor(shrinkwrapJson: IShrinkwrapYaml) {

--- a/apps/rush-lib/src/cli/utilities/pnpm/PnpmShrinkwrapFile.ts
+++ b/apps/rush-lib/src/cli/utilities/pnpm/PnpmShrinkwrapFile.ts
@@ -115,18 +115,21 @@ export class PnpmShrinkwrapFile extends BaseShrinkwrapFile {
       return undefined;
     }
 
-    const version: string = packageDescription.dependencies[dependencyName];
-    if (version) {
-      // e.g.:  "/gulp-karma/0.0.5/karma@0.13.22"
-      // capture 0: "/gulp-karma/0.0.5/"
-      // capture 1: "0.0.5"
-      const specialVersionCase: RegExp = /\/[a-z\-]+\/(.*)\//;
-      const match: RegExpMatchArray | null = version.match(specialVersionCase);
-      if (match) {
-        return match[1];
-      }
+    if (!packageDescription.dependencies.hasOwnProperty(dependencyName)) {
+      return undefined;
     }
-    return version;
+
+    const version: string = packageDescription.dependencies[dependencyName];
+    // version will be either:
+    // A - the version (e.g. "0.0.5")
+    // B - a peer dep version (e.g. "/gulp-karma/0.0.5/karma@0.13.22"
+    //                           or "/sinon-chai/2.8.0/chai@3.5.0+sinon@1.17.7")
+
+    // check to see if this is the special style of specifiers
+    // e.g.:  "/gulp-karma/0.0.5/karma@0.13.22"
+    // split it by forward slashes, then grab the second group
+    // if the second group doesn't exist, return the version directly
+    return version ? (version.split('/')[2] || version) : undefined;
   }
 
   private constructor(shrinkwrapJson: IShrinkwrapYaml) {


### PR DESCRIPTION
There are certain dependencies in the shrinkwrap that have a different format, e.g.:

```
'file:projects/gulp-core-build-karma.tgz':
    dependencies:
      '@microsoft/node-library-build': 4.2.14
      '@types/bluebird': 3.5.3
      '@types/gulp': 3.8.32
      '@types/karma': 0.13.33
      '@types/log4js': 0.0.33
      '@types/node': 6.0.88
      chai: 3.5.0
      gulp: 3.9.1
      gulp-karma: /gulp-karma/0.0.5/karma@0.13.22
      istanbul-instrumenter-loader: /istanbul-instrumenter-loader/3.0.0/webpack@3.6.0
      karma: 0.13.22
      karma-coverage: 0.5.5
      karma-mocha: /karma-mocha/0.2.2/mocha@3.4.2
      karma-mocha-clean-reporter: 0.0.1
      karma-phantomjs-launcher: /karma-phantomjs-launcher/1.0.4/karma@0.13.22
      karma-sinon-chai: /karma-sinon-chai/1.2.4/5fc1304e1e69a328078cebf8183ed10a
      karma-webpack: /karma-webpack/2.0.9/webpack@3.6.0
      lolex: 1.4.0
      mocha: 3.4.2
      phantomjs-polyfill: 0.0.2
      phantomjs-prebuilt: 2.1.16
      sinon: 1.17.7
      sinon-chai: /sinon-chai/2.8.0/chai@3.5.0+sinon@1.17.7
      webpack: 3.6.0
    dev: false
    name: '@rush-temp/gulp-core-build-karma'
    resolution:
      tarball: 'file:projects/gulp-core-build-karma.tgz'
    version: 0.0.0
```

We need to be able to extract the version from these strings to verify that the shrinkwrap file is providing the dependency as listed in the `package.json`.