### PR TITLE
Add support for using all cores on windows machines with -p max flag

### DIFF
--- a/apps/rush-lib/src/cli/actions/CustomRushAction.ts
+++ b/apps/rush-lib/src/cli/actions/CustomRushAction.ts
@@ -131,7 +131,8 @@ export class CustomRushAction extends BaseRushAction {
         parameterLongName: '--parallelism',
         parameterShortName: '-p',
         key: 'COUNT',
-        description: 'Specify the number of concurrent build processes.'
+        description: 'Specify the number of concurrent build processes'
+          + ` A value of 'max' can be used to achieve the maximum default parallelism.`
           + ' If omitted, the parallelism will be based on the number of CPU cores.'
       });
     }

--- a/apps/rush-lib/src/cli/actions/CustomRushAction.ts
+++ b/apps/rush-lib/src/cli/actions/CustomRushAction.ts
@@ -16,7 +16,7 @@ import {
 
 import {
   CommandLineFlagParameter,
-  CommandLineIntegerParameter,
+  CommandLineStringParameter,
   CommandLineStringListParameter,
   CommandLineOptionParameter,
   ICommandLineActionOptions
@@ -39,7 +39,7 @@ export class CustomRushAction extends BaseRushAction {
   private _fromFlag: CommandLineStringListParameter;
   private _toFlag: CommandLineStringListParameter;
   private _verboseParameter: CommandLineFlagParameter;
-  private _parallelismParameter: CommandLineIntegerParameter | undefined;
+  private _parallelismParameter: CommandLineStringParameter | undefined;
 
   constructor(private _parser: RushCommandLineParser,
     options: ICommandLineActionOptions,
@@ -75,9 +75,9 @@ export class CustomRushAction extends BaseRushAction {
 
     // if this is parallizable, then use the value from the flag (undefined or a number),
     // if this is not parallelized, then use 1 core
-    const parallelism: number | undefined = this._isParallelized()
+    const parallelism: string | undefined = this._isParallelized()
       ? this._parallelismParameter!.value
-      : 1;
+      : '1';
 
     // collect all custom flags here
     const customFlags: string[] = [];
@@ -127,7 +127,7 @@ export class CustomRushAction extends BaseRushAction {
 
   protected onDefineParameters(): void {
     if (this._isParallelized()) {
-      this._parallelismParameter = this.defineIntegerParameter({
+      this._parallelismParameter = this.defineStringParameter({
         parameterLongName: '--parallelism',
         parameterShortName: '-p',
         key: 'COUNT',

--- a/apps/rush-lib/src/cli/actions/CustomRushAction.ts
+++ b/apps/rush-lib/src/cli/actions/CustomRushAction.ts
@@ -132,8 +132,8 @@ export class CustomRushAction extends BaseRushAction {
         parameterShortName: '-p',
         key: 'COUNT',
         description: 'Specify the number of concurrent build processes'
-          + ` A value of 'max' can be used to achieve the maximum default parallelism.`
-          + ' If omitted, the parallelism will be based on the number of CPU cores.'
+          + ' The value "max" can be specified to indicate the number of CPU cores.'
+          + ' If this parameter omitted, the default value depends on the operating system and number of CPU cores.'
       });
     }
     this._toFlag = this.defineStringListParameter({

--- a/apps/rush-lib/src/cli/logic/TaskSelector.ts
+++ b/apps/rush-lib/src/cli/logic/TaskSelector.ts
@@ -15,7 +15,7 @@ export interface ITaskSelectorConstructor {
   commandToRun: string;
   customFlags: string[];
   isQuietMode: boolean;
-  parallelism: number;
+  parallelism:  string;
   isIncrementalBuildAllowed: boolean;
   changedProjectsOnly: boolean;
 }

--- a/common/changes/@microsoft/rush/chrisgo-max-parallel_2018-03-16-21-22.json
+++ b/common/changes/@microsoft/rush/chrisgo-max-parallel_2018-03-16-21-22.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Add support for overriding the default windows parallelism with 'max'.",
+      "packageName": "@microsoft/rush",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "christiango@users.noreply.github.com"
+}


### PR DESCRIPTION
A change was made recently to rush to make it such that the default parallelism is set to be 1 less than the number of cores on windows. This was to address some performance issues windows users were experiencing when trying to do other tasks while a rush build was running. 

However, in CI environments, we want the maximum amount of available parallelism to get faster builds. This change introduces a 'max' argument to the -p flag that always sets the paralellism to equal the number of cores on the CPU. 