### PR TITLE
Change the way Rush prints output, to make it more readable and easy …

### DIFF
--- a/apps/rush-lib/src/cli/taskRunner/TaskRunner.ts
+++ b/apps/rush-lib/src/cli/taskRunner/TaskRunner.ts
@@ -26,6 +26,8 @@ export default class TaskRunner {
   private _hasAnyFailures: boolean;
   private _parallelism: number;
   private _currentActiveTasks: number;
+  private _totalTasks: number;
+  private _completedTasks: number;
 
   constructor(quietMode: boolean, parallelism: number | undefined) {
     this._tasks = new Map<string, ITask>();
@@ -113,6 +115,8 @@ export default class TaskRunner {
    */
   public execute(): Promise<void> {
     this._currentActiveTasks = 0;
+    this._completedTasks = 0;
+    this._totalTasks = this._tasks.size;
     console.log(`Executing a maximum of ${this._parallelism} simultaneous processes...${os.EOL}`);
 
     this._checkForCyclicDependencies(this._tasks.values(), []);
@@ -178,7 +182,7 @@ export default class TaskRunner {
       this._currentActiveTasks++;
       const task: ITask = ctask;
       task.status = TaskStatus.Executing;
-      console.log(colors.white(`> Starting task [${task.name}]`));
+      console.log(colors.white(`[${task.name}] started`));
 
       task.stopwatch = Stopwatch.start();
       task.writer = Interleaver.registerTask(task.name, this._quietMode);
@@ -189,6 +193,7 @@ export default class TaskRunner {
           task.writer.close();
 
           this._currentActiveTasks--;
+          this._completedTasks++;
           switch (result) {
             case TaskStatus.Success:
               this._markTaskAsSuccess(task);
@@ -225,7 +230,7 @@ export default class TaskRunner {
    * Marks a task as having failed and marks each of its dependents as blocked
    */
   private _markTaskAsFailed(task: ITask): void {
-    console.log(colors.red(`${os.EOL}> Completed task [${task.name}] with errors!`));
+    console.log(colors.red(`${os.EOL}${this._getCurrentCompletedTaskString()}[${task.name}] failed to build!`));
     task.status = TaskStatus.Failure;
     task.dependents.forEach((dependent: ITask) => {
       this._markTaskAsBlocked(dependent, task);
@@ -237,7 +242,9 @@ export default class TaskRunner {
    */
   private _markTaskAsBlocked(task: ITask, failedTask: ITask): void {
     if (task.status === TaskStatus.Ready) {
-      console.log(colors.red(`> [${task.name}] blocked by [${failedTask.name}]!`));
+      this._completedTasks++;
+      console.log(colors.red(`${this._getCurrentCompletedTaskString()}`
+        + `[${task.name}] blocked by [${failedTask.name}]!`));
       task.status = TaskStatus.Blocked;
       task.dependents.forEach((dependent: ITask) => {
         this._markTaskAsBlocked(dependent, failedTask);
@@ -249,7 +256,8 @@ export default class TaskRunner {
    * Marks a task as being completed, and removes it from the dependencies list of all its dependents
    */
   private _markTaskAsSuccess(task: ITask): void {
-    console.log(colors.green(`> Completed task [${task.name}] in ${task.stopwatch.toString()}`));
+    console.log(colors.green(`${this._getCurrentCompletedTaskString()}`
+      + `[${task.name}] completed successfully in ${task.stopwatch.toString()}`));
     task.status = TaskStatus.Success;
 
     task.dependents.forEach((dependent: ITask) => {
@@ -263,7 +271,8 @@ export default class TaskRunner {
    * list of all its dependents
    */
   private _markTaskAsSuccessWithWarning(task: ITask): void {
-    console.log(colors.yellow(`> Completed task [${task.name}] with warnings in ${task.stopwatch.toString()}`));
+    console.log(colors.yellow(`${this._getCurrentCompletedTaskString()}`
+      + `[${task.name}] completed with warnings in ${task.stopwatch.toString()}`));
     task.status = TaskStatus.SuccessWithWarning;
     task.dependents.forEach((dependent: ITask) => {
       dependent.isIncrementalBuildAllowed = false;
@@ -275,11 +284,15 @@ export default class TaskRunner {
    * Marks a task as skipped.
    */
   private _markTaskAsSkipped(task: ITask): void {
-    console.log(colors.green(`> Skipped task [${task.name}] in ${task.stopwatch.toString()}`));
+    console.log(colors.green(`${this._getCurrentCompletedTaskString()}[${task.name}] skipped`));
     task.status = TaskStatus.Skipped;
     task.dependents.forEach((dependent: ITask) => {
       dependent.dependencies.delete(task);
     });
+  }
+
+  private _getCurrentCompletedTaskString(): string {
+    return `${this._completedTasks} of ${this._totalTasks}: `;
   }
 
   /**


### PR DESCRIPTION
…to tell how far into a build you are

E.g. 
```
Starting "rush rebuild"                                                                                              
                                                                                                                     
Executing a maximum of 7 simultaneous processes...                                                                   
                                                                                                                     
[@microsoft/node-core-library] started                                                                               
[@microsoft/ts-command-line] started                                                                                 
1 of 28: [@microsoft/ts-command-line] completed successfully in 12.16 seconds                                        
2 of 28: [@microsoft/node-core-library] completed successfully in 16.04 seconds                                      
[@microsoft/api-extractor] started                                                                                   
[@microsoft/gulp-core-build] started                                                                                 
3 of 28: [@microsoft/gulp-core-build] completed successfully in 17.05 seconds                                        
[@microsoft/gulp-core-build-serve] started                                                                           
[@microsoft/gulp-core-build-mocha] started                                                                           
[@microsoft/gulp-core-build-webpack] started                                                                         
[@microsoft/gulp-core-build-karma] started                                                                           
4 of 28: [@microsoft/gulp-core-build-webpack] completed successfully in 10.52 seconds                                
5 of 28: [@microsoft/gulp-core-build-karma] completed successfully in 11.05 seconds                                  
6 of 28: [@microsoft/gulp-core-build-serve] completed successfully in 11.62 seconds                                  
7 of 28: [@microsoft/gulp-core-build-mocha] completed successfully in 11.64 seconds                                  
8 of 28: [@microsoft/api-extractor] completed successfully in 34.17 seconds                                          
[@microsoft/gulp-core-build-typescript] started                                                                      
[api-extractor-test-01] started                                                                                      
9 of 28: [api-extractor-test-01] completed successfully in 7.23 seconds                                              
[api-extractor-test-02] started                                                                                      
10 of 28: [@microsoft/gulp-core-build-typescript] completed successfully in 14.75 seconds                            
[@microsoft/node-library-build] started                                                                              
11 of 28: [api-extractor-test-02] completed successfully in 7.77 seconds                                             
[api-extractor-test-03] started                                                                                      
12 of 28: [api-extractor-test-03] completed successfully in 2.94 seconds                                             
13 of 28: [@microsoft/node-library-build] completed successfully in 6.98 seconds                                     
[@microsoft/api-documenter] started                                                                                  
[@microsoft/decorators] started                                                                                      
[@microsoft/rush] started                                                                                            
[@microsoft/resolve-chunk-plugin] started                                                                            
[@microsoft/loader-raw-script] started                                                                               
[@microsoft/load-themed-styles] started                                                                              
[@microsoft/package-deps-hash] started                                                                               
14 of 28: [@microsoft/decorators] completed successfully in 13.52 seconds                                            
[@microsoft/set-webpack-public-path-plugin] started                                                                  
15 of 28: [@microsoft/resolve-chunk-plugin] completed successfully in 14.35 seconds                                  
[@microsoft/stream-collator] started                                                                                 
16 of 28: [@microsoft/load-themed-styles] completed successfully in 15.83 seconds                                    
[@microsoft/loader-load-themed-styles] started                                                                       
17 of 28: [@microsoft/loader-raw-script] completed successfully in 16.02 seconds                                     
[@microsoft/gulp-core-build-sass] started                                                                            
18 of 28: [@microsoft/rush] completed successfully in 17.87 seconds                                                  
                                                                                                                     
```