### PR TITLE
Only delete PNPM store in a --clean install

### DIFF
--- a/apps/rush-lib/src/cli/logic/InstallManager.ts
+++ b/apps/rush-lib/src/cli/logic/InstallManager.ts
@@ -550,7 +550,7 @@ export default class InstallManager {
         console.log(`Deleting the "npm-tmp" folder`);
         this._asyncRecycler.moveFolder(this._rushConfiguration.npmTmpFolder);
 
-      } else {
+      } else if (installType !== InstallType.Normal) {
         console.log(`Deleting the "pnpm-store" folder`);
         this._asyncRecycler.moveFolder(this._rushConfiguration.pnpmStoreFolder);
       }

--- a/common/changes/@microsoft/rush/nickpape-dont-delete-store_2018-02-14-02-42.json
+++ b/common/changes/@microsoft/rush/nickpape-dont-delete-store_2018-02-14-02-42.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Fix an issue where we always deleted the PNPM store. This is not necessary since the store is transactional. We should only delete the store if it is a --clean install.",
+      "packageName": "@microsoft/rush",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "nickpape-msft@users.noreply.github.com"
+}


### PR DESCRIPTION
The store should be transactional and therefore should never be corrupted. Only delete the store if they give us the --clean flag.