### PR TITLE
Anything written to stderr should cause process to fail

### DIFF
--- a/common/changes/@microsoft/gulp-core-build/nickpape-stderr-causes-failure_2018-01-18-01-44.json
+++ b/common/changes/@microsoft/gulp-core-build/nickpape-stderr-causes-failure_2018-01-18-01-44.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/gulp-core-build",
+      "comment": "If shouldWarningsFailBuild, then we will hook stderr and fail the build if anything consequential is written there",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@microsoft/gulp-core-build",
+  "email": "nickpape-msft@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/gulp-core-build/nickpape-stderr-causes-failure_2018-01-18-01-44.json
+++ b/common/changes/@microsoft/gulp-core-build/nickpape-stderr-causes-failure_2018-01-18-01-44.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/gulp-core-build",
-      "comment": "If shouldWarningsFailBuild, then we will hook stderr and fail the build if anything consequential is written there",
+      "comment": "Add a feature where when shouldWarningsFailBuild is true, then we will hook stderr and fail the build if anything consequential is written there",
       "type": "minor"
     }
   ],

--- a/common/reviews/api/gulp-core-build.api.ts
+++ b/common/reviews/api/gulp-core-build.api.ts
@@ -123,7 +123,7 @@ interface IBuildConfig {
   }
   relogIssues?: boolean;
   rootPath: string;
-  shouldWarningsFailBuild?: boolean;
+  shouldWarningsFailBuild: boolean;
   showToast?: boolean;
   srcFolder: string;
   tempFolder: string;

--- a/core-build/gulp-core-build/src/IBuildConfig.ts
+++ b/core-build/gulp-core-build/src/IBuildConfig.ts
@@ -96,7 +96,7 @@ export interface IBuildConfig {
   /**
    * Should warnings be written to STDERR and cause build to return non-zero exit code
    */
-  shouldWarningsFailBuild?: boolean;
+  shouldWarningsFailBuild: boolean;
 
   /**
    * Arguments passed in.

--- a/core-build/gulp-core-build/src/index.ts
+++ b/core-build/gulp-core-build/src/index.ts
@@ -350,7 +350,7 @@ export function initialize(gulp: typeof Gulp): void {
     }
   }
 
-  initializeLogging(gulp, undefined, undefined);
+  initializeLogging(gulp, getConfig(), undefined, undefined);
 
   Object.keys(_taskMap).forEach(taskName => _registerTask(gulp, taskName, _taskMap[taskName]));
 

--- a/core-build/gulp-core-build/src/logging.ts
+++ b/core-build/gulp-core-build/src/logging.ts
@@ -278,7 +278,7 @@ function exitProcess(errorCode: number): void {
   }
 }
 
-function wireUpProcessErrorHandling(shouldWarningsFailBuild: boolean | undefined): void {
+function wireUpProcessErrorHandling(shouldWarningsFailBuild: boolean): void {
   if (!wiredUpErrorHandling) {
     wiredUpErrorHandling = true;
 
@@ -305,15 +305,15 @@ function wireUpProcessErrorHandling(shouldWarningsFailBuild: boolean | undefined
           console.error('Process terminated before summary could be written, possible error in async code not ' +
                         'continuing!');
           console.log('Trying to exit with exit code 1');
-          process.exit(1);
+          exitProcess(1);
         } else {
           if (localCache.exitCode !== 0) {
             console.log(`Exiting with exit code: ${localCache.exitCode}`);
-            process.exit(localCache.exitCode);
+            exitProcess(localCache.exitCode);
           } else if (wroteToStdErr) {
-            console.log(`Data written to stderr is treated as a failure.`);
+            console.error(`The build failed because a task wrote output to stderr.`);
             console.log(`Exiting with exit code: 1`);
-            process.exit(1);
+            exitProcess(1);
           }
         }
       }
@@ -793,7 +793,7 @@ export function initialize(
     writeSummary(() => {
       // error if we have any errors
       if (localCache.taskErrors > 0 ||
-        (getWarnings().length && getConfig().shouldWarningsFailBuild) ||
+        (getWarnings().length && config.shouldWarningsFailBuild) ||
         getErrors().length ||
         localCache.testsFailed > 0) {
         exitProcess(1);

--- a/core-build/gulp-core-build/src/logging.ts
+++ b/core-build/gulp-core-build/src/logging.ts
@@ -308,7 +308,7 @@ function wireUpProcessErrorHandling(shouldWarningsFailBuild: boolean | undefined
           process.exit(1);
         } else {
           if (localCache.exitCode !== 0) {
-            console.log(`Exiting with exit code: ${localCache.exitCode || 1}`);
+            console.log(`Exiting with exit code: ${localCache.exitCode}`);
             process.exit(localCache.exitCode);
           } else if (wroteToStdErr) {
             console.log(`Data written to stderr is treated as a failure.`);

--- a/core-build/gulp-core-build/src/logging.ts
+++ b/core-build/gulp-core-build/src/logging.ts
@@ -283,18 +283,19 @@ function wireUpProcessErrorHandling(): void {
   if (!wiredUpErrorHandling) {
     wiredUpErrorHandling = true;
 
-    const oldStdErr: Function = process.stderr.write;
-
     let wroteToStdErr: boolean = false;
 
-    // tslint:disable-next-line:no-function-expression
-    process.stderr.write = function (text: string | Buffer): boolean {
-      if (!!text.toString()) {
-        wroteToStdErr = true;
-        return oldStdErr.apply(process.stderr, arguments);
-      }
-      return true;
-    };
+    if (getConfig().shouldWarningsFailBuild) {
+      const oldStdErr: Function = process.stderr.write;
+      // tslint:disable-next-line:no-function-expression
+      process.stderr.write = function (text: string | Buffer): boolean {
+        if (!!text.toString()) {
+          wroteToStdErr = true;
+          return oldStdErr.apply(process.stderr, arguments);
+        }
+        return true;
+      };
+    }
 
     process.on('exit', (code: number) => {
       duringFastExit = true;

--- a/core-build/gulp-core-build/src/logging.ts
+++ b/core-build/gulp-core-build/src/logging.ts
@@ -186,8 +186,8 @@ function writeSummary(callback: () => void): void {
     afterStreamsFlushed(() => {
       log(gutil.colors.magenta('==================[ Finished ]=================='));
 
-      if (shouldRelogIssues && getWarnings().length) {
-        const warnings: string[] = getWarnings();
+      const warnings: string[] = getWarnings();
+      if (shouldRelogIssues) {
         for (let x: number = 0; x < warnings.length; x++) {
           console.error(gutil.colors.yellow(warnings[x]));
         }

--- a/core-build/gulp-core-build/src/tasks/JestTask.ts
+++ b/core-build/gulp-core-build/src/tasks/JestTask.ts
@@ -189,9 +189,14 @@ export class JestTask extends GulpTask<IJestConfig> {
       jestConfig['cacheDirectory'] = this.taskConfig.cacheDirectory;
     }
 
+    // suppress 'Running coverage on untested files...' warning
+    const oldTTY: true | undefined = process.stdout.isTTY;
+    process.stdout.isTTY = undefined;
+
     Jest.runCLI(jestConfig,
       [this.buildConfig.rootPath]).then(
       (result: { results: Jest.AggregatedResult, globalConfig: Jest.GlobalConfig }) => {
+        process.stdout.isTTY = oldTTY;
         if (result.results.numFailedTests || result.results.numFailedTestSuites) {
           completeCallback(new Error('Jest tests failed'));
         } else {
@@ -202,6 +207,7 @@ export class JestTask extends GulpTask<IJestConfig> {
         }
       },
       (err) => {
+        process.stdout.isTTY = oldTTY;
         completeCallback(err);
       });
   }

--- a/core-build/gulp-core-build/src/test/mockBuildConfig.ts
+++ b/core-build/gulp-core-build/src/test/mockBuildConfig.ts
@@ -12,5 +12,6 @@ export const mockBuildConfig: IBuildConfig = {
   tempFolder: 'temp',
   verbose: false,
   production: false,
-  args: {}
+  args: {},
+  shouldWarningsFailBuild: false
 };


### PR DESCRIPTION
If the `shouldWarningsFailBuild === true`, then we should capture anything written to `process.stderr`. If anything significant is written to `stderr`, we will fail the build.

We have had several cases where things are writing to stderr but are making it into the master build (and causing developers to get the "success with warnings" message). This change will make it impossible to check in any changes that will cause errant warnings to be written to the console.