### PR TITLE
Bump PNPM to 1.31.0

### DIFF
--- a/rush.json
+++ b/rush.json
@@ -1,5 +1,5 @@
 {
-  "pnpmVersion": "1.29.1",
+  "pnpmVersion": "1.31.0",
   "rushVersion": "4.2.3",
   "nodeSupportedVersionRange": ">=6.9.0 <9.0.0",
   "projectFolderMinDepth": 1,


### PR DESCRIPTION
* This fixes an issue where the `--no-optional` flag had no effect. This makes WBT/Rush/pnpm more stable when working cross-platform between Mac and Windows.

https://github.com/pnpm/pnpm/issues/1014