### PR TITLE
Allow an incremental build mode where we dont invalidate downstream packages

### DIFF
--- a/apps/rush-lib/src/cli/actions/CustomRushAction.ts
+++ b/apps/rush-lib/src/cli/actions/CustomRushAction.ts
@@ -91,7 +91,7 @@ export class CustomRushAction extends BaseRushAction {
       }
     });
 
-    let changedProjectsOnly: boolean = this.options.actionVerb === 'build' && this._changedProjectsOnly.value;
+    const changedProjectsOnly: boolean = this.options.actionVerb === 'build' && this._changedProjectsOnly.value;
 
     const tasks: TaskSelector = new TaskSelector(
       {

--- a/apps/rush-lib/src/cli/actions/CustomRushAction.ts
+++ b/apps/rush-lib/src/cli/actions/CustomRushAction.ts
@@ -35,7 +35,7 @@ interface ICustomOptionInstance {
 export class CustomRushAction extends BaseRushAction {
   private customOptions: Map<string, ICustomOptionInstance> = new Map<string, ICustomOptionInstance>();
 
-  private _ignoreDownstream: CommandLineFlagParameter;
+  private _changedProjectsOnly: CommandLineFlagParameter;
   private _fromFlag: CommandLineStringListParameter;
   private _toFlag: CommandLineStringListParameter;
   private _verboseParameter: CommandLineFlagParameter;
@@ -91,10 +91,7 @@ export class CustomRushAction extends BaseRushAction {
       }
     });
 
-    let invalidateDownstream: boolean = true;
-    if (this.options.actionVerb === 'build' && this._ignoreDownstream.value) {
-      invalidateDownstream = false;
-    }
+    let changedProjectsOnly: boolean = this.options.actionVerb === 'build' && this._changedProjectsOnly.value;
 
     const tasks: TaskSelector = new TaskSelector(
       {
@@ -106,7 +103,7 @@ export class CustomRushAction extends BaseRushAction {
         isQuietMode,
         parallelism,
         isIncrementalBuildAllowed: this.options.actionVerb === 'build',
-        invalidateDownstream
+        changedProjectsOnly
       }
     );
 
@@ -156,10 +153,11 @@ export class CustomRushAction extends BaseRushAction {
       description: 'Display the logs during the build, rather than just displaying the build status summary'
     });
     if (this.options.actionVerb === 'build') {
-      this._ignoreDownstream = this.defineFlagParameter({
-        parameterLongName: '--no-deps',
+      this._changedProjectsOnly = this.defineFlagParameter({
+        parameterLongName: '--changed-projects-only',
+        parameterShortName: '-cpo',
         description: 'If specified, the incremental build will only rebuild projects that have changed, '
-          + 'but not their dependents.'
+          + 'but not any projects that directly or indirectly depend on the changed package.'
       });
     }
 

--- a/apps/rush-lib/src/cli/logic/TaskSelector.ts
+++ b/apps/rush-lib/src/cli/logic/TaskSelector.ts
@@ -17,6 +17,7 @@ export interface ITaskSelectorConstructor {
   isQuietMode: boolean;
   parallelism: number;
   isIncrementalBuildAllowed: boolean;
+  invalidateDownstream: boolean;
 }
 
 /**
@@ -34,7 +35,10 @@ export class TaskSelector {
 
   constructor(private _options: ITaskSelectorConstructor) {
 
-    this._taskRunner = new TaskRunner(this._options.isQuietMode, this._options.parallelism);
+    this._taskRunner = new TaskRunner(
+      this._options.isQuietMode,
+      this._options.parallelism,
+      this._options.invalidateDownstream);
 
     try {
       this._rushLinkJson = JsonFile.load(this._options.rushConfiguration.rushLinkJsonFilename);

--- a/apps/rush-lib/src/cli/logic/TaskSelector.ts
+++ b/apps/rush-lib/src/cli/logic/TaskSelector.ts
@@ -17,7 +17,7 @@ export interface ITaskSelectorConstructor {
   isQuietMode: boolean;
   parallelism: number;
   isIncrementalBuildAllowed: boolean;
-  invalidateDownstream: boolean;
+  changedProjectsOnly: boolean;
 }
 
 /**
@@ -38,7 +38,7 @@ export class TaskSelector {
     this._taskRunner = new TaskRunner(
       this._options.isQuietMode,
       this._options.parallelism,
-      this._options.invalidateDownstream);
+      this._options.changedProjectsOnly);
 
     try {
       this._rushLinkJson = JsonFile.load(this._options.rushConfiguration.rushLinkJsonFilename);

--- a/apps/rush-lib/src/cli/taskRunner/TaskRunner.ts
+++ b/apps/rush-lib/src/cli/taskRunner/TaskRunner.ts
@@ -21,6 +21,7 @@ import TaskError from './TaskError';
  */
 export default class TaskRunner {
   private _tasks: Map<string, ITask>;
+  private _invalidateDownstream: boolean;
   private _buildQueue: ITask[];
   private _quietMode: boolean;
   private _hasAnyFailures: boolean;
@@ -29,11 +30,14 @@ export default class TaskRunner {
   private _totalTasks: number;
   private _completedTasks: number;
 
-  constructor(quietMode: boolean, parallelism: number | undefined) {
+  constructor(quietMode: boolean,
+    parallelism: number | undefined,
+    invalidateDownstream: boolean) {
     this._tasks = new Map<string, ITask>();
     this._buildQueue = [];
     this._quietMode = quietMode;
     this._hasAnyFailures = false;
+    this._invalidateDownstream = invalidateDownstream;
 
     if (parallelism) {
       this._parallelism = parallelism;
@@ -261,7 +265,9 @@ export default class TaskRunner {
     task.status = TaskStatus.Success;
 
     task.dependents.forEach((dependent: ITask) => {
-      dependent.isIncrementalBuildAllowed = false;
+      if (this._invalidateDownstream) {
+        dependent.isIncrementalBuildAllowed = false;
+      }
       dependent.dependencies.delete(task);
     });
   }
@@ -275,7 +281,9 @@ export default class TaskRunner {
       + `[${task.name}] completed with warnings in ${task.stopwatch.toString()}`));
     task.status = TaskStatus.SuccessWithWarning;
     task.dependents.forEach((dependent: ITask) => {
-      dependent.isIncrementalBuildAllowed = false;
+      if (this._invalidateDownstream) {
+        dependent.isIncrementalBuildAllowed = false;
+      }
       dependent.dependencies.delete(task);
     });
   }

--- a/apps/rush-lib/src/cli/taskRunner/TaskRunner.ts
+++ b/apps/rush-lib/src/cli/taskRunner/TaskRunner.ts
@@ -21,7 +21,7 @@ import TaskError from './TaskError';
  */
 export default class TaskRunner {
   private _tasks: Map<string, ITask>;
-  private _invalidateDownstream: boolean;
+  private _changedProjectsOnly: boolean;
   private _buildQueue: ITask[];
   private _quietMode: boolean;
   private _hasAnyFailures: boolean;
@@ -32,12 +32,12 @@ export default class TaskRunner {
 
   constructor(quietMode: boolean,
     parallelism: number | undefined,
-    invalidateDownstream: boolean) {
+    changedProjectsOnly: boolean) {
     this._tasks = new Map<string, ITask>();
     this._buildQueue = [];
     this._quietMode = quietMode;
     this._hasAnyFailures = false;
-    this._invalidateDownstream = invalidateDownstream;
+    this._changedProjectsOnly = changedProjectsOnly;
 
     if (parallelism) {
       this._parallelism = parallelism;
@@ -265,7 +265,7 @@ export default class TaskRunner {
     task.status = TaskStatus.Success;
 
     task.dependents.forEach((dependent: ITask) => {
-      if (this._invalidateDownstream) {
+      if (!this._changedProjectsOnly) {
         dependent.isIncrementalBuildAllowed = false;
       }
       dependent.dependencies.delete(task);
@@ -281,7 +281,7 @@ export default class TaskRunner {
       + `[${task.name}] completed with warnings in ${task.stopwatch.toString()}`));
     task.status = TaskStatus.SuccessWithWarning;
     task.dependents.forEach((dependent: ITask) => {
-      if (this._invalidateDownstream) {
+      if (!this._changedProjectsOnly) {
         dependent.isIncrementalBuildAllowed = false;
       }
       dependent.dependencies.delete(task);

--- a/common/changes/@microsoft/rush/nickpape-rush-fast-build_2018-01-26-20-36.json
+++ b/common/changes/@microsoft/rush/nickpape-rush-fast-build_2018-01-26-20-36.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Add a --no-deps flag to 'rush build', which will skip rebuilding of downstream packages. It will only rebuild projects that change, but not their dependents.",
+      "packageName": "@microsoft/rush",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "nickpape-msft@users.noreply.github.com"
+}


### PR DESCRIPTION
This is a useful feature in a developer's inner loop. Oftentimes, they may be working on a package, but they don't care about building downstream packages (perhaps they are running gulp serve in a leaf node, and just trying to fix a bug in a project in the middle of the tree). While this may not guarantee a 100% "correct"  build, it can be helpful for a large number of cases (especially when not changing any API signatures).