### PR TITLE
If an install fails, PNPM should clean store before restarting

### DIFF
--- a/apps/rush-lib/src/cli/logic/InstallManager.ts
+++ b/apps/rush-lib/src/cli/logic/InstallManager.ts
@@ -662,14 +662,10 @@ export default class InstallManager {
             Utilities.createFolderWithRetry(commonNodeModulesFolder);
           }
         });
-    } catch (error) {
-      // Delete anything hanging around in the Async Recycler in case of total failure
+    } finally {
+      // Delete anything hanging around in the Async Recycler
       this._asyncRecycler.deleteAll();
-      throw error;
     }
-
-    // Delete anything hanging around in the Async Recycler after success
-    this._asyncRecycler.deleteAll();
 
     this._fixupNpm5Regression();
 

--- a/apps/rush-lib/src/cli/logic/InstallManager.ts
+++ b/apps/rush-lib/src/cli/logic/InstallManager.ts
@@ -617,10 +617,6 @@ export default class InstallManager {
       }
     }
 
-    // If any folders were moved into the AsyncRecycler, get that going before we start
-    // the expensive "npm install" operation.
-    this._asyncRecycler.deleteAll();
-
     // Run "npm install" in the common folder
 
     // NOTE:
@@ -645,28 +641,35 @@ export default class InstallManager {
     console.log(os.EOL + colors.bold(`Running "${this._rushConfiguration.packageManager} install" in`
       + ` ${this._rushConfiguration.commonTempFolder}`) + os.EOL);
 
-    Utilities.executeCommandWithRetry(packageManagerFilename,
-      installArgs,
-      MAX_INSTALL_ATTEMPTS,
-      this._rushConfiguration.commonTempFolder,
-      false, () => {
-        if (this._rushConfiguration.packageManager === 'pnpm') {
-          // If there is a failure in pnpm, it is possible that it left the
-          // store in a bad state. Therefore, we should clean out the store
-          // before attempting the install again.
+    try {
+      Utilities.executeCommandWithRetry(packageManagerFilename,
+        installArgs,
+        MAX_INSTALL_ATTEMPTS,
+        this._rushConfiguration.commonTempFolder,
+        false, () => {
+          if (this._rushConfiguration.packageManager === 'pnpm') {
+            // If there is a failure in pnpm, it is possible that it left the
+            // store in a bad state. Therefore, we should clean out the store
+            // before attempting the install again.
 
-          console.log(colors.yellow(`Deleting the "node_modules" folder`));
-          this._asyncRecycler.moveFolder(commonNodeModulesFolder);
-          console.log(colors.yellow(`Deleting the "pnpm-store" folder`));
-          this._asyncRecycler.moveFolder(this._rushConfiguration.pnpmStoreFolder);
+            console.log(colors.yellow(`Deleting the "node_modules" folder`));
+            this._asyncRecycler.moveFolder(commonNodeModulesFolder);
+            console.log(colors.yellow(`Deleting the "pnpm-store" folder`));
+            this._asyncRecycler.moveFolder(this._rushConfiguration.pnpmStoreFolder);
 
-          // Since it may be a while before the package manager gets around to creating the "node_modules" folder,
-          // create an empty folder so that the warning on the next attempt of "rush install"
-          Utilities.createFolderWithRetry(commonNodeModulesFolder);
+            // Since it may be a while before the package manager gets around to creating the "node_modules" folder,
+            // create an empty folder so that the warning on the next attempt of "rush install"
+            Utilities.createFolderWithRetry(commonNodeModulesFolder);
+          }
+        });
+    } catch (error) {
+      // Delete anything hanging around in the Async Recycler in case of total failure
+      this._asyncRecycler.deleteAll();
+      throw error;
+    }
 
-          this._asyncRecycler.deleteAll();
-        }
-      });
+    // Delete anything hanging around in the Async Recycler after success
+    this._asyncRecycler.deleteAll();
 
     this._fixupNpm5Regression();
 

--- a/apps/rush-lib/src/utilities/Utilities.ts
+++ b/apps/rush-lib/src/utilities/Utilities.ts
@@ -237,7 +237,7 @@ export default class Utilities {
    * Attempts to run Utilities.executeCommand() up to maxAttempts times before giving up.
    */
   public static executeCommandWithRetry(command: string, args: string[], maxAttempts: number,
-    workingDirectory: string, suppressOutput: boolean = false): void {
+    workingDirectory: string, suppressOutput: boolean = false, retryCallback?: () => void): void {
 
     if (maxAttempts < 1) {
       throw new Error('The maxAttempts parameter cannot be less than 1');
@@ -257,6 +257,9 @@ export default class Utilities {
         if (attemptNumber < maxAttempts) {
           ++attemptNumber;
           console.log(`Trying again (attempt #${attemptNumber})...` + os.EOL);
+          if (retryCallback) {
+            retryCallback();
+          }
           continue;
         } else {
           console.error(`Giving up after ${attemptNumber} attempts` + os.EOL);

--- a/common/changes/@microsoft/rush/nickpape-pnpm-clean-folders_2018-02-01-22-36.json
+++ b/common/changes/@microsoft/rush/nickpape-pnpm-clean-folders_2018-02-01-22-36.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Fix issue with pnpm where store was not removed after an unsuccessful installation",
+      "packageName": "@microsoft/rush",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "nickpape-msft@users.noreply.github.com"
+}


### PR DESCRIPTION
If you try to reinstall after the EPERM error in pnpm (https://github.com/pnpm/pnpm/issues/1015), you can end up with a corrupted store. It is safest to go ahead and clean out the store before attempting to reinstall.