### PR TITLE
Several fixes for packageTypings generator

### DIFF
--- a/build-tests/api-extractor-test-01/dist/index-internal.d.ts
+++ b/build-tests/api-extractor-test-01/dist/index-internal.d.ts
@@ -72,6 +72,24 @@ export declare class DecoratorTest {
     test(): void;
 }
 
+/**
+ * Referenced by DefaultExportEdgeCaseReferencer.
+ * @public
+ */
+export declare class default {
+}
+
+/**
+ * @public
+ */
+export declare class DefaultExportEdgeCase {
+    /**
+     * This reference is encountered before the definition of DefaultExportEdgeCase.
+     * The symbol.name will be "default" in this situation.
+     */
+    reference: default;
+}
+
 /** @public */
 export declare class ForgottenExportConsumer1 {
     test1(): IForgottenExport | undefined;

--- a/build-tests/api-extractor-test-01/dist/index-internal.d.ts
+++ b/build-tests/api-extractor-test-01/dist/index-internal.d.ts
@@ -7,6 +7,7 @@
  * @packagedocumentation
  */
 
+/// <reference types="jest" />
 
 /**
  * Example of an abstract class that is directly exported.

--- a/build-tests/api-extractor-test-01/dist/index-internal.d.ts
+++ b/build-tests/api-extractor-test-01/dist/index-internal.d.ts
@@ -62,6 +62,13 @@ export declare class AmbientConsumer {
 }
 
 /**
+ * Referenced by DefaultExportEdgeCaseReferencer.
+ * @public
+ */
+export declare class ClassExportedAsDefault {
+}
+
+/**
  * Tests a decorator
  * @public
  */
@@ -73,13 +80,6 @@ export declare class DecoratorTest {
 }
 
 /**
- * Referenced by DefaultExportEdgeCaseReferencer.
- * @public
- */
-export declare class default {
-}
-
-/**
  * @public
  */
 export declare class DefaultExportEdgeCase {
@@ -87,7 +87,7 @@ export declare class DefaultExportEdgeCase {
      * This reference is encountered before the definition of DefaultExportEdgeCase.
      * The symbol.name will be "default" in this situation.
      */
-    reference: default;
+    reference: ClassExportedAsDefault;
 }
 
 /** @public */

--- a/build-tests/api-extractor-test-01/etc/api-extractor-test-01.api.ts
+++ b/build-tests/api-extractor-test-01/etc/api-extractor-test-01.api.ts
@@ -26,8 +26,17 @@ class AmbientConsumer {
 }
 
 // @public
+class ClassExportedAsDefault {
+}
+
+// @public
 class DecoratorTest {
   test(): void;
+}
+
+// @public (undocumented)
+class DefaultExportEdgeCase {
+  reference: ClassExportedAsDefault;
 }
 
 // @public (undocumented)

--- a/build-tests/api-extractor-test-01/src/DefaultExportEdgeCase.ts
+++ b/build-tests/api-extractor-test-01/src/DefaultExportEdgeCase.ts
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+/**
+ * @public
+ */
+export class DefaultExportEdgeCase {
+  /**
+   * This reference is encountered before the definition of DefaultExportEdgeCase.
+   * The symbol.name will be "default" in this situation.
+   */
+  public reference: ClassExportedAsDefault;
+}
+
+/**
+ * Referenced by DefaultExportEdgeCaseReferencer.
+ * @public
+ */
+export default class ClassExportedAsDefault {
+}

--- a/build-tests/api-extractor-test-01/src/index.ts
+++ b/build-tests/api-extractor-test-01/src/index.ts
@@ -91,3 +91,8 @@ export { default as IInterfaceAsDefaultExport } from './IInterfaceAsDefaultExpor
 
 export { default as AbstractClass } from './AbstractClass';
 export { default as AbstractClass2, AbstractClass3 } from './AbstractClass2';
+
+export {
+  DefaultExportEdgeCase,
+  default as ClassExportedAsDefault
+} from './DefaultExportEdgeCase';

--- a/build-tests/api-extractor-test-02/dist/index-internal.d.ts
+++ b/build-tests/api-extractor-test-02/dist/index-internal.d.ts
@@ -7,7 +7,7 @@
  * @packagedocumentation
  */
 
-/// <reference types="jest" />
+import { ISimpleInterface } from 'api-extractor-test-01';
 import { ReexportedClass } from 'api-extractor-test-01';
 import * as semver1 from 'semver';
 import * as semver2 from 'semver';
@@ -39,13 +39,6 @@ export declare function importedModuleAsGenericParameter(): GenericInterface<sem
  * @public
  */
 export declare function importedModuleAsReturnType(): semver1.SemVer | undefined;
-
-/**
- * A simple, normal definition
- * @public
- */
-declare interface ISimpleInterface {
-}
 
 /**
  * Example of a class that inherits from an externally imported class.

--- a/build-tests/api-extractor-test-02/dist/index-internal.d.ts
+++ b/build-tests/api-extractor-test-02/dist/index-internal.d.ts
@@ -7,6 +7,7 @@
  * @packagedocumentation
  */
 
+/// <reference types="jest" />
 import { ReexportedClass } from 'api-extractor-test-01';
 import * as semver1 from 'semver';
 import * as semver2 from 'semver';

--- a/build-tests/api-extractor-test-02/dist/index-internal.d.ts
+++ b/build-tests/api-extractor-test-02/dist/index-internal.d.ts
@@ -7,7 +7,7 @@
  * @packagedocumentation
  */
 
-import { ReexportedClass as RenamedReexportedClass } from 'api-extractor-test-01';
+import { ReexportedClass } from 'api-extractor-test-01';
 import * as semver1 from 'semver';
 import * as semver2 from 'semver';
 import * as semver3 from 'semver';
@@ -50,6 +50,6 @@ declare interface ISimpleInterface {
  * Example of a class that inherits from an externally imported class.
  * @public
  */
-export declare class SubclassWithImport extends RenamedReexportedClass implements ISimpleInterface {
+export declare class SubclassWithImport extends ReexportedClass implements ISimpleInterface {
     test(): void;
 }

--- a/build-tests/api-extractor-test-02/package.json
+++ b/build-tests/api-extractor-test-02/package.json
@@ -10,7 +10,6 @@
   },
   "dependencies": {
     "@microsoft/api-extractor": "5.2.7",
-    "@types/jest": "~21.1.8",
     "@types/semver": "5.3.33",
     "@types/node": "8.5.8",
     "api-extractor-test-01": "1.0.0",

--- a/build-tests/api-extractor-test-02/src/index.ts
+++ b/build-tests/api-extractor-test-02/src/index.ts
@@ -13,3 +13,11 @@
 export { SubclassWithImport } from './SubclassWithImport';
 
 export * from './TypeFromImportedModule';
+
+import { AmbientConsumer } from 'api-extractor-test-01';
+
+// Test that the ambient types are accessible even though api-extractor-02 doesn't
+// import Jest
+const x = new AmbientConsumer();
+const y = x.definitelyTyped();
+const z = y.config;

--- a/build-tests/api-extractor-test-02/tsconfig.json
+++ b/build-tests/api-extractor-test-02/tsconfig.json
@@ -8,8 +8,7 @@
     "experimentalDecorators": true,
     "strictNullChecks": true,
     "types": [
-      "node",
-      "jest"
+      "node"
     ],
     "lib": [
       "es5",

--- a/common/changes/@microsoft/api-extractor/pgonzal-ae-default-bug_2018-02-16-00-20.json
+++ b/common/changes/@microsoft/api-extractor/pgonzal-ae-default-bug_2018-02-16-00-20.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor",
+      "comment": "Fix an issue where the packageTypings feature sometimes emitted \"default\" instead of the class name",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/api-extractor/pgonzal-ae-default-bug_2018-02-16-00-21.json
+++ b/common/changes/@microsoft/api-extractor/pgonzal-ae-default-bug_2018-02-16-00-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor",
+      "comment": "Improve the packageTypings feature to support triple-slash references to typings",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/api-extractor/pgonzal-ae-default-bug_2018-02-16-00-55.json
+++ b/common/changes/@microsoft/api-extractor/pgonzal-ae-default-bug_2018-02-16-00-55.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor",
+      "comment": "Fix an issue where the packageTypings feature didn't handle some import/export patterns",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor",
+  "email": "pgonzal@users.noreply.github.com"
+}


### PR DESCRIPTION
This fixes various minor issues encountered while migrating a bunch of projects to use the PackageTypingsGenerator:
- Fix a bug where class names were appearing as `default` in certain situations where `symbol.name` is returns `"default"` even though the definition has a name
- Ensure triple-slash references are included in the output *.d.ts file
- Fix a bug where several import/export patterns were not handled correctly
- Fix a bug where `symbolIsExported` was only considered the first time the Entry was encountered
