### PR TITLE
Pin karma-webpack to 3.0.9

### DIFF
--- a/common/changes/@microsoft/gulp-core-build-karma/nickpape-pin-karma-webpack_2018-02-27-19-44.json
+++ b/common/changes/@microsoft/gulp-core-build-karma/nickpape-pin-karma-webpack_2018-02-27-19-44.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/gulp-core-build-karma",
+      "comment": "Pin karma-webpack to 3.0.9, since the latest 3.0.12 has an issue with a missing dependency in package.json, which causes pnpm installs to fail.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/gulp-core-build-karma",
+  "email": "nickpape-msft@users.noreply.github.com"
+}

--- a/core-build/gulp-core-build-karma/package.json
+++ b/core-build/gulp-core-build-karma/package.json
@@ -24,7 +24,7 @@
     "karma-mocha-clean-reporter": "~0.0.1",
     "karma-phantomjs-launcher": "~1.0.0",
     "karma-sinon-chai": "~1.2.0",
-    "karma-webpack": "~2.0.4",
+    "karma-webpack": "2.0.9",
     "lolex": "~1.4.0",
     "mocha": "~3.4.2",
     "phantomjs-polyfill": "~0.0.2",


### PR DESCRIPTION
3.0.12 has missing dependencies in it's package.json (on babel-runtime), which is causing pnpm installations to fail. Since we are deprecating karma, the easiest fix is to simply pin karma-webpack to a working version.