### PR TITLE
Lock down @types versions

### DIFF
--- a/apps/api-documenter/package.json
+++ b/apps/api-documenter/package.json
@@ -29,6 +29,6 @@
     "@types/js-yaml": "3.9.1",
     "@types/node": "8.5.8",
     "gulp": "~3.9.1",
-    "@types/jest": "~21.1.8"
+    "@types/jest": "21.1.10"
   }
 }

--- a/apps/api-extractor/package.json
+++ b/apps/api-extractor/package.json
@@ -45,6 +45,6 @@
     "@types/lodash": "4.14.74",
     "gulp": "~3.9.1",
     "@microsoft/node-library-build": "4.3.13",
-    "@types/jest": "~21.1.8"
+    "@types/jest": "21.1.10"
   }
 }

--- a/build-tests/api-extractor-test-01/package.json
+++ b/build-tests/api-extractor-test-01/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@microsoft/api-extractor": "5.3.7",
-    "@types/jest": "~21.1.8",
+    "@types/jest": "21.1.10",
     "@types/node": "8.5.8",
     "fs-extra": "~0.26.7",
     "typescript": "~2.4.1"

--- a/build-tests/api-extractor-test-03/package.json
+++ b/build-tests/api-extractor-test-03/package.json
@@ -7,7 +7,7 @@
     "build": "node build.js"
   },
   "dependencies": {
-   "@types/jest": "~21.1.8",
+    "@types/jest": "21.1.10",
     "@types/node": "8.5.8",
     "api-extractor-test-02": "1.0.0",
     "fs-extra": "~0.26.7",

--- a/build-tests/web-library-build-test/package.json
+++ b/build-tests/web-library-build-test/package.json
@@ -11,7 +11,7 @@
   "devDependencies": {
     "@types/chai": "3.4.34",
     "chai": "~3.5.0",
-    "@types/jest": "~21.1.8",
+    "@types/jest": "21.1.10",
     "@types/node": "8.5.8"
   },
   "dependencies": {

--- a/common/changes/@microsoft/api-documenter/pgonzal-fix-types_2018-03-12-19-53.json
+++ b/common/changes/@microsoft/api-documenter/pgonzal-fix-types_2018-03-12-19-53.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-documenter",
+      "comment": "Locked down some \"@types/\" dependency versions to avoid upgrade conflicts",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/api-documenter",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/api-extractor/pgonzal-fix-types_2018-03-12-19-53.json
+++ b/common/changes/@microsoft/api-extractor/pgonzal-fix-types_2018-03-12-19-53.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor",
+      "comment": "Locked down some \"@types/\" dependency versions to avoid upgrade conflicts",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/gulp-core-build-webpack/pgonzal-fix-types_2018-03-12-19-53.json
+++ b/common/changes/@microsoft/gulp-core-build-webpack/pgonzal-fix-types_2018-03-12-19-53.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/gulp-core-build-webpack",
+      "comment": "Locked down some \"@types/\" dependency versions to avoid upgrade conflicts",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/gulp-core-build-webpack",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/loader-load-themed-styles/pgonzal-fix-types_2018-03-12-19-53.json
+++ b/common/changes/@microsoft/loader-load-themed-styles/pgonzal-fix-types_2018-03-12-19-53.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/loader-load-themed-styles",
+      "comment": "Locked down some \"@types/\" dependency versions to avoid upgrade conflicts",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/loader-load-themed-styles",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/resolve-chunk-plugin/pgonzal-fix-types_2018-03-12-19-53.json
+++ b/common/changes/@microsoft/resolve-chunk-plugin/pgonzal-fix-types_2018-03-12-19-53.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/resolve-chunk-plugin",
+      "comment": "Locked down some \"@types/\" dependency versions to avoid upgrade conflicts",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/resolve-chunk-plugin",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/set-webpack-public-path-plugin/pgonzal-fix-types_2018-03-12-19-53.json
+++ b/common/changes/@microsoft/set-webpack-public-path-plugin/pgonzal-fix-types_2018-03-12-19-53.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/set-webpack-public-path-plugin",
+      "comment": "Locked down some \"@types/\" dependency versions to avoid upgrade conflicts",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/set-webpack-public-path-plugin",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/ts-command-line/pgonzal-fix-types_2018-03-12-19-53.json
+++ b/common/changes/@microsoft/ts-command-line/pgonzal-fix-types_2018-03-12-19-53.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/ts-command-line",
+      "comment": "Locked down some \"@types/\" dependency versions to avoid upgrade conflicts",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/ts-command-line",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/config/rush/shrinkwrap.yaml
+++ b/common/config/rush/shrinkwrap.yaml
@@ -62,7 +62,7 @@ dependencies:
   '@types/serve-static': 1.13.1
   '@types/sinon': 1.16.34
   '@types/source-map': 0.5.0
-  '@types/tapable': 0.2.3
+  '@types/tapable': 0.2.4
   '@types/through2': 2.0.32
   '@types/uglify-js': 2.6.29
   '@types/vinyl': 1.2.30
@@ -79,7 +79,7 @@ dependencies:
   deasync: 0.1.12
   del: 2.2.2
   end-of-stream: 1.1.0
-  express: 4.16.2
+  express: 4.16.3
   fs-extra: 0.26.7
   git-repo-info: 1.1.4
   glob: 7.0.6
@@ -130,7 +130,7 @@ dependencies:
   merge2: 1.0.3
   minimatch: 3.0.4
   mocha: 3.4.2
-  node-forge: 0.7.2
+  node-forge: 0.7.4
   node-notifier: 5.0.2
   npm-package-arg: 5.1.2
   object-assign: 4.1.1
@@ -472,10 +472,10 @@ packages:
     dev: false
     resolution:
       integrity: sha1-3TS72OMv5OdPLj2KwH+KpbRaR6w=
-  /@types/tapable/0.2.3:
+  /@types/tapable/0.2.4:
     dev: false
     resolution:
-      integrity: sha1-CIiw8gzH5Y4cIqGIi06WPu+qgQo=
+      integrity: sha512-pclMAvhPnXJcJu1ZZ8bQthuUcdDWzDuxDdbSf6l1U6s4fP6EBiZpPsOZYqFOrbqDV97sXGFSsb6AUpiLfv4xIA==
   /@types/through2/2.0.32:
     dependencies:
       '@types/node': 8.5.8
@@ -501,7 +501,7 @@ packages:
   /@types/webpack/3.0.11:
     dependencies:
       '@types/node': 8.5.8
-      '@types/tapable': 0.2.3
+      '@types/tapable': 0.2.4
       '@types/uglify-js': 2.6.29
     dev: false
     resolution:
@@ -535,7 +535,7 @@ packages:
       node: '>= 0.6'
     resolution:
       integrity: sha1-w8p0NJOGSMPg2cHjKN1otiLChMo=
-  /accepts/1.3.4:
+  /accepts/1.3.5:
     dependencies:
       mime-types: 2.1.18
       negotiator: 0.6.1
@@ -543,7 +543,7 @@ packages:
     engines:
       node: '>= 0.6'
     resolution:
-      integrity: sha1-hiRnWMfdbSGmR0/whKR0DsBesh8=
+      integrity: sha1-63d99gEXI6OxTopywIBcjoZ0a9I=
   /acorn-dynamic-import/2.0.2:
     dependencies:
       acorn: 4.0.13
@@ -562,12 +562,12 @@ packages:
       node: '>=0.4.0'
     resolution:
       integrity: sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c=
-  /acorn/5.5.0:
+  /acorn/5.5.3:
     dev: false
     engines:
       node: '>=0.4.0'
     resolution:
-      integrity: sha512-arn53F07VXmls4o4pUhSzBa4fvaagPRe7AVZ8l7NHxFWUie2DsuFSBMMNAkgzRlOhEhzAnxeKyaWVzOH4xqp/g==
+      integrity: sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ==
   /after/0.8.2:
     dev: false
     resolution:
@@ -664,14 +664,14 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=
-  /ansi-styles/3.2.0:
+  /ansi-styles/3.2.1:
     dependencies:
       color-convert: 1.9.1
     dev: false
     engines:
       node: '>=4'
     resolution:
-      integrity: sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==
+      integrity: sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==
   /ansi-wrap/0.1.0:
     dev: false
     engines:
@@ -711,7 +711,7 @@ packages:
   /are-we-there-yet/1.1.4:
     dependencies:
       delegates: 1.0.0
-      readable-stream: 2.3.4
+      readable-stream: 2.3.5
     dev: false
     resolution:
       integrity: sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=
@@ -906,7 +906,7 @@ packages:
   /autoprefixer/6.3.7:
     dependencies:
       browserslist: 1.3.6
-      caniuse-db: 1.0.30000810
+      caniuse-db: 1.0.30000813
       normalize-range: 0.1.2
       num2fraction: 1.2.2
       postcss: 5.2.18
@@ -998,8 +998,8 @@ packages:
   /babel-plugin-istanbul/4.1.5:
     dependencies:
       find-up: 2.1.0
-      istanbul-lib-instrument: 1.9.2
-      test-exclude: 4.2.0
+      istanbul-lib-instrument: 1.10.1
+      test-exclude: 4.2.1
     dev: false
     resolution:
       integrity: sha1-Z2DN2Xf0EdPhdbsGTyvDJ9mbK24=
@@ -1274,7 +1274,7 @@ packages:
       isobject: 3.0.1
       kind-of: 6.0.2
       repeat-element: 1.1.2
-      snapdragon: 0.8.1
+      snapdragon: 0.8.2
       snapdragon-node: 2.1.1
       split-string: 3.1.0
       to-regex: 3.0.2
@@ -1351,7 +1351,7 @@ packages:
       integrity: sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==
   /browserslist/1.3.6:
     dependencies:
-      caniuse-db: 1.0.30000810
+      caniuse-db: 1.0.30000813
     dev: false
     resolution:
       integrity: sha1-lS/0jVZGPTtTj4XvL46t39KEsTM=
@@ -1469,10 +1469,10 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=
-  /caniuse-db/1.0.30000810:
+  /caniuse-db/1.0.30000813:
     dev: false
     resolution:
-      integrity: sha1-vSWDDEHvq2Qzmi44H0lnc0PIRQk=
+      integrity: sha1-4KHGA/iICteHsqNWUrJzPzKl4po=
   /caseless/0.11.0:
     dev: false
     resolution:
@@ -1524,16 +1524,16 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=
-  /chalk/2.3.1:
+  /chalk/2.3.2:
     dependencies:
-      ansi-styles: 3.2.0
+      ansi-styles: 3.2.1
       escape-string-regexp: 1.0.5
-      supports-color: 5.2.0
+      supports-color: 5.3.0
     dev: false
     engines:
       node: '>=4'
     resolution:
-      integrity: sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==
+      integrity: sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==
   /charenc/0.0.2:
     dev: false
     resolution:
@@ -1593,14 +1593,14 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==
-  /clean-css/4.1.9:
+  /clean-css/4.1.11:
     dependencies:
       source-map: 0.5.7
     dev: false
     engines:
       node: '>= 4.0'
     resolution:
-      integrity: sha1-Nc7ornaHpJuYA09w3gDE7dOCYwE=
+      integrity: sha1-Ls3xRaujj1R0DybO/Q/z4D4SXWo=
   /cli-cursor/1.0.2:
     dependencies:
       restore-cursor: 1.0.1
@@ -1703,10 +1703,10 @@ packages:
     dev: false
     resolution:
       integrity: sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==
-  /commander/2.14.1:
+  /commander/2.15.0:
     dev: false
     resolution:
-      integrity: sha512-+YR16o3rK53SmWHU3rEM3tPAh2rwb1yPcQX5irVn7mb0gXbwuCCrnkbV5+PBfETdfg1vui07nM6PCG1zndcjQw==
+      integrity: sha512-7B1ilBwtYSbetCgTY1NJFg+gVpestg0fdA1MhC1Vs4ssyfSXnCAjFr+QcQM9/RedXC0EaUx1sG8Smgw2VfgKEg==
   /commander/2.3.0:
     dev: false
     engines:
@@ -1721,6 +1721,10 @@ packages:
       node: '>= 0.6.x'
     resolution:
       integrity: sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=
+  /compare-versions/3.1.0:
+    dev: false
+    resolution:
+      integrity: sha512-4hAxDSBypT/yp2ySFD346So6Ragw5xmBn/e/agIGl3bZr6DLUqnoRZPusxKrXdYRZpgexO9daejmIenlq/wrIQ==
   /component-bind/1.0.0:
     dev: false
     resolution:
@@ -1744,13 +1748,23 @@ packages:
   /concat-stream/1.6.0:
     dependencies:
       inherits: 2.0.3
-      readable-stream: 2.3.4
+      readable-stream: 2.3.5
       typedarray: 0.0.6
     dev: false
     engines:
       '0': node >= 0.8
     resolution:
       integrity: sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=
+  /concat-stream/1.6.1:
+    dependencies:
+      inherits: 2.0.3
+      readable-stream: 2.3.5
+      typedarray: 0.0.6
+    dev: false
+    engines:
+      '0': node >= 0.8
+    resolution:
+      integrity: sha512-gslSSJx03QKa59cIKqeJO9HQ/WZMotvYJCuaUULrLpjj8oG40kV2Z+gz82pVxlTkOADi4PJxQPPfhl1ELYrrXw==
   /connect-livereload/0.5.4:
     dev: false
     resolution:
@@ -1867,14 +1881,14 @@ packages:
       integrity: sha1-rLniIaThe9sHbpBlfEK5PjcmzwY=
   /cross-spawn/3.0.1:
     dependencies:
-      lru-cache: 4.1.1
+      lru-cache: 4.1.2
       which: 1.3.0
     dev: false
     resolution:
       integrity: sha1-ElYDfsufDF9549bvE14wdwGEuYI=
   /cross-spawn/5.1.0:
     dependencies:
-      lru-cache: 4.1.1
+      lru-cache: 4.1.2
       shebang-command: 1.2.0
       which: 1.3.0
     dev: false
@@ -1963,7 +1977,7 @@ packages:
       integrity: sha1-XQKkaFCt8bSjF5RqOSj8y1v9BCU=
   /d/1.0.0:
     dependencies:
-      es5-ext: 0.10.39
+      es5-ext: 0.10.40
     dev: false
     resolution:
       integrity: sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=
@@ -2193,12 +2207,12 @@ packages:
       node: '>=0.3.1'
     resolution:
       integrity: sha1-yc45Okt8vQsFinJck98pkCeGj/k=
-  /diff/3.4.0:
+  /diff/3.5.0:
     dev: false
     engines:
       node: '>=0.3.1'
     resolution:
-      integrity: sha512-QpVuMTEoJMF7cKzi6bvWhRulU1fZqZnvyVQgNhPaxxuTYwyjn/j1v9falseQ/uXWwPnO56RBfwtg4h/EQXmucA==
+      integrity: sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==
   /diffie-hellman/5.0.2:
     dependencies:
       bn.js: 4.11.8
@@ -2233,15 +2247,15 @@ packages:
     dev: false
     resolution:
       integrity: sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=
-  /duplexify/3.5.3:
+  /duplexify/3.5.4:
     dependencies:
       end-of-stream: 1.1.0
       inherits: 2.0.3
-      readable-stream: 2.3.4
+      readable-stream: 2.3.5
       stream-shift: 1.0.0
     dev: false
     resolution:
-      integrity: sha512-g8ID9OroF9hKt2POf8YLayy+9594PzmM3scI00/uBXocX3TWNgoB67hjzkFe9ITAbQOne/lLdBxHXvYUM4ZgGA==
+      integrity: sha512-JzYSLYMhoVVBe8+mbHQ4KgpvHpm0DZpJuL8PY93Vyv1fW7jYJ90LoXa1di/CVbJM+TgMs91rbDapE/RNIfnJsA==
   /ecc-jsbn/0.1.1:
     dependencies:
       jsbn: 0.1.1
@@ -2355,17 +2369,17 @@ packages:
     dev: false
     resolution:
       integrity: sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=
-  /es5-ext/0.10.39:
+  /es5-ext/0.10.40:
     dependencies:
       es6-iterator: 2.0.3
       es6-symbol: 3.1.1
     dev: false
     resolution:
-      integrity: sha512-AlaXZhPHl0po/uxMx1tyrlt1O86M6D5iVaDH8UgLfgek4kXTX6vzsRfJQWC2Ku+aG8pkw1XWzh9eTkwfVrsD5g==
+      integrity: sha512-S9Fh3oya5OOvYSNGvPZJ+vyrs6VYpe1IXPowVe3N1OhaiwVaGlwfn3Zf5P5klYcWOA0toIwYQW8XEv/QqhdHvQ==
   /es6-iterator/2.0.3:
     dependencies:
       d: 1.0.0
-      es5-ext: 0.10.39
+      es5-ext: 0.10.40
       es6-symbol: 3.1.1
     dev: false
     resolution:
@@ -2373,7 +2387,7 @@ packages:
   /es6-map/0.1.5:
     dependencies:
       d: 1.0.0
-      es5-ext: 0.10.39
+      es5-ext: 0.10.40
       es6-iterator: 2.0.3
       es6-set: 0.1.5
       es6-symbol: 3.1.1
@@ -2388,7 +2402,7 @@ packages:
   /es6-set/0.1.5:
     dependencies:
       d: 1.0.0
-      es5-ext: 0.10.39
+      es5-ext: 0.10.40
       es6-iterator: 2.0.3
       es6-symbol: 3.1.1
       event-emitter: 0.3.5
@@ -2398,14 +2412,14 @@ packages:
   /es6-symbol/3.1.1:
     dependencies:
       d: 1.0.0
-      es5-ext: 0.10.39
+      es5-ext: 0.10.40
     dev: false
     resolution:
       integrity: sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=
   /es6-weak-map/2.0.2:
     dependencies:
       d: 1.0.0
-      es5-ext: 0.10.39
+      es5-ext: 0.10.40
       es6-iterator: 2.0.3
       es6-symbol: 3.1.1
     dev: false
@@ -2548,7 +2562,7 @@ packages:
   /event-emitter/0.3.5:
     dependencies:
       d: 1.0.0
-      es5-ext: 0.10.39
+      es5-ext: 0.10.40
     dev: false
     resolution:
       integrity: sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=
@@ -2644,7 +2658,7 @@ packages:
       extend-shallow: 2.0.1
       posix-character-classes: 0.1.1
       regex-not: 1.0.2
-      snapdragon: 0.8.1
+      snapdragon: 0.8.2
       to-regex: 3.0.2
     dev: false
     engines:
@@ -2678,7 +2692,7 @@ packages:
       integrity: sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=
   /expect/21.2.1:
     dependencies:
-      ansi-styles: 3.2.0
+      ansi-styles: 3.2.1
       jest-diff: 21.2.1
       jest-get-type: 21.2.0
       jest-matcher-utils: 21.2.1
@@ -2687,9 +2701,9 @@ packages:
     dev: false
     resolution:
       integrity: sha512-orfQQqFRTX0jH7znRIGi8ZMR8kTNpXklTTz8+HGTpmTKZo3Occ6JNB5FXMb8cRuiiC/GyDqsr30zUa66ACYlYw==
-  /express/4.16.2:
+  /express/4.16.3:
     dependencies:
-      accepts: 1.3.4
+      accepts: 1.3.5
       array-flatten: 1.1.1
       body-parser: 1.18.2
       content-disposition: 0.5.2
@@ -2701,7 +2715,7 @@ packages:
       encodeurl: 1.0.2
       escape-html: 1.0.3
       etag: 1.8.1
-      finalhandler: 1.1.0
+      finalhandler: 1.1.1
       fresh: 0.5.2
       merge-descriptors: 1.0.1
       methods: 1.1.2
@@ -2712,10 +2726,10 @@ packages:
       qs: 6.5.1
       range-parser: 1.2.0
       safe-buffer: 5.1.1
-      send: 0.16.1
-      serve-static: 1.13.1
+      send: 0.16.2
+      serve-static: 1.13.2
       setprototypeof: 1.1.0
-      statuses: 1.3.1
+      statuses: 1.4.0
       type-is: 1.6.16
       utils-merge: 1.0.1
       vary: 1.1.2
@@ -2723,7 +2737,7 @@ packages:
     engines:
       node: '>= 0.10.0'
     resolution:
-      integrity: sha1-41xt/i1kt9ygpc1PIXgb4ymeB2w=
+      integrity: sha1-avilAjUNsyRuzEvs9rWjTSL37VM=
   /extend-shallow/2.0.1:
     dependencies:
       is-extendable: 0.1.1
@@ -2769,7 +2783,7 @@ packages:
       extend-shallow: 2.0.1
       fragment-cache: 0.2.1
       regex-not: 1.0.2
-      snapdragon: 0.8.1
+      snapdragon: 0.8.2
       to-regex: 3.0.2
     dev: false
     engines:
@@ -2909,6 +2923,20 @@ packages:
       node: '>= 0.8'
     resolution:
       integrity: sha1-zgtoVbRYU+eRsvzGgARtiCU91/U=
+  /finalhandler/1.1.1:
+    dependencies:
+      debug: 2.6.9
+      encodeurl: 1.0.2
+      escape-html: 1.0.3
+      on-finished: 2.3.0
+      parseurl: 1.3.2
+      statuses: 1.4.0
+      unpipe: 1.0.0
+    dev: false
+    engines:
+      node: '>= 0.8'
+    resolution:
+      integrity: sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==
   /find-index/0.1.1:
     dev: false
     resolution:
@@ -3433,7 +3461,7 @@ packages:
       object-assign: 4.1.1
       object.omit: 2.0.1
       object.pick: 1.3.0
-      readable-stream: 2.3.4
+      readable-stream: 2.3.5
       try-json-parse: 0.1.1
       vinyl: 1.2.0
     dev: false
@@ -3450,7 +3478,7 @@ packages:
       integrity: sha1-nvyNMl+YBcx2aP3059YNSxQQ8s8=
   /gulp-clean-css/3.0.4:
     dependencies:
-      clean-css: 4.1.9
+      clean-css: 4.1.11
       gulp-util: 3.0.8
       through2: 2.0.3
       vinyl-sourcemaps-apply: 0.2.1
@@ -3606,7 +3634,7 @@ packages:
   /gulp-replace/0.5.4:
     dependencies:
       istextorbinary: 1.0.2
-      readable-stream: 2.3.4
+      readable-stream: 2.3.5
       replacestream: 4.0.3
     dev: false
     engines:
@@ -3757,7 +3785,7 @@ packages:
   /har-validator/2.0.6:
     dependencies:
       chalk: 1.1.3
-      commander: 2.14.1
+      commander: 2.15.0
       is-my-json-valid: 2.17.2
       pinkie-promise: 2.0.1
     dev: false
@@ -3955,10 +3983,12 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-TCu8inWJmP7r9e1oWA921GdotLw=
-  /hosted-git-info/2.5.0:
+  /hosted-git-info/2.6.0:
     dev: false
+    engines:
+      node: '>=4'
     resolution:
-      integrity: sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==
+      integrity: sha512-lIbgIIQA3lz5XaB6vxakj6sDHADJiZadYEJB+FgA+C4nubM1NwcuvUr9EJPmnH1skZqpqUzWborWo8EIUi0Sdw==
   /html-encoding-sniffer/1.0.2:
     dependencies:
       whatwg-encoding: 1.0.3
@@ -3985,10 +4015,10 @@ packages:
       node: '>= 0.6'
     resolution:
       integrity: sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=
-  /http-parser-js/0.4.10:
+  /http-parser-js/0.4.11:
     dev: false
     resolution:
-      integrity: sha1-ksnBN0w1CF912zWexWzCV8u5P6Q=
+      integrity: sha512-QCR5O2AjjMW8Mo4HyI1ctFcv+O99j/0g367V3YoVnrNw5hkDvAWZD0lWGcc+F4yN3V55USPCVix4efb75HxFfA==
   /http-proxy/1.16.2:
     dependencies:
       eventemitter3: 1.2.0
@@ -4505,26 +4535,27 @@ packages:
     dev: false
     resolution:
       integrity: sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=
-  /istanbul-api/1.2.2:
+  /istanbul-api/1.3.1:
     dependencies:
       async: 2.6.0
+      compare-versions: 3.1.0
       fileset: 2.0.3
-      istanbul-lib-coverage: 1.1.2
-      istanbul-lib-hook: 1.1.0
-      istanbul-lib-instrument: 1.9.2
-      istanbul-lib-report: 1.1.3
-      istanbul-lib-source-maps: 1.2.3
-      istanbul-reports: 1.1.4
+      istanbul-lib-coverage: 1.2.0
+      istanbul-lib-hook: 1.2.0
+      istanbul-lib-instrument: 1.10.1
+      istanbul-lib-report: 1.1.4
+      istanbul-lib-source-maps: 1.2.4
+      istanbul-reports: 1.3.0
       js-yaml: 3.9.1
       mkdirp: 0.5.1
       once: 1.4.0
     dev: false
     resolution:
-      integrity: sha512-kH5YRdqdbs5hiH4/Rr1Q0cSAGgjh3jTtg8vu9NLebBAoK3adVO4jk81J+TYOkTr2+Q4NLeb1ACvmEt65iG/Vbw==
+      integrity: sha512-duj6AlLcsWNwUpfyfHt0nWIeRiZpuShnP40YTxOGQgtaN8fd6JYSxsvxUphTDy8V5MfDXo4s/xVCIIvVCO808g==
   /istanbul-instrumenter-loader/3.0.0:
     dependencies:
       convert-source-map: 1.5.1
-      istanbul-lib-instrument: 1.9.2
+      istanbul-lib-instrument: 1.10.1
       loader-utils: 1.1.0
       schema-utils: 0.3.0
     dev: false
@@ -4537,7 +4568,7 @@ packages:
   /istanbul-instrumenter-loader/3.0.0/webpack@3.6.0:
     dependencies:
       convert-source-map: 1.5.1
-      istanbul-lib-instrument: 1.9.2
+      istanbul-lib-instrument: 1.10.1
       loader-utils: 1.1.0
       schema-utils: 0.3.0
       webpack: 3.6.0
@@ -4548,53 +4579,63 @@ packages:
     peerDependencies: *ref_5
     resolution:
       integrity: sha512-alLSEFX06ApU75sm5oWcaVNaiss/bgMRiWTct3g0P0ZZTKjR+6QiCcuVOKDI1kWJgwHEnIXsv/dWm783kPpmtw==
-  /istanbul-lib-coverage/1.1.2:
+  /istanbul-lib-coverage/1.2.0:
     dev: false
     resolution:
-      integrity: sha512-tZYA0v5A7qBSsOzcebJJ/z3lk3oSzH62puG78DbBA1+zupipX2CakDyiPV3pOb8He+jBwVimuwB0dTnh38hX0w==
-  /istanbul-lib-hook/1.1.0:
+      integrity: sha512-GvgM/uXRwm+gLlvkWHTjDAvwynZkL9ns15calTrmhGgowlwJBbWMYzWbKqE2DT6JDP1AFXKa+Zi0EkqNCUqY0A==
+  /istanbul-lib-hook/1.2.0:
     dependencies:
       append-transform: 0.4.0
     dev: false
     resolution:
-      integrity: sha512-U3qEgwVDUerZ0bt8cfl3dSP3S6opBoOtk3ROO5f2EfBr/SRiD9FQqzwaZBqFORu8W7O0EXpai+k7kxHK13beRg==
-  /istanbul-lib-instrument/1.9.2:
+      integrity: sha512-p3En6/oGkFQV55Up8ZPC2oLxvgSxD8CzA0yBrhRZSh3pfv3OFj9aSGVC0yoerAi/O4u7jUVnOGVX1eVFM+0tmQ==
+  /istanbul-lib-instrument/1.10.1:
     dependencies:
       babel-generator: 6.26.1
       babel-template: 6.26.0
       babel-traverse: 6.26.0
       babel-types: 6.26.0
       babylon: 6.18.0
-      istanbul-lib-coverage: 1.1.2
+      istanbul-lib-coverage: 1.2.0
       semver: 5.3.0
     dev: false
     resolution:
-      integrity: sha512-nz8t4HQ2206a/3AXi+NHFWEa844DMpPsgbcUteJbt1j8LX1xg56H9rOMnhvcvVvPbW60qAIyrSk44H8ZDqaSSA==
-  /istanbul-lib-report/1.1.3:
+      integrity: sha512-1dYuzkOCbuR5GRJqySuZdsmsNKPL3PTuyPevQfoCXJePT9C8y1ga75neU+Tuy9+yS3G/dgx8wgOmp2KLpgdoeQ==
+  /istanbul-lib-report/1.1.4:
     dependencies:
-      istanbul-lib-coverage: 1.1.2
+      istanbul-lib-coverage: 1.2.0
       mkdirp: 0.5.1
       path-parse: 1.0.5
       supports-color: 3.2.3
     dev: false
     resolution:
-      integrity: sha512-D4jVbMDtT2dPmloPJS/rmeP626N5Pr3Rp+SovrPn1+zPChGHcggd/0sL29jnbm4oK9W0wHjCRsdch9oLd7cm6g==
+      integrity: sha512-Azqvq5tT0U09nrncK3q82e/Zjkxa4tkFZv7E6VcqP0QCPn6oNljDPfrZEC/umNXds2t7b8sRJfs6Kmpzt8m2kA==
   /istanbul-lib-source-maps/1.2.3:
     dependencies:
       debug: 3.1.0
-      istanbul-lib-coverage: 1.1.2
+      istanbul-lib-coverage: 1.2.0
       mkdirp: 0.5.1
       rimraf: 2.6.2
       source-map: 0.5.7
     dev: false
     resolution:
       integrity: sha512-fDa0hwU/5sDXwAklXgAoCJCOsFsBplVQ6WBldz5UwaqOzmDhUK4nfuR7/G//G2lERlblUNJB8P6e8cXq3a7MlA==
-  /istanbul-reports/1.1.4:
+  /istanbul-lib-source-maps/1.2.4:
+    dependencies:
+      debug: 3.1.0
+      istanbul-lib-coverage: 1.2.0
+      mkdirp: 0.5.1
+      rimraf: 2.6.2
+      source-map: 0.5.7
+    dev: false
+    resolution:
+      integrity: sha512-UzuK0g1wyQijiaYQxj/CdNycFhAd2TLtO2obKQMTZrZ1jzEMRY3rvpASEKkaxbRR6brvdovfA03znPa/pXcejg==
+  /istanbul-reports/1.3.0:
     dependencies:
       handlebars: 4.0.11
     dev: false
     resolution:
-      integrity: sha512-DfSTVOTkuO+kRmbO8Gk650Wqm1WRGr6lrdi2EwDK1vxpS71vdlLd613EpzOKdIFioB5f/scJTjeWBnvd1FWejg==
+      integrity: sha512-y2Z2IMqE1gefWUaVjrBm0mSKvUkaBy9Vqz8iwr/r40Y9hBbIteH5wqHG/9DLTfJ9xUnUT2j7A3+VVJ6EaYBllA==
   /istanbul-threshold-checker/0.1.0:
     dependencies:
       istanbul: 0.3.22
@@ -4666,13 +4707,13 @@ packages:
   /jest-cli/21.2.1:
     dependencies:
       ansi-escapes: 3.0.0
-      chalk: 2.3.1
+      chalk: 2.3.2
       glob: 7.1.2
       graceful-fs: 4.1.11
       is-ci: 1.1.0
-      istanbul-api: 1.2.2
-      istanbul-lib-coverage: 1.1.2
-      istanbul-lib-instrument: 1.9.2
+      istanbul-api: 1.3.1
+      istanbul-lib-coverage: 1.2.0
+      istanbul-lib-instrument: 1.10.1
       istanbul-lib-source-maps: 1.2.3
       jest-changed-files: 21.2.0
       jest-config: 21.2.1
@@ -4692,7 +4733,7 @@ packages:
       string-length: 2.0.0
       strip-ansi: 4.0.0
       which: 1.3.0
-      worker-farm: 1.5.4
+      worker-farm: 1.6.0
       yargs: 9.0.1
     dev: false
     engines:
@@ -4701,7 +4742,7 @@ packages:
       integrity: sha512-T1BzrbFxDIW/LLYQqVfo94y/hhaj1NzVQkZgBumAC+sxbjMROI7VkihOdxNR758iYbQykL2ZOWUBurFgkQrzdg==
   /jest-config/21.2.1:
     dependencies:
-      chalk: 2.3.1
+      chalk: 2.3.2
       glob: 7.1.2
       jest-environment-jsdom: 21.2.1
       jest-environment-node: 21.2.1
@@ -4717,8 +4758,8 @@ packages:
       integrity: sha512-fJru5HtlD/5l2o25eY9xT0doK3t2dlglrqoGpbktduyoI0T5CwuB++2YfoNZCrgZipTwPuAGonYv0q7+8yDc/A==
   /jest-diff/21.2.1:
     dependencies:
-      chalk: 2.3.1
-      diff: 3.4.0
+      chalk: 2.3.2
+      diff: 3.5.0
       jest-get-type: 21.2.0
       pretty-format: 21.2.1
     dev: false
@@ -4754,13 +4795,13 @@ packages:
       jest-docblock: 21.2.0
       micromatch: 2.3.11
       sane: 2.4.1
-      worker-farm: 1.5.4
+      worker-farm: 1.6.0
     dev: false
     resolution:
       integrity: sha512-5LhsY/loPH7wwOFRMs+PT4aIAORJ2qwgbpMFlbWbxfN0bk3ZCwxJ530vrbSiTstMkYLao6JwBkLhCJ5XbY7ZHw==
   /jest-jasmine2/21.2.1:
     dependencies:
-      chalk: 2.3.1
+      chalk: 2.3.2
       expect: 21.2.1
       graceful-fs: 4.1.11
       jest-diff: 21.2.1
@@ -4773,7 +4814,7 @@ packages:
       integrity: sha512-lw8FXXIEekD+jYNlStfgNsUHpfMWhWWCgHV7n0B7mA/vendH7vBFs8xybjQsDzJSduptBZJHqQX9SMssya9+3A==
   /jest-matcher-utils/21.2.1:
     dependencies:
-      chalk: 2.3.1
+      chalk: 2.3.2
       jest-get-type: 21.2.0
       pretty-format: 21.2.1
     dev: false
@@ -4781,7 +4822,7 @@ packages:
       integrity: sha512-kn56My+sekD43dwQPrXBl9Zn9tAqwoy25xxe7/iY4u+mG8P3ALj5IK7MLHZ4Mi3xW7uWVCjGY8cm4PqgbsqMCg==
   /jest-message-util/21.2.1:
     dependencies:
-      chalk: 2.3.1
+      chalk: 2.3.2
       micromatch: 2.3.11
       slash: 1.0.0
     dev: false
@@ -4804,7 +4845,7 @@ packages:
   /jest-resolve/21.2.0:
     dependencies:
       browser-resolve: 1.11.2
-      chalk: 2.3.1
+      chalk: 2.3.2
       is-builtin-module: 1.0.0
     dev: false
     resolution:
@@ -4820,7 +4861,7 @@ packages:
       jest-util: 21.2.1
       pify: 3.0.0
       throat: 4.1.0
-      worker-farm: 1.5.4
+      worker-farm: 1.6.0
     dev: false
     resolution:
       integrity: sha512-Anb72BOQlHqF/zETqZ2K20dbYsnqW/nZO7jV8BYENl+3c44JhMrA8zd1lt52+N7ErnsQMd2HHKiVwN9GYSXmrg==
@@ -4829,7 +4870,7 @@ packages:
       babel-core: 6.26.0
       babel-jest: /babel-jest/21.2.0/babel-core@6.26.0
       babel-plugin-istanbul: 4.1.5
-      chalk: 2.3.1
+      chalk: 2.3.2
       convert-source-map: 1.5.1
       graceful-fs: 4.1.11
       jest-config: 21.2.1
@@ -4848,7 +4889,7 @@ packages:
       integrity: sha512-6omlpA3+NSE+rHwD0PQjNEjZeb2z+oRmuehMfM1tWQVum+E0WV3pFt26Am0DUfQkkPyTABvxITRjCUclYgSOsA==
   /jest-snapshot/21.2.1:
     dependencies:
-      chalk: 2.3.1
+      chalk: 2.3.2
       jest-diff: 21.2.1
       jest-matcher-utils: 21.2.1
       mkdirp: 0.5.1
@@ -4860,7 +4901,7 @@ packages:
   /jest-util/21.2.1:
     dependencies:
       callsites: 2.0.0
-      chalk: 2.3.1
+      chalk: 2.3.2
       graceful-fs: 4.1.11
       jest-message-util: 21.2.1
       jest-mock: 21.2.0
@@ -4871,7 +4912,7 @@ packages:
       integrity: sha512-r20W91rmHY3fnCoO7aOAlyfC51x2yeV3xF+prGsJAUsYhKeV670ZB8NO88Lwm7ASu8SdH0S+U+eFf498kjhA4g==
   /jest-validate/21.2.1:
     dependencies:
-      chalk: 2.3.1
+      chalk: 2.3.2
       jest-get-type: 21.2.0
       leven: 2.1.0
       pretty-format: 21.2.1
@@ -4923,7 +4964,7 @@ packages:
       html-encoding-sniffer: 1.0.2
       nwmatcher: 1.4.3
       parse5: 1.5.1
-      request: 2.83.0
+      request: 2.85.0
       sax: 1.2.4
       symbol-tree: 3.2.2
       tough-cookie: 2.3.4
@@ -5174,17 +5215,9 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-odePw6UEdMuAhF07O24dpJpEbo4=
-  /lazy-cache/2.0.2:
-    dependencies:
-      set-getter: 0.1.0
-    dev: false
-    engines:
-      node: '>=0.10.0'
-    resolution:
-      integrity: sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=
   /lazystream/1.0.0:
     dependencies:
-      readable-stream: 2.3.4
+      readable-stream: 2.3.5
     dev: false
     engines:
       node: '>= 0.6.3'
@@ -5627,13 +5660,13 @@ packages:
     dev: false
     resolution:
       integrity: sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=
-  /lru-cache/4.1.1:
+  /lru-cache/4.1.2:
     dependencies:
       pseudomap: 1.0.2
       yallist: 2.1.2
     dev: false
     resolution:
-      integrity: sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==
+      integrity: sha512-wgeVXhrDwAWnIF/yZARsFnMBtdFXOg1b8RIrhilp+0iDYN4mdQcNZElDZ0e4B64BhaxeQ5zN7PMyvu7we1kPeQ==
   /make-iterator/1.0.0:
     dependencies:
       kind-of: 3.2.2
@@ -5708,7 +5741,7 @@ packages:
   /memory-fs/0.4.1:
     dependencies:
       errno: 0.1.7
-      readable-stream: 2.3.4
+      readable-stream: 2.3.5
     dev: false
     resolution:
       integrity: sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=
@@ -5735,7 +5768,7 @@ packages:
       integrity: sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=
   /merge-stream/1.0.1:
     dependencies:
-      readable-stream: 2.3.4
+      readable-stream: 2.3.5
     dev: false
     resolution:
       integrity: sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=
@@ -5788,7 +5821,7 @@ packages:
       nanomatch: 1.2.9
       object.pick: 1.3.0
       regex-not: 1.0.2
-      snapdragon: 0.8.1
+      snapdragon: 0.8.2
       to-regex: 3.0.2
     dev: false
     engines:
@@ -6008,7 +6041,7 @@ packages:
       kind-of: 6.0.2
       object.pick: 1.3.0
       regex-not: 1.0.2
-      snapdragon: 0.8.1
+      snapdragon: 0.8.2
       to-regex: 3.0.2
     dev: false
     engines:
@@ -6033,10 +6066,10 @@ packages:
     dev: false
     resolution:
       integrity: sha512-nJmSswG4As/MkRq7QZFuH/sf/yuv8ODdMZrY4Bedjp77a5MK4A6s7YbBB64c9u79EBUOfXUXBvArmvzTD0X+6g==
-  /node-forge/0.7.2:
+  /node-forge/0.7.4:
     dev: false
     resolution:
-      integrity: sha512-XTBoBY8NoeGAqQywTM8BjBz/Ro37eTmVF657yf6JumfOhxW9eET43Hve5+6L4+lo3hTDx7kTbC1WfasTHinDpg==
+      integrity: sha512-8Df0906+tq/omxuCZD6PqhPaQDYuyJ1d+VITgxoIA8zvQd1ru+nMJcDChHH324MWitIgbVkAkQoGEEVJNpn/PA==
   /node-gyp/3.6.2:
     dependencies:
       fstream: 1.0.11
@@ -6047,7 +6080,7 @@ packages:
       nopt: 3.0.6
       npmlog: 4.1.2
       osenv: 0.1.5
-      request: 2.83.0
+      request: 2.85.0
       rimraf: 2.5.4
       semver: 5.3.0
       tar: 2.2.1
@@ -6077,10 +6110,10 @@ packages:
       process: 0.11.10
       punycode: 1.4.1
       querystring-es3: 0.2.1
-      readable-stream: 2.3.4
+      readable-stream: 2.3.5
       stream-browserify: 2.0.1
       stream-http: 2.8.0
-      string_decoder: 1.0.3
+      string_decoder: 1.1.0
       timers-browserify: 2.0.6
       tty-browserify: 0.0.0
       url: 0.11.0
@@ -6140,7 +6173,7 @@ packages:
       integrity: sha1-xkZdvwirzU2zWTF/eaxopkayj/k=
   /normalize-package-data/2.4.0:
     dependencies:
-      hosted-git-info: 2.5.0
+      hosted-git-info: 2.6.0
       is-builtin-module: 1.0.0
       semver: 5.3.0
       validate-npm-package-license: 3.0.3
@@ -6163,7 +6196,7 @@ packages:
       integrity: sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=
   /npm-package-arg/5.1.2:
     dependencies:
-      hosted-git-info: 2.5.0
+      hosted-git-info: 2.6.0
       osenv: 0.1.5
       semver: 5.3.0
       validate-npm-package-name: 3.0.0
@@ -6372,7 +6405,7 @@ packages:
   /ordered-read-streams/0.3.0:
     dependencies:
       is-stream: 1.1.0
-      readable-stream: 2.3.4
+      readable-stream: 2.3.5
     dev: false
     resolution:
       integrity: sha1-cTfmmzKYuzQiR6G77jiByA4v14s=
@@ -6656,7 +6689,7 @@ packages:
       hasha: 2.2.0
       kew: 0.7.0
       progress: 1.1.8
-      request: 2.83.0
+      request: 2.85.0
       request-progress: 2.0.1
       which: 1.3.0
     dev: false
@@ -6809,9 +6842,9 @@ packages:
       integrity: sha1-AA29H47vIXqjaLmiEsX8QLKo8/I=
   /postcss/6.0.19:
     dependencies:
-      chalk: 2.3.1
+      chalk: 2.3.2
       source-map: 0.6.1
-      supports-color: 5.2.0
+      supports-color: 5.3.0
     dev: false
     engines:
       node: '>=4.0.0'
@@ -6832,7 +6865,7 @@ packages:
   /pretty-format/21.2.1:
     dependencies:
       ansi-regex: 3.0.0
-      ansi-styles: 3.2.0
+      ansi-styles: 3.2.1
     dev: false
     resolution:
       integrity: sha512-ZdWPGYAnYfcVP8yKA3zFjCn8s4/17TeYH28MXuC8vTp0o21eXjbFGcOAXZEaDaOFJjc3h2qa7HQNHNshhvoh2A==
@@ -6986,7 +7019,7 @@ packages:
       node: '>= 0.8'
     resolution:
       integrity: sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k=
-  /read-package-json/2.0.12:
+  /read-package-json/2.0.13:
     dependencies:
       glob: 7.1.2
       json-parse-better-errors: 1.0.1
@@ -6996,13 +7029,13 @@ packages:
     optionalDependencies:
       graceful-fs: 4.1.11
     resolution:
-      integrity: sha512-m7/I0+tP6D34EVvSlzCtuVA4D/dHL6OpLcn2e4XVP5X57pCKGUy1JjRSBVKHWpB+vUU91sL85h84qX0MdXzBSw==
+      integrity: sha512-/1dZ7TRZvGrYqE0UAfN6qQb5GYBsNcqS1C0tNK601CFOJmtHI7NIGXwetEPU/OtoFHZL3hDxm4rolFFVE9Bnmg==
   /read-package-tree/5.1.6:
     dependencies:
       debuglog: 1.0.1
       dezalgo: 1.0.3
       once: 1.4.0
-      read-package-json: 2.0.12
+      read-package-json: 2.0.13
       readdir-scoped-modules: 1.0.2
     dev: false
     resolution:
@@ -7071,7 +7104,7 @@ packages:
     dev: false
     resolution:
       integrity: sha1-fPTFTvZI44EwhMY23SB54WbAgdk=
-  /readable-stream/2.3.4:
+  /readable-stream/2.3.5:
     dependencies:
       core-util-is: 1.0.2
       inherits: 2.0.3
@@ -7082,7 +7115,7 @@ packages:
       util-deprecate: 1.0.2
     dev: false
     resolution:
-      integrity: sha512-vuYxeWYM+fde14+rajzqgeohAI7YoJcHE7kXDAc4Nk0EbuKnJfqtY9YtRkLo/tqkuF7MsBQRhPnPeyjYITp3ZQ==
+      integrity: sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==
   /readdir-scoped-modules/1.0.2:
     dependencies:
       debuglog: 1.0.1
@@ -7096,7 +7129,7 @@ packages:
     dependencies:
       graceful-fs: 4.1.11
       minimatch: 3.0.4
-      readable-stream: 2.3.4
+      readable-stream: 2.3.5
       set-immediate-shim: 1.0.1
     dev: false
     engines:
@@ -7203,7 +7236,7 @@ packages:
     dependencies:
       escape-string-regexp: 1.0.5
       object-assign: 4.1.1
-      readable-stream: 2.3.4
+      readable-stream: 2.3.5
     dev: false
     resolution:
       integrity: sha512-AC0FiLS352pBBiZhd4VXB1Ab/lh0lEgpP+GGvZqbQh8a5cmXVoTe5EX/YeTFArnp4SRGTHh1qCHu9lGs1qG8sA==
@@ -7240,7 +7273,7 @@ packages:
       node: '>= 4'
     resolution:
       integrity: sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=
-  /request/2.83.0:
+  /request/2.85.0:
     dependencies:
       aws-sign2: 0.7.0
       aws4: 1.6.0
@@ -7268,7 +7301,7 @@ packages:
     engines:
       node: '>= 4'
     resolution:
-      integrity: sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==
+      integrity: sha512-8H7Ehijd4js+s6wuVPLjwORxD4zeuyjYugprdOXlPSqaApmL/QOy+EB/beICHVCHkGMKNh5rvihb5ov+IDw4mg==
   /require-directory/2.1.1:
     dev: false
     engines:
@@ -7465,26 +7498,6 @@ packages:
       node: '>= 0.8.0'
     resolution:
       integrity: sha1-dl52B8gFVFK7pvCwUllTUJhgNt4=
-  /send/0.16.1:
-    dependencies:
-      debug: 2.6.9
-      depd: 1.1.2
-      destroy: 1.0.4
-      encodeurl: 1.0.2
-      escape-html: 1.0.3
-      etag: 1.8.1
-      fresh: 0.5.2
-      http-errors: 1.6.2
-      mime: 1.4.1
-      ms: 2.0.0
-      on-finished: 2.3.0
-      range-parser: 1.2.0
-      statuses: 1.3.1
-    dev: false
-    engines:
-      node: '>= 0.8.0'
-    resolution:
-      integrity: sha512-ElCLJdJIKPk6ux/Hocwhk7NFHpI3pVm/IZOYWqUmoxcgeyM+MpxHHKhb8QmlJDX1pU6WrgaHBkVNm73Sv7uc2A==
   /send/0.16.2:
     dependencies:
       debug: 2.6.9
@@ -7513,7 +7526,7 @@ packages:
       integrity: sha1-kM/xnQLgcCf9dn9erT57ldHnOAw=
   /serve-index/1.9.1:
     dependencies:
-      accepts: 1.3.4
+      accepts: 1.3.5
       batch: 0.6.1
       debug: 2.6.9
       escape-html: 1.0.3
@@ -7525,17 +7538,6 @@ packages:
       node: '>= 0.8.0'
     resolution:
       integrity: sha1-03aNabHn2C5c4FD/9bRTvqEqkjk=
-  /serve-static/1.13.1:
-    dependencies:
-      encodeurl: 1.0.2
-      escape-html: 1.0.3
-      parseurl: 1.3.2
-      send: 0.16.1
-    dev: false
-    engines:
-      node: '>= 0.8.0'
-    resolution:
-      integrity: sha512-hSMUZrsPa/I09VYFJwa627JJkNs0NrfL1Uzuup+GqHfToR2KcsXFymXSV90hoyw3M+msjFuQly+YzIH/q0MGlQ==
   /serve-static/1.13.2:
     dependencies:
       encodeurl: 1.0.2
@@ -7551,14 +7553,6 @@ packages:
     dev: false
     resolution:
       integrity: sha1-BF+XgtARrppoA93TgrJDkrPYkPc=
-  /set-getter/0.1.0:
-    dependencies:
-      to-object-path: 0.3.0
-    dev: false
-    engines:
-      node: '>=0.10.0'
-    resolution:
-      integrity: sha1-12nBgsnVpR9AkUXy+6guXoboA3Y=
   /set-immediate-shim/1.0.1:
     dev: false
     engines:
@@ -7683,7 +7677,7 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==
-  /snapdragon/0.8.1:
+  /snapdragon/0.8.2:
     dependencies:
       base: 0.11.2
       debug: 2.6.9
@@ -7692,12 +7686,12 @@ packages:
       map-cache: 0.2.2
       source-map: 0.5.7
       source-map-resolve: 0.5.1
-      use: 2.0.2
+      use: 3.1.0
     dev: false
     engines:
       node: '>=0.10.0'
     resolution:
-      integrity: sha1-4StUh/re0+PeoKyR6UAL91tAE3A=
+      integrity: sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==
   /sntp/1.0.9:
     dependencies:
       hoek: 2.16.3
@@ -7819,7 +7813,7 @@ packages:
       integrity: sha1-Gsu/tZJDbRC76PeFt8xvgoFQEsM=
   /spawn-sync/1.0.15:
     dependencies:
-      concat-stream: 1.6.0
+      concat-stream: 1.6.1
       os-shim: 0.1.3
     dev: false
     resolution:
@@ -7913,14 +7907,14 @@ packages:
       integrity: sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==
   /stdout-stream/1.4.0:
     dependencies:
-      readable-stream: 2.3.4
+      readable-stream: 2.3.5
     dev: false
     resolution:
       integrity: sha1-osfIWH5U2UJ+qe2zrD8s1SLfN4s=
   /stream-browserify/2.0.1:
     dependencies:
       inherits: 2.0.3
-      readable-stream: 2.3.4
+      readable-stream: 2.3.5
     dev: false
     resolution:
       integrity: sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=
@@ -7938,7 +7932,7 @@ packages:
     dependencies:
       builtin-status-codes: 3.0.0
       inherits: 2.0.3
-      readable-stream: 2.3.4
+      readable-stream: 2.3.5
       to-arraybuffer: 1.0.1
       xtend: 4.0.1
     dev: false
@@ -7996,6 +7990,12 @@ packages:
     dev: false
     resolution:
       integrity: sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==
+  /string_decoder/1.1.0:
+    dependencies:
+      safe-buffer: 5.1.1
+    dev: false
+    resolution:
+      integrity: sha512-8zQpRF6juocE69ae7CSPmYEGJe4VCXwP6S6dxUWI7i53Gwv54/ec41fiUA+X7BPGGv7fRSQJjBQVa0gomGaOgg==
   /stringstream/0.0.5:
     dev: false
     resolution:
@@ -8122,14 +8122,14 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=
-  /supports-color/5.2.0:
+  /supports-color/5.3.0:
     dependencies:
       has-flag: 3.0.0
     dev: false
     engines:
       node: '>=4'
     resolution:
-      integrity: sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==
+      integrity: sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==
   /symbol-tree/3.2.2:
     dev: false
     resolution:
@@ -8174,7 +8174,7 @@ packages:
       integrity: sha1-4Ma8TSa5AxJEEOT+2BEDAU38H1k=
   /ternary-stream/2.0.1:
     dependencies:
-      duplexify: 3.5.3
+      duplexify: 3.5.4
       fork-stream: 0.0.4
       merge-stream: 1.0.1
       through2: 2.0.3
@@ -8183,16 +8183,16 @@ packages:
       node: '>= 0.10.0'
     resolution:
       integrity: sha1-Bk5Im0tb9gumpre8fy9cJ07Pgmk=
-  /test-exclude/4.2.0:
+  /test-exclude/4.2.1:
     dependencies:
       arrify: 1.0.1
-      micromatch: 2.3.11
+      micromatch: 3.1.9
       object-assign: 4.1.1
       read-pkg-up: 1.0.1
       require-main-filename: 1.0.1
     dev: false
     resolution:
-      integrity: sha512-8hMFzjxbPv6xSlwGhXSvOMJ/vTy3bkng+2pxmf6E1z6VF7I9nIyNfvHtaw+NBPgvz647gADBbMSbwLfZYppT/w==
+      integrity: sha512-qpqlP/8Zl+sosLxBcVKl9vYy26T9NPalxSzzCP/OY6K7j938ui2oKgo+kRZYfxAeIpLqpbVnsHq1tyV70E4lWQ==
   /textextensions/1.0.2:
     dev: false
     resolution:
@@ -8239,7 +8239,7 @@ packages:
       integrity: sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=
   /through2/2.0.3:
     dependencies:
-      readable-stream: 2.3.4
+      readable-stream: 2.3.5
       xtend: 4.0.1
     dev: false
     resolution:
@@ -8398,7 +8398,7 @@ packages:
       integrity: sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ==
   /tslint-microsoft-contrib/5.0.3:
     dependencies:
-      tsutils: 2.21.2
+      tsutils: 2.22.2
     dev: false
     peerDependencies: &ref_3
       tslint: ^5.1.0
@@ -8408,7 +8408,7 @@ packages:
   /tslint-microsoft-contrib/5.0.3/tslint@5.9.1+typescript@2.4.2:
     dependencies:
       tslint: /tslint/5.9.1/typescript@2.4.2
-      tsutils: /tsutils/2.21.2/typescript@2.4.2
+      tsutils: /tsutils/2.22.2/typescript@2.4.2
       typescript: 2.4.2
     dev: false
     id: registry.npmjs.org/tslint-microsoft-contrib/5.0.3
@@ -8419,16 +8419,16 @@ packages:
     dependencies:
       babel-code-frame: 6.26.0
       builtin-modules: 1.1.1
-      chalk: 2.3.1
-      commander: 2.14.1
-      diff: 3.4.0
+      chalk: 2.3.2
+      commander: 2.15.0
+      diff: 3.5.0
       glob: 7.1.2
       js-yaml: 3.9.1
       minimatch: 3.0.4
       resolve: 1.5.0
       semver: 5.3.0
       tslib: 1.9.0
-      tsutils: 2.21.2
+      tsutils: 2.22.2
     dev: false
     engines:
       node: '>=4.8.0'
@@ -8440,16 +8440,16 @@ packages:
     dependencies:
       babel-code-frame: 6.26.0
       builtin-modules: 1.1.1
-      chalk: 2.3.1
-      commander: 2.14.1
-      diff: 3.4.0
+      chalk: 2.3.2
+      commander: 2.15.0
+      diff: 3.5.0
       glob: 7.1.2
       js-yaml: 3.9.1
       minimatch: 3.0.4
       resolve: 1.5.0
       semver: 5.3.0
       tslib: 1.9.0
-      tsutils: /tsutils/2.21.2/typescript@2.4.2
+      tsutils: /tsutils/2.22.2/typescript@2.4.2
       typescript: 2.4.2
     dev: false
     engines:
@@ -8458,23 +8458,23 @@ packages:
     peerDependencies: *ref_1
     resolution:
       integrity: sha1-ElX4ej/1frCw4fDmEKi0dIBGya4=
-  /tsutils/2.21.2:
+  /tsutils/2.22.2:
     dependencies:
       tslib: 1.9.0
     dev: false
     peerDependencies: &ref_2
       typescript: '>=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev'
     resolution:
-      integrity: sha512-iaIuyjIUeFLdD39MYdzqBuY7Zv6+uGxSwRH4mf+HuzsnznjFz0R2tGrAe0/JvtNh91WrN8UN/DZRFTZNDuVekA==
-  /tsutils/2.21.2/typescript@2.4.2:
+      integrity: sha512-u06FUSulCJ+Y8a2ftuqZN6kIGqdP2yJjUPEngXqmdPND4UQfb04igcotH+dw+IFr417yP6muCLE8/5/Qlfnx0w==
+  /tsutils/2.22.2/typescript@2.4.2:
     dependencies:
       tslib: 1.9.0
       typescript: 2.4.2
     dev: false
-    id: registry.npmjs.org/tsutils/2.21.2
+    id: registry.npmjs.org/tsutils/2.22.2
     peerDependencies: *ref_2
     resolution:
-      integrity: sha512-iaIuyjIUeFLdD39MYdzqBuY7Zv6+uGxSwRH4mf+HuzsnznjFz0R2tGrAe0/JvtNh91WrN8UN/DZRFTZNDuVekA==
+      integrity: sha512-u06FUSulCJ+Y8a2ftuqZN6kIGqdP2yJjUPEngXqmdPND4UQfb04igcotH+dw+IFr417yP6muCLE8/5/Qlfnx0w==
   /tty-browserify/0.0.0:
     dev: false
     resolution:
@@ -8630,16 +8630,14 @@ packages:
     dev: false
     resolution:
       integrity: sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=
-  /use/2.0.2:
+  /use/3.1.0:
     dependencies:
-      define-property: 0.2.5
-      isobject: 3.0.1
-      lazy-cache: 2.0.2
+      kind-of: 6.0.2
     dev: false
     engines:
       node: '>=0.10.0'
     resolution:
-      integrity: sha1-riig1y+TvyJCKhii43mZMRLeyOg=
+      integrity: sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==
   /user-home/1.1.1:
     dev: false
     engines:
@@ -8648,7 +8646,7 @@ packages:
       integrity: sha1-K1viOjK2Onyd640PKNSFcko98ZA=
   /useragent/2.3.0:
     dependencies:
-      lru-cache: 4.1.1
+      lru-cache: 4.1.2
       tmp: 0.0.33
     dev: false
     resolution:
@@ -8739,7 +8737,7 @@ packages:
       integrity: sha1-mmhRzhysHBzqX+hsCTHWIMLPqeY=
   /vinyl-fs/2.4.4:
     dependencies:
-      duplexify: 3.5.3
+      duplexify: 3.5.4
       glob-stream: 5.3.5
       graceful-fs: 4.1.11
       gulp-sourcemaps: 1.6.0
@@ -8749,7 +8747,7 @@ packages:
       merge-stream: 1.0.1
       mkdirp: 0.5.1
       object-assign: 4.1.1
-      readable-stream: 2.3.4
+      readable-stream: 2.3.5
       strip-bom: 2.0.0
       strip-bom-stream: 1.0.0
       through2: 2.0.3
@@ -8885,7 +8883,7 @@ packages:
       integrity: sha512-aqYp18kPphgoO5c/+NaUvEeACtZjMESmDChuD3NBciVpah3XpMEU9VAAtIaB1BsfJWWTSdv8Vv1m3T0aRk2dUw==
   /webpack/3.6.0:
     dependencies:
-      acorn: 5.5.0
+      acorn: 5.5.3
       acorn-dynamic-import: 2.0.2
       ajv: 5.2.2
       ajv-keywords: /ajv-keywords/2.1.1/ajv@5.2.2
@@ -8914,7 +8912,7 @@ packages:
       integrity: sha512-OsHT3D0W0KmPPh60tC7asNnOmST6bKTiR90UyEdT9QYoaJ4OYN4Gg7WK1k3VxHK07ZoiYWPsKvlS/gAjwL/vRA==
   /websocket-driver/0.7.0:
     dependencies:
-      http-parser-js: 0.4.10
+      http-parser-js: 0.4.11
       websocket-extensions: 0.1.3
     dev: false
     engines:
@@ -8988,13 +8986,12 @@ packages:
     dev: false
     resolution:
       integrity: sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=
-  /worker-farm/1.5.4:
+  /worker-farm/1.6.0:
     dependencies:
       errno: 0.1.7
-      xtend: 4.0.1
     dev: false
     resolution:
-      integrity: sha512-ITyClEvcfv0ozqJl1vmWFWhvI+OIrkbInYqkEPE50wFPXj8J9Gd3FYf8+CkZJXJJsQBYe+2DvmoK9Zhx5w8W+w==
+      integrity: sha512-6w+3tHbM87WnSWnENBUvA2pxJPLhQUg5LKwUQHq3r+XPhIM+Gh2R5ycbwPCyuGbNg+lPgdcnQUhuC02kJCvffQ==
   /wrap-ansi/2.1.0:
     dependencies:
       string-width: 1.0.2
@@ -9185,7 +9182,7 @@ packages:
       validator: 8.2.0
     dev: false
     optionalDependencies:
-      commander: 2.14.1
+      commander: 2.15.0
     resolution:
       integrity: sha512-DUOKC/IhbkdLKKiV89gw9DUauTV8U/8yJl1sjf6MtDmzevLKOF2duNJ495S3MFVjqZarr+qNGCPbkg4mu4PpLw==
   'file:projects/api-documenter.tgz':
@@ -9202,6 +9199,7 @@ packages:
     dev: false
     name: '@rush-temp/api-documenter'
     resolution:
+      integrity: sha512-Cew5jJSIEbg8F5UBX7ePyD8xXI1VP3d77xgzZuevCehJ3kgkTkRKOBCqlvzvk9eojYZfod17+jfBh392Jdmp7Q==
       tarball: 'file:projects/api-documenter.tgz'
     version: 0.0.0
   'file:projects/api-extractor-test-01.tgz':
@@ -9213,6 +9211,7 @@ packages:
     dev: false
     name: '@rush-temp/api-extractor-test-01'
     resolution:
+      integrity: sha512-wrQNPlifyc1e7W0vfTkJylHhlCnNr0lSbkdY8FjwCMJbIngq/G45WdXshNE+jqKU+QPRMPHD6RYTKdUs1Dj0Jg==
       tarball: 'file:projects/api-extractor-test-01.tgz'
     version: 0.0.0
   'file:projects/api-extractor-test-02.tgz':
@@ -9225,6 +9224,7 @@ packages:
     dev: false
     name: '@rush-temp/api-extractor-test-02'
     resolution:
+      integrity: sha512-ix0Sn+8BEcm2Re8zdIEwNvQWVp84pzYHHdtlW2Um/YC/K03FSZLn49ZJvrw1UXovU8BfWRakfjJVXlNbYsnYnw==
       tarball: 'file:projects/api-extractor-test-02.tgz'
     version: 0.0.0
   'file:projects/api-extractor-test-03.tgz':
@@ -9236,6 +9236,7 @@ packages:
     dev: false
     name: '@rush-temp/api-extractor-test-03'
     resolution:
+      integrity: sha512-NI7TmjFwM6DSdg6ZzYvjoufolEJ+kg4qWw+1vJlMF967iXBtfv08CoXGSWVIzFISFomrV+B+O9puHocPZfEv3A==
       tarball: 'file:projects/api-extractor-test-03.tgz'
     version: 0.0.0
   'file:projects/api-extractor-test-04.tgz':
@@ -9245,6 +9246,7 @@ packages:
     dev: false
     name: '@rush-temp/api-extractor-test-04'
     resolution:
+      integrity: sha512-bXp+5gHpZI0/dLpxPgmcrOevMk8IuPN5/pKfoTZwXPTuOpdPVaCDL/dNFG5fKp45QpfkIFzf5izQefLH9xrRpA==
       tarball: 'file:projects/api-extractor-test-04.tgz'
     version: 0.0.0
   'file:projects/api-extractor.tgz':
@@ -9266,6 +9268,7 @@ packages:
     dev: false
     name: '@rush-temp/api-extractor'
     resolution:
+      integrity: sha512-d5+0IRpuDeX/PeDKvahse8Vp73Nx7bsfqp9iDriMvX1HiPF5UwUswpy1CkVpvkScjsvjOezYUf70sWgZ7oYcaQ==
       tarball: 'file:projects/api-extractor.tgz'
     version: 0.0.0
   'file:projects/decorators.tgz':
@@ -9278,6 +9281,7 @@ packages:
     dev: false
     name: '@rush-temp/decorators'
     resolution:
+      integrity: sha512-5S73ZhAYxbInjQwKcAty8Hbgp5at+T4mJVZbS1jN/ZIGzxkC/e79bxpCpNolrS7c2l4nFnXxsXVsJcbAuc0LKQ==
       tarball: 'file:projects/decorators.tgz'
     version: 0.0.0
   'file:projects/gulp-core-build-karma.tgz':
@@ -9309,6 +9313,7 @@ packages:
     dev: false
     name: '@rush-temp/gulp-core-build-karma'
     resolution:
+      integrity: sha512-Fx5+5DphTY+kRmdYDGUI8r5nSFRxOYAfXdca7PrRXbfnHwJB1VrPkHwdL2/bKjHjX/jOsoa0Y4j5bIYnXwERWQ==
       tarball: 'file:projects/gulp-core-build-karma.tgz'
     version: 0.0.0
   'file:projects/gulp-core-build-mocha.tgz':
@@ -9327,6 +9332,7 @@ packages:
     dev: false
     name: '@rush-temp/gulp-core-build-mocha'
     resolution:
+      integrity: sha512-YrvUBZRvYQ3h+keUQcETyjywWuSjQGCSaJwsSEZ6hOAPxoSsDePwrTnIzckYvmhU9n4SHQ6f2nMT3AYa4UDgAQ==
       tarball: 'file:projects/gulp-core-build-mocha.tgz'
     version: 0.0.0
   'file:projects/gulp-core-build-sass.tgz':
@@ -9354,6 +9360,7 @@ packages:
     dev: false
     name: '@rush-temp/gulp-core-build-sass'
     resolution:
+      integrity: sha512-kTzez2xlmf+/40HKHwtTi032oChrlcBaZfx552OuZ7Vsc1UNc5xSzZZok4AjQo7FhS/ZF7vw1FwZnuNoVA7ICg==
       tarball: 'file:projects/gulp-core-build-sass.tgz'
     version: 0.0.0
   'file:projects/gulp-core-build-serve.tgz':
@@ -9374,16 +9381,17 @@ packages:
       '@types/vinyl': 1.2.30
       colors: 1.1.2
       deasync: 0.1.12
-      express: 4.16.2
+      express: 4.16.3
       gulp: 3.9.1
       gulp-connect: 5.5.0
       gulp-open: 2.0.0
       gulp-util: 3.0.8
-      node-forge: 0.7.2
+      node-forge: 0.7.4
       sudo: 1.0.3
     dev: false
     name: '@rush-temp/gulp-core-build-serve'
     resolution:
+      integrity: sha512-RTkPNgH6USvV2px3WNG76PMikOrL5ZTsnqeIdYUAyvGnsp1JoYP38qS8VKDL/ypJ7jLDKiCZtXoTmR4cJT26Rg==
       tarball: 'file:projects/gulp-core-build-serve.tgz'
     version: 0.0.0
   'file:projects/gulp-core-build-typescript.tgz':
@@ -9418,6 +9426,7 @@ packages:
     dev: false
     name: '@rush-temp/gulp-core-build-typescript'
     resolution:
+      integrity: sha512-dufYqVfoGulCb5SZucFlrBRqK3USydSQk2P9J5lE4J/ea0AmhbGq1G+GeIA0R549usg1wZlNxT3q3M1Acs+9ZA==
       tarball: 'file:projects/gulp-core-build-typescript.tgz'
     version: 0.0.0
   'file:projects/gulp-core-build-webpack.tgz':
@@ -9429,6 +9438,7 @@ packages:
       '@types/orchestrator': 0.0.30
       '@types/q': 0.0.32
       '@types/source-map': 0.5.0
+      '@types/tapable': 0.2.4
       '@types/uglify-js': 2.6.29
       '@types/webpack': 3.0.11
       colors: 1.1.2
@@ -9438,6 +9448,7 @@ packages:
     dev: false
     name: '@rush-temp/gulp-core-build-webpack'
     resolution:
+      integrity: sha512-Vxsyz93pynshot6Z4H/BNgFFS2XdXzE5C1Wp4gEM+KrC4FIdI7Nt6GDN6gMl1n2U0mhccEnzEe2bW2fAPVrD8Q==
       tarball: 'file:projects/gulp-core-build-webpack.tgz'
     version: 0.0.0
   'file:projects/gulp-core-build.tgz':
@@ -9490,6 +9501,7 @@ packages:
     dev: false
     name: '@rush-temp/gulp-core-build'
     resolution:
+      integrity: sha512-UFMW/AtSWnMHtM2ab5aZ7puq5roqwVRidXJH18Voi7lvkn0h56qY6zpZv33msHl8fjSupLAPklP389XWbs1s4A==
       tarball: 'file:projects/gulp-core-build.tgz'
     version: 0.0.0
   'file:projects/load-themed-styles.tgz':
@@ -9502,6 +9514,7 @@ packages:
     dev: false
     name: '@rush-temp/load-themed-styles'
     resolution:
+      integrity: sha512-l9iLkTC8LIRIiY4M/Akn/XOSaoHDj4uDW6PCB3YzDkYkqmFzdA9DIl0ryqSTNJ80J2L9qC8zhGt3dPewh3WUnQ==
       tarball: 'file:projects/load-themed-styles.tgz'
     version: 0.0.0
   'file:projects/loader-load-themed-styles.tgz':
@@ -9509,6 +9522,7 @@ packages:
       '@types/loader-utils': 1.1.2
       '@types/mocha': 2.2.38
       '@types/node': 8.5.8
+      '@types/tapable': 0.2.4
       '@types/webpack': 3.0.11
       chai: 3.5.0
       gulp: 3.9.1
@@ -9516,6 +9530,7 @@ packages:
     dev: false
     name: '@rush-temp/loader-load-themed-styles'
     resolution:
+      integrity: sha512-ihlx+FRgXD7wIy2AXEsVmwgL+DIEkZaiJxfxwDh9s5jZJR/4jctRX0Za/K20E12CbJyH0KQ8Hb64aqxPNxuzZg==
       tarball: 'file:projects/loader-load-themed-styles.tgz'
     version: 0.0.0
   'file:projects/loader-raw-script.tgz':
@@ -9529,6 +9544,7 @@ packages:
     dev: false
     name: '@rush-temp/loader-raw-script'
     resolution:
+      integrity: sha512-MD4139FvydnunJUwid5j2QOKPDa749Uqrbkf2lGVSRc1Cf4Oe9pxYqluqd/EP8DCLnUBsh31m1cqkb+u0614gQ==
       tarball: 'file:projects/loader-raw-script.tgz'
     version: 0.0.0
   'file:projects/loader-set-webpack-public-path.tgz':
@@ -9544,6 +9560,7 @@ packages:
     dev: false
     name: '@rush-temp/loader-set-webpack-public-path'
     resolution:
+      integrity: sha512-5wYfA9ECcm3rvUCMcJIf2GgwwXlaYgTb+hbLv2JlRMLe0D2/4Zf86y9FVeJ+ltB3VGT0StsScqoX2CatAOubSQ==
       tarball: 'file:projects/loader-set-webpack-public-path.tgz'
     version: 0.0.0
   'file:projects/node-core-library.tgz':
@@ -9563,6 +9580,7 @@ packages:
     dev: false
     name: '@rush-temp/node-core-library'
     resolution:
+      integrity: sha512-0sCNe08kJsxT94SeaXdgAA2EJcUpezyIdDxn/esns5Qz0Ohg7JN/GscFtxITrJ4cvDaoL9aTSQxLvHw2S1jRIQ==
       tarball: 'file:projects/node-core-library.tgz'
     version: 0.0.0
   'file:projects/node-library-build.tgz':
@@ -9573,6 +9591,7 @@ packages:
     dev: false
     name: '@rush-temp/node-library-build'
     resolution:
+      integrity: sha512-vx4sensgBBMQwwcxb29C6DJHIxW2GYZdoY6gcFOkaEQ7LfS96AvbZzCxE5weSV2RiQEXA1fkSi28f6uaylixew==
       tarball: 'file:projects/node-library-build.tgz'
     version: 0.0.0
   'file:projects/package-deps-hash.tgz':
@@ -9585,12 +9604,13 @@ packages:
     dev: false
     name: '@rush-temp/package-deps-hash'
     resolution:
+      integrity: sha512-oX4Z+d0zutWG4clSgBVyYdmO4XSB6nfx9hTkzrWyJfi5yKqdA2PVMX9g+eAew4SLZFpniHmsLehyUrPQcHBJLw==
       tarball: 'file:projects/package-deps-hash.tgz'
     version: 0.0.0
   'file:projects/resolve-chunk-plugin.tgz':
     dependencies:
       '@types/mocha': 2.2.38
-      '@types/tapable': 0.2.3
+      '@types/tapable': 0.2.4
       '@types/webpack': 3.0.11
       chai: 3.5.0
       gulp: 3.9.1
@@ -9598,6 +9618,7 @@ packages:
     dev: false
     name: '@rush-temp/resolve-chunk-plugin'
     resolution:
+      integrity: sha512-PxqHMj6scZthDkoQrhEUDeE8R8BDOR8zUMlODVhrPfHnzawAiwAB8tdIcxHoE9nssB53ZmUH3zCG16QaSzvG3A==
       tarball: 'file:projects/resolve-chunk-plugin.tgz'
     version: 0.0.0
   'file:projects/rush-lib.tgz':
@@ -9640,6 +9661,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-lib'
     resolution:
+      integrity: sha512-lSCKx4cMFO5vQVCYrXKDSC8xFpNZHMwZuDiW3hKnTokmatHj6bodnAPpzRpotCA2dc3+OAee/6CeKNTc/eMlMg==
       tarball: 'file:projects/rush-lib.tgz'
     version: 0.0.0
   'file:projects/rush.tgz':
@@ -9658,6 +9680,7 @@ packages:
     dev: false
     name: '@rush-temp/rush'
     resolution:
+      integrity: sha512-cjpALyIU7pO9dWV+w446TnFy9HVeL1qxn+DejHIDzBqy3NIVk5Bss6WF5Qd45dIAdPG5QNB0092aBWcgIhvjuQ==
       tarball: 'file:projects/rush.tgz'
     version: 0.0.0
   'file:projects/set-webpack-public-path-plugin.tgz':
@@ -9665,7 +9688,7 @@ packages:
       '@types/lodash': 4.14.74
       '@types/mocha': 2.2.38
       '@types/node': 8.5.8
-      '@types/tapable': 0.2.3
+      '@types/tapable': 0.2.4
       '@types/uglify-js': 2.6.29
       '@types/webpack': 3.0.11
       chai: 3.5.0
@@ -9676,6 +9699,7 @@ packages:
     dev: false
     name: '@rush-temp/set-webpack-public-path-plugin'
     resolution:
+      integrity: sha512-Unsd8Unh4bM32D+MUJMr+H8p+b3u55bJ4K5XP4TPLU6nuCRaak0uAmZkKX8kZg7+CAufUbBVZUCh0PWuJ2dxlg==
       tarball: 'file:projects/set-webpack-public-path-plugin.tgz'
     version: 0.0.0
   'file:projects/stream-collator.tgz':
@@ -9691,6 +9715,7 @@ packages:
     dev: false
     name: '@rush-temp/stream-collator'
     resolution:
+      integrity: sha512-ddnO+m5puIqTpNAMuAB0XAjRkMxekXbvMpfdK4Wndmq4X+Dfp8KIOCXGPfgRvAtoXsewTcuqKJurhlah8ES+Bg==
       tarball: 'file:projects/stream-collator.tgz'
     version: 0.0.0
   'file:projects/ts-command-line.tgz':
@@ -9707,6 +9732,7 @@ packages:
     dev: false
     name: '@rush-temp/ts-command-line'
     resolution:
+      integrity: sha512-6lUgbN6SXgfo6FIP89TxVb+SHopnleqYtz1rYDbfJYW9NSdm0c4a0/4QmfKg23QPjdJPdvNs8DPjWYl+AqqvpA==
       tarball: 'file:projects/ts-command-line.tgz'
     version: 0.0.0
   'file:projects/web-library-build-test.tgz':
@@ -9719,6 +9745,7 @@ packages:
     dev: false
     name: '@rush-temp/web-library-build-test'
     resolution:
+      integrity: sha512-3aYFApRGVnMFtme8+Aj78lyIoUE1glGlp+E9xwINt2t+BuPjexd5mGun4CRvetCPWPHpJt+012SKu0gPKFp6Nw==
       tarball: 'file:projects/web-library-build-test.tgz'
     version: 0.0.0
   'file:projects/web-library-build.tgz':
@@ -9730,6 +9757,7 @@ packages:
     dev: false
     name: '@rush-temp/web-library-build'
     resolution:
+      integrity: sha512-VJu654Hj095UGjwLtjUumGp7szPX3D+9EZgpUlBXMR9ku3W2KVsyrUI3nY2KJOoUi6cXR7jH351YFjfZGu6EoQ==
       tarball: 'file:projects/web-library-build.tgz'
     version: 0.0.0
 registry: 'https://registry.npmjs.org/'
@@ -9766,7 +9794,7 @@ specifiers:
   '@rush-temp/ts-command-line': 'file:./projects/ts-command-line.tgz'
   '@rush-temp/web-library-build': 'file:./projects/web-library-build.tgz'
   '@rush-temp/web-library-build-test': 'file:./projects/web-library-build-test.tgz'
-  '@types/argparse': ~1.0.33
+  '@types/argparse': 1.0.33
   '@types/assertion-error': 1.0.30
   '@types/bluebird': 3.5.3
   '@types/chai': 3.4.34
@@ -9780,10 +9808,10 @@ specifiers:
   '@types/gulp-istanbul': 0.9.30
   '@types/gulp-mocha': 0.0.29
   '@types/gulp-util': 3.0.30
-  '@types/jest': ~21.1.8
+  '@types/jest': 21.1.10
   '@types/js-yaml': 3.9.1
   '@types/karma': 0.13.33
-  '@types/loader-utils': ~1.1.0
+  '@types/loader-utils': 1.1.2
   '@types/lodash': 4.14.74
   '@types/log4js': 0.0.33
   '@types/mime': 0.0.29
@@ -9799,7 +9827,7 @@ specifiers:
   '@types/serve-static': 1.13.1
   '@types/sinon': 1.16.34
   '@types/source-map': 0.5.0
-  '@types/tapable': 0.2.3
+  '@types/tapable': 0.2.4
   '@types/through2': 2.0.32
   '@types/uglify-js': 2.6.29
   '@types/vinyl': 1.2.30

--- a/core-build/gulp-core-build-webpack/package.json
+++ b/core-build/gulp-core-build-webpack/package.json
@@ -27,6 +27,7 @@
     "@types/orchestrator": "0.0.30",
     "@types/q": "0.0.32",
     "@types/source-map": "0.5.0",
+    "@types/tapable": "0.2.4",
     "@types/uglify-js": "2.6.29",
     "@types/webpack": "3.0.11"
   }

--- a/libraries/ts-command-line/package.json
+++ b/libraries/ts-command-line/package.json
@@ -14,7 +14,7 @@
   "license": "MIT",
   "dependencies": {
     "argparse": "~1.0.9",
-    "@types/argparse": "~1.0.33",
+    "@types/argparse": "1.0.33",
     "colors": "~1.1.2",
     "@types/node": "8.5.8"
   },

--- a/webpack/loader-load-themed-styles/package.json
+++ b/webpack/loader-load-themed-styles/package.json
@@ -16,7 +16,7 @@
   "devDependencies": {
     "@types/mocha": "2.2.38",
     "@types/node": "8.5.8",
-    "@types/loader-utils": "~1.1.0",
+    "@types/loader-utils": "1.1.0",
     "@types/webpack": "3.0.11",
     "chai": "~3.5.0",
     "gulp": "~3.9.1",

--- a/webpack/loader-load-themed-styles/package.json
+++ b/webpack/loader-load-themed-styles/package.json
@@ -16,7 +16,7 @@
   "devDependencies": {
     "@types/mocha": "2.2.38",
     "@types/node": "8.5.8",
-    "@types/loader-utils": "1.1.0",
+    "@types/loader-utils": "1.1.2",
     "@types/tapable": "0.2.4",
     "@types/webpack": "3.0.11",
     "chai": "~3.5.0",

--- a/webpack/loader-load-themed-styles/package.json
+++ b/webpack/loader-load-themed-styles/package.json
@@ -17,6 +17,7 @@
     "@types/mocha": "2.2.38",
     "@types/node": "8.5.8",
     "@types/loader-utils": "1.1.0",
+    "@types/tapable": "0.2.4",
     "@types/webpack": "3.0.11",
     "chai": "~3.5.0",
     "gulp": "~3.9.1",

--- a/webpack/resolve-chunk-plugin/package.json
+++ b/webpack/resolve-chunk-plugin/package.json
@@ -10,10 +10,10 @@
     "build": "gulp test --clean"
   },
   "dependencies": {
+    "@types/tapable": "0.2.4",
     "@types/webpack": "3.0.11"
   },
   "devDependencies": {
-    "@types/tapable": "0.2.3",
     "@types/mocha": "2.2.38",
     "chai": "~3.5.0",
     "gulp": "~3.9.1",

--- a/webpack/set-webpack-public-path-plugin/package.json
+++ b/webpack/set-webpack-public-path-plugin/package.json
@@ -13,10 +13,10 @@
     "@types/node": "8.5.8",
     "uglify-js": "~3.0.28",
     "lodash": "~4.15.0",
+    "@types/tapable": "0.2.4",
     "@types/webpack": "3.0.11"
   },
   "devDependencies": {
-    "@types/tapable": "0.2.3",
     "@types/lodash": "4.14.74",
     "@types/mocha": "2.2.38",
     "@types/uglify-js": "2.6.29",


### PR DESCRIPTION
Recently we had some upgrade breaks due to new versions of "@types/" packages being published with breaking changes.  This PR updates projects to follow the rules:

1. Projects must never use a "~" range for @types projects, because typings never follow SemVer
2. Projects must directly reference the transitive closure of indirect dependencies, since "@types/" projects never constrain versions for their dependencies on other "@types/" packages