### PR TITLE
Force publishing of node-library-build

### DIFF
--- a/common/changes/@microsoft/node-library-build/pgonzal-temp_2018-01-18-00-38.json
+++ b/common/changes/@microsoft/node-library-build/pgonzal-temp_2018-01-18-00-38.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/node-library-build",
+      "comment": "Update dependency of node-library-build",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/node-library-build",
+  "email": "pgonzal@users.noreply.github.com"
+}


### PR DESCRIPTION
The recent changes didn't cause **node-library-build** to get published for some reason. This change log will.