### PR TITLE
Stop stream-collator from redirecting warnings to stdout

### DIFF
--- a/common/changes/@microsoft/stream-collator/nickpape-fix-stream-collator-warnings_2018-01-22-23-24.json
+++ b/common/changes/@microsoft/stream-collator/nickpape-fix-stream-collator-warnings_2018-01-22-23-24.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/stream-collator",
+      "comment": "Remove code which redirected warnings to stdout.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/stream-collator",
+  "email": "nickpape-msft@users.noreply.github.com"
+}

--- a/libraries/stream-collator/src/Interleaver.ts
+++ b/libraries/stream-collator/src/Interleaver.ts
@@ -33,8 +33,7 @@ interface ITaskWriterInfo {
 
 enum ITaskOutputStream {
   stdout = 1,
-  stderr = 2,
-  warning = 3
+  stderr = 2
 }
 
 /**
@@ -79,13 +78,7 @@ export default class Interleaver {
       getStdError: (): string => this._getTaskOutput(taskName, ITaskOutputStream.stderr),
       getStdOutput: (): string => this._getTaskOutput(taskName),
       write: (data: string): void => this._writeTaskOutput(taskName, data),
-      writeError: (data: string): void => {
-        const stream: ITaskOutputStream = (data.indexOf('Warning - ') === 0) ?
-          ITaskOutputStream.warning : // Warning written to stderr
-          ITaskOutputStream.stderr;
-
-        this._writeTaskOutput(taskName, data, stream);
-      },
+      writeError: (data: string): void => this._writeTaskOutput(taskName, data, ITaskOutputStream.stderr),
       writeLine: (data: string): void => this._writeTaskOutput(taskName, data + os.EOL)
     };
   }
@@ -120,10 +113,8 @@ export default class Interleaver {
     if (this._activeTask === taskName) {
       if (stream === ITaskOutputStream.stdout && !taskInfo.quietMode) {
         this._stdout.write(data);
-      } else if (stream === ITaskOutputStream.warning && !taskInfo.quietMode) {
-        this._stdout.write(colors.yellow(data));
       } else if (stream === ITaskOutputStream.stderr) {
-        this._stdout.write(colors.red(data));
+        this._stdout.write(data);
       }
     }
   }

--- a/libraries/stream-collator/src/test/Interleaver.test.ts
+++ b/libraries/stream-collator/src/test/Interleaver.test.ts
@@ -4,7 +4,6 @@
 /// <reference types="mocha" />
 
 import { assert } from 'chai';
-import * as colors from 'colors';
 import * as os from 'os';
 
 import Interleaver, { ITaskWriter } from '../Interleaver';

--- a/libraries/stream-collator/src/test/Interleaver.test.ts
+++ b/libraries/stream-collator/src/test/Interleaver.test.ts
@@ -86,26 +86,12 @@ describe('Interleaver tests', () => {
       done();
     });
 
-    it('should redirect warnings to stdout in yellow', (done: MochaDone) => {
-      const taskA: ITaskWriter = Interleaver.registerTask('A');
-      const warning: string = 'Warning - This is a warning';
-
-      taskA.writeError(warning);
-      assert.equal(stdout.read(), colors.yellow(warning));
-
-      taskA.close();
-
-      assert.equal(taskA.getStdOutput(), warning);
-      assert.equal(taskA.getStdError(), '');
-      done();
-    });
-
-    it('should write errors in red', (done: MochaDone) => {
+    it('should write errors to stderr', (done: MochaDone) => {
       const taskA: ITaskWriter = Interleaver.registerTask('A');
       const error: string = 'Critical error';
 
       taskA.writeError(error);
-      assert.equal(stdout.read(), colors.red(error));
+      assert.equal(stdout.read(), error);
 
       taskA.close();
 


### PR DESCRIPTION
Stream collator appeared to have some code that redirected warnings from stderr to stdout. This was because we didn't want warnings to fail a Rush build. However, we have changed the implementation in Rush, so that Rush always reports everything written to stderr, and we have changed GCB to always fail if `treatWarningsAsErrors === true` and something is written to stderr.

The problem with the code the way it is right now is that Stream Collator is effectively swallowing warnings (by redirecting them to stdout), such that Rush is no longer able to report the warnings in the summary (whereas Rush used to watch for specific warning strings in order to report them in the summary even if they were written to stdout).