### PR TITLE
Rush should warn about unsupported versions of the NodeJS runtime

### DIFF
--- a/apps/rush-lib/package.json
+++ b/apps/rush-lib/package.json
@@ -6,6 +6,10 @@
     "type": "git",
     "url": "https://github.com/microsoft/web-build-tools"
   },
+  "engines": {
+    "node": ">=5.6.0"
+  },
+  "engineStrict": true,
   "homepage": "http://aka.ms/rush",
   "main": "lib/index.js",
   "typings": "dist/index-internal.d.ts",

--- a/apps/rush-lib/src/start.ts
+++ b/apps/rush-lib/src/start.ts
@@ -4,20 +4,28 @@
 import * as colors from 'colors';
 import * as semver from 'semver';
 
-// check to ensure that we are using a supported version of NodeJS, otherwise write a warning
-if (semver.satisfies(process.versions.node, '< 6.0.0')) {
-  console.error(colors.red(`You are using an outdated version of Node ("${process.versions.node}").`
-    + ` You should upgrade to Node 6 or Node 8.`));
+const nodeVersion: string = process.versions.node;
+
+// We are on an ancient version of NodeJS that is known not to work with Rush
+if (semver.satisfies(nodeVersion, '<= 6.4.0')) {
+  console.error(colors.red(`Your version of Node.js (${nodeVersion}) is very old and incompatible with Rush.`
+    + ` Please upgrade to the latest Long-Term Support (LTS) version.`));
   process.exit(1);
-} else if (semver.satisfies(process.versions.node, '<= 6.4.0')) {
-  console.warn(colors.yellow(`You are using an outdated version of Node ("${process.versions.node}").`
-    + ` You should upgrade to Node >=6.5.0 or Node 8, as some Rush features may not work.`));
-} else if (semver.satisfies(process.versions.node, '^7.0.0')) {
-  console.warn(colors.yellow(`You are using a non-LTS version of Node ("${process.versions.node}").`
-    + ` You should consider upgrading to Node 8 or downgrading to Node 6, as some Rush features may not work.`));
-} else if (semver.satisfies(process.versions.node, '^9.0.0')) {
-  console.warn(colors.yellow(`You are using a new, non-LTS version of Node ("${process.versions.node}").`
-    + ` You should consider downgrading to Node 8, as some Rush features may not work.`));
+}
+
+// We are on a much newer release than we have tested and support
+else if (semver.satisfies(nodeVersion, '>=9.0.0')) {
+  console.warn(colors.yellow(`Your version of Node.js (${nodeVersion}) has not been tested with this release of Rush.`
+    + ` The Rush team will not accept issue reports for it.`
+    + ` Please consider upgrading Rush or downgrading Node.js.`));
+}
+
+// We are not on an LTS release
+else if (!semver.satisfies(nodeVersion, '^6.9.0')
+      && !semver.satisfies(nodeVersion, '^8.9.0')) {
+  console.warn(colors.yellow(`Your version of Node.js (${nodeVersion}) is not a Long-Term Support (LTS) release.`
+    + ` These versions frequently contain bugs, and the Rush team will not accept issue reports for them.`
+    + ` Please consider installing a stable release.`));
 }
 
 import Rush from './Rush';

--- a/apps/rush-lib/src/start.ts
+++ b/apps/rush-lib/src/start.ts
@@ -1,6 +1,25 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
+import * as colors from 'colors';
+import * as semver from 'semver';
+
+// check to ensure that we are using a supported version of NodeJS, otherwise write a warning
+if (semver.satisfies(process.versions.node, '< 6.0.0')) {
+  console.error(colors.red(`You are using an outdated version of Node ("${process.versions.node}").`
+    + ` You should upgrade to Node 6 or Node 8.`));
+  process.exit(1);
+} else if (semver.satisfies(process.versions.node, '<= 6.4.0')) {
+  console.warn(colors.yellow(`You are using an outdated version of Node ("${process.versions.node}").`
+    + ` You should upgrade to Node >=6.5.0 or Node 8, as some Rush features may not work.`));
+} else if (semver.satisfies(process.versions.node, '^7.0.0')) {
+  console.warn(colors.yellow(`You are using a non-LTS version of Node ("${process.versions.node}").`
+    + ` You should consider upgrading to Node 8 or downgrading to Node 6, as some Rush features may not work.`));
+} else if (semver.satisfies(process.versions.node, '^9.0.0')) {
+  console.warn(colors.yellow(`You are using a new, non-LTS version of Node ("${process.versions.node}").`
+    + ` You should consider downgrading to Node 8, as some Rush features may not work.`));
+}
+
 import Rush from './Rush';
 
 Rush.launch(Rush.version, false);

--- a/apps/rush-lib/src/start.ts
+++ b/apps/rush-lib/src/start.ts
@@ -6,6 +6,8 @@ import * as semver from 'semver';
 
 const nodeVersion: string = process.versions.node;
 
+// tslint:disable-next-line
+
 // We are on an ancient version of NodeJS that is known not to work with Rush
 if (semver.satisfies(nodeVersion, '<= 6.4.0')) {
   console.error(colors.red(`Your version of Node.js (${nodeVersion}) is very old and incompatible with Rush.`
@@ -14,6 +16,7 @@ if (semver.satisfies(nodeVersion, '<= 6.4.0')) {
 }
 
 // We are on a much newer release than we have tested and support
+// tslint:disable-next-line
 else if (semver.satisfies(nodeVersion, '>=9.0.0')) {
   console.warn(colors.yellow(`Your version of Node.js (${nodeVersion}) has not been tested with this release of Rush.`
     + ` The Rush team will not accept issue reports for it.`
@@ -21,6 +24,7 @@ else if (semver.satisfies(nodeVersion, '>=9.0.0')) {
 }
 
 // We are not on an LTS release
+// tslint:disable-next-line
 else if (!semver.satisfies(nodeVersion, '^6.9.0')
       && !semver.satisfies(nodeVersion, '^8.9.0')) {
   console.warn(colors.yellow(`Your version of Node.js (${nodeVersion}) is not a Long-Term Support (LTS) release.`

--- a/apps/rush/package.json
+++ b/apps/rush/package.json
@@ -17,6 +17,10 @@
     "type": "git",
     "url": "https://github.com/microsoft/web-build-tools"
   },
+  "engines": {
+    "node": ">=5.6.0"
+  },
+  "engineStrict": true,
   "homepage": "http://aka.ms/rush",
   "scripts": {
     "build": "gulp test --clean"

--- a/common/changes/@microsoft/rush/nickpape-rush-warn-on-unsupported-node_2018-02-22-02-18.json
+++ b/common/changes/@microsoft/rush/nickpape-rush-warn-on-unsupported-node_2018-02-22-02-18.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Add a notice for unsupported versions of NodeJS runtime",
+      "packageName": "@microsoft/rush",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "nickpape-msft@users.noreply.github.com"
+}


### PR DESCRIPTION
* Versions <6 will fail, since they don't support all of es6
* Versions >=6.0.0 <=6.4.0 may fail, since they don't support all of es6
* Versions ^7.0.0 are non-LTS, and are not officially supported but should work.
* Versions ^9.0.0 are non-LTS, and are not officially supported.