### PR TITLE
Fix pnpm shrinkwrap parsing for peed dep version of scoped packages

### DIFF
--- a/apps/rush-lib/src/cli/utilities/pnpm/PnpmShrinkwrapFile.ts
+++ b/apps/rush-lib/src/cli/utilities/pnpm/PnpmShrinkwrapFile.ts
@@ -124,6 +124,7 @@ export class PnpmShrinkwrapFile extends BaseShrinkwrapFile {
     // A - the version (e.g. "0.0.5")
     // B - a peer dep version (e.g. "/gulp-karma/0.0.5/karma@0.13.22"
     //                           or "/sinon-chai/2.8.0/chai@3.5.0+sinon@1.17.7")
+    // C - a peer dep version of a scoped package ("/@scope/package/0.0.5/karma@0.13.22")
 
     // check to see if this is the special style of specifiers
     // e.g.:  "/gulp-karma/0.0.5/karma@0.13.22"
@@ -131,11 +132,28 @@ export class PnpmShrinkwrapFile extends BaseShrinkwrapFile {
     // if the second group doesn't exist, return the version directly
     if (version) {
       const versionParts: string[] = version.split('/');
-      if (versionParts.length !== 1 && versionParts.length !== 4) {
-        throw new Error(`Cannot parse pnpm shrinkwrap version specifier: `
-          + `"${version}" for "${dependencyName}"`);
+
+      // (A) the version
+      if (versionParts.length === 1) {
+        return version;
       }
-      return versionParts[2] || version;
+
+      if (versionParts[1][0] === '@') {
+        // (C) a peer dep version of a scoped package
+        if (versionParts.length === 5) {
+          return versionParts[3];
+        }
+      } else {
+        // (B) a peer dep version
+        if (versionParts.length === 4) {
+          return versionParts[2];
+        }
+      }
+
+      // None of the cases matched
+      throw new Error(`Cannot parse pnpm shrinkwrap version specifier: `
+        + `"${version}" for "${dependencyName}"`);
+
     } else {
       return undefined;
     }

--- a/common/changes/@microsoft/rush/master_2018-01-15-21-49.json
+++ b/common/changes/@microsoft/rush/master_2018-01-15-21-49.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Fix pnpm shrinkwrap parsing",
+      "packageName": "@microsoft/rush",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "configurator@users.noreply.github.com"
+}


### PR DESCRIPTION
`pnpm` version specifiers such as `/@storybook/addon-actions/3.3.9/react-dom@15.6.2+react@15.6.2` crash the version parser, because it doesn't expect the scope specifier there. This causes `rush generate` to succeed in generating a file, but `rush install` to immediately fail when trying to read the same file.

This small commit fixes the issue.