### PR TITLE
Add optional flag to custom command and fix other minor issues

### DIFF
--- a/apps/rush-lib/src/cli/actions/CustomCommandFactory.ts
+++ b/apps/rush-lib/src/cli/actions/CustomCommandFactory.ts
@@ -46,11 +46,13 @@ export class CustomCommandFactory {
           throw new Error(`Cannot define two custom actions with the same name: "${command.name}"`);
         }
         customActions.set(command.name, new CustomRushAction(parser, {
-          actionVerb: command.name,
-          summary: command.summary,
-          documentation: command.documentation || command.summary
-        },
-        command.parallelized));
+            actionVerb: command.name,
+            summary: command.summary,
+            documentation: command.documentation || command.summary
+          },
+          command.parallelized,
+          command.optional
+        ));
       });
 
       // Associate each custom option to a command

--- a/apps/rush-lib/src/cli/actions/CustomCommandFactory.ts
+++ b/apps/rush-lib/src/cli/actions/CustomCommandFactory.ts
@@ -51,7 +51,7 @@ export class CustomCommandFactory {
             documentation: command.documentation || command.summary
           },
           command.parallelized,
-          command.optional
+          command.ignoreMissingScript
         ));
       });
 

--- a/apps/rush-lib/src/cli/actions/CustomRushAction.ts
+++ b/apps/rush-lib/src/cli/actions/CustomRushAction.ts
@@ -43,8 +43,9 @@ export class CustomRushAction extends BaseRushAction {
 
   constructor(private _parser: RushCommandLineParser,
     options: ICommandLineActionOptions,
-    private _parallelized: boolean = false) {
-
+    private _parallelized: boolean = false,
+    private _optional: boolean = false
+  ) {
     super(options);
   }
 
@@ -67,7 +68,7 @@ export class CustomRushAction extends BaseRushAction {
       throw new Error(`File not found: ${this.rushConfiguration.rushLinkJsonFilename}` +
         `${os.EOL}Did you run "rush link"?`);
     }
-    this.eventHooksManager.handle(Event.preRushBuild);
+    this._doBeforeTask();
 
     const stopwatch: Stopwatch = Stopwatch.start();
 
@@ -103,7 +104,8 @@ export class CustomRushAction extends BaseRushAction {
         isQuietMode,
         parallelism,
         isIncrementalBuildAllowed: this.options.actionVerb === 'build',
-        changedProjectsOnly
+        changedProjectsOnly,
+        optional: this._optional
       }
     );
 
@@ -111,16 +113,12 @@ export class CustomRushAction extends BaseRushAction {
       () => {
         stopwatch.stop();
         console.log(colors.green(`rush ${this.options.actionVerb} (${stopwatch.toString()})`));
-        this._collectTelemetry(stopwatch, true);
-        this._parser.flushTelemetry();
-        this.eventHooksManager.handle(Event.postRushBuild, this._parser.isDebug);
+        this._doAfterTask(stopwatch, true);
       },
       () => {
         stopwatch.stop();
         console.log(colors.red(`rush ${this.options.actionVerb} - Errors! (${stopwatch.toString()})`));
-        this._collectTelemetry(stopwatch, false);
-        this._parser.flushTelemetry();
-        this.eventHooksManager.handle(Event.postRushBuild, this._parser.isDebug);
+        this._doAfterTask(stopwatch, false);
         this._parser.exitWithError();
       });
   }
@@ -189,6 +187,25 @@ export class CustomRushAction extends BaseRushAction {
     return this.options.actionVerb === 'build'
       || this.options.actionVerb === 'rebuild'
       || this._parallelized;
+  }
+
+  private _doBeforeTask(): void {
+    if (this.options.actionVerb !== 'build' && this.options.actionVerb !== 'rebuild') {
+      // Only collects information for built-in tasks like build or rebuild.
+      return;
+    }
+
+    this.eventHooksManager.handle(Event.preRushBuild);
+  }
+
+  private _doAfterTask(stopwatch: Stopwatch, success: boolean): void {
+    if (this.options.actionVerb !== 'build' && this.options.actionVerb !== 'rebuild') {
+      // Only collects information for built-in tasks like build or rebuild.
+      return;
+    }
+    this._collectTelemetry(stopwatch, success);
+    this._parser.flushTelemetry();
+    this.eventHooksManager.handle(Event.postRushBuild, this._parser.isDebug);
   }
 
   private _collectTelemetry(stopwatch: Stopwatch, success: boolean): void {

--- a/apps/rush-lib/src/cli/actions/CustomRushAction.ts
+++ b/apps/rush-lib/src/cli/actions/CustomRushAction.ts
@@ -44,7 +44,7 @@ export class CustomRushAction extends BaseRushAction {
   constructor(private _parser: RushCommandLineParser,
     options: ICommandLineActionOptions,
     private _parallelized: boolean = false,
-    private _optional: boolean = false
+    private _ignoreMissingScript: boolean = false
   ) {
     super(options);
   }
@@ -105,7 +105,7 @@ export class CustomRushAction extends BaseRushAction {
         parallelism,
         isIncrementalBuildAllowed: this.options.actionVerb === 'build',
         changedProjectsOnly,
-        optional: this._optional
+        ignoreMissingScript: this._ignoreMissingScript
       }
     );
 

--- a/apps/rush-lib/src/cli/logic/TaskSelector.ts
+++ b/apps/rush-lib/src/cli/logic/TaskSelector.ts
@@ -6,7 +6,7 @@ import { default as RushConfigurationProject } from '../../data/RushConfiguratio
 import { JsonFile } from '@microsoft/node-core-library';
 
 import TaskRunner from '../taskRunner/TaskRunner';
-import ProjectBuildTask from '../taskRunner/ProjectBuildTask';
+import ProjectTask from '../taskRunner/ProjectTask';
 
 export interface ITaskSelectorConstructor {
   rushConfiguration: RushConfiguration;
@@ -18,13 +18,14 @@ export interface ITaskSelectorConstructor {
   parallelism:  string;
   isIncrementalBuildAllowed: boolean;
   changedProjectsOnly: boolean;
+  optional: boolean;
 }
 
 /**
  * This class is responsible for:
  *  - based on to/from flags, solving the dependency graph and figuring out which projects need to be run
- *  - creating a ProjectBuildTask for each project that needs to be built
- *  - registering the necessary ProjectBuildTasks with the TaskRunner, which actually orchestrates execution
+ *  - creating a ProjectTask for each project that needs to be built
+ *  - registering the necessary ProjectTasks with the TaskRunner, which actually orchestrates execution
  *
  * This class is currently only used by CustomRushAction
  */
@@ -162,12 +163,14 @@ export class TaskSelector {
   private _registerTask(project: RushConfigurationProject | undefined): void {
     if (project) {
 
-      const projectTask: ProjectBuildTask = new ProjectBuildTask(
+      const projectTask: ProjectTask = new ProjectTask(
         project,
         this._options.rushConfiguration,
         this._options.commandToRun,
         this._options.customFlags,
-        this._options.isIncrementalBuildAllowed);
+        this._options.isIncrementalBuildAllowed,
+        this._options.optional
+      );
 
       if (!this._taskRunner.hasTask(projectTask.name)) {
         this._taskRunner.addTask(projectTask);

--- a/apps/rush-lib/src/cli/logic/TaskSelector.ts
+++ b/apps/rush-lib/src/cli/logic/TaskSelector.ts
@@ -18,7 +18,7 @@ export interface ITaskSelectorConstructor {
   parallelism:  string;
   isIncrementalBuildAllowed: boolean;
   changedProjectsOnly: boolean;
-  optional: boolean;
+  ignoreMissingScript: boolean;
 }
 
 /**
@@ -169,7 +169,7 @@ export class TaskSelector {
         this._options.commandToRun,
         this._options.customFlags,
         this._options.isIncrementalBuildAllowed,
-        this._options.optional
+        this._options.ignoreMissingScript
       );
 
       if (!this._taskRunner.hasTask(projectTask.name)) {

--- a/apps/rush-lib/src/cli/taskRunner/ProjectTask.ts
+++ b/apps/rush-lib/src/cli/taskRunner/ProjectTask.ts
@@ -28,7 +28,7 @@ interface IPackageDependencies extends IPackageDeps {
 /**
  * A TaskRunner task which cleans and builds a project
  */
-export default class ProjectBuildTask implements ITaskDefinition {
+export default class ProjectTask implements ITaskDefinition {
   public get name(): string {
     return this._rushProject.packageName;
   }
@@ -40,28 +40,29 @@ export default class ProjectBuildTask implements ITaskDefinition {
     private _rushConfiguration: RushConfiguration,
     private _commandToRun: string,
     private _customFlags: string[],
-    public isIncrementalBuildAllowed: boolean
+    public isIncrementalBuildAllowed: boolean,
+    private _optional: boolean
   ) {}
 
   public execute(writer: ITaskWriter): Promise<TaskStatus> {
     return new Promise<TaskStatus>((resolve: (status: TaskStatus) => void, reject: (errors: TaskError[]) => void) => {
       try {
-        const build: string = this._getScriptToRun();
-        const deps: IPackageDependencies | undefined = this._getPackageDependencies(build, writer);
-        this._executeTask(build, writer, deps, resolve, reject);
+        const taskCommand: string = this._getScriptToRun();
+        const deps: IPackageDependencies | undefined = this._getPackageDependencies(taskCommand, writer);
+        this._executeTask(taskCommand, writer, deps, resolve, reject);
       } catch (error) {
         reject([new TaskError('executing', error.toString())]);
       }
     });
   }
 
-  private _getPackageDependencies(buildCommand: string, writer: ITaskWriter): IPackageDependencies | undefined {
+  private _getPackageDependencies(taskCommand: string, writer: ITaskWriter): IPackageDependencies | undefined {
     let deps: IPackageDependencies | undefined = undefined;
     PackageChangeAnalyzer.rushConfig = this._rushConfiguration;
     try {
       deps = {
         files: PackageChangeAnalyzer.instance.getPackageDepsHash(this._rushProject.packageName)!.files,
-        arguments: buildCommand
+        arguments: taskCommand
       };
     } catch (error) {
       writer.writeLine('Unable to calculate incremental build state. ' +
@@ -71,7 +72,7 @@ export default class ProjectBuildTask implements ITaskDefinition {
   }
 
   private _executeTask(
-    buildCommand: string,
+    taskCommand: string,
     writer: ITaskWriter,
     currentPackageDeps: IPackageDependencies | undefined,
     resolve: (status: TaskStatus) => void,
@@ -107,29 +108,29 @@ export default class ProjectBuildTask implements ITaskDefinition {
           fsx.unlinkSync(currentDepsPath);
         }
 
-        if (!buildCommand) {
+        if (!taskCommand) {
           // tslint:disable-next-line:max-line-length
-          writer.writeLine(`The 'build' or 'test' command was registered in the package.json but is blank, so no action will be taken.`);
-          resolve(TaskStatus.Success);
+          writer.writeLine(`The task command ${this._commandToRun} was registered in the package.json but is blank, so no action will be taken.`);
+          resolve(TaskStatus.Skipped);
           return;
         }
 
-        // Run the build step
-        writer.writeLine(buildCommand);
-        const buildTask: child_process.ChildProcess =
-          Utilities.executeShellCommandAsync(buildCommand, projectFolder, process.env, true);
+        // Run the task
+        writer.writeLine(taskCommand);
+        const task: child_process.ChildProcess =
+          Utilities.executeShellCommandAsync(taskCommand, projectFolder, process.env, true);
 
         // Hook into events, in order to get live streaming of build log
-        buildTask.stdout.on('data', (data: string) => {
+        task.stdout.on('data', (data: string) => {
           writer.write(data);
         });
 
-        buildTask.stderr.on('data', (data: string) => {
+        task.stderr.on('data', (data: string) => {
           writer.writeError(data);
           this._hasWarningOrError = true;
         });
 
-        buildTask.on('close', (code: number) => {
+        task.on('close', (code: number) => {
           // Write the logs to disk
           this._writeLogsToDisk(writer);
 
@@ -172,14 +173,14 @@ export default class ProjectBuildTask implements ITaskDefinition {
     } else {
       script = this._getScriptCommand(this._commandToRun);
 
-      if (script === undefined) {
+      if (script === undefined && !this._optional) {
         // tslint:disable-next-line:max-line-length
         throw new Error(`The project [${this._rushProject.packageName}] does not define a '${this._commandToRun}' command in the 'scripts' section of its package.json`);
       }
     }
 
-    if (script === '') {
-      return script;
+    if (!script) {
+      return '';
     }
 
     return `${script} ${this._customFlags.join(' ')}`;

--- a/apps/rush-lib/src/cli/taskRunner/ProjectTask.ts
+++ b/apps/rush-lib/src/cli/taskRunner/ProjectTask.ts
@@ -41,7 +41,7 @@ export default class ProjectTask implements ITaskDefinition {
     private _commandToRun: string,
     private _customFlags: string[],
     public isIncrementalBuildAllowed: boolean,
-    private _optional: boolean
+    private _ignoreMissingScript: boolean
   ) {}
 
   public execute(writer: ITaskWriter): Promise<TaskStatus> {
@@ -173,7 +173,7 @@ export default class ProjectTask implements ITaskDefinition {
     } else {
       script = this._getScriptCommand(this._commandToRun);
 
-      if (script === undefined && !this._optional) {
+      if (script === undefined && !this._ignoreMissingScript) {
         // tslint:disable-next-line:max-line-length
         throw new Error(`The project [${this._rushProject.packageName}] does not define a '${this._commandToRun}' command in the 'scripts' section of its package.json`);
       }

--- a/apps/rush-lib/src/data/CommandLineConfiguration.ts
+++ b/apps/rush-lib/src/data/CommandLineConfiguration.ts
@@ -16,6 +16,7 @@ export interface ICustomCommand {
   summary: string;
   documentation: string | undefined;
   parallelized: boolean;
+  optional: boolean;
 }
 
 export interface ICustomEnumValue {

--- a/apps/rush-lib/src/data/CommandLineConfiguration.ts
+++ b/apps/rush-lib/src/data/CommandLineConfiguration.ts
@@ -16,7 +16,7 @@ export interface ICustomCommand {
   summary: string;
   documentation: string | undefined;
   parallelized: boolean;
-  optional: boolean;
+  ignoreMissingScript: boolean;
 }
 
 export interface ICustomEnumValue {

--- a/apps/rush-lib/src/data/CommandLineConfiguration.ts
+++ b/apps/rush-lib/src/data/CommandLineConfiguration.ts
@@ -16,7 +16,7 @@ export interface ICustomCommand {
   summary: string;
   documentation: string | undefined;
   parallelized: boolean;
-  ignoreMissingScript: boolean;
+  ignoreMissingScript: boolean | undefined;
 }
 
 export interface ICustomEnumValue {

--- a/apps/rush-lib/src/schemas/command-line.schema.json
+++ b/apps/rush-lib/src/schemas/command-line.schema.json
@@ -20,7 +20,7 @@
         "title": "Custom Command",
         "type": "object",
         "additionalProperties": false,
-        "required": [ "name", "summary", "documentation", "parallelized" ],
+        "required": [ "name", "summary", "documentation", "parallelized", "optional" ],
         "properties": {
           "name": {
             "title": "Custom Command Name",
@@ -40,6 +40,11 @@
           "parallelized": {
             "title": "Is Parallelized",
             "description": "Describes whether or not this command can be run in parallel (with multiple instances running on several projects simultaneously). Defaults to 'true'.",
+            "type": "boolean"
+          },
+          "optional": {
+            "title": "Is optional and only applies to projects with corresponding npm script",
+            "description": "Indicates whether the command runs on every project or just projects that have the corresponding npm script.",
             "type": "boolean"
           }
         }

--- a/apps/rush-lib/src/schemas/command-line.schema.json
+++ b/apps/rush-lib/src/schemas/command-line.schema.json
@@ -20,7 +20,7 @@
         "title": "Custom Command",
         "type": "object",
         "additionalProperties": false,
-        "required": [ "name", "summary", "documentation", "parallelized", "optional" ],
+        "required": [ "name", "summary", "documentation", "parallelized" ],
         "properties": {
           "name": {
             "title": "Custom Command Name",
@@ -42,9 +42,9 @@
             "description": "Describes whether or not this command can be run in parallel (with multiple instances running on several projects simultaneously). Defaults to 'true'.",
             "type": "boolean"
           },
-          "optional": {
-            "title": "Is optional and only applies to projects with corresponding npm script",
-            "description": "Indicates whether the command runs on every project or just projects that have the corresponding npm script.",
+          "ignoreMissingScript": {
+            "title": "Ignore missing script",
+            "description": "Normally Rush requires that each project's package.json has a \"script\" entry matching the custom command name. To disable this check, set \"ignoreMissingScript\" to true.",
             "type": "boolean"
           }
         }

--- a/common/changes/@microsoft/rush/qz2017-custom_action_2018-03-20-22-08.json
+++ b/common/changes/@microsoft/rush/qz2017-custom_action_2018-03-20-22-08.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Add \"ignoreMissingScript\" flag to custom command and fix other minor issues",
+      "packageName": "@microsoft/rush",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "qz2017@users.noreply.github.com"
+}


### PR DESCRIPTION
1. Add optional flag to custom command. If true, only projects with corresponding npm script will run this command. If false, all projects should have the npm script and run this command.
2. Fix naming in custom action code to be more generic.
3. Only collect telemetry for build/rebuild command.