### PR TITLE
Enable generatePackageTypings for some projects

### DIFF
--- a/apps/api-extractor/src/TypeScriptHelpers.ts
+++ b/apps/api-extractor/src/TypeScriptHelpers.ts
@@ -199,4 +199,35 @@ export default class TypeScriptHelpers {
 
     return lines.join('\n');
   }
+
+  /**
+   * Returns a JSDoc comment containing the provided content.
+   * @remarks
+   * This is the inverse of the extractJSDocContent() operation.
+   *
+   * WARNING: This function assumes that the content does not include strings
+   * such as "*\/" which would prematurely terminate the comment.
+   */
+  // Examples:
+  // "this is\na test\n" --> "/**\n * this is\n * a test\n */\n"
+  // "single line comment" --> "/** single line comment */"
+  public static formatJSDocContent(content: string): string {
+    const lines: string[] = content.split(TypeScriptHelpers._newLineRegEx);
+    if (!content || lines.length === 0) {
+      return '';
+    }
+
+    if (lines.length < 2) {
+      return `/** ${content} */`;
+    } else {
+      // If there was a trailing newline, remove it
+      if (lines[lines.length - 1] === '') {
+        lines.pop();
+      }
+
+      return '/**\n * '
+        + lines.join('\n * ')
+        + '\n */';
+    }
+  }
 }

--- a/apps/api-extractor/src/TypeScriptHelpers.ts
+++ b/apps/api-extractor/src/TypeScriptHelpers.ts
@@ -33,6 +33,11 @@ export default class TypeScriptHelpers {
   private static _jsdocTrimRightRegEx: RegExp = /\s*$/;
 
   /**
+   * Invalid comment sequence
+   */
+  private static _jsdocCommentTerminator: RegExp = /[*][/]/g;
+
+  /**
    * This traverses any type aliases to find the original place where an item was defined.
    * For example, suppose a class is defined as "export default class MyClass { }"
    * but exported from the package's index.ts like this:
@@ -202,23 +207,28 @@ export default class TypeScriptHelpers {
 
   /**
    * Returns a JSDoc comment containing the provided content.
+   *
    * @remarks
    * This is the inverse of the extractJSDocContent() operation.
-   *
-   * WARNING: This function assumes that the content does not include strings
-   * such as "*\/" which would prematurely terminate the comment.
    */
   // Examples:
   // "this is\na test\n" --> "/**\n * this is\n * a test\n */\n"
   // "single line comment" --> "/** single line comment */"
   public static formatJSDocContent(content: string): string {
-    const lines: string[] = content.split(TypeScriptHelpers._newLineRegEx);
-    if (!content || lines.length === 0) {
+    if (!content) {
+      return '';
+    }
+
+    // If the string contains "*/", then replace it with "*\/"
+    const escapedContent: string = content.replace(TypeScriptHelpers._jsdocCommentTerminator, '*\\/');
+
+    const lines: string[] = escapedContent.split(TypeScriptHelpers._newLineRegEx);
+    if (lines.length === 0) {
       return '';
     }
 
     if (lines.length < 2) {
-      return `/** ${content} */`;
+      return `/** ${escapedContent} */`;
     } else {
       // If there was a trailing newline, remove it
       if (lines[lines.length - 1] === '') {

--- a/apps/api-extractor/src/generators/PackageTypingsGenerator.ts
+++ b/apps/api-extractor/src/generators/PackageTypingsGenerator.ts
@@ -286,6 +286,13 @@ export default class PackageTypingsGenerator {
 
     this._entries.sort((a, b) => a.getSortKey().localeCompare(b.getSortKey()));
 
+    // If there is a @packagedocumentation header, put it first:
+    const packageDocumentation: string = this._context.package.documentation.originalAedoc;
+    if (packageDocumentation) {
+      this._indentedWriter.writeLine(TypeScriptHelpers.formatJSDocContent(packageDocumentation));
+      this._indentedWriter.writeLine();
+    }
+
     // Emit the imports first
     for (const entry of this._entries) {
       if (entry.importPackagePath) {

--- a/apps/api-extractor/src/generators/PackageTypingsGenerator.ts
+++ b/apps/api-extractor/src/generators/PackageTypingsGenerator.ts
@@ -453,14 +453,8 @@ export default class PackageTypingsGenerator {
 
     this._entries.push(entry);
     this._entriesBySymbol.set(followedSymbol, entry);
-    console.log('======> ' + entry.localName);
 
     for (const declaration of followedSymbol.declarations || []) {
-      // console.log(PrettyPrinter.dumpTree(declaration));
-      // console.log('-------------------------------------');
-      // console.log(declaration.getText());
-      // console.log('=====================================');
-
       this._collectTypes(declaration);
     }
 

--- a/apps/api-extractor/src/test/TypeScriptHelpers.test.ts
+++ b/apps/api-extractor/src/test/TypeScriptHelpers.test.ts
@@ -110,6 +110,10 @@ describe('TypeScriptHelpers tests', () => {
                ' * C\n' +
                ' */',
         output: 'A\n\nB\n\nC\n'
+      },
+      { // 16
+        input: '/**   *\\/   */',  // a properly escaped terminator
+        output: '*\\/'
       }
     ];
 
@@ -126,12 +130,36 @@ describe('TypeScriptHelpers tests', () => {
 
     const testCases: ITestCase[] = [
       { // 0
-        input: 'this is\na test\n',
-        output: '/**\n * this is\n * a test\n */\n'
+        input: '',
+        output: ''
       },
       { // 1
+        input: 'a',
+        output: '/** a */'
+      },
+      { // 2
+        input: '\na',
+        output: '/**\n * \n * a\n */'
+      },
+      { // 3
+        input: 'a\n',
+        output: '/**\n * a\n */'
+      },
+      { // 4
+        input: '  \na\n  ',
+        output: '/**\n *   \n * a\n *   \n */'
+      },
+      { // 5
+        input: 'this is\na test\n',
+        output: '/**\n * this is\n * a test\n */'
+      },
+      { // 6
         input: 'single line comment',
         output: '/** single line comment */'
+      },
+      { // 7
+        input: 'a */ b',
+        output: '/** a *\\/ b */'
       }
     ];
 

--- a/apps/api-extractor/src/test/TypeScriptHelpers.test.ts
+++ b/apps/api-extractor/src/test/TypeScriptHelpers.test.ts
@@ -137,7 +137,7 @@ describe('TypeScriptHelpers tests', () => {
 
     for (let i: number = 0; i < testCases.length; ++i) {
       it(`JSDoc test case ${i}`, () => {
-        expect(TypeScriptHelpers.extractJSDocContent(testCases[i].input, console.log))
+        expect(TypeScriptHelpers.formatJSDocContent(testCases[i].input))
         .toBe(testCases[i].output);
       });
     }

--- a/apps/api-extractor/src/test/TypeScriptHelpers.test.ts
+++ b/apps/api-extractor/src/test/TypeScriptHelpers.test.ts
@@ -23,7 +23,7 @@ describe('TypeScriptHelpers tests', () => {
 
   });
 
-  describe('extractCommentContent()', () => {
+  describe('extractJSDocContent()', () => {
 
     const testCases: ITestCase[] = [
       { // 0
@@ -122,4 +122,25 @@ describe('TypeScriptHelpers tests', () => {
 
   });
 
+  describe('formatJSDocContent()', () => {
+
+    const testCases: ITestCase[] = [
+      { // 0
+        input: 'this is\na test\n',
+        output: '/**\n * this is\n * a test\n */\n'
+      },
+      { // 1
+        input: 'single line comment',
+        output: '/** single line comment */'
+      }
+    ];
+
+    for (let i: number = 0; i < testCases.length; ++i) {
+      it(`JSDoc test case ${i}`, () => {
+        expect(TypeScriptHelpers.extractJSDocContent(testCases[i].input, console.log))
+        .toBe(testCases[i].output);
+      });
+    }
+
+  });
 });

--- a/apps/rush-lib/config/api-extractor.json
+++ b/apps/rush-lib/config/api-extractor.json
@@ -2,5 +2,6 @@
   "enabled": true,
   "apiReviewFolder": "../../common/reviews/api",
   "apiJsonFolder": "./temp",
-  "entry": "lib/index.d.ts"
+  "entry": "lib/index.d.ts",
+  "generatePackageTypings": true
 }

--- a/build-tests/api-extractor-test-01/dist/index-internal.d.ts
+++ b/build-tests/api-extractor-test-01/dist/index-internal.d.ts
@@ -1,3 +1,12 @@
+/**
+ * Example documentation for the package.
+ * 
+ * @remarks
+ * Additional remarks
+ * 
+ * @packagedocumentation
+ */
+
 
 /**
  * Test different kinds of ambient definitions

--- a/build-tests/api-extractor-test-01/dist/index-internal.d.ts
+++ b/build-tests/api-extractor-test-01/dist/index-internal.d.ts
@@ -1,3 +1,4 @@
+// Unsupported re-export: IInterfaceAsDefaultExport
 /**
  * Example documentation for the package.
  * 

--- a/build-tests/api-extractor-test-01/dist/index-internal.d.ts
+++ b/build-tests/api-extractor-test-01/dist/index-internal.d.ts
@@ -1,4 +1,3 @@
-// Unsupported re-export: IInterfaceAsDefaultExport
 /**
  * Example documentation for the package.
  * 
@@ -73,6 +72,17 @@ declare interface IForgottenExport {
  */
 declare interface IForgottenExport_2 {
     instance2: string;
+}
+
+/**
+ * This interface is exported as the default export for its source file.
+ * @public
+ */
+export declare interface IInterfaceAsDefaultExport {
+    /**
+     * A member of the interface
+     */
+    member: string;
 }
 
 /**

--- a/build-tests/api-extractor-test-01/etc/api-extractor-test-01.api.ts
+++ b/build-tests/api-extractor-test-01/etc/api-extractor-test-01.api.ts
@@ -27,6 +27,11 @@ class ForgottenExportConsumer2 {
 }
 
 // @public
+interface IInterfaceAsDefaultExport {
+  member: string;
+}
+
+// @public
 interface ISimpleInterface {
 }
 

--- a/build-tests/api-extractor-test-01/src/IInterfaceAsDefaultExport.ts
+++ b/build-tests/api-extractor-test-01/src/IInterfaceAsDefaultExport.ts
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+/**
+ * This interface is exported as the default export for its source file.
+ * @public
+ */
+interface IInterfaceAsDefaultExport {
+  /**
+   * A member of the interface
+   */
+  member: string;
+}
+
+export default IInterfaceAsDefaultExport;

--- a/build-tests/api-extractor-test-01/src/index.ts
+++ b/build-tests/api-extractor-test-01/src/index.ts
@@ -86,3 +86,5 @@ export class DecoratorTest {
 
 export { ForgottenExportConsumer1 } from './ForgottenExportConsumer1';
 export { ForgottenExportConsumer2 } from './ForgottenExportConsumer2';
+
+export { default as IInterfaceAsDefaultExport } from './IInterfaceAsDefaultExport';

--- a/build-tests/api-extractor-test-02/dist/index-internal.d.ts
+++ b/build-tests/api-extractor-test-02/dist/index-internal.d.ts
@@ -1,3 +1,12 @@
+/**
+ * Example documentation for the package.
+ * 
+ * @remarks
+ * Additional remarks
+ * 
+ * @packagedocumentation
+ */
+
 import { ReexportedClass as RenamedReexportedClass } from 'api-extractor-test-01';
 
 /**

--- a/build-tests/api-extractor-test-02/etc/api-extractor-test-02.api.ts
+++ b/build-tests/api-extractor-test-02/etc/api-extractor-test-02.api.ts
@@ -4,4 +4,3 @@ class SubclassWithImport extends RenamedReexportedClass, implements ISimpleInter
   test(): void;
 }
 
-// (No @packagedocumentation comment for this package)

--- a/build-tests/api-extractor-test-02/src/index.ts
+++ b/build-tests/api-extractor-test-02/src/index.ts
@@ -1,5 +1,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
+/**
+ * Example documentation for the package.
+ *
+ * @remarks
+ * Additional remarks
+ *
+ * @packagedocumentation
+ */
+
 export { SubclassWithImport } from './SubclassWithImport';
 

--- a/common/changes/@microsoft/api-extractor/pgonzal-dts-generator-5_2018-01-12-01-56.json
+++ b/common/changes/@microsoft/api-extractor/pgonzal-dts-generator-5_2018-01-12-01-56.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor",
+      "comment": "Add some incremental improvements for the experimental PackageTypingsGenerator feature",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/gulp-core-build-typescript/pgonzal-dts-generator-5_2018-01-12-01-56.json
+++ b/common/changes/@microsoft/gulp-core-build-typescript/pgonzal-dts-generator-5_2018-01-12-01-56.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/gulp-core-build-typescript",
+      "comment": "Add a new setting \"generatePackageTypings\" for the API Extractor task",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@microsoft/gulp-core-build-typescript",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/core-build/gulp-core-build-typescript/src/ApiExtractorTask.ts
+++ b/core-build/gulp-core-build-typescript/src/ApiExtractorTask.ts
@@ -54,6 +54,13 @@ export interface IApiExtractorTaskConfig {
    * https://github.com/SharePoint/ts-spec-gen that generates an online API documentation.
    */
   apiJsonFolder?: string;
+
+  /**
+   * If true, then API Extractor will generate consolidated \*.d.ts outputs for this project.
+   * The filenames are: "index-internal.d.ts", "index-preview.d.ts", and "index-public.d.ts".
+   * @beta
+   */
+  generatePackageTypings?: boolean;
 }
 
 /**
@@ -141,6 +148,12 @@ export class ApiExtractorTask extends GulpTask<IApiExtractorTaskConfig>  {
           outputFolder: this.taskConfig.apiJsonFolder
         }
       };
+
+      if (this.taskConfig.generatePackageTypings) {
+        extractorConfig.packageTypings = {
+          enabled: true
+        };
+      }
 
       const extractorOptions: IExtractorOptions = {
         compilerProgram: compilerProgram,

--- a/core-build/gulp-core-build-typescript/src/schemas/api-extractor.schema.json
+++ b/core-build/gulp-core-build-typescript/src/schemas/api-extractor.schema.json
@@ -22,6 +22,10 @@
     "apiReviewFolder": {
       "description": "The file path of the folder containing already approved API files, relative to the project folder",
       "type": "string"
+    },
+    "generatePackageTypings": {
+      "description": "If true, then API Extractor will generate consolidated *.d.ts outputs for this project. The filenames are: \"index-internal.d.ts\", \"index-preview.d.ts\", and \"index-public.d.ts\".",
+      "type": "boolean"
     }
   }
 }

--- a/core-build/test-web-library-build/config/api-extractor.json
+++ b/core-build/test-web-library-build/config/api-extractor.json
@@ -2,5 +2,6 @@
   "enabled": true,
   "apiReviewFolder": "../../common/reviews/api",
   "apiJsonFolder": "./temp",
-  "entry": "lib/test.d.ts"
+  "entry": "lib/test.d.ts",
+  "generatePackageTypings": true
 }

--- a/libraries/decorators/config/api-extractor.json
+++ b/libraries/decorators/config/api-extractor.json
@@ -2,5 +2,6 @@
   "enabled": true,
   "apiReviewFolder": "../../common/reviews/api",
   "apiJsonFolder": "./temp",
-  "entry": "lib/index.d.ts"
+  "entry": "lib/index.d.ts",
+  "generatePackageTypings": true
 }


### PR DESCRIPTION
This PR fixes a few more PackageTypesGenerator edge cases, enables support in for this feature in GCB, and enables it for some preliminary projects.  Specific fixes:

- The \@packagedocumentation comment is now passed through to the emitted d.ts file
- Fixed a bug where certain definitions were incorrectly classified as ambient
