### PR TITLE
Fix tslint warnings that were breaking Travis

### DIFF
--- a/apps/api-extractor/package.json
+++ b/apps/api-extractor/package.json
@@ -44,7 +44,7 @@
     "@types/colors": "1.1.3",
     "@types/lodash": "4.14.74",
     "gulp": "~3.9.1",
-    "@microsoft/node-library-build": "4.3.2",
+    "@microsoft/node-library-build": "4.3.3",
     "@types/jest": "~21.1.8"
   }
 }

--- a/common/changes/@microsoft/api-extractor/pgonzal-fix-travis_2018-01-17-20-53.json
+++ b/common/changes/@microsoft/api-extractor/pgonzal-fix-travis_2018-01-17-20-53.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@microsoft/api-extractor",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/gulp-core-build-karma/pgonzal-fix-travis_2018-01-17-20-53.json
+++ b/common/changes/@microsoft/gulp-core-build-karma/pgonzal-fix-travis_2018-01-17-20-53.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@microsoft/gulp-core-build-karma",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/gulp-core-build-karma",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/gulp-core-build-mocha/pgonzal-fix-travis_2018-01-17-20-53.json
+++ b/common/changes/@microsoft/gulp-core-build-mocha/pgonzal-fix-travis_2018-01-17-20-53.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@microsoft/gulp-core-build-mocha",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/gulp-core-build-mocha",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/gulp-core-build-sass/pgonzal-fix-travis_2018-01-17-20-53.json
+++ b/common/changes/@microsoft/gulp-core-build-sass/pgonzal-fix-travis_2018-01-17-20-53.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/gulp-core-build-sass",
+      "comment": "Remove deprecated tslint rule \"typeof-compare\"",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/gulp-core-build-sass",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/gulp-core-build-serve/pgonzal-fix-travis_2018-01-17-20-53.json
+++ b/common/changes/@microsoft/gulp-core-build-serve/pgonzal-fix-travis_2018-01-17-20-53.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@microsoft/gulp-core-build-serve",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/gulp-core-build-serve",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/gulp-core-build-typescript/pgonzal-fix-travis_2018-01-17-20-53.json
+++ b/common/changes/@microsoft/gulp-core-build-typescript/pgonzal-fix-travis_2018-01-17-20-53.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/gulp-core-build-typescript",
+      "comment": "Remove deprecated tslint rule \"typeof-compare\"",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/gulp-core-build-typescript",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/gulp-core-build-webpack/pgonzal-fix-travis_2018-01-17-20-53.json
+++ b/common/changes/@microsoft/gulp-core-build-webpack/pgonzal-fix-travis_2018-01-17-20-53.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@microsoft/gulp-core-build-webpack",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/gulp-core-build-webpack",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/gulp-core-build/pgonzal-fix-travis_2018-01-17-20-53.json
+++ b/common/changes/@microsoft/gulp-core-build/pgonzal-fix-travis_2018-01-17-20-53.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@microsoft/gulp-core-build",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/gulp-core-build",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/node-core-library/pgonzal-fix-travis_2018-01-17-20-53.json
+++ b/common/changes/@microsoft/node-core-library/pgonzal-fix-travis_2018-01-17-20-53.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@microsoft/node-core-library",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/node-core-library",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/ts-command-line/pgonzal-fix-travis_2018-01-17-20-53.json
+++ b/common/changes/@microsoft/ts-command-line/pgonzal-fix-travis_2018-01-17-20-53.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@microsoft/ts-command-line",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/ts-command-line",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/config/rush/shrinkwrap.yaml
+++ b/common/config/rush/shrinkwrap.yaml
@@ -1,5 +1,5 @@
 dependencies:
-  '@microsoft/node-library-build': 4.3.2
+  '@microsoft/node-library-build': 4.3.3
   '@rush-temp/api-documenter': 'file:projects/api-documenter.tgz'
   '@rush-temp/api-extractor': 'file:projects/api-extractor.tgz'
   '@rush-temp/api-extractor-test-01': 'file:projects/api-extractor-test-01.tgz'
@@ -157,10 +157,10 @@ dependencies:
   yargs: 4.6.0
   z-schema: 3.18.4
 packages:
-  /@microsoft/api-extractor/5.1.2:
+  /@microsoft/api-extractor/5.1.3:
     dependencies:
-      '@microsoft/node-core-library': 0.4.2
-      '@microsoft/ts-command-line': 2.3.2
+      '@microsoft/node-core-library': 0.4.3
+      '@microsoft/ts-command-line': 2.3.3
       '@types/fs-extra': 0.0.37
       '@types/node': 8.5.8
       '@types/z-schema': 3.16.31
@@ -172,22 +172,22 @@ packages:
       z-schema: 3.18.4
     dev: false
     resolution:
-      integrity: sha1-PeUSl7yekNCAhyxu1OZAi3VY+Yw=
-  /@microsoft/gulp-core-build-mocha/3.3.2:
+      integrity: sha1-q7jgilqMKRXKr2Is6dhQVIBoOLY=
+  /@microsoft/gulp-core-build-mocha/3.3.3:
     dependencies:
-      '@microsoft/gulp-core-build': 3.4.2
+      '@microsoft/gulp-core-build': 3.4.3
       '@types/node': 8.5.8
       gulp: 3.9.1
       gulp-istanbul: 0.10.4
       gulp-mocha: 2.2.0
     dev: false
     resolution:
-      integrity: sha1-UVwGgP73FCkwuMC3g9bgCzR1foE=
-  /@microsoft/gulp-core-build-typescript/4.6.0:
+      integrity: sha1-Y8PI9qs9CQufK1OWHV44qXlk5Yw=
+  /@microsoft/gulp-core-build-typescript/4.7.0:
     dependencies:
-      '@microsoft/api-extractor': 5.1.2
-      '@microsoft/gulp-core-build': 3.4.2
-      '@microsoft/node-core-library': 0.4.2
+      '@microsoft/api-extractor': 5.1.3
+      '@microsoft/gulp-core-build': 3.4.3
+      '@microsoft/node-core-library': 0.4.3
       '@types/fs-extra': 0.0.37
       '@types/gulp': 3.8.32
       '@types/node': 8.5.8
@@ -206,15 +206,15 @@ packages:
       merge2: 1.0.3
       object-assign: 4.1.1
       through2: 2.0.3
-      tslint: /tslint/5.6.0/typescript@2.4.2
-      tslint-microsoft-contrib: /tslint-microsoft-contrib/5.0.2/tslint@5.6.0+typescript@2.4.2
+      tslint: /tslint/5.9.1/typescript@2.4.2
+      tslint-microsoft-contrib: /tslint-microsoft-contrib/5.0.2/tslint@5.9.1+typescript@2.4.2
       typescript: 2.4.2
     dev: false
     resolution:
-      integrity: sha1-QpW8twns4KjYU+V1aL6sB+Qno+8=
-  /@microsoft/gulp-core-build/3.4.2:
+      integrity: sha1-u554ZwjROWVzBGhe0SOPesy5/98=
+  /@microsoft/gulp-core-build/3.4.3:
     dependencies:
-      '@microsoft/node-core-library': 0.4.2
+      '@microsoft/node-core-library': 0.4.3
       '@types/assertion-error': 1.0.30
       '@types/chai': 3.4.34
       '@types/chalk': 0.4.31
@@ -258,8 +258,8 @@ packages:
       z-schema: 3.18.4
     dev: false
     resolution:
-      integrity: sha1-1Pj9qu4KmzLNeopMimV1qTSuTBY=
-  /@microsoft/node-core-library/0.4.2:
+      integrity: sha1-+dpQMvdnELdXAY+ZbbVSn/Wd3Dk=
+  /@microsoft/node-core-library/0.4.3:
     dependencies:
       '@types/fs-extra': 0.0.37
       '@types/node': 8.5.8
@@ -269,19 +269,19 @@ packages:
       z-schema: 3.18.4
     dev: false
     resolution:
-      integrity: sha1-f/Qd4hjepTILPPSN9jXsAWH3I84=
-  /@microsoft/node-library-build/4.3.2:
+      integrity: sha1-o18ml57dHZOip8hTfLHugKDHRQg=
+  /@microsoft/node-library-build/4.3.3:
     dependencies:
-      '@microsoft/gulp-core-build': 3.4.2
-      '@microsoft/gulp-core-build-mocha': 3.3.2
-      '@microsoft/gulp-core-build-typescript': 4.6.0
+      '@microsoft/gulp-core-build': 3.4.3
+      '@microsoft/gulp-core-build-mocha': 3.3.3
+      '@microsoft/gulp-core-build-typescript': 4.7.0
       '@types/gulp': 3.8.32
       '@types/node': 8.5.8
       gulp: 3.9.1
     dev: false
     resolution:
-      integrity: sha1-Z3B5SglQf1NwzI3KCFlKBS3XFvI=
-  /@microsoft/ts-command-line/2.3.2:
+      integrity: sha1-8zURjvjHF+8ft2HUaDgtgCgyAZw=
+  /@microsoft/ts-command-line/2.3.3:
     dependencies:
       '@types/argparse': 1.0.33
       '@types/node': 8.5.8
@@ -289,7 +289,7 @@ packages:
       colors: 1.1.2
     dev: false
     resolution:
-      integrity: sha1-8LghRgpSAqBgdAWbVSHSC+aK/Ek=
+      integrity: sha1-b7kCJCQle2g6D8yhI4XDGTzgzk0=
   /@types/argparse/1.0.33:
     dev: false
     resolution:
@@ -890,7 +890,7 @@ packages:
   /autoprefixer/6.3.7:
     dependencies:
       browserslist: 1.3.6
-      caniuse-db: 1.0.30000792
+      caniuse-db: 1.0.30000793
       normalize-range: 0.1.2
       num2fraction: 1.2.2
       postcss: 5.2.18
@@ -1117,6 +1117,7 @@ packages:
   /bcrypt-pbkdf/1.0.1:
     dependencies:
       tweetnacl: 0.14.5
+    dev: false
     optional: true
     resolution:
       integrity: sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=
@@ -1129,6 +1130,7 @@ packages:
   /better-assert/1.0.2:
     dependencies:
       callsite: 1.0.0
+    dev: false
     resolution:
       integrity: sha1-QIZrnhueC1W0gYlDEeaPr/rrxSI=
   /big.js/3.2.0:
@@ -1359,7 +1361,7 @@ packages:
       integrity: sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==
   /browserslist/1.3.6:
     dependencies:
-      caniuse-db: 1.0.30000792
+      caniuse-db: 1.0.30000793
     dev: false
     resolution:
       integrity: sha1-lS/0jVZGPTtTj4XvL46t39KEsTM=
@@ -1481,10 +1483,10 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=
-  /caniuse-db/1.0.30000792:
+  /caniuse-db/1.0.30000793:
     dev: false
     resolution:
-      integrity: sha1-p9rG3J9RgbZ1/Wnlywb++1IxV/g=
+      integrity: sha1-PADGbkI6ehkHx92Wdpp4sq+opy4=
   /caseless/0.11.0:
     dev: false
     resolution:
@@ -1531,6 +1533,7 @@ packages:
       has-ansi: 2.0.0
       strip-ansi: 3.0.1
       supports-color: 2.0.0
+    dev: false
     engines:
       node: '>=0.10.0'
     resolution:
@@ -2354,6 +2357,7 @@ packages:
   /ecc-jsbn/0.1.1:
     dependencies:
       jsbn: 0.1.1
+    dev: false
     optional: true
     resolution:
       integrity: sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=
@@ -3223,6 +3227,7 @@ packages:
       - node-pre-gyp
     dependencies:
       nan: 2.8.0
+    dev: false
     engines:
       node: '>=0.8.0'
     optional: true
@@ -3673,7 +3678,7 @@ packages:
     dev: false
     engines:
       node: '>=0.6'
-    peerDependencies: &ref_3
+    peerDependencies: &ref_4
       karma: '>=0.10 <=0.13'
     resolution:
       integrity: sha1-RLoZejEFTlyXOlujOUITwUKAOVg=
@@ -3688,7 +3693,7 @@ packages:
     engines:
       node: '>=0.6'
     id: registry.npmjs.org/gulp-karma/0.0.5
-    peerDependencies: *ref_3
+    peerDependencies: *ref_4
     resolution:
       integrity: sha1-RLoZejEFTlyXOlujOUITwUKAOVg=
   /gulp-match/1.0.3:
@@ -4660,7 +4665,7 @@ packages:
     dev: false
     engines:
       node: '>= 4.3 < 5.0.0 || >= 5.10'
-    peerDependencies: &ref_4
+    peerDependencies: &ref_5
       webpack: ^2.0.0 || ^3.0.0
     resolution:
       integrity: sha512-alLSEFX06ApU75sm5oWcaVNaiss/bgMRiWTct3g0P0ZZTKjR+6QiCcuVOKDI1kWJgwHEnIXsv/dWm783kPpmtw==
@@ -4675,7 +4680,7 @@ packages:
     engines:
       node: '>= 4.3 < 5.0.0 || >= 5.10'
     id: registry.npmjs.org/istanbul-instrumenter-loader/3.0.0
-    peerDependencies: *ref_4
+    peerDependencies: *ref_5
     resolution:
       integrity: sha512-alLSEFX06ApU75sm5oWcaVNaiss/bgMRiWTct3g0P0ZZTKjR+6QiCcuVOKDI1kWJgwHEnIXsv/dWm783kPpmtw==
   /istanbul-lib-coverage/1.1.1:
@@ -5020,10 +5025,10 @@ packages:
     dev: false
     resolution:
       integrity: sha1-2t2e8BkkvHKLA/L3l5vb1i96Kqo=
-  /js-base64/2.4.0:
+  /js-base64/2.4.1:
     dev: false
     resolution:
-      integrity: sha512-Wehd+7Pf9tFvGb+ydPm9TjYjV8X1YHOVyG8QyELZxEMqOhemVwGRmoG8iQ/soqI3n8v4xn59zaLxiCJiaaRzKA==
+      integrity: sha512-2h586r2I/CqU7z1aa1kBgWaVAXWAZK+zHnceGi/jFgn7+7VSluxYer/i3xOZVearCxxXvyDkLtTBo+OeJCA3kA==
   /js-tokens/3.0.2:
     dev: false
     resolution:
@@ -5153,7 +5158,7 @@ packages:
       integrity: sha1-6G961LxefGLX8uJC3ydRzPk/Rvo=
   /karma-mocha/0.2.2:
     dev: false
-    peerDependencies: &ref_5
+    peerDependencies: &ref_6
       mocha: '*'
     resolution:
       integrity: sha1-OI7ZF9oV3LGW0bkVwZNO+AMZP44=
@@ -5162,7 +5167,7 @@ packages:
       mocha: 3.4.2
     dev: false
     id: registry.npmjs.org/karma-mocha/0.2.2
-    peerDependencies: *ref_5
+    peerDependencies: *ref_6
     resolution:
       integrity: sha1-OI7ZF9oV3LGW0bkVwZNO+AMZP44=
   /karma-phantomjs-launcher/1.0.4:
@@ -5170,7 +5175,7 @@ packages:
       lodash: 4.15.0
       phantomjs-prebuilt: 2.1.16
     dev: false
-    peerDependencies: &ref_6
+    peerDependencies: &ref_7
       karma: '>=0.9'
     resolution:
       integrity: sha1-0jyjSAG9qYY60xjju0vUBisTrNI=
@@ -5181,14 +5186,14 @@ packages:
       phantomjs-prebuilt: 2.1.16
     dev: false
     id: registry.npmjs.org/karma-phantomjs-launcher/1.0.4
-    peerDependencies: *ref_6
+    peerDependencies: *ref_7
     resolution:
       integrity: sha1-0jyjSAG9qYY60xjju0vUBisTrNI=
   /karma-sinon-chai/1.2.4:
     dependencies:
       lolex: 1.6.0
     dev: false
-    peerDependencies: &ref_7
+    peerDependencies: &ref_8
       chai: ^3.2.0
       sinon: ^1.17.2
       sinon-chai: ^2.8.0
@@ -5202,7 +5207,7 @@ packages:
       sinon-chai: /sinon-chai/2.8.0/chai@3.5.0+sinon@1.17.7
     dev: false
     id: registry.npmjs.org/karma-sinon-chai/1.2.4
-    peerDependencies: *ref_7
+    peerDependencies: *ref_8
     resolution:
       integrity: sha1-/qk19ivjNmzwJxyNi+UcDHDkCrw=
   /karma-webpack/2.0.9:
@@ -5213,7 +5218,7 @@ packages:
       source-map: 0.5.7
       webpack-dev-middleware: 1.12.2
     dev: false
-    peerDependencies: &ref_9
+    peerDependencies: &ref_10
       webpack: ^1.0.0 || ^2.0.0 || ^3.0.0
     resolution:
       integrity: sha512-F1j3IG/XhiMzcunAXbWXH95uizjzr3WdTzmVWlta8xqxcCtAu9FByCb4sccIMxaVFAefpgnUW9KlCo0oLvIX6A==
@@ -5227,7 +5232,7 @@ packages:
       webpack-dev-middleware: /webpack-dev-middleware/1.12.2/webpack@3.6.0
     dev: false
     id: registry.npmjs.org/karma-webpack/2.0.9
-    peerDependencies: *ref_9
+    peerDependencies: *ref_10
     resolution:
       integrity: sha512-F1j3IG/XhiMzcunAXbWXH95uizjzr3WdTzmVWlta8xqxcCtAu9FByCb4sccIMxaVFAefpgnUW9KlCo0oLvIX6A==
   /karma/0.13.22:
@@ -6970,7 +6975,7 @@ packages:
   /postcss/5.2.18:
     dependencies:
       chalk: 1.1.3
-      js-base64: 2.4.0
+      js-base64: 2.4.1
       source-map: 0.5.7
       supports-color: 3.2.3
     dev: false
@@ -7630,7 +7635,7 @@ packages:
       integrity: sha1-9YdyIs4+kx7a4DnxfrNxbnE3+M8=
   /scss-tokenizer/0.2.3:
     dependencies:
-      js-base64: 2.4.0
+      js-base64: 2.4.1
       source-map: 0.4.4
     dev: false
     resolution:
@@ -7821,7 +7826,7 @@ packages:
       integrity: sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=
   /sinon-chai/2.8.0:
     dev: false
-    peerDependencies: &ref_8
+    peerDependencies: &ref_9
       chai: '>=1.9.2 <4'
       sinon: '>=1.4.0 <2'
     resolution:
@@ -7832,7 +7837,7 @@ packages:
       sinon: 1.17.7
     dev: false
     id: registry.npmjs.org/sinon-chai/2.8.0
-    peerDependencies: *ref_8
+    peerDependencies: *ref_9
     resolution:
       integrity: sha1-Qyqbv9Uab8AHmPTSUmqCnAYGh6w=
   /sinon/1.17.7:
@@ -7972,6 +7977,7 @@ packages:
   /source-map/0.2.0:
     dependencies:
       amdefine: 1.0.1
+    dev: false
     engines:
       node: '>=0.8.0'
     optional: true
@@ -8197,6 +8203,7 @@ packages:
   /strip-ansi/3.0.1:
     dependencies:
       ansi-regex: 2.1.1
+    dev: false
     engines:
       node: '>=0.10.0'
     resolution:
@@ -8584,19 +8591,9 @@ packages:
     dependencies:
       tsutils: 2.19.0
     dev: false
-    peerDependencies: &ref_2
+    peerDependencies: &ref_3
       tslint: ^5.1.0
       typescript: ^2.1.0
-    resolution:
-      integrity: sha1-7MKnl/d3oS8AZpRM7AyBqefFnuk=
-  /tslint-microsoft-contrib/5.0.2/tslint@5.6.0+typescript@2.4.2:
-    dependencies:
-      tslint: /tslint/5.6.0/typescript@2.4.2
-      tsutils: /tsutils/2.19.0/typescript@2.4.2
-      typescript: 2.4.2
-    dev: false
-    id: registry.npmjs.org/tslint-microsoft-contrib/5.0.2
-    peerDependencies: *ref_2
     resolution:
       integrity: sha1-7MKnl/d3oS8AZpRM7AyBqefFnuk=
   /tslint-microsoft-contrib/5.0.2/tslint@5.9.1+typescript@2.4.2:
@@ -8606,30 +8603,9 @@ packages:
       typescript: 2.4.2
     dev: false
     id: registry.npmjs.org/tslint-microsoft-contrib/5.0.2
-    peerDependencies: *ref_2
+    peerDependencies: *ref_3
     resolution:
       integrity: sha1-7MKnl/d3oS8AZpRM7AyBqefFnuk=
-  /tslint/5.6.0/typescript@2.4.2:
-    dependencies:
-      babel-code-frame: 6.26.0
-      colors: 1.1.2
-      commander: 2.13.0
-      diff: 3.4.0
-      glob: 7.1.2
-      minimatch: 3.0.4
-      resolve: 1.5.0
-      semver: 5.3.0
-      tslib: 1.8.1
-      tsutils: /tsutils/2.19.0/typescript@2.4.2
-      typescript: 2.4.2
-    dev: false
-    engines:
-      node: '>=4.1.2'
-    id: registry.npmjs.org/tslint/5.6.0
-    peerDependencies:
-      typescript: '>=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev'
-    resolution:
-      integrity: sha1-CIqmxgJmIzOGULKQCCirPt9Z9s8=
   /tslint/5.9.1:
     dependencies:
       babel-code-frame: 6.26.0
@@ -8647,7 +8623,7 @@ packages:
     dev: false
     engines:
       node: '>=4.8.0'
-    peerDependencies: &ref_11
+    peerDependencies: &ref_1
       typescript: '>=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev'
     resolution:
       integrity: sha1-ElX4ej/1frCw4fDmEKi0dIBGya4=
@@ -8670,7 +8646,7 @@ packages:
     engines:
       node: '>=4.8.0'
     id: registry.npmjs.org/tslint/5.9.1
-    peerDependencies: *ref_11
+    peerDependencies: *ref_1
     resolution:
       integrity: sha1-ElX4ej/1frCw4fDmEKi0dIBGya4=
   /tsscmp/1.0.5:
@@ -8683,7 +8659,7 @@ packages:
     dependencies:
       tslib: 1.8.1
     dev: false
-    peerDependencies: &ref_1
+    peerDependencies: &ref_2
       typescript: '>=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >= 2.4.0-dev || >= 2.5.0-dev || >= 2.6.0-dev || >= 2.7.0-dev || >= 2.8.0-dev'
     resolution:
       integrity: sha512-qjgvrvtzRUtOmqlZTfBFtep6s+ymuBLsHOC4ee9JNA+AZIbnR/x4C2Y7QFhOGpD2R3lDp0BBcnxb0vnMVrU7Aw==
@@ -8693,7 +8669,7 @@ packages:
       typescript: 2.4.2
     dev: false
     id: registry.npmjs.org/tsutils/2.19.0
-    peerDependencies: *ref_1
+    peerDependencies: *ref_2
     resolution:
       integrity: sha512-qjgvrvtzRUtOmqlZTfBFtep6s+ymuBLsHOC4ee9JNA+AZIbnR/x4C2Y7QFhOGpD2R3lDp0BBcnxb0vnMVrU7Aw==
   /tty-browserify/0.0.0:
@@ -8771,6 +8747,7 @@ packages:
     resolution:
       integrity: sha512-0h/qGay016GG2lVav3Kz174F3T2Vjlz2v6HCt+WDQpoXfco0hWwF5gHK9yh88mUYvIC+N7Z8NT8WpjSp1yoqGA==
   /uglify-to-browserify/1.0.2:
+    dev: false
     optional: true
     resolution:
       integrity: sha1-bgkk1r2mta/jSeOabWMoUKD4grc=
@@ -9105,7 +9082,7 @@ packages:
     dev: false
     engines:
       node: '>=0.6'
-    peerDependencies: &ref_10
+    peerDependencies: &ref_11
       webpack: ^1.0.0 || ^2.0.0 || ^3.0.0
     resolution:
       integrity: sha512-FCrqPy1yy/sN6U/SaEZcHKRXGlqU0DUaEBL45jkUYoB8foVb6wCnbIJ1HKIx+qUFTW+3JpVcCJCxZ8VATL4e+A==
@@ -9121,7 +9098,7 @@ packages:
     engines:
       node: '>=0.6'
     id: registry.npmjs.org/webpack-dev-middleware/1.12.2
-    peerDependencies: *ref_10
+    peerDependencies: *ref_11
     resolution:
       integrity: sha512-FCrqPy1yy/sN6U/SaEZcHKRXGlqU0DUaEBL45jkUYoB8foVb6wCnbIJ1HKIx+qUFTW+3JpVcCJCxZ8VATL4e+A==
   /webpack-sources/1.1.0:
@@ -9487,7 +9464,7 @@ packages:
     version: 0.0.0
   'file:projects/api-extractor.tgz':
     dependencies:
-      '@microsoft/node-library-build': 4.3.2
+      '@microsoft/node-library-build': 4.3.3
       '@types/colors': 1.1.3
       '@types/fs-extra': 0.0.37
       '@types/jest': 21.1.10
@@ -9520,7 +9497,7 @@ packages:
     version: 0.0.0
   'file:projects/gulp-core-build-karma.tgz':
     dependencies:
-      '@microsoft/node-library-build': 4.3.2
+      '@microsoft/node-library-build': 4.3.3
       '@types/bluebird': 3.5.3
       '@types/gulp': 3.8.32
       '@types/karma': 0.13.33
@@ -9551,7 +9528,7 @@ packages:
     version: 0.0.0
   'file:projects/gulp-core-build-mocha.tgz':
     dependencies:
-      '@microsoft/node-library-build': 4.3.2
+      '@microsoft/node-library-build': 4.3.3
       '@types/gulp': 3.8.32
       '@types/gulp-istanbul': 0.9.30
       '@types/gulp-mocha': 0.0.29
@@ -9569,7 +9546,7 @@ packages:
     version: 0.0.0
   'file:projects/gulp-core-build-sass.tgz':
     dependencies:
-      '@microsoft/node-library-build': 4.3.2
+      '@microsoft/node-library-build': 4.3.3
       '@types/express': 4.0.35
       '@types/express-serve-static-core': 4.0.41
       '@types/gulp': 3.8.32
@@ -9599,7 +9576,7 @@ packages:
     version: 0.0.0
   'file:projects/gulp-core-build-serve.tgz':
     dependencies:
-      '@microsoft/node-library-build': 4.3.2
+      '@microsoft/node-library-build': 4.3.3
       '@types/express': 4.0.35
       '@types/express-serve-static-core': 4.0.41
       '@types/gulp': 3.8.32
@@ -9628,7 +9605,7 @@ packages:
     version: 0.0.0
   'file:projects/gulp-core-build-typescript.tgz':
     dependencies:
-      '@microsoft/node-library-build': 4.3.2
+      '@microsoft/node-library-build': 4.3.3
       '@types/fs-extra': 0.0.37
       '@types/gulp': 3.8.32
       '@types/gulp-util': 3.0.30
@@ -9662,7 +9639,7 @@ packages:
     version: 0.0.0
   'file:projects/gulp-core-build-webpack.tgz':
     dependencies:
-      '@microsoft/node-library-build': 4.3.2
+      '@microsoft/node-library-build': 4.3.3
       '@types/gulp': 3.8.32
       '@types/node': 8.5.8
       '@types/orchestrator': 0.0.30
@@ -9680,7 +9657,7 @@ packages:
     version: 0.0.0
   'file:projects/gulp-core-build.tgz':
     dependencies:
-      '@microsoft/node-library-build': 4.3.2
+      '@microsoft/node-library-build': 4.3.3
       '@types/assertion-error': 1.0.30
       '@types/chai': 3.4.34
       '@types/chalk': 0.4.31
@@ -9785,7 +9762,7 @@ packages:
     version: 0.0.0
   'file:projects/node-core-library.tgz':
     dependencies:
-      '@microsoft/node-library-build': 4.3.2
+      '@microsoft/node-library-build': 4.3.3
       '@types/chai': 3.4.34
       '@types/fs-extra': 0.0.37
       '@types/mocha': 2.2.38
@@ -9944,7 +9921,7 @@ packages:
     version: 0.0.0
   'file:projects/ts-command-line.tgz':
     dependencies:
-      '@microsoft/node-library-build': 4.3.2
+      '@microsoft/node-library-build': 4.3.3
       '@types/argparse': 1.0.33
       '@types/colors': 1.1.3
       '@types/node': 8.5.8
@@ -9973,7 +9950,7 @@ registry: 'https://registry.npmjs.org/'
 shrinkwrapMinorVersion: 4
 shrinkwrapVersion: 3
 specifiers:
-  '@microsoft/node-library-build': 4.3.2
+  '@microsoft/node-library-build': 4.3.3
   '@rush-temp/api-documenter': 'file:./projects/api-documenter.tgz'
   '@rush-temp/api-extractor': 'file:./projects/api-extractor.tgz'
   '@rush-temp/api-extractor-test-01': 'file:./projects/api-extractor-test-01.tgz'

--- a/core-build/gulp-core-build-karma/package.json
+++ b/core-build/gulp-core-build-karma/package.json
@@ -34,7 +34,7 @@
     "webpack": "~3.6.0"
   },
   "devDependencies": {
-    "@microsoft/node-library-build": "4.3.2",
+    "@microsoft/node-library-build": "4.3.3",
     "@types/gulp": "3.8.32",
     "@types/karma": "0.13.33",
     "@types/log4js": "0.0.33",

--- a/core-build/gulp-core-build-mocha/package.json
+++ b/core-build/gulp-core-build-mocha/package.json
@@ -20,7 +20,7 @@
     "gulp-mocha": "~2.2.0"
   },
   "devDependencies": {
-    "@microsoft/node-library-build": "4.3.2",
+    "@microsoft/node-library-build": "4.3.3",
     "@types/gulp": "3.8.32",
     "@types/gulp-istanbul": "0.9.30",
     "@types/gulp-mocha": "0.0.29",

--- a/core-build/gulp-core-build-sass/gulpfile.js
+++ b/core-build/gulp-core-build-sass/gulpfile.js
@@ -2,15 +2,4 @@
 
 let build = require('@microsoft/node-library-build');
 
-// Temporarily fix rules that aren't compatible with the old version of TSLint
-build.tslint.setConfig({
-  lintConfig: {
-    rules: {
-      'no-duplicate-case': false,
-      'valid-typeof': false,
-      'typeof-compare': true
-    }
-  }
-});
-
 build.initialize(require('gulp'));

--- a/core-build/gulp-core-build-sass/package.json
+++ b/core-build/gulp-core-build-sass/package.json
@@ -29,7 +29,7 @@
     "through2": "~2.0.1"
   },
   "devDependencies": {
-    "@microsoft/node-library-build": "4.3.2",
+    "@microsoft/node-library-build": "4.3.3",
     "@types/express": "4.0.35",
     "@types/express-serve-static-core": "4.0.41",
     "@types/gulp": "3.8.32",

--- a/core-build/gulp-core-build-serve/package.json
+++ b/core-build/gulp-core-build-serve/package.json
@@ -26,7 +26,7 @@
     "sudo": "~1.0.3"
   },
   "devDependencies": {
-    "@microsoft/node-library-build": "4.3.2",
+    "@microsoft/node-library-build": "4.3.3",
     "@types/express": "4.0.35",
     "@types/express-serve-static-core": "4.0.41",
     "@types/gulp": "3.8.32",

--- a/core-build/gulp-core-build-typescript/gulpfile.js
+++ b/core-build/gulp-core-build-typescript/gulpfile.js
@@ -23,15 +23,4 @@ build.task(
   )
 );
 
-// Temporarily fix rules that aren't compatible with the old version of TSLint
-build.tslint.setConfig({
-  lintConfig: {
-    rules: {
-      'no-duplicate-case': false,
-      'valid-typeof': false,
-      'typeof-compare': true
-    }
-  }
-});
-
 build.initialize(require('gulp'));

--- a/core-build/gulp-core-build-typescript/package.json
+++ b/core-build/gulp-core-build-typescript/package.json
@@ -39,7 +39,7 @@
     "typescript": "~2.4.1"
   },
   "devDependencies": {
-    "@microsoft/node-library-build": "4.3.2",
+    "@microsoft/node-library-build": "4.3.3",
     "@types/gulp-util": "3.0.30",
     "@types/orchestrator": "0.0.30",
     "@types/q": "0.0.32",

--- a/core-build/gulp-core-build-webpack/package.json
+++ b/core-build/gulp-core-build-webpack/package.json
@@ -21,7 +21,7 @@
     "webpack": "~3.6.0"
   },
   "devDependencies": {
-    "@microsoft/node-library-build": "4.3.2",
+    "@microsoft/node-library-build": "4.3.3",
     "@types/orchestrator": "0.0.30",
     "@types/q": "0.0.32",
     "@types/source-map": "0.5.0",

--- a/core-build/gulp-core-build/package.json
+++ b/core-build/gulp-core-build/package.json
@@ -58,7 +58,7 @@
   },
   "devDependencies": {
     "@types/z-schema": "3.16.31",
-    "@microsoft/node-library-build": "4.3.2",
+    "@microsoft/node-library-build": "4.3.3",
     "chai": "~3.5.0"
   }
 }

--- a/libraries/node-core-library/package.json
+++ b/libraries/node-core-library/package.json
@@ -22,6 +22,6 @@
     "chai": "~3.5.0",
     "gulp": "~3.9.1",
     "mocha": "~3.4.2",
-    "@microsoft/node-library-build": "4.3.2"
+    "@microsoft/node-library-build": "4.3.3"
   }
 }

--- a/libraries/ts-command-line/package.json
+++ b/libraries/ts-command-line/package.json
@@ -23,6 +23,6 @@
     "chai": "~3.5.0",
     "gulp": "~3.9.1",
     "mocha": "~3.4.2",
-    "@microsoft/node-library-build": "4.3.2"
+    "@microsoft/node-library-build": "4.3.3"
   }
 }

--- a/rush.json
+++ b/rush.json
@@ -1,6 +1,6 @@
 {
   "pnpmVersion": "1.29.1",
-  "rushVersion": "4.2.1",
+  "rushVersion": "4.2.2",
   "nodeSupportedVersionRange": ">=6.9.0 <9.0.0",
   "projectFolderMinDepth": 1,
 

--- a/rush.json
+++ b/rush.json
@@ -1,5 +1,5 @@
 {
-  "pnpmVersion": "1.25.1",
+  "pnpmVersion": "1.29.1",
   "rushVersion": "4.2.1",
   "nodeSupportedVersionRange": ">=6.9.0 <9.0.0",
   "projectFolderMinDepth": 1,


### PR DESCRIPTION
This upgrades the cyclic dependencies in web-build-tools to complete the fix from #489.