### PR TITLE
(api-extractor) Add preliminary support for generating public/preview *.d.ts outputs

### DIFF
--- a/apps/api-extractor/.vscode/launch.json
+++ b/apps/api-extractor/.vscode/launch.json
@@ -4,13 +4,13 @@
   // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
   "version": "0.2.0",
   "configurations": [
+
     {
       "type": "node",
       "request": "launch",
       "name": "test-01",
       "program": "${workspaceFolder}/lib/start.js",
       "cwd": "${workspaceFolder}/../../build-tests/api-extractor-test-01",
-      "sourceMaps": false,
       "args": [
         "run",
         "-l"
@@ -22,7 +22,17 @@
       "name": "test-02",
       "program": "${workspaceFolder}/lib/start.js",
       "cwd": "${workspaceFolder}/../../build-tests/api-extractor-test-02",
-      "sourceMaps": false,
+      "args": [
+        "run",
+        "-l"
+      ]
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "test-04",
+      "program": "${workspaceFolder}/lib/start.js",
+      "cwd": "${workspaceFolder}/../../build-tests/api-extractor-test-04",
       "args": [
         "run",
         "-l"

--- a/apps/api-extractor/src/extractor/Extractor.ts
+++ b/apps/api-extractor/src/extractor/Extractor.ts
@@ -345,15 +345,15 @@ export class Extractor {
 
       this._generateTypingsFile(packageTypingsGenerator,
         this.actualConfig.packageTypings.dtsFilePathForInternal!,
-        PackageTypingsDtsKind.internalRelease);
+        PackageTypingsDtsKind.InternalRelease);
 
       this._generateTypingsFile(packageTypingsGenerator,
         this.actualConfig.packageTypings.dtsFilePathForPreview!,
-        PackageTypingsDtsKind.previewRelease);
+        PackageTypingsDtsKind.PreviewRelease);
 
       this._generateTypingsFile(packageTypingsGenerator,
         this.actualConfig.packageTypings.dtsFilePathForPublic!,
-        PackageTypingsDtsKind.publicRelease);
+        PackageTypingsDtsKind.PublicRelease);
       }
 
     if (this._localBuild) {

--- a/apps/api-extractor/src/extractor/Extractor.ts
+++ b/apps/api-extractor/src/extractor/Extractor.ts
@@ -344,17 +344,17 @@ export class Extractor {
       packageTypingsGenerator.analyze();
 
       this._generateTypingsFile(packageTypingsGenerator,
-        this.actualConfig.packageTypings.dtsFilePathForInternal!,
-        PackageTypingsDtsKind.InternalRelease);
+        this.actualConfig.packageTypings.dtsFilePathForPublic!,
+        PackageTypingsDtsKind.PublicRelease);
 
       this._generateTypingsFile(packageTypingsGenerator,
         this.actualConfig.packageTypings.dtsFilePathForPreview!,
         PackageTypingsDtsKind.PreviewRelease);
 
       this._generateTypingsFile(packageTypingsGenerator,
-        this.actualConfig.packageTypings.dtsFilePathForPublic!,
-        PackageTypingsDtsKind.PublicRelease);
-      }
+        this.actualConfig.packageTypings.dtsFilePathForInternal!,
+        PackageTypingsDtsKind.InternalRelease);
+    }
 
     if (this._localBuild) {
       // For a local build, fail if there were errors (but ignore warnings)

--- a/apps/api-extractor/src/extractor/Extractor.ts
+++ b/apps/api-extractor/src/extractor/Extractor.ts
@@ -346,7 +346,15 @@ export class Extractor {
       this._generateTypingsFile(packageTypingsGenerator,
         this.actualConfig.packageTypings.dtsFilePathForInternal!,
         PackageTypingsDtsKind.internalRelease);
-    }
+
+      this._generateTypingsFile(packageTypingsGenerator,
+        this.actualConfig.packageTypings.dtsFilePathForPreview!,
+        PackageTypingsDtsKind.previewRelease);
+
+      this._generateTypingsFile(packageTypingsGenerator,
+        this.actualConfig.packageTypings.dtsFilePathForPublic!,
+        PackageTypingsDtsKind.publicRelease);
+      }
 
     if (this._localBuild) {
       // For a local build, fail if there were errors (but ignore warnings)

--- a/apps/api-extractor/src/generators/packageTypings/Entry.ts
+++ b/apps/api-extractor/src/generators/packageTypings/Entry.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
+import { ReleaseTag } from '../../aedoc/ReleaseTag';
 import * as ts from 'typescript';
 
 /**
@@ -13,6 +14,7 @@ export interface IEntryParameters {
   importPackagePath: string | undefined;
   importPackageExportName: string | undefined;
   importPackageKey: string | undefined;
+  releaseTag: ReleaseTag;
 }
 
 /**
@@ -80,6 +82,11 @@ export class Entry {
   public readonly importPackageKey: string | undefined;
 
   /**
+   * The release tag parsed from the doc comments for this Entry.
+   */
+  public readonly releaseTag: ReleaseTag;
+
+  /**
    * If true, this entry should be emitted using the "export" keyword instead of the "declare" keyword.
    */
   public exported: boolean = false;
@@ -93,6 +100,7 @@ export class Entry {
     this.importPackagePath = parameters.importPackagePath;
     this.importPackageExportName = parameters.importPackageExportName;
     this.importPackageKey = parameters.importPackageKey;
+    this.releaseTag = parameters.releaseTag;
   }
 
   public getSortKey(): string {

--- a/apps/api-extractor/src/generators/packageTypings/PackageTypingsGenerator.ts
+++ b/apps/api-extractor/src/generators/packageTypings/PackageTypingsGenerator.ts
@@ -133,7 +133,7 @@ export class PackageTypingsGenerator {
     indentedWriter.clear();
 
     for (const analyzeWarning of this._analyzeWarnings) {
-      indentedWriter.writeLine('// ' + analyzeWarning);
+      indentedWriter.writeLine('// Warning: ' + analyzeWarning);
     }
 
     // If there is a @packagedocumentation header, put it first:
@@ -332,7 +332,9 @@ export class PackageTypingsGenerator {
 
     let releaseTag: ReleaseTag = ReleaseTag.None;
 
-    const releaseTagRegExp: RegExp = /(?:\s|\*)@(internal|alpha|beta|public)/g;
+    // We don't want to match "bill@example.com".  But we do want to match "/**@public*/".
+    // So for now we require whitespace or a star before/after the string.
+    const releaseTagRegExp: RegExp = /(?:\s|\*)@(internal|alpha|beta|public)(?:\s|\*)/g;
 
     for (const declaration of fullyFollowedSymbol.declarations || []) {
       const sourceFileText: string = declaration.getSourceFile().text;

--- a/build-tests/api-extractor-test-01/dist/index-preview.d.ts
+++ b/build-tests/api-extractor-test-01/dist/index-preview.d.ts
@@ -1,0 +1,171 @@
+/**
+ * api-extractor-test-01
+ * 
+ * @remarks
+ * This library is consumed by api-extractor-test-02 and api-extractor-test-03.
+ * It tests the basic types of definitions, and all the weird cases for following
+ * chains of type aliases.
+ * 
+ * @packagedocumentation
+ */
+
+/// <reference types="jest" />
+
+/**
+ * Example of an abstract class that is directly exported.
+ * @public
+ */
+export declare abstract class AbstractClass {
+    abstract test(): void;
+}
+
+/**
+ * Example of an abstract class that is exported separately from its
+ * definition.
+ *
+ * @public
+ */
+export declare abstract class AbstractClass2 {
+    abstract test2(): void;
+}
+
+/**
+ * Example of an abstract class that is not the default export
+ *
+ * @public
+ */
+export declare abstract class AbstractClass3 {
+    abstract test3(): void;
+}
+
+/**
+ * Test different kinds of ambient definitions
+ * @public
+ */
+export declare class AmbientConsumer {
+    /**
+     * Found via tsconfig.json's "lib" setting, which specifies the built-in "es2015.collection"
+     */
+    builtinDefinition1(): Map<string, string>;
+    /**
+     * Found via tsconfig.json's "lib" setting, which specifies the built-in "es2015.promise"
+     */
+    builtinDefinition2(): Promise<void>;
+    /**
+     * Configured via tsconfig.json's "lib" setting, which specifies "@types/jest".
+     * The emitted index.d.ts gets a reference like this:  <reference types="jest" />
+     */
+    definitelyTyped(): jest.Context;
+    /**
+     * Found via tsconfig.json's "include" setting point to a *.d.ts file.
+     * This is an old-style Definitely Typed definition, which is the worst possible kind,
+     * because consumers are expected to provide this, with no idea where it came from.
+     */
+    localTypings(): IAmbientInterfaceExample;
+}
+
+/**
+ * Referenced by DefaultExportEdgeCaseReferencer.
+ * @public
+ */
+export declare class ClassExportedAsDefault {
+}
+
+/**
+ * Tests a decorator
+ * @public
+ */
+export declare class DecoratorTest {
+    /**
+     * Function with a decorator
+     */
+    test(): void;
+}
+
+/**
+ * @public
+ */
+export declare class DefaultExportEdgeCase {
+    /**
+     * This reference is encountered before the definition of DefaultExportEdgeCase.
+     * The symbol.name will be "default" in this situation.
+     */
+    reference: ClassExportedAsDefault;
+}
+
+/** @public */
+export declare class ForgottenExportConsumer1 {
+    test1(): IForgottenExport | undefined;
+}
+
+/** @public */
+export declare class ForgottenExportConsumer2 {
+    test2(): IForgottenExport_2 | undefined;
+}
+
+/**
+ * The ForgottenExportConsumer1 class relies on this IForgottenExport.
+ *
+ * This should end up as a non-exported "IForgottenExport" in the index.d.ts.
+ */
+declare interface IForgottenExport {
+    instance1: string;
+}
+
+/**
+ * The ForgottenExportConsumer2 class relies on this IForgottenExport.
+ *
+ * This should end up as a non-exported "IForgottenExport_2" in the index.d.ts.
+ * It is renamed to avoid a conflict with the IForgottenExport from ForgottenExportConsumer1.
+ */
+declare interface IForgottenExport_2 {
+    instance2: string;
+}
+
+/**
+ * This interface is exported as the default export for its source file.
+ * @public
+ */
+export declare interface IInterfaceAsDefaultExport {
+    /**
+     * A member of the interface
+     */
+    member: string;
+}
+
+/**
+ * A simple, normal definition
+ * @public
+ */
+export declare interface ISimpleInterface {
+}
+
+/**
+ * This class gets aliased twice before being exported from the package.
+ * @public
+ */
+export declare class ReexportedClass {
+    getSelfReference(): ReexportedClass;
+    getValue(): string;
+}
+
+/**
+ * This class has links such as {@link TypeReferencesInAedoc}.
+ * @internal
+ */
+export declare class _TypeReferencesInAedoc {
+    /**
+     * Returns a value
+     * @param arg1 - The input parameter of type {@link TypeReferencesInAedoc}.
+     * @returns An object of type {@link TypeReferencesInAedoc}.
+     */
+    getValue(arg1: _TypeReferencesInAedoc): _TypeReferencesInAedoc;
+    /** {@inheritdoc api-extractor-test-01:TypeReferencesInAedoc.getValue} */
+    getValue2(arg1: _TypeReferencesInAedoc): _TypeReferencesInAedoc;
+}
+
+/**
+ * Example decorator
+ * @public
+ */
+export declare function virtual(target: Object, propertyKey: string | symbol, descriptor: TypedPropertyDescriptor<any>): void;

--- a/build-tests/api-extractor-test-01/dist/index-preview.d.ts
+++ b/build-tests/api-extractor-test-01/dist/index-preview.d.ts
@@ -149,20 +149,7 @@ export declare class ReexportedClass {
     getValue(): string;
 }
 
-/**
- * This class has links such as {@link TypeReferencesInAedoc}.
- * @internal
- */
-export declare class _TypeReferencesInAedoc {
-    /**
-     * Returns a value
-     * @param arg1 - The input parameter of type {@link TypeReferencesInAedoc}.
-     * @returns An object of type {@link TypeReferencesInAedoc}.
-     */
-    getValue(arg1: _TypeReferencesInAedoc): _TypeReferencesInAedoc;
-    /** {@inheritdoc api-extractor-test-01:TypeReferencesInAedoc.getValue} */
-    getValue2(arg1: _TypeReferencesInAedoc): _TypeReferencesInAedoc;
-}
+// Removed for this release type: _TypeReferencesInAedoc
 
 /**
  * Example decorator

--- a/build-tests/api-extractor-test-01/dist/index-public.d.ts
+++ b/build-tests/api-extractor-test-01/dist/index-public.d.ts
@@ -1,0 +1,171 @@
+/**
+ * api-extractor-test-01
+ * 
+ * @remarks
+ * This library is consumed by api-extractor-test-02 and api-extractor-test-03.
+ * It tests the basic types of definitions, and all the weird cases for following
+ * chains of type aliases.
+ * 
+ * @packagedocumentation
+ */
+
+/// <reference types="jest" />
+
+/**
+ * Example of an abstract class that is directly exported.
+ * @public
+ */
+export declare abstract class AbstractClass {
+    abstract test(): void;
+}
+
+/**
+ * Example of an abstract class that is exported separately from its
+ * definition.
+ *
+ * @public
+ */
+export declare abstract class AbstractClass2 {
+    abstract test2(): void;
+}
+
+/**
+ * Example of an abstract class that is not the default export
+ *
+ * @public
+ */
+export declare abstract class AbstractClass3 {
+    abstract test3(): void;
+}
+
+/**
+ * Test different kinds of ambient definitions
+ * @public
+ */
+export declare class AmbientConsumer {
+    /**
+     * Found via tsconfig.json's "lib" setting, which specifies the built-in "es2015.collection"
+     */
+    builtinDefinition1(): Map<string, string>;
+    /**
+     * Found via tsconfig.json's "lib" setting, which specifies the built-in "es2015.promise"
+     */
+    builtinDefinition2(): Promise<void>;
+    /**
+     * Configured via tsconfig.json's "lib" setting, which specifies "@types/jest".
+     * The emitted index.d.ts gets a reference like this:  <reference types="jest" />
+     */
+    definitelyTyped(): jest.Context;
+    /**
+     * Found via tsconfig.json's "include" setting point to a *.d.ts file.
+     * This is an old-style Definitely Typed definition, which is the worst possible kind,
+     * because consumers are expected to provide this, with no idea where it came from.
+     */
+    localTypings(): IAmbientInterfaceExample;
+}
+
+/**
+ * Referenced by DefaultExportEdgeCaseReferencer.
+ * @public
+ */
+export declare class ClassExportedAsDefault {
+}
+
+/**
+ * Tests a decorator
+ * @public
+ */
+export declare class DecoratorTest {
+    /**
+     * Function with a decorator
+     */
+    test(): void;
+}
+
+/**
+ * @public
+ */
+export declare class DefaultExportEdgeCase {
+    /**
+     * This reference is encountered before the definition of DefaultExportEdgeCase.
+     * The symbol.name will be "default" in this situation.
+     */
+    reference: ClassExportedAsDefault;
+}
+
+/** @public */
+export declare class ForgottenExportConsumer1 {
+    test1(): IForgottenExport | undefined;
+}
+
+/** @public */
+export declare class ForgottenExportConsumer2 {
+    test2(): IForgottenExport_2 | undefined;
+}
+
+/**
+ * The ForgottenExportConsumer1 class relies on this IForgottenExport.
+ *
+ * This should end up as a non-exported "IForgottenExport" in the index.d.ts.
+ */
+declare interface IForgottenExport {
+    instance1: string;
+}
+
+/**
+ * The ForgottenExportConsumer2 class relies on this IForgottenExport.
+ *
+ * This should end up as a non-exported "IForgottenExport_2" in the index.d.ts.
+ * It is renamed to avoid a conflict with the IForgottenExport from ForgottenExportConsumer1.
+ */
+declare interface IForgottenExport_2 {
+    instance2: string;
+}
+
+/**
+ * This interface is exported as the default export for its source file.
+ * @public
+ */
+export declare interface IInterfaceAsDefaultExport {
+    /**
+     * A member of the interface
+     */
+    member: string;
+}
+
+/**
+ * A simple, normal definition
+ * @public
+ */
+export declare interface ISimpleInterface {
+}
+
+/**
+ * This class gets aliased twice before being exported from the package.
+ * @public
+ */
+export declare class ReexportedClass {
+    getSelfReference(): ReexportedClass;
+    getValue(): string;
+}
+
+/**
+ * This class has links such as {@link TypeReferencesInAedoc}.
+ * @internal
+ */
+export declare class _TypeReferencesInAedoc {
+    /**
+     * Returns a value
+     * @param arg1 - The input parameter of type {@link TypeReferencesInAedoc}.
+     * @returns An object of type {@link TypeReferencesInAedoc}.
+     */
+    getValue(arg1: _TypeReferencesInAedoc): _TypeReferencesInAedoc;
+    /** {@inheritdoc api-extractor-test-01:TypeReferencesInAedoc.getValue} */
+    getValue2(arg1: _TypeReferencesInAedoc): _TypeReferencesInAedoc;
+}
+
+/**
+ * Example decorator
+ * @public
+ */
+export declare function virtual(target: Object, propertyKey: string | symbol, descriptor: TypedPropertyDescriptor<any>): void;

--- a/build-tests/api-extractor-test-01/dist/index-public.d.ts
+++ b/build-tests/api-extractor-test-01/dist/index-public.d.ts
@@ -149,20 +149,7 @@ export declare class ReexportedClass {
     getValue(): string;
 }
 
-/**
- * This class has links such as {@link TypeReferencesInAedoc}.
- * @internal
- */
-export declare class _TypeReferencesInAedoc {
-    /**
-     * Returns a value
-     * @param arg1 - The input parameter of type {@link TypeReferencesInAedoc}.
-     * @returns An object of type {@link TypeReferencesInAedoc}.
-     */
-    getValue(arg1: _TypeReferencesInAedoc): _TypeReferencesInAedoc;
-    /** {@inheritdoc api-extractor-test-01:TypeReferencesInAedoc.getValue} */
-    getValue2(arg1: _TypeReferencesInAedoc): _TypeReferencesInAedoc;
-}
+// Removed for this release type: _TypeReferencesInAedoc
 
 /**
  * Example decorator

--- a/build-tests/api-extractor-test-02/dist/index-preview.d.ts
+++ b/build-tests/api-extractor-test-02/dist/index-preview.d.ts
@@ -1,0 +1,53 @@
+/**
+ * api-extractor-test-02
+ * 
+ * @remarks
+ * This library consumes api-extractor-test-01 and is consumed by api-extractor-test-03.
+ * 
+ * @packagedocumentation
+ */
+
+import { ISimpleInterface } from 'api-extractor-test-01';
+import { ReexportedClass } from 'api-extractor-test-01';
+import * as semver1 from 'semver';
+
+/**
+ * An interface with a generic parameter.
+ * @public
+ */
+export declare interface GenericInterface<T> {
+    member: T;
+}
+
+/** @public */
+export declare function importDeduping1(arg1: ISimpleInterface, arg2: ISimpleInterface): void;
+
+/** @public */
+export declare function importDeduping2(arg1: ISimpleInterface, arg2: ISimpleInterface): void;
+
+/**
+ * A class that inherits from a type defined in the "semver" module imported from \@types/semver.
+ * @public
+ */
+export declare class ImportedModuleAsBaseClass extends semver1.SemVer {
+}
+
+/**
+ * A generic parameter that references the "semver" module imported from \@types/semver.
+ * @public
+ */
+export declare function importedModuleAsGenericParameter(): GenericInterface<semver1.SemVer> | undefined;
+
+/**
+ * This definition references the "semver" module imported from \@types/semver.
+ * @public
+ */
+export declare function importedModuleAsReturnType(): semver1.SemVer | undefined;
+
+/**
+ * Example of a class that inherits from an externally imported class.
+ * @public
+ */
+export declare class SubclassWithImport extends ReexportedClass implements ISimpleInterface {
+    test(): void;
+}

--- a/build-tests/api-extractor-test-02/dist/index-public.d.ts
+++ b/build-tests/api-extractor-test-02/dist/index-public.d.ts
@@ -1,0 +1,53 @@
+/**
+ * api-extractor-test-02
+ * 
+ * @remarks
+ * This library consumes api-extractor-test-01 and is consumed by api-extractor-test-03.
+ * 
+ * @packagedocumentation
+ */
+
+import { ISimpleInterface } from 'api-extractor-test-01';
+import { ReexportedClass } from 'api-extractor-test-01';
+import * as semver1 from 'semver';
+
+/**
+ * An interface with a generic parameter.
+ * @public
+ */
+export declare interface GenericInterface<T> {
+    member: T;
+}
+
+/** @public */
+export declare function importDeduping1(arg1: ISimpleInterface, arg2: ISimpleInterface): void;
+
+/** @public */
+export declare function importDeduping2(arg1: ISimpleInterface, arg2: ISimpleInterface): void;
+
+/**
+ * A class that inherits from a type defined in the "semver" module imported from \@types/semver.
+ * @public
+ */
+export declare class ImportedModuleAsBaseClass extends semver1.SemVer {
+}
+
+/**
+ * A generic parameter that references the "semver" module imported from \@types/semver.
+ * @public
+ */
+export declare function importedModuleAsGenericParameter(): GenericInterface<semver1.SemVer> | undefined;
+
+/**
+ * This definition references the "semver" module imported from \@types/semver.
+ * @public
+ */
+export declare function importedModuleAsReturnType(): semver1.SemVer | undefined;
+
+/**
+ * Example of a class that inherits from an externally imported class.
+ * @public
+ */
+export declare class SubclassWithImport extends ReexportedClass implements ISimpleInterface {
+    test(): void;
+}

--- a/build-tests/api-extractor-test-04/dist/index-internal.d.ts
+++ b/build-tests/api-extractor-test-04/dist/index-internal.d.ts
@@ -1,0 +1,82 @@
+/**
+ * api-extractor-test-04
+ * 
+ * Test scenarios for trimming alpha/beta/internal definitions from the generated *.d.ts files.
+ * 
+ * @packagedocumentation
+ */
+
+
+/**
+ * This is an alpha class.
+ * @alpha
+ */
+export declare class AlphaClass {
+    /**
+     * This is a comment
+     */
+    undecoratedMember(): void;
+    /**
+     * This is an internal member
+     * @internal
+     */
+    _internalMember(): void;
+}
+
+/**
+ * This is a beta class
+ * @beta
+ */
+export declare class BetaClass {
+    /**
+     * This is a comment
+     */
+    undecoratedMember(): void;
+    /**
+     * This is an alpha comment
+     * @alpha
+     */
+    alphaMember(): void;
+    /**
+     * This is an internal member
+     * @internal
+     */
+    _internalMember(): void;
+}
+
+/**
+ * This is an internal class
+ * @internal
+ */
+export declare class InternalClass {
+    /**
+     * This is a comment
+     */
+    undecoratedMember(): void;
+}
+
+/**
+ * This is a public class
+ * @public
+ */
+export declare class PublicClass {
+    /**
+     * This is a comment
+     */
+    undecoratedMember(): void;
+    /**
+     * This is a beta comment
+     * @beta
+     */
+    betaMember(): void;
+    /**
+     * This is an alpha comment
+     * @alpha
+     */
+    alphaMember(): void;
+    /**
+     * This is an internal member
+     * @internal
+     */
+    _internalMember(): void;
+}

--- a/build-tests/api-extractor-test-04/dist/index-preview.d.ts
+++ b/build-tests/api-extractor-test-04/dist/index-preview.d.ts
@@ -7,21 +7,7 @@
  */
 
 
-/**
- * This is an alpha class.
- * @alpha
- */
-export declare class AlphaClass {
-    /**
-     * This is a comment
-     */
-    undecoratedMember(): void;
-    /**
-     * This is an internal member
-     * @internal
-     */
-    _internalMember(): void;
-}
+// Removed for this release type: AlphaClass
 
 /**
  * This is a beta class
@@ -44,16 +30,7 @@ export declare class BetaClass {
     _internalMember(): void;
 }
 
-/**
- * This is an internal class
- * @internal
- */
-export declare class InternalClass {
-    /**
-     * This is a comment
-     */
-    undecoratedMember(): void;
-}
+// Removed for this release type: InternalClass
 
 /**
  * This is a public class

--- a/build-tests/api-extractor-test-04/dist/index-preview.d.ts
+++ b/build-tests/api-extractor-test-04/dist/index-preview.d.ts
@@ -1,0 +1,82 @@
+/**
+ * api-extractor-test-04
+ * 
+ * Test scenarios for trimming alpha/beta/internal definitions from the generated *.d.ts files.
+ * 
+ * @packagedocumentation
+ */
+
+
+/**
+ * This is an alpha class.
+ * @alpha
+ */
+export declare class AlphaClass {
+    /**
+     * This is a comment
+     */
+    undecoratedMember(): void;
+    /**
+     * This is an internal member
+     * @internal
+     */
+    _internalMember(): void;
+}
+
+/**
+ * This is a beta class
+ * @beta
+ */
+export declare class BetaClass {
+    /**
+     * This is a comment
+     */
+    undecoratedMember(): void;
+    /**
+     * This is an alpha comment
+     * @alpha
+     */
+    alphaMember(): void;
+    /**
+     * This is an internal member
+     * @internal
+     */
+    _internalMember(): void;
+}
+
+/**
+ * This is an internal class
+ * @internal
+ */
+export declare class InternalClass {
+    /**
+     * This is a comment
+     */
+    undecoratedMember(): void;
+}
+
+/**
+ * This is a public class
+ * @public
+ */
+export declare class PublicClass {
+    /**
+     * This is a comment
+     */
+    undecoratedMember(): void;
+    /**
+     * This is a beta comment
+     * @beta
+     */
+    betaMember(): void;
+    /**
+     * This is an alpha comment
+     * @alpha
+     */
+    alphaMember(): void;
+    /**
+     * This is an internal member
+     * @internal
+     */
+    _internalMember(): void;
+}

--- a/build-tests/api-extractor-test-04/dist/index-public.d.ts
+++ b/build-tests/api-extractor-test-04/dist/index-public.d.ts
@@ -1,0 +1,82 @@
+/**
+ * api-extractor-test-04
+ * 
+ * Test scenarios for trimming alpha/beta/internal definitions from the generated *.d.ts files.
+ * 
+ * @packagedocumentation
+ */
+
+
+/**
+ * This is an alpha class.
+ * @alpha
+ */
+export declare class AlphaClass {
+    /**
+     * This is a comment
+     */
+    undecoratedMember(): void;
+    /**
+     * This is an internal member
+     * @internal
+     */
+    _internalMember(): void;
+}
+
+/**
+ * This is a beta class
+ * @beta
+ */
+export declare class BetaClass {
+    /**
+     * This is a comment
+     */
+    undecoratedMember(): void;
+    /**
+     * This is an alpha comment
+     * @alpha
+     */
+    alphaMember(): void;
+    /**
+     * This is an internal member
+     * @internal
+     */
+    _internalMember(): void;
+}
+
+/**
+ * This is an internal class
+ * @internal
+ */
+export declare class InternalClass {
+    /**
+     * This is a comment
+     */
+    undecoratedMember(): void;
+}
+
+/**
+ * This is a public class
+ * @public
+ */
+export declare class PublicClass {
+    /**
+     * This is a comment
+     */
+    undecoratedMember(): void;
+    /**
+     * This is a beta comment
+     * @beta
+     */
+    betaMember(): void;
+    /**
+     * This is an alpha comment
+     * @alpha
+     */
+    alphaMember(): void;
+    /**
+     * This is an internal member
+     * @internal
+     */
+    _internalMember(): void;
+}

--- a/build-tests/api-extractor-test-04/dist/index-public.d.ts
+++ b/build-tests/api-extractor-test-04/dist/index-public.d.ts
@@ -7,53 +7,11 @@
  */
 
 
-/**
- * This is an alpha class.
- * @alpha
- */
-export declare class AlphaClass {
-    /**
-     * This is a comment
-     */
-    undecoratedMember(): void;
-    /**
-     * This is an internal member
-     * @internal
-     */
-    _internalMember(): void;
-}
+// Removed for this release type: AlphaClass
 
-/**
- * This is a beta class
- * @beta
- */
-export declare class BetaClass {
-    /**
-     * This is a comment
-     */
-    undecoratedMember(): void;
-    /**
-     * This is an alpha comment
-     * @alpha
-     */
-    alphaMember(): void;
-    /**
-     * This is an internal member
-     * @internal
-     */
-    _internalMember(): void;
-}
+// Removed for this release type: BetaClass
 
-/**
- * This is an internal class
- * @internal
- */
-export declare class InternalClass {
-    /**
-     * This is a comment
-     */
-    undecoratedMember(): void;
-}
+// Removed for this release type: InternalClass
 
 /**
  * This is a public class

--- a/common/changes/@microsoft/api-extractor/pgonzal-ae-trimming-2_2018-03-06-01-00.json
+++ b/common/changes/@microsoft/api-extractor/pgonzal-ae-trimming-2_2018-03-06-01-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor",
+      "comment": "Add preliminary support for preview and public outputs for packageTypings gtenerator",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor",
+  "email": "pgonzal@users.noreply.github.com"
+}


### PR DESCRIPTION
This is part of the sprint for trimming definitions from the generated *.d.ts files:

- Set up unit test projects
- Implement temporary strategy for parsing comments
- Trim top-level definitions based on release type