### PR TITLE
Consolidate some text handling functions

### DIFF
--- a/apps/api-documenter/src/yaml/YamlDocumenter.ts
+++ b/apps/api-documenter/src/yaml/YamlDocumenter.ts
@@ -4,7 +4,7 @@
 import * as fsx from 'fs-extra';
 import * as path from 'path';
 import yaml = require('js-yaml');
-import { JsonFile, JsonSchema } from '@microsoft/node-core-library';
+import { JsonFile, JsonSchema, Text } from '@microsoft/node-core-library';
 import {
   MarkupElement,
   IApiMethod,
@@ -376,7 +376,7 @@ export class YamlDocumenter {
       stringified = `### YamlMime:${yamlMimeType}\n` + stringified;
     }
 
-    const normalized: string = stringified.split('\n').join('\r\n');
+    const normalized: string = Text.convertToCrLf(stringified);
 
     fsx.mkdirsSync(path.dirname(filePath));
     fsx.writeFileSync(filePath, normalized);

--- a/apps/api-extractor/src/generators/ApiFileGenerator.ts
+++ b/apps/api-extractor/src/generators/ApiFileGenerator.ts
@@ -2,6 +2,7 @@
 // See LICENSE in the project root for license information.
 
 import * as fs from 'fs';
+import { Text } from '@microsoft/node-core-library';
 import { ExtractorContext } from '../ExtractorContext';
 import { AstStructuredType } from '../ast/AstStructuredType';
 import { AstEnum } from '../ast/AstEnum';
@@ -66,7 +67,7 @@ export class ApiFileGenerator extends AstItemVisitor {
     this._insideTypeLiteral = 0;
     // Normalize to CRLF
     this.visit(context.package);
-    const fileContent: string = this._indentedWriter.toString().replace(/\r?\n/g, '\r\n');
+    const fileContent: string = Text.convertToCrLf(this._indentedWriter.toString());
     return fileContent;
   }
 

--- a/apps/api-extractor/src/generators/packageTypings/PackageTypingsGenerator.ts
+++ b/apps/api-extractor/src/generators/packageTypings/PackageTypingsGenerator.ts
@@ -5,6 +5,7 @@
 
 import * as fs from 'fs';
 import * as ts from 'typescript';
+import { Text } from '@microsoft/node-core-library';
 
 import { ExtractorContext } from '../../ExtractorContext';
 import { IndentedWriter } from '../../utils/IndentedWriter';
@@ -69,7 +70,7 @@ export class PackageTypingsGenerator {
     this._generateTypingsFileContent(indentedWriter, dtsKind);
 
     // Normalize to CRLF
-    const fileContent: string = indentedWriter.toString().replace(/\r?\n/g, '\r\n');
+    const fileContent: string = Text.convertToCrLf(indentedWriter.toString());
 
     fs.writeFileSync(dtsFilename, fileContent);
   }

--- a/apps/rush-lib/src/cli/logic/InstallManager.ts
+++ b/apps/rush-lib/src/cli/logic/InstallManager.ts
@@ -10,7 +10,7 @@ import * as semver from 'semver';
 import * as tar from 'tar';
 import * as wordwrap from 'wordwrap';
 import globEscape = require('glob-escape');
-import { JsonFile, LockFile } from '@microsoft/node-core-library';
+import { JsonFile, LockFile, Text } from '@microsoft/node-core-library';
 
 import AsyncRecycler from '../../utilities/AsyncRecycler';
 import RushConfiguration, {
@@ -602,8 +602,7 @@ export default class InstallManager {
         const pathToDeleteWithoutStar: string = path.join(commonNodeModulesFolder, RushConstants.rushTempNpmScope);
         console.log(`Deleting ${pathToDeleteWithoutStar}\\*`);
         // Glob can't handle Windows paths
-        const normalizedpathToDeleteWithoutStar: string
-          = Utilities.getAllReplaced(pathToDeleteWithoutStar, '\\', '/');
+        const normalizedpathToDeleteWithoutStar: string = Text.replaceAll(pathToDeleteWithoutStar, '\\', '/');
 
         // Example: "C:/MyRepo/common/temp/node_modules/@rush-temp/*"
         for (const tempModulePath of glob.sync(globEscape(normalizedpathToDeleteWithoutStar) + '/*')) {
@@ -736,8 +735,7 @@ export default class InstallManager {
     const pathToDeleteWithoutStar: string = path.join(this._rushConfiguration.commonTempFolder,
       'node_modules', RushConstants.rushTempNpmScope);
     // Glob can't handle Windows paths
-    const normalizedpathToDeleteWithoutStar: string
-      = Utilities.getAllReplaced(pathToDeleteWithoutStar, '\\', '/');
+    const normalizedpathToDeleteWithoutStar: string = Text.replaceAll(pathToDeleteWithoutStar, '\\', '/');
 
     let anyChanges: boolean = false;
 

--- a/apps/rush-lib/src/cli/logic/pnpm/PnpmLinkManager.ts
+++ b/apps/rush-lib/src/cli/logic/pnpm/PnpmLinkManager.ts
@@ -6,7 +6,7 @@ import * as os from 'os';
 import * as path from 'path';
 import uriEncode = require('strict-uri-encode');
 
-import { JsonFile } from '@microsoft/node-core-library';
+import { JsonFile, Text } from '@microsoft/node-core-library';
 
 import {
   BaseLinkManager,
@@ -135,7 +135,7 @@ export class PnpmLinkManager extends BaseLinkManager {
       `${unscopedTempProjectName}.tgz`);
 
     // e.g.: C%3A%2Fwbt%2Fcommon%2Ftemp%2Fprojects%2Fapi-documenter.tgz
-    const escapedPathToTgzFile: string = uriEncode(pathToTgzFile.split(path.sep).join('/'));
+    const escapedPathToTgzFile: string = uriEncode(Text.replaceAll(pathToTgzFile, path.sep, '/'));
 
     // tslint:disable-next-line:max-line-length
     // e.g.: C:\wbt\common\temp\node_modules\.local\C%3A%2Fwbt%2Fcommon%2Ftemp%2Fprojects%2Fapi-documenter.tgz\node_modules

--- a/apps/rush-lib/src/data/ApprovedPackagesConfiguration.ts
+++ b/apps/rush-lib/src/data/ApprovedPackagesConfiguration.ts
@@ -4,7 +4,7 @@
 import * as fsx from 'fs-extra';
 import * as path from 'path';
 import * as os from 'os';
-import { JsonFile, JsonSchema } from '@microsoft/node-core-library';
+import { JsonFile, JsonSchema, Text } from '@microsoft/node-core-library';
 
 import Utilities from '../utilities/Utilities';
 
@@ -162,7 +162,7 @@ export class ApprovedPackagesConfiguration {
     body = '// DO NOT ADD COMMENTS IN THIS FILE.'
       + '  They will be lost when the Rush tool resaves it.\n' + body;
 
-    body = Utilities.getAllReplaced(body, '\n', '\r\n');
+    body = Text.convertToCrLf(body);
     fsx.writeFileSync(this._jsonFilename, body);
   }
 

--- a/apps/rush-lib/src/data/test/RushConfiguration.test.ts
+++ b/apps/rush-lib/src/data/test/RushConfiguration.test.ts
@@ -4,6 +4,7 @@
 /// <reference types='mocha' />
 
 import { assert } from 'chai';
+import { Text } from '@microsoft/node-core-library';
 import RushConfiguration from '../RushConfiguration';
 import { ApprovedPackagesPolicy } from '../ApprovedPackagesPolicy';
 import RushConfigurationProject from '../RushConfigurationProject';
@@ -11,7 +12,7 @@ import * as path from 'path';
 import Utilities from '../../utilities/Utilities';
 
 function normalizePathForComparison(pathToNormalize: string): string {
-  return Utilities.getAllReplaced(pathToNormalize, '\\', '/').toUpperCase();
+  return Text.replaceAll(pathToNormalize, '\\', '/').toUpperCase();
 }
 
 function assertPathProperty(validatedPropertyName: string, absolutePath: string, relativePath: string): void {

--- a/apps/rush-lib/src/utilities/Utilities.ts
+++ b/apps/rush-lib/src/utilities/Utilities.ts
@@ -364,17 +364,6 @@ export default class Utilities {
   }
 
   /**
-   * Returns the same thing as targetString.replace(searchValue, replaceValue), except that
-   * all matches are replaced, rather than just the first match.
-   * @param targetString  - The string to be modified
-   * @param searchValue   - The value to search for
-   * @param replaceValue  - The replacement text
-   */
-  public static getAllReplaced(targetString: string, searchValue: string, replaceValue: string): string {
-    return targetString.split(searchValue).join(replaceValue);
-  }
-
-  /**
    * For strings passed to a shell command, this adds appropriate escaping
    * to avoid misinterpretation of spaces or special characters.
    *

--- a/common/changes/@microsoft/api-documenter/pgonzal-text-lib_2018-03-14-23-06.json
+++ b/common/changes/@microsoft/api-documenter/pgonzal-text-lib_2018-03-14-23-06.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@microsoft/api-documenter",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/api-documenter",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/api-extractor/pgonzal-text-lib_2018-03-14-23-06.json
+++ b/common/changes/@microsoft/api-extractor/pgonzal-text-lib_2018-03-14-23-06.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@microsoft/api-extractor",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/node-core-library/pgonzal-text-lib_2018-03-14-23-06.json
+++ b/common/changes/@microsoft/node-core-library/pgonzal-text-lib_2018-03-14-23-06.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/node-core-library",
+      "comment": "Add new Text API",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@microsoft/node-core-library",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush/pgonzal-text-lib_2018-03-14-23-06.json
+++ b/common/changes/@microsoft/rush/pgonzal-text-lib_2018-03-14-23-06.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@microsoft/rush",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/reviews/api/node-core-library.api.ts
+++ b/common/reviews/api/node-core-library.api.ts
@@ -74,3 +74,10 @@ class Path {
   static isUnder(childPath: string, parentFolderPath: string): boolean;
 }
 
+// @public
+class Text {
+  static convertToCrLf(input: string): string;
+  static convertToLf(input: string): string;
+  static replaceAll(input: string, searchValue: string, replaceValue: string): string;
+}
+

--- a/libraries/node-core-library/src/FileDiffTest.ts
+++ b/libraries/node-core-library/src/FileDiffTest.ts
@@ -5,6 +5,7 @@ import * as path from 'path';
 import * as fsx from 'fs-extra';
 
 import { PackageJsonLookup } from './PackageJsonLookup';
+import { Text } from './Text';
 
 /**
  * Implements a unit testing strategy that generates output files, and then
@@ -84,7 +85,7 @@ export class FileDiffTest {
   }
 
   private static _getNormalizedContent(s: string): string {
-    return s.replace(/\r\n/g, '\n').replace(/\r/g, '') // convert to Unix-style newlines
+    return Text.convertToLf(s) // convert to Unix-style newlines
       .replace(/\s+\n/g, '\n') // strip spaces from end of line
       .replace(/\n+$/g, '');  // strip newlines from end of file
   }

--- a/libraries/node-core-library/src/JsonFile.ts
+++ b/libraries/node-core-library/src/JsonFile.ts
@@ -6,6 +6,7 @@ import * as os from 'os';
 import * as jju from 'jju';
 
 import { JsonSchema, IJsonSchemaErrorInfo, IJsonSchemaValidateOptions } from './JsonSchema';
+import { Text } from './Text';
 
 /**
  * Options for JsonFile.stringify()
@@ -92,7 +93,7 @@ export class JsonFile {
     if (options && options.unixNewlines) {
       return stringified;
     } else {
-      return JsonFile._getAllReplaced(stringified, '\n', '\r\n');
+      return Text.convertToCrLf(stringified);
     }
 
   }
@@ -197,16 +198,5 @@ export class JsonFile {
       }
     }
     return result;
-  }
-
-  /**
-   * Returns the same thing as targetString.replace(searchValue, replaceValue), except that
-   * all matches are replaced, rather than just the first match.
-   * @param targetString  The string to be modified
-   * @param searchValue   The value to search for
-   * @param replaceValue  The replacement text
-   */
-  private static _getAllReplaced(targetString: string, searchValue: string, replaceValue: string): string {
-    return targetString.split(searchValue).join(replaceValue);
   }
 }

--- a/libraries/node-core-library/src/Text.ts
+++ b/libraries/node-core-library/src/Text.ts
@@ -1,0 +1,41 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+/**
+ * Operations for working with strings that contain text.
+ *
+ * @remarks
+ * The utilities provided by this class are intended to be simple, small, and very
+ * broadly applicable.
+ *
+ * @public
+ */
+export class Text {
+  private static readonly _newLineRegEx: RegExp = /\r\n|\n\r|\r|\n/g;
+
+  /**
+   * Returns the same thing as targetString.replace(searchValue, replaceValue), except that
+   * all matches are replaced, rather than just the first match.
+   * @param input         - The string to be modified
+   * @param searchValue   - The value to search for
+   * @param replaceValue  - The replacement text
+   */
+  public static replaceAll(input: string, searchValue: string, replaceValue: string): string {
+    return input.split(searchValue).join(replaceValue);
+  }
+
+  /**
+   * Converts all newlines in the provided string to use Windows-style CRLF end of line characters.
+   */
+  public static convertToCrLf(input: string): string {
+    return input.replace(Text._newLineRegEx, '\r\n');
+  }
+
+  /**
+   * Converts all newlines in the provided string to use Unix-style LF end of line characters.
+   */
+  public static convertToLf(input: string): string {
+    return input.replace(Text._newLineRegEx, '\n');
+  }
+
+}

--- a/libraries/node-core-library/src/index.ts
+++ b/libraries/node-core-library/src/index.ts
@@ -24,3 +24,4 @@ export {
   LockFile
 } from './LockFile';
 export { Path } from './Path';
+export { Text } from './Text';


### PR DESCRIPTION
This PR introduces three new API functions:

- Text.replaceAll()
- Text.convertToCrLf()
- Text.convertToLf()

This deduplicates a bunch of expressions and utility functions scattered throughout our code.