### PR TITLE
Fix issue with duplicated import statements in generated *.d.ts files

### DIFF
--- a/apps/api-extractor/src/PrettyPrinter.ts
+++ b/apps/api-extractor/src/PrettyPrinter.ts
@@ -65,7 +65,7 @@ export default class PrettyPrinter {
     */
   public static getDeclarationSummary(node: ts.Node): string {
     const rootSpan: Span = new Span(node);
-    rootSpan.modify((span: Span, previousSpan: Span | undefined, parentSpan: Span | undefined) => {
+    rootSpan.forEach((span: Span) => {
       switch (span.kind) {
         case ts.SyntaxKind.JSDocComment:   // strip any code comments
         case ts.SyntaxKind.DeclareKeyword: // strip the "declare" keyword

--- a/apps/api-extractor/src/generators/PackageTypingsGenerator.ts
+++ b/apps/api-extractor/src/generators/PackageTypingsGenerator.ts
@@ -584,7 +584,14 @@ export default class PackageTypingsGenerator {
   private _modifySpan(span: Span, entry: Entry): void {
     const previousSpan: Span | undefined = span.previousSibling;
 
+    let recurseChildren: boolean = true;
+
     switch (span.kind) {
+      case ts.SyntaxKind.JSDocComment:
+        // For now, we don't transform JSDoc comment nodes at all
+        recurseChildren = false;
+        break;
+
       case ts.SyntaxKind.ExportKeyword:
       case ts.SyntaxKind.DefaultKeyword:
       case ts.SyntaxKind.DeclareKeyword:
@@ -660,8 +667,10 @@ export default class PackageTypingsGenerator {
         break;
     }
 
-    for (const child of span.children) {
-      this._modifySpan(child, entry);
+    if (recurseChildren) {
+      for (const child of span.children) {
+        this._modifySpan(child, entry);
+      }
     }
   }
 

--- a/apps/api-extractor/src/generators/Span.ts
+++ b/apps/api-extractor/src/generators/Span.ts
@@ -103,8 +103,6 @@ export class Span {
   // To improve performance, substrings are not allocated until actually needed
   public readonly startIndex: number;
   public readonly endIndex: number;
-  public separatorStartIndex: number;
-  public separatorEndIndex: number;
 
   public readonly children: Span[];
 
@@ -113,12 +111,15 @@ export class Span {
   private _parent: Span | undefined;
   private _previousSibling: Span | undefined;
 
+  private _separatorStartIndex: number;
+  private _separatorEndIndex: number;
+
   public constructor(node: ts.Node) {
     this.node = node;
     this.startIndex = node.getStart();
     this.endIndex = node.end;
-    this.separatorStartIndex = 0;
-    this.separatorEndIndex = 0;
+    this._separatorStartIndex = 0;
+    this._separatorEndIndex = 0;
     this.children = [];
     this.modification = new SpanModification(this);
 
@@ -158,8 +159,8 @@ export class Span {
             }
             separatorRecipient = lastChild;
           }
-          separatorRecipient.separatorStartIndex = previousChildSpan.endIndex;
-          separatorRecipient.separatorEndIndex = childSpan.startIndex;
+          separatorRecipient._separatorStartIndex = previousChildSpan.endIndex;
+          separatorRecipient._separatorEndIndex = childSpan.startIndex;
         }
       }
 
@@ -220,7 +221,7 @@ export class Span {
    * Here we mean "next" according to an inorder traversal, not necessarily a sibling.
    */
   public get separator(): string {
-    return this._getSubstring(this.separatorStartIndex, this.separatorEndIndex);
+    return this._getSubstring(this._separatorStartIndex, this._separatorEndIndex);
   }
 
   /**

--- a/build-tests/api-extractor-test-01/dist/index-internal.d.ts
+++ b/build-tests/api-extractor-test-01/dist/index-internal.d.ts
@@ -148,6 +148,21 @@ export declare class ReexportedClass {
 }
 
 /**
+ * This class has links such as {@link TypeReferencesInAedoc}.
+ * @internal
+ */
+export declare class _TypeReferencesInAedoc {
+    /**
+     * Returns a value
+     * @param arg1 - The input parameter of type {@link TypeReferencesInAedoc}.
+     * @returns An object of type {@link TypeReferencesInAedoc}.
+     */
+    getValue(arg1: _TypeReferencesInAedoc): _TypeReferencesInAedoc;
+    /** {@inheritdoc api-extractor-test-01:TypeReferencesInAedoc.getValue} */
+    getValue2(arg1: _TypeReferencesInAedoc): _TypeReferencesInAedoc;
+}
+
+/**
  * Example decorator
  * @public
  */

--- a/build-tests/api-extractor-test-01/etc/api-extractor-test-01.api.ts
+++ b/build-tests/api-extractor-test-01/etc/api-extractor-test-01.api.ts
@@ -1,3 +1,13 @@
+// WARNING: Unable to find referenced export "api-extractor-test-01:TypeReferencesInAedoc"
+// @internal
+class _TypeReferencesInAedoc {
+  // WARNING: Unable to find referenced export "api-extractor-test-01:TypeReferencesInAedoc"
+  // WARNING: Unable to find referenced export "api-extractor-test-01:TypeReferencesInAedoc"
+  getValue(arg1: TypeReferencesInAedoc): TypeReferencesInAedoc;
+  // WARNING: Unable to find referenced export "api-extractor-test-01:TypeReferencesInAedoc"
+  getValue2(arg1: TypeReferencesInAedoc): TypeReferencesInAedoc;
+}
+
 // @public
 class AbstractClass {
   // (undocumented)

--- a/build-tests/api-extractor-test-01/src/TypeReferencesInAedoc.ts
+++ b/build-tests/api-extractor-test-01/src/TypeReferencesInAedoc.ts
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+/**
+ * This class has links such as {@link TypeReferencesInAedoc}.
+ * @internal
+ */
+export class TypeReferencesInAedoc {
+  /**
+   * Returns a value
+   * @param arg1 - The input parameter of type {@link TypeReferencesInAedoc}.
+   * @returns An object of type {@link TypeReferencesInAedoc}.
+   */
+  public getValue(arg1: TypeReferencesInAedoc): TypeReferencesInAedoc {
+    return this;
+  }
+
+  /** {@inheritdoc api-extractor-test-01:TypeReferencesInAedoc.getValue} */
+  public getValue2(arg1: TypeReferencesInAedoc): TypeReferencesInAedoc {
+    return this;
+  }
+}

--- a/build-tests/api-extractor-test-01/src/index.ts
+++ b/build-tests/api-extractor-test-01/src/index.ts
@@ -96,3 +96,5 @@ export {
   DefaultExportEdgeCase,
   default as ClassExportedAsDefault
 } from './DefaultExportEdgeCase';
+
+export { TypeReferencesInAedoc as _TypeReferencesInAedoc } from './TypeReferencesInAedoc';

--- a/build-tests/api-extractor-test-02/dist/index-internal.d.ts
+++ b/build-tests/api-extractor-test-02/dist/index-internal.d.ts
@@ -19,6 +19,12 @@ export declare interface GenericInterface<T> {
     member: T;
 }
 
+/** @public */
+export declare function importDeduping1(arg1: ISimpleInterface, arg2: ISimpleInterface2): void;
+
+/** @public */
+export declare function importDeduping2(arg1: ISimpleInterface, arg2: ISimpleInterface2): void;
+
 /**
  * A class that inherits from a type defined in the "semver" module imported from \@types/semver.
  * @public

--- a/build-tests/api-extractor-test-02/dist/index-internal.d.ts
+++ b/build-tests/api-extractor-test-02/dist/index-internal.d.ts
@@ -20,23 +20,23 @@ export declare interface GenericInterface<T> {
 }
 
 /** @public */
-export declare function importDeduping1(arg1: ISimpleInterface, arg2: ISimpleInterface2): void;
+export declare function importDeduping1(arg1: ISimpleInterface, arg2: ISimpleInterface): void;
 
 /** @public */
-export declare function importDeduping2(arg1: ISimpleInterface, arg2: ISimpleInterface2): void;
+export declare function importDeduping2(arg1: ISimpleInterface, arg2: ISimpleInterface): void;
 
 /**
  * A class that inherits from a type defined in the "semver" module imported from \@types/semver.
  * @public
  */
-export declare class ImportedModuleAsBaseClass extends semver3.SemVer {
+export declare class ImportedModuleAsBaseClass extends semver1.SemVer {
 }
 
 /**
  * A generic parameter that references the "semver" module imported from \@types/semver.
  * @public
  */
-export declare function importedModuleAsGenericParameter(): GenericInterface<semver2.SemVer> | undefined;
+export declare function importedModuleAsGenericParameter(): GenericInterface<semver1.SemVer> | undefined;
 
 /**
  * This definition references the "semver" module imported from \@types/semver.

--- a/build-tests/api-extractor-test-02/dist/index-internal.d.ts
+++ b/build-tests/api-extractor-test-02/dist/index-internal.d.ts
@@ -10,8 +10,6 @@
 import { ISimpleInterface } from 'api-extractor-test-01';
 import { ReexportedClass } from 'api-extractor-test-01';
 import * as semver1 from 'semver';
-import * as semver2 from 'semver';
-import * as semver3 from 'semver';
 
 /**
  * An interface with a generic parameter.

--- a/build-tests/api-extractor-test-02/etc/api-extractor-test-02.api.ts
+++ b/build-tests/api-extractor-test-02/etc/api-extractor-test-02.api.ts
@@ -4,6 +4,12 @@ interface GenericInterface<T> {
   member: T;
 }
 
+// @public (undocumented)
+export function importDeduping1(arg1: ISimpleInterface, arg2: ISimpleInterface2): void;
+
+// @public (undocumented)
+export function importDeduping2(arg1: ISimpleInterface, arg2: ISimpleInterface2): void;
+
 // @public
 class ImportedModuleAsBaseClass extends semver3.SemVer {
 }

--- a/build-tests/api-extractor-test-02/src/ImportDeduping1.ts
+++ b/build-tests/api-extractor-test-02/src/ImportDeduping1.ts
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+// These should get deduped with the imports from ImportDeduping2.ts
+
+import { ISimpleInterface } from 'api-extractor-test-01';
+import { ISimpleInterface as ISimpleInterface2 } from 'api-extractor-test-01';
+
+/** @public */
+export function importDeduping1(arg1: ISimpleInterface, arg2: ISimpleInterface2): void {
+  console.log('Success');
+}

--- a/build-tests/api-extractor-test-02/src/ImportDeduping2.ts
+++ b/build-tests/api-extractor-test-02/src/ImportDeduping2.ts
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+// These should get deduped with the imports from ImportDeduping1.ts
+
+import { ISimpleInterface as ISimpleInterface2 } from 'api-extractor-test-01';
+import { ISimpleInterface } from 'api-extractor-test-01';
+
+/** @public */
+export function importDeduping2(arg1: ISimpleInterface, arg2: ISimpleInterface2): void {
+  console.log('Success');
+}

--- a/build-tests/api-extractor-test-02/src/index.ts
+++ b/build-tests/api-extractor-test-02/src/index.ts
@@ -14,6 +14,9 @@ export { SubclassWithImport } from './SubclassWithImport';
 
 export * from './TypeFromImportedModule';
 
+export { importDeduping1 } from './ImportDeduping1';
+export { importDeduping2 } from './ImportDeduping2';
+
 import { AmbientConsumer } from 'api-extractor-test-01';
 
 // Test that the ambient types are accessible even though api-extractor-02 doesn't

--- a/common/changes/@microsoft/api-extractor/pgonzal-ae-import-multiplicity_2018-02-17-01-52.json
+++ b/common/changes/@microsoft/api-extractor/pgonzal-ae-import-multiplicity_2018-02-17-01-52.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor",
+      "comment": "Fix several bugs with the way that imports were being deduplicated by the packageTypings feature",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor",
+  "email": "pgonzal@users.noreply.github.com"
+}


### PR DESCRIPTION
This PR improves the way that imports are processed by the packageTypings feature for API Extractor.  For example, these definitions:

```typescript
import * as semver1 from 'semver';
import * as semver2 from 'semver';
import * as semver3 from 'semver';
import { ISimpleInterface } from 'api-extractor-test-01';
import { ISimpleInterface as ISimpleInterface2 } from 'api-extractor-test-01';
```
...will be simplified to this:
```typescript
import * as semver1 from 'semver';
import { ISimpleInterface } from 'api-extractor-test-01';
```
...and all references to these symbols will be automatically fixed up to use the simplified names.

This change required some improvements to the Span class:  It now tracks the parent and previous sibling for each span in the tree.  Also the `Span.modify()` helper was removed, since it turns out to be better for the caller to implement the traversal directly.
