### PR TITLE
Treat warnings as errors in production mode when building node-library-build & web-library-build

### DIFF
--- a/common/changes/@microsoft/node-library-build/nickpape-errors-as-warnings_2018-01-18-22-09.json
+++ b/common/changes/@microsoft/node-library-build/nickpape-errors-as-warnings_2018-01-18-22-09.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@microsoft/node-library-build",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/node-library-build",
+  "email": "nickpape-msft@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/web-library-build/nickpape-errors-as-warnings_2018-01-18-22-09.json
+++ b/common/changes/@microsoft/web-library-build/nickpape-errors-as-warnings_2018-01-18-22-09.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@microsoft/web-library-build",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/web-library-build",
+  "email": "nickpape-msft@users.noreply.github.com"
+}

--- a/common/reviews/api/node-library-build.api.ts
+++ b/common/reviews/api/node-library-build.api.ts
@@ -131,7 +131,7 @@ interface IBuildConfig {
   }
   relogIssues?: boolean;
   rootPath: string;
-  shouldWarningsFailBuild?: boolean;
+  shouldWarningsFailBuild: boolean;
   showToast?: boolean;
   srcFolder: string;
   tempFolder: string;

--- a/common/reviews/api/web-library-build.api.ts
+++ b/common/reviews/api/web-library-build.api.ts
@@ -131,7 +131,7 @@ interface IBuildConfig {
   }
   relogIssues?: boolean;
   rootPath: string;
-  shouldWarningsFailBuild?: boolean;
+  shouldWarningsFailBuild: boolean;
   showToast?: boolean;
   srcFolder: string;
   tempFolder: string;

--- a/core-build/node-library-build/gulpfile.js
+++ b/core-build/node-library-build/gulpfile.js
@@ -5,6 +5,10 @@ let apiExtractor = require('@microsoft/gulp-core-build-typescript').apiExtractor
 let typescript = require('@microsoft/gulp-core-build-typescript').typescript;
 let mocha = require('@microsoft/gulp-core-build-mocha');
 
+build.setConfig({
+  shouldWarningsFailBuild: build.getConfig().production
+});
+
 build.task('default', build.serial(typescript, mocha, apiExtractor));
 
 build.initialize(require('gulp'));

--- a/core-build/web-library-build/gulpfile.js
+++ b/core-build/web-library-build/gulpfile.js
@@ -4,6 +4,10 @@ let build = require('@microsoft/gulp-core-build');
 let typescript = require('@microsoft/gulp-core-build-typescript').typescript;
 let apiExtractor = require('@microsoft/gulp-core-build-typescript').apiExtractor;
 
+build.setConfig({
+  shouldWarningsFailBuild: build.getConfig().production
+});
+
 build.task('default', build.serial(typescript, apiExtractor));
 
 build.initialize(require('gulp'));


### PR DESCRIPTION
Treat warnings as errors in production mode when building node-library-build & web-library-build