### PR TITLE
[api-extractor] Fix a bug with handling of merged declarations

### DIFF
--- a/apps/api-extractor/src/api/ApiItem.ts
+++ b/apps/api-extractor/src/api/ApiItem.ts
@@ -401,14 +401,3 @@ export type ApiMember = IApiProperty | IApiMethod | IApiConstructor;
  */
 export type ApiItem = IApiProperty | ApiMember | IApiFunction | IApiConstructor |
    IApiClass | IApiEnum | IApiEnumMember | IApiInterface | IApiNamespace | IApiPackage;
-
-/**
- * Describes a return type and description of the return type
- * that is given in documentation comments.
- *
- * @alpha
- */
-export interface IApiReturnValue {
-  type: string;
-  description: MarkupBasicElement[];
-}

--- a/apps/api-extractor/src/generators/packageTypings/AstDeclaration.ts
+++ b/apps/api-extractor/src/generators/packageTypings/AstDeclaration.ts
@@ -94,6 +94,10 @@ export class AstDeclaration {
       throw new Error('Program Bug: Invalid call to notifyChildAttach()');
     }
 
+    if (this.astSymbol.analyzed) {
+      throw new Error('Program Bug: _notifyChildAttach() called after analysis is already complete');
+    }
+
     this._analyzedChildren.push(child);
   }
 

--- a/apps/api-extractor/src/generators/packageTypings/AstSymbol.ts
+++ b/apps/api-extractor/src/generators/packageTypings/AstSymbol.ts
@@ -59,6 +59,8 @@ export class AstSymbol {
 
   private readonly _rootAstSymbol: AstSymbol;
 
+  // This flag is unused if this is not the root symbol.
+  // Being "analyzed" is a property of the root symbol.
   private _analyzed: boolean = false;
 
   public constructor(parameters: IAstSymbolParameters) {
@@ -83,9 +85,12 @@ export class AstSymbol {
   /**
    * Returns true if the AstSymbolTable.analyze() was called for this object.
    * See that function for details.
+   * @remarks
+   * AstSymbolTable.analyze() is always performed on the root AstSymbol.  This function
+   * returns true if-and-only-if the root symbol was analyzed.
    */
   public get analyzed(): boolean {
-    return this._analyzed;
+    return this.rootAstSymbol._analyzed;
   }
 
   /**
@@ -108,6 +113,9 @@ export class AstSymbol {
    * @internal
    */
   public _notifyDeclarationAttach(astDeclaration: AstDeclaration): void {
+    if (this.analyzed) {
+      throw new Error('Program Bug: _notifyDeclarationAttach() called after analysis is already complete');
+    }
     this._astDeclarations.push(astDeclaration);
   }
 
@@ -117,6 +125,9 @@ export class AstSymbol {
    * @internal
    */
   public _notifyAnalyzed(): void {
+    if (this.parentAstSymbol) {
+      throw new Error('Program Bug: _notifyAnalyzed() called for an AstSymbol which is not the root');
+    }
     this._analyzed = true;
   }
 

--- a/apps/api-extractor/src/generators/packageTypings/AstSymbol.ts
+++ b/apps/api-extractor/src/generators/packageTypings/AstSymbol.ts
@@ -125,7 +125,7 @@ export class AstSymbol {
    * @internal
    */
   public _notifyAnalyzed(): void {
-    if (this.parentAstSymbol) {
+    if (this.rootAstSymbol !== this) {
       throw new Error('Program Bug: _notifyAnalyzed() called for an AstSymbol which is not the root');
     }
     this._analyzed = true;

--- a/apps/api-extractor/src/generators/packageTypings/AstSymbolTable.ts
+++ b/apps/api-extractor/src/generators/packageTypings/AstSymbolTable.ts
@@ -139,7 +139,7 @@ export class AstSymbolTable {
       this._analyzeChildTree(astDeclaration.declaration, astDeclaration);
     }
 
-    astSymbol._notifyAnalyzed();
+    rootAstSymbol._notifyAnalyzed();
 
     if (!astSymbol.astImport) {
       // If this symbol is not imported, then we also analyze any referencedAstSymbols
@@ -223,10 +223,6 @@ export class AstSymbolTable {
 
     for (const childNode of node.getChildren()) {
       this._analyzeChildTree(childNode, newGoverningAstDeclaration || governingAstDeclaration);
-    }
-
-    if (newGoverningAstDeclaration) {
-      newGoverningAstDeclaration.astSymbol._notifyAnalyzed();
     }
   }
 

--- a/build-tests/api-extractor-test-01/dist/index-internal.d.ts
+++ b/build-tests/api-extractor-test-01/dist/index-internal.d.ts
@@ -173,6 +173,40 @@ export declare interface IInterfaceAsDefaultExport {
 }
 
 /**
+ * IMergedInterface instance 1.
+ * @alpha
+ */
+export declare interface IMergedInterface {
+    type: string;
+    reference: IMergedInterfaceReferencee;
+}
+
+/**
+ * IMergedInterface instance 2.
+ * @alpha
+ */
+export declare interface IMergedInterface {
+    type: string;
+    reference: IMergedInterfaceReferencee;
+}
+
+/**
+ * @alpha
+ */
+export declare interface IMergedInterfaceReferencee {
+}
+
+/**
+ * api-extractor-test-01
+ *
+ * @remarks
+ * This library is consumed by api-extractor-test-02 and api-extractor-test-03.
+ * It tests the basic types of definitions, and all the weird cases for following
+ * chains of type aliases.
+ *
+ * @packagedocumentation
+ */
+/**
  * A simple, normal definition
  * @public
  */

--- a/build-tests/api-extractor-test-01/dist/index-preview.d.ts
+++ b/build-tests/api-extractor-test-01/dist/index-preview.d.ts
@@ -172,6 +172,20 @@ export declare interface IInterfaceAsDefaultExport {
     member: string;
 }
 
+// Removed for this release type: IMergedInterface
+
+// Removed for this release type: IMergedInterfaceReferencee
+
+/**
+ * api-extractor-test-01
+ *
+ * @remarks
+ * This library is consumed by api-extractor-test-02 and api-extractor-test-03.
+ * It tests the basic types of definitions, and all the weird cases for following
+ * chains of type aliases.
+ *
+ * @packagedocumentation
+ */
 /**
  * A simple, normal definition
  * @public

--- a/build-tests/api-extractor-test-01/dist/index-public.d.ts
+++ b/build-tests/api-extractor-test-01/dist/index-public.d.ts
@@ -165,6 +165,20 @@ export declare interface IInterfaceAsDefaultExport {
     member: string;
 }
 
+// Removed for this release type: IMergedInterface
+
+// Removed for this release type: IMergedInterfaceReferencee
+
+/**
+ * api-extractor-test-01
+ *
+ * @remarks
+ * This library is consumed by api-extractor-test-02 and api-extractor-test-03.
+ * It tests the basic types of definitions, and all the weird cases for following
+ * chains of type aliases.
+ *
+ * @packagedocumentation
+ */
 /**
  * A simple, normal definition
  * @public

--- a/build-tests/api-extractor-test-01/etc/api-extractor-test-01.api.ts
+++ b/build-tests/api-extractor-test-01/etc/api-extractor-test-01.api.ts
@@ -87,6 +87,18 @@ interface IInterfaceAsDefaultExport {
   member: string;
 }
 
+// @alpha
+interface IMergedInterface {
+  // (undocumented)
+  reference: IMergedInterfaceReferencee;
+  // (undocumented)
+  type: string;
+}
+
+// @alpha (undocumented)
+interface IMergedInterfaceReferencee {
+}
+
 // @public
 interface ISimpleInterface {
 }

--- a/build-tests/api-extractor-test-01/src/DeclarationMerging.ts
+++ b/build-tests/api-extractor-test-01/src/DeclarationMerging.ts
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+/**
+ * @alpha
+ */
+export interface IMergedInterfaceReferencee {
+}
+
+/**
+ * IMergedInterface instance 1.
+ * @alpha
+ */
+export interface IMergedInterface {
+  type: string;
+  reference: IMergedInterfaceReferencee;
+}
+
+/**
+ * IMergedInterface instance 2.
+ * @alpha
+ */
+export interface IMergedInterface {
+  type: string;
+  reference: IMergedInterfaceReferencee;
+}

--- a/build-tests/api-extractor-test-01/src/index.ts
+++ b/build-tests/api-extractor-test-01/src/index.ts
@@ -13,12 +13,6 @@
  */
 
 /**
- * Test the alias-following logic:  This class gets aliased twice before being
- * exported from the package.
- */
-export { ReexportedClass1 as ReexportedClass } from './ReexportedClass1';
-
-/**
  * A simple, normal definition
  * @public
  */
@@ -86,20 +80,28 @@ export class DecoratorTest {
   }
 }
 
-export { ForgottenExportConsumer1 } from './ForgottenExportConsumer1';
-export { ForgottenExportConsumer2 } from './ForgottenExportConsumer2';
-export { ForgottenExportConsumer3 } from './ForgottenExportConsumer3';
-
-export { default as IInterfaceAsDefaultExport } from './IInterfaceAsDefaultExport';
-
 export { default as AbstractClass } from './AbstractClass';
 export { default as AbstractClass2, AbstractClass3 } from './AbstractClass2';
+
+export { ClassWithTypeLiterals } from './ClassWithTypeLiterals';
+
+export * from './DeclarationMerging';
 
 export {
   DefaultExportEdgeCase,
   default as ClassExportedAsDefault
 } from './DefaultExportEdgeCase';
 
-export { TypeReferencesInAedoc as _TypeReferencesInAedoc } from './TypeReferencesInAedoc';
+export { ForgottenExportConsumer1 } from './ForgottenExportConsumer1';
+export { ForgottenExportConsumer2 } from './ForgottenExportConsumer2';
+export { ForgottenExportConsumer3 } from './ForgottenExportConsumer3';
 
-export { ClassWithTypeLiterals } from './ClassWithTypeLiterals';
+export { default as IInterfaceAsDefaultExport } from './IInterfaceAsDefaultExport';
+
+/**
+ * Test the alias-following logic:  This class gets aliased twice before being
+ * exported from the package.
+ */
+export { ReexportedClass1 as ReexportedClass } from './ReexportedClass1';
+
+export { TypeReferencesInAedoc as _TypeReferencesInAedoc } from './TypeReferencesInAedoc';

--- a/common/changes/@microsoft/api-extractor/pgonzal-merged-declaration_2018-03-19-18-06.json
+++ b/common/changes/@microsoft/api-extractor/pgonzal-merged-declaration_2018-03-19-18-06.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor",
+      "comment": "Fix a bug where packageTypings failed to handle merged declarations properly",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/reviews/api/api-extractor.api.ts
+++ b/common/reviews/api/api-extractor.api.ts
@@ -157,9 +157,7 @@ interface IApiProperty extends IApiBaseDefinition {
 
 // @alpha
 interface IApiReturnValue {
-  // (undocumented)
   description: MarkupBasicElement[];
-  // (undocumented)
   type: string;
 }
 


### PR DESCRIPTION
When we tried to upgrade the cyclic dependencies, API Extractor failed to process an API item that accidentally had two definitions that were being merged:

```typescript
/**
 * Return value of a method or function.
 * @alpha
 */
export interface IApiReturnValue {
  /**
   * The data type returned by the function
   */
  type: string;

  /**
   * Describes the return value
   */
  description: MarkupBasicElement[];
}

. . .

/**
 * Describes a return type and description of the return type
 * that is given in documentation comments.
 *
 * @alpha
 */
export interface IApiReturnValue {
  type: string;
  description: MarkupBasicElement[];
}

```

I removed the duplicate definition, but also fixed up the *.d.ts generator to handle this case correctly.