### PR TITLE
Rush should link to the realpath of a symlink when using PNPM

### DIFF
--- a/apps/rush-lib/src/cli/logic/pnpm/PnpmLinkManager.ts
+++ b/apps/rush-lib/src/cli/logic/pnpm/PnpmLinkManager.ts
@@ -167,6 +167,11 @@ export class PnpmLinkManager extends BaseLinkManager {
         throw Error(`Dependency "${dependencyName}" is not a symlink in "${pathToLocalInstallation}`);
       }
 
+      // The dependencyLocalInstallationSymlink is just a symlink to another folder.
+      // To reduce the number of filesystem reads that are needed, we will link to where that symlink
+      // it pointed, rather than linking to a link.
+      const dependencyLocalInstallationRealpath: string = fsx.realpathSync(dependencyLocalInstallationSymlink);
+
       const newLocalFolderPath: string = path.join(
           localPackage.folderPath, 'node_modules', dependencyName);
 
@@ -174,7 +179,7 @@ export class PnpmLinkManager extends BaseLinkManager {
       if (DEBUG) {
         // read the version number for diagnostic purposes
         const packageJsonForDependency: IPackageJson = fsx.readJsonSync(
-          path.join(dependencyLocalInstallationSymlink, RushConstants.packageJsonFilename));
+          path.join(dependencyLocalInstallationRealpath, RushConstants.packageJsonFilename));
 
         version = packageJsonForDependency.version;
       }
@@ -185,7 +190,7 @@ export class PnpmLinkManager extends BaseLinkManager {
         newLocalFolderPath
       );
 
-      newLocalPackage.symlinkTargetFolderPath = dependencyLocalInstallationSymlink;
+      newLocalPackage.symlinkTargetFolderPath = dependencyLocalInstallationRealpath;
       localPackage.addChild(newLocalPackage);
     }
 

--- a/common/changes/@microsoft/rush/nickpape-pnpm-symlink-perf_2018-01-26-19-49.json
+++ b/common/changes/@microsoft/rush/nickpape-pnpm-symlink-perf_2018-01-26-19-49.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "When Rush links PNPM packages to their dependencies, it should link to the realpath, rather than linking to the symlink. This will improve performance of builds by reducing the number of file system reads that are needed.",
+      "packageName": "@microsoft/rush",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "nickpape-msft@users.noreply.github.com"
+}


### PR DESCRIPTION
Right now, we are linking to the the symlink in the `common\temp\node_modules\.local\` folder. However, we ideally should follow that link. This will reduce the number of file system reads that are necessary when tooling code accesses the node_modules folder.