### PR TITLE
Update PNPM to 1.32.0

### DIFF
--- a/rush.json
+++ b/rush.json
@@ -1,5 +1,5 @@
 {
-  "pnpmVersion": "1.31.0",
+  "pnpmVersion": "1.32.0",
   "rushVersion": "4.2.3",
   "nodeSupportedVersionRange": ">=6.9.0 <9.0.0",
   "projectFolderMinDepth": 1,


### PR DESCRIPTION
1.31.6 had several bugfixes around optional dependencies which otherwise may cause problems in web-build-tools.