### PR TITLE
Add a "--conservative" flag for "rush generate"

### DIFF
--- a/apps/rush-lib/src/cli/actions/GenerateAction.ts
+++ b/apps/rush-lib/src/cli/actions/GenerateAction.ts
@@ -92,6 +92,10 @@ export default class GenerateAction extends BaseRushAction {
         + ' because its algorithm always performs a clean installation.'));
     }
 
+    if (this._conservativeParameter.value && this.rushConfiguration.packageManager !== 'pnpm') {
+      throw new Error(`The --conservative flag is only supported for pnpm.`);
+    }
+
     ApprovedPackagesChecker.rewriteConfigFiles(this.rushConfiguration);
 
     const installManager: InstallManager = new InstallManager(this.rushConfiguration);

--- a/common/changes/@microsoft/rush/pgonzal-rush-conservative-generate_2018-03-02-00-20.json
+++ b/common/changes/@microsoft/rush/pgonzal-rush-conservative-generate_2018-03-02-00-20.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Add a new command-line flag \"--conservative\" which causes \"rush generate\" to perform a minimal upgrade",
+      "packageName": "@microsoft/rush",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush/pgonzal-rush-conservative-generate_2018-03-02-00-50.json
+++ b/common/changes/@microsoft/rush/pgonzal-rush-conservative-generate_2018-03-02-00-50.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Improved \"rush generate\" so that if interrupted, it does not leave you with a deleted shrinkwrap.yaml; the new integrity checks eliminate the need for this, and it was annoying",
+      "packageName": "@microsoft/rush",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "pgonzal@users.noreply.github.com"
+}


### PR DESCRIPTION
Scenario:

1. A person adds a new dependency to their project's `package.json`
2. This requires them to run `rush generate`

Normally this also forces an upgrade of all SemVer range dependencies in shrinkwrap.yaml, which frequently requires the person to fix compatibility issues unrelated to their change.

This is unnecessary for repos that already handle these upgrades automatically in a separate branch.  This PR introduces a new switch "--conservative" that causes PNPM to upgrade only the minimal set of dependencies required to satisfy your `package.json` changes.

**NOTE:** This change requires pnpm-1.35.2 with the fix for https://github.com/pnpm/pnpm/issues/1054
