### PR TITLE
Introduce a new setting "skipRushCheck"

### DIFF
--- a/apps/rush-lib/src/data/RushConfigurationProject.ts
+++ b/apps/rush-lib/src/data/RushConfigurationProject.ts
@@ -20,6 +20,7 @@ export interface IRushConfigurationProjectJson {
   cyclicDependencyProjects: string[];
   versionPolicyName?: string;
   shouldPublish?: boolean;
+  skipRushCheck?: boolean;
 }
 
 /**
@@ -39,6 +40,7 @@ export default class RushConfigurationProject {
   private _versionPolicyName: string | undefined;
   private _versionPolicy: VersionPolicy;
   private _shouldPublish: boolean;
+  private _skipRushCheck: boolean;
   private _downstreamDependencyProjects: string[];
   private readonly _rushConfiguration: RushConfiguration;
 
@@ -105,8 +107,9 @@ export default class RushConfigurationProject {
         this._cyclicDependencyProjects.add(cyclicDependencyProject);
       }
     }
-    this._downstreamDependencyProjects = [];
     this._shouldPublish = !!projectJson.shouldPublish;
+    this._skipRushCheck = !!projectJson.skipRushCheck;
+    this._downstreamDependencyProjects = [];
     this._versionPolicyName = projectJson.versionPolicyName;
   }
 
@@ -198,6 +201,14 @@ export default class RushConfigurationProject {
    */
   public get shouldPublish(): boolean {
     return this._shouldPublish || !!this._versionPolicyName;
+  }
+
+  /**
+   * If true, then this project will be ignored by the "rush check" command.
+   * The default value is false.
+   */
+  public get skipRushCheck(): boolean {
+    return this._skipRushCheck;
   }
 
   /**

--- a/apps/rush-lib/src/data/VersionMismatchFinder.ts
+++ b/apps/rush-lib/src/data/VersionMismatchFinder.ts
@@ -47,14 +47,16 @@ export class VersionMismatchFinder {
 
   private _analyze(): void {
     this._projects.forEach((project: RushConfigurationProject) => {
-      this._addDependenciesToList(project.packageName,
-        project.packageJson.dependencies, project.cyclicDependencyProjects);
-      this._addDependenciesToList(project.packageName,
-        project.packageJson.devDependencies, project.cyclicDependencyProjects);
-      this._addDependenciesToList(project.packageName,
-        project.packageJson.peerDependencies, project.cyclicDependencyProjects);
-      this._addDependenciesToList(project.packageName,
-        project.packageJson.optionalDependencies, project.cyclicDependencyProjects);
+      if (!project.skipRushCheck) {
+        this._addDependenciesToList(project.packageName,
+          project.packageJson.dependencies, project.cyclicDependencyProjects);
+        this._addDependenciesToList(project.packageName,
+          project.packageJson.devDependencies, project.cyclicDependencyProjects);
+        this._addDependenciesToList(project.packageName,
+          project.packageJson.peerDependencies, project.cyclicDependencyProjects);
+        this._addDependenciesToList(project.packageName,
+          project.packageJson.optionalDependencies, project.cyclicDependencyProjects);
+      }
     });
 
     this._mismatches.forEach((mismatches: Map<string, string[]>, project: string) => {

--- a/apps/rush-lib/src/data/test/RushConfiguration.test.ts
+++ b/apps/rush-lib/src/data/test/RushConfiguration.test.ts
@@ -82,6 +82,11 @@ describe('RushConfiguration', () => {
     assertPathProperty('project1.projectFolder', project1.projectFolder, './repo/project1');
     assert.equal(project1.tempProjectName, '@rush-temp/project1', 'Failed to validate project1.tempProjectName');
     assert.equal(project1.unscopedTempProjectName, 'project1');
+    assert.equal(project1.skipRushCheck, false);
+
+    // Validate project2 settings
+    const project2: RushConfigurationProject = rushConfiguration.getProjectByName('project2')!;
+    assert.equal(project2.skipRushCheck, true);
 
     done();
   });

--- a/apps/rush-lib/src/data/test/repo/rush-npm.json
+++ b/apps/rush-lib/src/data/test/repo/rush-npm.json
@@ -38,7 +38,8 @@
     {
       "packageName": "project2",
       "projectFolder": "project2",
-      "reviewCategory": "third-party"
+      "reviewCategory": "third-party",
+      "skipRushCheck": true
     },
 
     {

--- a/apps/rush-lib/src/schemas/rush.schema.json
+++ b/apps/rush-lib/src/schemas/rush.schema.json
@@ -149,6 +149,10 @@
             "description": "A flag indicating that changes to this project will be published to npm, which affects the Rush change and publish workflows.",
             "type": "boolean"
           },
+          "skipRushCheck": {
+            "description": "If true, then this project will be ignored by the \"rush check\" command.  The default value is false.",
+            "type": "boolean"
+          },
           "versionPolicyName": {
             "description": "An optional version policy associated with the project. Version policies are defined in \"version-policies.json file.",
             "type": "string"

--- a/apps/rush/README.md
+++ b/apps/rush/README.md
@@ -46,7 +46,9 @@ To see Rush build some real projects, try running these commands:  :-)
 $ git clone https://github.com/Microsoft/web-build-tools
 $ cd web-build-tools
 $ rush install
+$ rush install  # <-- instantaneous!
 $ rush rebuild
+$ rush build    # <-- instantaneous!
 ```
 _(If you don't have a GitHub account set up, you can use `rush install --bypass-policy`.)_
 

--- a/common/reviews/api/rush-lib.api.ts
+++ b/common/reviews/api/rush-lib.api.ts
@@ -243,6 +243,7 @@ class RushConfigurationProject {
   readonly projectRelativeFolder: string;
   readonly reviewCategory: string;
   readonly shouldPublish: boolean;
+  readonly skipRushCheck: boolean;
   readonly tempProjectName: string;
   readonly unscopedTempProjectName: string;
   // @beta


### PR DESCRIPTION
The `rush check` command is normally used to confirm/enforce a single consistent version for any direct-dependencies, across all projects in the repo.

However, sometimes a project needs to violate this rule.  For example, because it is in the process of being migrated into the monorepo, or because it is a backwards compatibility shim.

To support this scenario, I'm introducing a new project-specific setting in **rush.json**.  For example, this is how you would disable `rush check` from processing project2:

```json
  "projects": [
    {
      "packageName": "project1",
      "projectFolder": "project1"
    },
    {
      "packageName": "project2",
      "projectFolder": "project2",
      "skipRushCheck": true
    },
    {
      "packageName": "project3",
      "projectFolder": "project3"
    }
  ]
```