### PR TITLE
Fix two minor Rush issues

### DIFF
--- a/apps/rush-lib/src/cli/logic/pnpm/PnpmShrinkwrapFile.ts
+++ b/apps/rush-lib/src/cli/logic/pnpm/PnpmShrinkwrapFile.ts
@@ -6,6 +6,15 @@ import * as semver from 'semver';
 import Utilities from '../../../utilities/Utilities';
 import { BaseShrinkwrapFile } from '../base/BaseShrinkwrapFile';
 
+// This is based on PNPM's own configuration:
+// https://github.com/pnpm/pnpm-shrinkwrap/blob/master/src/write.ts
+const SHRINKWRAP_YAML_FORMAT: yaml.DumpOptions = {
+  lineWidth: 1000,
+  noCompatMode: true,
+  noRefs: true,
+  sortKeys: true
+};
+
 interface IShrinkwrapDependencyJson {
   /** Information about the resolved package */
   resolution: {
@@ -118,10 +127,7 @@ export class PnpmShrinkwrapFile extends BaseShrinkwrapFile {
    * Serializes the PNPM Shrinkwrap file
    */
   protected serialize(): string {
-    return yaml.safeDump(this._shrinkwrapJson, {
-      sortKeys: true,
-      noRefs: true
-    });
+    return yaml.safeDump(this._shrinkwrapJson, SHRINKWRAP_YAML_FORMAT);
   }
 
   /**

--- a/apps/rush-lib/src/cli/logic/pnpm/PnpmShrinkwrapFile.ts
+++ b/apps/rush-lib/src/cli/logic/pnpm/PnpmShrinkwrapFile.ts
@@ -119,7 +119,8 @@ export class PnpmShrinkwrapFile extends BaseShrinkwrapFile {
    */
   protected serialize(): string {
     return yaml.safeDump(this._shrinkwrapJson, {
-      sortKeys: true
+      sortKeys: true,
+      noRefs: true
     });
   }
 

--- a/apps/rush-lib/src/start.ts
+++ b/apps/rush-lib/src/start.ts
@@ -1,37 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import * as colors from 'colors';
-import * as semver from 'semver';
-
-const nodeVersion: string = process.versions.node;
-
-// tslint:disable-next-line
-
-// We are on an ancient version of NodeJS that is known not to work with Rush
-if (semver.satisfies(nodeVersion, '<= 6.4.0')) {
-  console.error(colors.red(`Your version of Node.js (${nodeVersion}) is very old and incompatible with Rush.`
-    + ` Please upgrade to the latest Long-Term Support (LTS) version.`));
-  process.exit(1);
-}
-
-// We are on a much newer release than we have tested and support
-// tslint:disable-next-line
-else if (semver.satisfies(nodeVersion, '>=9.0.0')) {
-  console.warn(colors.yellow(`Your version of Node.js (${nodeVersion}) has not been tested with this release of Rush.`
-    + ` The Rush team will not accept issue reports for it.`
-    + ` Please consider upgrading Rush or downgrading Node.js.`));
-}
-
-// We are not on an LTS release
-// tslint:disable-next-line
-else if (!semver.satisfies(nodeVersion, '^6.9.0')
-      && !semver.satisfies(nodeVersion, '^8.9.0')) {
-  console.warn(colors.yellow(`Your version of Node.js (${nodeVersion}) is not a Long-Term Support (LTS) release.`
-    + ` These versions frequently contain bugs, and the Rush team will not accept issue reports for them.`
-    + ` Please consider installing a stable release.`));
-}
-
 import Rush from './Rush';
 
 Rush.launch(Rush.version, false);

--- a/apps/rush/package.json
+++ b/apps/rush/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "@microsoft/node-core-library": "1.0.0",
     "@microsoft/rush-lib": "4.3.0",
+    "colors": "~1.1.2",
     "fs-extra": "~0.26.7",
     "semver": "~5.3.0"
   },

--- a/apps/rush/src/start.ts
+++ b/apps/rush/src/start.ts
@@ -1,6 +1,37 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
+import * as colors from 'colors';
+import * as semver from 'semver';
+
+const nodeVersion: string = process.versions.node;
+
+// tslint:disable-next-line
+
+// We are on an ancient version of NodeJS that is known not to work with Rush
+if (semver.satisfies(nodeVersion, '<= 6.4.0')) {
+  console.error(colors.red(`Your version of Node.js (${nodeVersion}) is very old and incompatible with Rush.`
+    + ` Please upgrade to the latest Long-Term Support (LTS) version.`));
+  process.exit(1);
+}
+
+// We are on a much newer release than we have tested and support
+// tslint:disable-next-line
+else if (semver.satisfies(nodeVersion, '>=9.0.0')) {
+  console.warn(colors.yellow(`Your version of Node.js (${nodeVersion}) has not been tested with this release of Rush.`
+    + ` The Rush team will not accept issue reports for it.`
+    + ` Please consider upgrading Rush or downgrading Node.js.`));
+}
+
+// We are not on an LTS release
+// tslint:disable-next-line
+else if (!semver.satisfies(nodeVersion, '^6.9.0')
+      && !semver.satisfies(nodeVersion, '^8.9.0')) {
+  console.warn(colors.yellow(`Your version of Node.js (${nodeVersion}) is not a Long-Term Support (LTS) release.`
+    + ` These versions frequently contain bugs, and the Rush team will not accept issue reports for them.`
+    + ` Please consider installing a stable release.`));
+}
+
 import * as path from 'path';
 import { JsonFile, IPackageJson } from '@microsoft/node-core-library';
 

--- a/common/changes/@microsoft/rush/pgonzal-rush-fixes_2018-03-20-19-33.json
+++ b/common/changes/@microsoft/rush/pgonzal-rush-fixes_2018-03-20-19-33.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Move the environment checks from rush-lib to rush",
+      "packageName": "@microsoft/rush",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush/pgonzal-rush-fixes_2018-03-20-19-34.json
+++ b/common/changes/@microsoft/rush/pgonzal-rush-fixes_2018-03-20-19-34.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Fix an annoyance where common/temp/shrinkwrap.yaml was formatted in a way that made diffs less readable",
+      "packageName": "@microsoft/rush",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "pgonzal@users.noreply.github.com"
+}


### PR DESCRIPTION
1. The common/temp/shrinkwrap.yaml was folding duplicates, which made diffs less readable
2. The environment version check needs to happen during startup of rush, not in the entry point for rush-lib  (Regression from #539)