### PR TITLE
Rush: reduce how often we need to run generate

### DIFF
--- a/apps/rush-lib/src/cli/logic/InstallManager.ts
+++ b/apps/rush-lib/src/cli/logic/InstallManager.ts
@@ -386,7 +386,7 @@ export default class InstallManager {
         tempPackageJson.dependencies![pair.packageName] = pair.packageVersion;
 
         if (shrinkwrapFile) {
-          if (!shrinkwrapFile.hasCompatibleDependency(pair.packageName, pair.packageVersion,
+          if (!shrinkwrapFile.tryEnsureCompatibleDependency(pair.packageName, pair.packageVersion,
             rushProject.tempProjectName)) {
             console.log(colors.yellow(
               wrap(`${os.EOL}The NPM shrinkwrap file is missing "${pair.packageName}"`

--- a/apps/rush-lib/src/cli/logic/InstallManager.ts
+++ b/apps/rush-lib/src/cli/logic/InstallManager.ts
@@ -268,11 +268,6 @@ export default class InstallManager {
       }
     }
 
-    // Either way, resync the temporary shrinkwrap file.
-    // Copy (or delete) common\npm-shrinkwrap.json --> common\temp\npm-shrinkwrap.json
-    this.syncFile(this._rushConfiguration.committedShrinkwrapFilename,
-      this._rushConfiguration.tempShrinkwrapFilename);
-
     // Also copy down the committed .npmrc file, if there is one
     // "common\config\rush\.npmrc" --> "common\temp\.npmrc"
     const committedNpmrcPath: string = path.join(this._rushConfiguration.commonRushConfigFolder, '.npmrc');
@@ -468,6 +463,14 @@ export default class InstallManager {
     // Example: "C:\MyRepo\common\temp\package.json"
     const commonPackageJsonFilename: string = path.join(this._rushConfiguration.commonTempFolder,
       RushConstants.packageJsonFilename);
+
+    if (shrinkwrapFile) {
+      // Resync the temporary shrinkwrap file.
+      // Copy (or delete) common\npm-shrinkwrap.json --> common\temp\npm-shrinkwrap.json
+      shrinkwrapFile.save(this._rushConfiguration.tempShrinkwrapFilename);
+    } else {
+      fsx.removeSync(this._rushConfiguration.tempShrinkwrapFilename);
+    }
 
     // Don't update the file timestamp unless the content has changed, since "rush install"
     // will consider this timestamp

--- a/apps/rush-lib/src/cli/logic/base/BaseShrinkwrapFile.ts
+++ b/apps/rush-lib/src/cli/logic/base/BaseShrinkwrapFile.ts
@@ -47,8 +47,8 @@ export abstract class BaseShrinkwrapFile {
    * Returns true if the shrinkwrap file includes a package that would satisfiying the specified
    * package name and SemVer version range for a given temp project.
    */
-  public hasCompatibleDependency(dependencyName: string, versionRange: string, tempProjectName: string): boolean {
-    const dependencyVersion: string | undefined = this.getDependencyVersion(dependencyName, tempProjectName);
+  public tryEnsureCompatibleDependency(dependencyName: string, versionRange: string, tempProjectName: string): boolean {
+    const dependencyVersion: string | undefined = this.tryEnsureDependencyVersion(dependencyName, tempProjectName);
     if (!dependencyVersion) {
       return false;
     }
@@ -62,7 +62,7 @@ export abstract class BaseShrinkwrapFile {
    */
   public abstract getTempProjectNames(): ReadonlyArray<string>;
 
-  protected abstract getDependencyVersion(dependencyName: string, tempProjectName?: string): string | undefined;
+  protected abstract tryEnsureDependencyVersion(dependencyName: string, tempProjectName?: string): string | undefined;
   protected abstract getTopLevelDependencyVersion(dependencyName: string): string | undefined;
   protected abstract serialize(): string;
 

--- a/apps/rush-lib/src/cli/logic/base/BaseShrinkwrapFile.ts
+++ b/apps/rush-lib/src/cli/logic/base/BaseShrinkwrapFile.ts
@@ -77,7 +77,7 @@ export abstract class BaseShrinkwrapFile {
   public abstract getTempProjectNames(): ReadonlyArray<string>;
 
   protected abstract tryEnsureDependencyVersion(dependencyName: string,
-    tempProjectName: string | undefined, versionRange: string | undefined): string | undefined;
+    tempProjectName: string, versionRange: string): string | undefined;
   protected abstract getTopLevelDependencyVersion(dependencyName: string): string | undefined;
   protected abstract serialize(): string;
 

--- a/apps/rush-lib/src/cli/logic/base/BaseShrinkwrapFile.ts
+++ b/apps/rush-lib/src/cli/logic/base/BaseShrinkwrapFile.ts
@@ -2,6 +2,7 @@
 // See LICENSE in the project root for license information.
 
 import * as colors from 'colors';
+import * as fsx from 'fs-extra';
 import * as semver from 'semver';
 import npmPackageArg = require('npm-package-arg');
 
@@ -19,6 +20,13 @@ export abstract class BaseShrinkwrapFile {
       return dictionary[key];
     }
     return undefined;
+  }
+
+  /**
+   * Serializes and saves the shrinkwrap file to specified location
+   */
+  public save(filePath: string): void {
+    fsx.writeFileSync(filePath, this.serialize());
   }
 
   /**
@@ -56,6 +64,7 @@ export abstract class BaseShrinkwrapFile {
 
   protected abstract getDependencyVersion(dependencyName: string, tempProjectName?: string): string | undefined;
   protected abstract getTopLevelDependencyVersion(dependencyName: string): string | undefined;
+  protected abstract serialize(): string;
 
   protected _getTempProjectNames(dependencies: { [key: string]: {} } ): ReadonlyArray<string> {
     const result: string[] = [];

--- a/apps/rush-lib/src/cli/logic/base/BaseShrinkwrapFile.ts
+++ b/apps/rush-lib/src/cli/logic/base/BaseShrinkwrapFile.ts
@@ -45,7 +45,20 @@ export abstract class BaseShrinkwrapFile {
 
   /**
    * Returns true if the shrinkwrap file includes a package that would satisfiying the specified
-   * package name and SemVer version range for a given temp project.
+   * package name and SemVer version range.  By default, the dependencies are resolved by looking
+   * at the root of the node_modules folder described by the shrinkwrap file.  However, if
+   * tempProjectName is specified, then the resolution will start in that subfolder.
+   *
+   * Consider this example:
+   *
+   * - node_modules\
+   *   - temp-project\
+   *     - lib-a@1.2.3
+   *     - lib-b@1.0.0
+   *   - lib-b@2.0.0
+   *
+   * In this example, hasCompatibleDependency("lib-b", ">= 1.1.0", "temp-project") would fail
+   * because it finds lib-b@1.0.0 which does not satisfy the pattern ">= 1.1.0".
    */
   public tryEnsureCompatibleDependency(dependencyName: string, versionRange: string, tempProjectName: string): boolean {
     const dependencyVersion: string | undefined =

--- a/apps/rush-lib/src/cli/logic/base/BaseShrinkwrapFile.ts
+++ b/apps/rush-lib/src/cli/logic/base/BaseShrinkwrapFile.ts
@@ -48,7 +48,8 @@ export abstract class BaseShrinkwrapFile {
    * package name and SemVer version range for a given temp project.
    */
   public tryEnsureCompatibleDependency(dependencyName: string, versionRange: string, tempProjectName: string): boolean {
-    const dependencyVersion: string | undefined = this.tryEnsureDependencyVersion(dependencyName, tempProjectName);
+    const dependencyVersion: string | undefined =
+      this.tryEnsureDependencyVersion(dependencyName, tempProjectName, versionRange);
     if (!dependencyVersion) {
       return false;
     }
@@ -62,7 +63,8 @@ export abstract class BaseShrinkwrapFile {
    */
   public abstract getTempProjectNames(): ReadonlyArray<string>;
 
-  protected abstract tryEnsureDependencyVersion(dependencyName: string, tempProjectName?: string): string | undefined;
+  protected abstract tryEnsureDependencyVersion(dependencyName: string,
+    tempProjectName: string | undefined, versionRange: string | undefined): string | undefined;
   protected abstract getTopLevelDependencyVersion(dependencyName: string): string | undefined;
   protected abstract serialize(): string;
 

--- a/apps/rush-lib/src/cli/logic/npm/NpmShrinkwrapFile.ts
+++ b/apps/rush-lib/src/cli/logic/npm/NpmShrinkwrapFile.ts
@@ -2,6 +2,10 @@ import * as fsx from 'fs-extra';
 import * as os from 'os';
 
 import {
+  JsonFile
+} from '@microsoft/node-core-library';
+
+import {
   BaseShrinkwrapFile
 } from '../base/BaseShrinkwrapFile';
 
@@ -46,11 +50,11 @@ export class NpmShrinkwrapFile extends BaseShrinkwrapFile {
   }
 
   protected serialize(): string {
-    return JSON.stringify(this._shrinkwrapJson, undefined, 2);
+    return JsonFile.stringify(this._shrinkwrapJson);
   }
 
   protected getTopLevelDependencyVersion(dependencyName: string): string | undefined {
-    return this.tryEnsureDependencyVersion(dependencyName);
+    return this.tryEnsureDependencyVersion(dependencyName, undefined, undefined);
   }
 
   /**
@@ -70,7 +74,9 @@ export class NpmShrinkwrapFile extends BaseShrinkwrapFile {
    * In this example, hasCompatibleDependency("lib-b", ">= 1.1.0", "temp-project") would fail
    * because it finds lib-b@1.0.0 which does not satisfy the pattern ">= 1.1.0".
    */
-  protected tryEnsureDependencyVersion(dependencyName: string, tempProjectName?: string): string | undefined {
+  protected tryEnsureDependencyVersion(dependencyName: string,
+    tempProjectName: string | undefined,
+    versionRange: string | undefined): string | undefined {
 
     // First, check under tempProjectName, as this is the first place "rush link" looks.
     let dependencyJson: IShrinkwrapDependencyJson | undefined = undefined;

--- a/apps/rush-lib/src/cli/logic/npm/NpmShrinkwrapFile.ts
+++ b/apps/rush-lib/src/cli/logic/npm/NpmShrinkwrapFile.ts
@@ -50,7 +50,7 @@ export class NpmShrinkwrapFile extends BaseShrinkwrapFile {
   }
 
   protected getTopLevelDependencyVersion(dependencyName: string): string | undefined {
-    return this.getDependencyVersion(dependencyName);
+    return this.tryEnsureDependencyVersion(dependencyName);
   }
 
   /**
@@ -70,7 +70,7 @@ export class NpmShrinkwrapFile extends BaseShrinkwrapFile {
    * In this example, hasCompatibleDependency("lib-b", ">= 1.1.0", "temp-project") would fail
    * because it finds lib-b@1.0.0 which does not satisfy the pattern ">= 1.1.0".
    */
-  protected getDependencyVersion(dependencyName: string, tempProjectName?: string): string | undefined {
+  protected tryEnsureDependencyVersion(dependencyName: string, tempProjectName?: string): string | undefined {
 
     // First, check under tempProjectName, as this is the first place "rush link" looks.
     let dependencyJson: IShrinkwrapDependencyJson | undefined = undefined;

--- a/apps/rush-lib/src/cli/logic/npm/NpmShrinkwrapFile.ts
+++ b/apps/rush-lib/src/cli/logic/npm/NpmShrinkwrapFile.ts
@@ -58,21 +58,9 @@ export class NpmShrinkwrapFile extends BaseShrinkwrapFile {
   }
 
   /**
-   * Returns true if the shrinkwrap file includes a package that would satisfiying the specified
-   * package name and SemVer version range.  By default, the dependencies are resolved by looking
-   * at the root of the node_modules folder described by the shrinkwrap file.  However, if
-   * tempProjectName is specified, then the resolution will start in that subfolder.
-   *
-   * Consider this example:
-   *
-   * - node_modules\
-   *   - temp-project\
-   *     - lib-a@1.2.3
-   *     - lib-b@1.0.0
-   *   - lib-b@2.0.0
-   *
-   * In this example, hasCompatibleDependency("lib-b", ">= 1.1.0", "temp-project") would fail
-   * because it finds lib-b@1.0.0 which does not satisfy the pattern ">= 1.1.0".
+   * @param dependencyName the name of the dependency to get a version for
+   * @param tempProjectName the name of the temp project to check for this dependency
+   * @param versionRange Not used, just exists to satisfy abstract API contract
    */
   protected tryEnsureDependencyVersion(dependencyName: string,
     tempProjectName: string | undefined,

--- a/apps/rush-lib/src/cli/logic/npm/NpmShrinkwrapFile.ts
+++ b/apps/rush-lib/src/cli/logic/npm/NpmShrinkwrapFile.ts
@@ -45,6 +45,10 @@ export class NpmShrinkwrapFile extends BaseShrinkwrapFile {
     return this._getTempProjectNames(this._shrinkwrapJson.dependencies);
   }
 
+  protected serialize(): string {
+    return JSON.stringify(this._shrinkwrapJson, undefined, 2);
+  }
+
   protected getTopLevelDependencyVersion(dependencyName: string): string | undefined {
     return this.getDependencyVersion(dependencyName);
   }

--- a/apps/rush-lib/src/cli/logic/pnpm/PnpmShrinkwrapFile.ts
+++ b/apps/rush-lib/src/cli/logic/pnpm/PnpmShrinkwrapFile.ts
@@ -116,6 +116,16 @@ export class PnpmShrinkwrapFile extends BaseShrinkwrapFile {
 
   /**
    * abstract
+   * Serializes the PNPM Shrinkwrap file
+   */
+  protected serialize(): string {
+    return yaml.safeDump(this._shrinkwrapJson, {
+      sortKeys: true
+    });
+  }
+
+  /**
+   * abstract
    * Gets the version number from the list of top-level dependencies in the "dependencies" section
    * of the shrinkwrap file
    */
@@ -126,7 +136,8 @@ export class PnpmShrinkwrapFile extends BaseShrinkwrapFile {
   /**
    * abstract
    * Gets the resolved version number of a dependency for a specific temp project.
-   * For PNPM, we can reuse the version that another project is using
+   * For PNPM, we can reuse the version that another project is using.
+   * Note that this function modifies the shrinkwrap data.
    */
   protected getDependencyVersion(dependencyName: string,
     tempProjectName: string,
@@ -167,6 +178,8 @@ export class PnpmShrinkwrapFile extends BaseShrinkwrapFile {
         });
 
         if (latestVersion !== '0.0.0') {
+          // go ahead and fixup the shrinkwrap file to point at this
+          this._shrinkwrapJson.packages[tempProjectDependencyKey].dependencies[dependencyName] = latestVersion;
           return latestVersion;
         }
       }

--- a/apps/rush-lib/src/cli/logic/pnpm/PnpmShrinkwrapFile.ts
+++ b/apps/rush-lib/src/cli/logic/pnpm/PnpmShrinkwrapFile.ts
@@ -139,7 +139,7 @@ export class PnpmShrinkwrapFile extends BaseShrinkwrapFile {
    * For PNPM, we can reuse the version that another project is using.
    * Note that this function modifies the shrinkwrap data.
    */
-  protected getDependencyVersion(dependencyName: string,
+  protected tryEnsureDependencyVersion(dependencyName: string,
     tempProjectName: string,
     checkOtherProjects: boolean = true): string | undefined {
     // PNPM doesn't have the same advantage of NPM, where we can skip generate as long as the
@@ -169,7 +169,8 @@ export class PnpmShrinkwrapFile extends BaseShrinkwrapFile {
         let latestVersion: string = minimumVersion;
 
         this.getTempProjectNames().forEach((otherTempProject: string) => {
-          const otherVersion: string | undefined = this.getDependencyVersion(dependencyName, otherTempProject, false);
+          const otherVersion: string | undefined =
+            this.tryEnsureDependencyVersion(dependencyName, otherTempProject, false);
           if (otherVersion) {
             if (semver.gt(otherVersion, latestVersion)) {
               latestVersion = otherVersion;

--- a/apps/rush-lib/src/cli/logic/pnpm/PnpmShrinkwrapFile.ts
+++ b/apps/rush-lib/src/cli/logic/pnpm/PnpmShrinkwrapFile.ts
@@ -152,7 +152,6 @@ export class PnpmShrinkwrapFile extends BaseShrinkwrapFile {
       throw new Error(`Program Bug: PNPM tryEnsureDependencyVersion() requires a tempProjectName`);
     }
 
-
     // Example: "project1"
     const unscopedTempProjectName: string = Utilities.parseScopedPackageName(tempProjectName).name;
     const tempProjectDependencyKey: string = `file:projects/${unscopedTempProjectName}.tgz`;

--- a/apps/rush-lib/src/cli/logic/test/ShrinkwrapFile.test.ts
+++ b/apps/rush-lib/src/cli/logic/test/ShrinkwrapFile.test.ts
@@ -18,9 +18,9 @@ describe('npm ShrinkwrapFile', () => {
 
   it('verifies temp project dependencies', () => {
     // Found locally
-    assert.isTrue(shrinkwrapFile.hasCompatibleDependency('jquery', '>=2.2.4 <3.0.0', '@rush-temp/project2'));
+    assert.isTrue(shrinkwrapFile.tryEnsureCompatibleDependency('jquery', '>=2.2.4 <3.0.0', '@rush-temp/project2'));
     // Found at root
-    assert.isTrue(shrinkwrapFile.hasCompatibleDependency('q', '~1.5.0', '@rush-temp/project2'));
+    assert.isTrue(shrinkwrapFile.tryEnsureCompatibleDependency('q', '~1.5.0', '@rush-temp/project2'));
   });
 
   it('extracts temp projects successfully', () => {
@@ -40,9 +40,9 @@ const shrinkwrapFile: BaseShrinkwrapFile = ShrinkwrapFileFactory.getShrinkwrapFi
   });
 
   it('verifies temp project dependencies', () => {
-    assert.isTrue(shrinkwrapFile.hasCompatibleDependency('jquery', '>=2.0.0 <3.0.0', '@rush-temp/project1'));
-    assert.isTrue(shrinkwrapFile.hasCompatibleDependency('q', '~1.5.0', '@rush-temp/project2'));
-    assert.isFalse(shrinkwrapFile.hasCompatibleDependency('left-pad', '~9.9.9', '@rush-temp/project1'));
+    assert.isTrue(shrinkwrapFile.tryEnsureCompatibleDependency('jquery', '>=2.0.0 <3.0.0', '@rush-temp/project1'));
+    assert.isTrue(shrinkwrapFile.tryEnsureCompatibleDependency('q', '~1.5.0', '@rush-temp/project2'));
+    assert.isFalse(shrinkwrapFile.tryEnsureCompatibleDependency('left-pad', '~9.9.9', '@rush-temp/project1'));
   });
 
   it('extracts temp projects successfully', () => {
@@ -52,7 +52,7 @@ const shrinkwrapFile: BaseShrinkwrapFile = ShrinkwrapFileFactory.getShrinkwrapFi
   });
 
   it('can reuse the latest version that another temp package is providing', () => {
-    assert.isTrue(shrinkwrapFile.hasCompatibleDependency('jquery', '>=2.0.0 <3.0.0', '@rush-temp/project3'));
+    assert.isTrue(shrinkwrapFile.tryEnsureCompatibleDependency('jquery', '>=2.0.0 <3.0.0', '@rush-temp/project3'));
   });
 });
 

--- a/apps/rush-lib/src/cli/logic/test/ShrinkwrapFile.test.ts
+++ b/apps/rush-lib/src/cli/logic/test/ShrinkwrapFile.test.ts
@@ -26,7 +26,7 @@ describe('npm ShrinkwrapFile', () => {
   it('extracts temp projects successfully', () => {
     const tempProjectNames: ReadonlyArray<string> = shrinkwrapFile.getTempProjectNames();
 
-    assert.deepEqual(tempProjectNames, ['@rush-temp/project1', '@rush-temp/project2']);
+    assert.deepEqual(tempProjectNames, ['@rush-temp/project1', '@rush-temp/project2' ]);
   });
 });
 
@@ -36,7 +36,6 @@ const filename: string = path.resolve(path.join(
 const shrinkwrapFile: BaseShrinkwrapFile = ShrinkwrapFileFactory.getShrinkwrapFile('pnpm', filename)!;
 
   it('verifies root-level dependency', () => {
-    assert.isTrue(shrinkwrapFile.hasCompatibleTopLevelDependency('jquery', '>=2.0.0 <3.0.0'));
     assert.isFalse(shrinkwrapFile.hasCompatibleTopLevelDependency('q', '~1.5.0'));
   });
 
@@ -49,7 +48,11 @@ const shrinkwrapFile: BaseShrinkwrapFile = ShrinkwrapFileFactory.getShrinkwrapFi
   it('extracts temp projects successfully', () => {
     const tempProjectNames: ReadonlyArray<string> = shrinkwrapFile.getTempProjectNames();
 
-    assert.deepEqual(tempProjectNames, ['@rush-temp/project1', '@rush-temp/project2']);
+    assert.deepEqual(tempProjectNames, ['@rush-temp/project1', '@rush-temp/project2', '@rush-temp/project3']);
+  });
+
+  it('can reuse the latest version that another temp package is providing', () => {
+    assert.isTrue(shrinkwrapFile.hasCompatibleDependency('jquery', '>=2.0.0 <3.0.0', '@rush-temp/project3'));
   });
 });
 

--- a/apps/rush-lib/src/cli/logic/test/shrinkwrapFile/shrinkwrap.yaml
+++ b/apps/rush-lib/src/cli/logic/test/shrinkwrapFile/shrinkwrap.yaml
@@ -1,9 +1,12 @@
 dependencies:
   '@rush-temp/project1': 'file:./projects/project1.tgz'
   '@rush-temp/project2': 'file:./projects/project2.tgz'
-  jquery: 2.9.9
+  '@rush-temp/project3': 'file:./projects/project3.tgz'
 packages:
-  /jquery/2.2.2:
+  /jquery/1.0.0:
+    resolution:
+      integrity: sha1-PjAtxh6zKaIenvrJN9cx8GETTFk=
+  /jquery/2.9.9:
     resolution:
       integrity: sha1-PjAtxh6zKaIenvrJN9cx8GETTFk=
   /q/1.5.3:
@@ -18,10 +21,14 @@ packages:
   'file:projects/project2.tgz':
     dependencies:
       q: 1.5.3
+      jquery: 1.0.0
+  'file:projects/project3.tgz':
+    dependencies:
+      q: 1.5.3
 registry: 'http://localhost:4873/'
 shrinkwrapVersion: 3
 specifiers:
   '@rush-temp/project1': 'file:./projects/project1.tgz'
   '@rush-temp/project2': 'file:./projects/project2.tgz'
-  jquery: '>=2.2.4 <3.0.0'
+  '@rush-temp/project3': 'file:./projects/project3.tgz'
   q: '~1.5.0'

--- a/common/changes/@microsoft/rush/nickpape-rush-no-generate_2018-02-24-01-58.json
+++ b/common/changes/@microsoft/rush/nickpape-rush-no-generate_2018-02-24-01-58.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "When using PNPM, Rush will check and see if other projects are using a dependency and will re-use it if possible. This way, a user will not have to run \"rush generate\" if they are adding a dependency that is already being used elsewhere in the monorepo.",
+      "packageName": "@microsoft/rush",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "nickpape-msft@users.noreply.github.com"
+}


### PR DESCRIPTION
In NPM-land, we used to check to see if a dependency at the root of the node_modules satisfied a dependency described in package.json. This worked because NPM describes the folder structure, as opposed to PNPM, which describes the dependency graph.

With the initial release of PNPM, we lost this heuristic. PNPM only installs what is in the shrinkwrap, regardless of what is in the package.json.

The solution is to modify the temp shrinkwrap file and add the missing dependency, but only if it is being reused by another Rush project.

There are 2 major changes:

1. When we are checking that the dependencies are satisfied by the shrinkwrap, if a dependency is missing from a project, we check all the other projects and collect the versions of the dependency that are being used. We then use the newest version other packages are using as the version that we check against.

2. We add this "newest version being used by other packages" to the shrinkwrap file before running the install.

This may cause issues with peer dependencies.