### PR TITLE
Bump PNPM to a version that has bundled dependencies

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -12,6 +12,7 @@ groups:
     conditions:
       files:
         - ".pullapprove.yml"
+        - ".travis.yml"
     required: 1
     users:
       - iclanton
@@ -40,6 +41,10 @@ groups:
         - "core-build/*"
         - "libraries/*"
         - "webpack/*"
+        - "rush.json"
+        - ".gitattributes"
+        - ".gitignore"
+        - "README.md"
     required: 1
     users:
       - iclanton

--- a/rush.json
+++ b/rush.json
@@ -1,6 +1,6 @@
 {
   "rushVersion": "4.2.5",
-  "pnpmVersion": "1.32.1",
+  "pnpmVersion": "1.33.2",
   "nodeSupportedVersionRange": ">=6.9.0 <7.0.0 || >=8.9.4 <9.0.0",
 
   "projectFolderMinDepth": 1,


### PR DESCRIPTION
Bump PNPM to `1.33.2`

* This version has bundled its dependencies, making it far more deterministic and reliable
* This version has removed several dependencies, making it faster to install and execute.