### PR TITLE
Rush `build` should add shrinkwrap to package-deps hash

### DIFF
--- a/apps/rush-lib/src/cli/logic/PackageChangeAnalyzer.ts
+++ b/apps/rush-lib/src/cli/logic/PackageChangeAnalyzer.ts
@@ -122,6 +122,19 @@ export class PackageChangeAnalyzer {
     //  });
     // }
 
+    // Add the shrinkwrap file to every project's dependencies
+    const shrinkwrapFile: string =
+      path.relative(PackageChangeAnalyzer.rushConfig.rushJsonFolder,
+        PackageChangeAnalyzer.rushConfig.committedShrinkwrapFilename)
+        .replace(/\\/g, '/');
+
+    for (const project of PackageChangeAnalyzer.rushConfig.projects) {
+      const shrinkwrapHash: string | undefined = noProjectHashes[shrinkwrapFile];
+      if (shrinkwrapHash) {
+        projectHashDeps.get(project.packageName)!.files[shrinkwrapFile] = shrinkwrapHash;
+      }
+    }
+
     return projectHashDeps;
   }
 

--- a/apps/rush-lib/src/cli/logic/base/BaseLinkManager.ts
+++ b/apps/rush-lib/src/cli/logic/base/BaseLinkManager.ts
@@ -167,7 +167,7 @@ export abstract class BaseLinkManager {
       .then(() => {
         stopwatch.stop();
         console.log(os.EOL + colors.green(`Linking finished successfully. (${stopwatch.toString()})`));
-        console.log(os.EOL + 'Next you should probably run: "rush rebuild"');
+        console.log(os.EOL + 'Next you should probably run "rush build" or "rush rebuild"');
       });
   }
 

--- a/apps/rush-lib/src/cli/logic/test/PackageChangeAnalyzer.test.ts
+++ b/apps/rush-lib/src/cli/logic/test/PackageChangeAnalyzer.test.ts
@@ -28,7 +28,8 @@ describe('PackageChangeAnalyzer', () => {
   it('can associate a file in a project folder with a project', () => {
     const repoHashDeps: IPackageDeps = {
       files: {
-        [fileA]: HASH
+        [fileA]: HASH,
+        [path.posix.join('common', 'config', 'rush', 'shrinkwrap.yaml')]: HASH
       }
     };
 
@@ -37,7 +38,9 @@ describe('PackageChangeAnalyzer', () => {
       projects: [{
         packageName: packageA,
         projectRelativeFolder: packageAPath
-      }]
+      }],
+      rushJsonFolder: '',
+      committedShrinkwrapFilename: 'common/config/rush/shrinkwrap.yaml'
     } as any; // tslint:disable-line:no-any
 
     const packageDeps: IPackageDeps | undefined = PackageChangeAnalyzer.instance.getPackageDepsHash(packageA);

--- a/common/changes/@microsoft/rush/nickpape-rush-build-consider-shrinkwrap.json_2018-02-07-00-48.json
+++ b/common/changes/@microsoft/rush/nickpape-rush-build-consider-shrinkwrap.json_2018-02-07-00-48.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Update Rush to consider the shrinkwrap file during incremental builds.",
+      "packageName": "@microsoft/rush",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "nickpape-msft@users.noreply.github.com"
+}


### PR DESCRIPTION
This will make `rush build` more reliable for the average user.