### PR TITLE
Improve the error message when loading rush.json from a newer release

### DIFF
--- a/apps/rush-lib/src/data/RushConfiguration.ts
+++ b/apps/rush-lib/src/data/RushConfiguration.ts
@@ -167,14 +167,17 @@ export default class RushConfiguration {
     // then the schema may have changed. This should no longer be a problem after Rush 4.0 and the C2R wrapper,
     // but we'll validate anyway.
     const expectedRushVersion: string = rushConfigurationJson.rushVersion;
+
+    const rushJsonBaseName: string = path.basename(rushJsonFilename);
+
     // If the version is missing or malformed, fall through and let the schema handle it.
     if (expectedRushVersion && semver.valid(expectedRushVersion)) {
       if (semver.lt(Rush.version, expectedRushVersion)) {
-        throw new Error(`Your rush tool is version ${Rush.version}, but rush.json ` +
-          `requires version ${rushConfigurationJson.rushVersion}. To upgrade, ` +
-          `run "npm install @microsoft/rush -g".`);
+        throw new Error(`Unable to load ${rushJsonBaseName} because its RushVersion is`
+          + ` ${rushConfigurationJson.rushVersion}, whereas @microsoft/rush-lib is version ${Rush.version}.`
+          + ` Consider upgrading the library.`);
       } else if (semver.lt(expectedRushVersion, MINIMUM_SUPPORTED_RUSH_JSON_VERSION)) {
-        throw new Error(`rush.json is version ${expectedRushVersion}, which is too old for this tool. ` +
+        throw new Error(`${rushJsonBaseName} is version ${expectedRushVersion}, which is too old for this tool. ` +
           `The minimum supported version is ${MINIMUM_SUPPORTED_RUSH_JSON_VERSION}.`);
       }
     }

--- a/apps/rush-lib/src/data/test/RushConfiguration.test.ts
+++ b/apps/rush-lib/src/data/test/RushConfiguration.test.ts
@@ -21,6 +21,15 @@ function assertPathProperty(validatedPropertyName: string, absolutePath: string,
 }
 
 describe('RushConfiguration', () => {
+  it ('can\'t load too new rush', (done: MochaDone) => {
+    const rushFilename: string = path.resolve(__dirname, 'repo', 'rush-too-new.json');
+
+    assert.throws(() => {
+      RushConfiguration.loadFromConfigurationFile(rushFilename);
+    }, 'Unable to load rush-too-new.json because its RushVersion is 99.0.0');
+
+    done();
+  });
 
   it('can load repo/rush-npm.json', (done: MochaDone) => {
     const rushFilename: string = path.resolve(__dirname, 'repo', 'rush-npm.json');

--- a/apps/rush-lib/src/data/test/repo/rush-too-new.json
+++ b/apps/rush-lib/src/data/test/repo/rush-too-new.json
@@ -1,0 +1,4 @@
+{
+  "npmVersion": "4.5.0",
+  "rushVersion": "99.0.0"
+}

--- a/common/changes/@microsoft/rush/pgonzal-rush-confusing-error_2018-01-19-20-15.json
+++ b/common/changes/@microsoft/rush/pgonzal-rush-confusing-error_2018-01-19-20-15.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Improve the error message when loading rush.json from a newer release",
+      "packageName": "@microsoft/rush",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "pgonzal@users.noreply.github.com"
+}


### PR DESCRIPTION
The old error:
```
Your rush tool is version 4.2.3, but rush.json requires version 99.0.0. To upgrade, run "npm install @microsoft/rush -g".
```

The new error:
```
'Unable to load rush-too-new.json because its RushVersion is 99.0.0, whereas @microsoft/rush-lib is version 4.2.3. Consider upgrading the library.'
```