### PR TITLE
Update Office Extension to API Documenter

### DIFF
--- a/apps/api-documenter/src/yaml/OfficeYamlDocumenter.ts
+++ b/apps/api-documenter/src/yaml/OfficeYamlDocumenter.ts
@@ -90,9 +90,6 @@ export class OfficeYamlDocumenter extends YamlDocumenter {
     if (uid.search(/Excel/i) !== -1) {
       return markup.replace(/\\\[(Api set:[^\]]+)\\\]/, `\\[ [$1](http://bing.com?type=excel) \\]`);
     }
-    else if (uid.search(/Word/i) !== -1) {
-      return markup.replace(/\\\[(Api set:[^\]]+)\\\]/, `\\[ [$1](http://bing.com?type=word) \\]`);
-    }
     else if (uid.search(/OneNote/i) !== -1) {
       return markup.replace(/\\\[(Api set:[^\]]+)\\\]/, `\\[ [$1](http://bing.com?type=onenote) \\]`);
     }
@@ -101,6 +98,9 @@ export class OfficeYamlDocumenter extends YamlDocumenter {
     }
     else if (uid.search(/Outlook/i) !== -1) {
       return markup.replace(/\\\[(Api set:[^\]]+)\\\]/, `\\[ [$1](http://bing.com?type=outlook) \\]`);
+    }
+    else if (uid.search(/Word/i) !== -1) {
+      return markup.replace(/\\\[(Api set:[^\]]+)\\\]/, `\\[ [$1](http://bing.com?type=word) \\]`);
     }
     else {
       return markup.replace(/\\\[(Api set:[^\]]+)\\\]/, `\\[ [$1](http://bing.com) \\]`);

--- a/apps/api-documenter/src/yaml/OfficeYamlDocumenter.ts
+++ b/apps/api-documenter/src/yaml/OfficeYamlDocumenter.ts
@@ -86,24 +86,25 @@ export class OfficeYamlDocumenter extends YamlDocumenter {
     // \[Api set: ExcelApi 1.1\]
     //
     // Hyperlink it like this:
-    // \[ [Api set: ExcelApi 1.1](http://bing.com?type=excel) \]
+    // \[ [API set: ExcelApi 1.1](http://bing.com?type=excel) \]
+    markup = markup.replace(/Api/, "API");
     if (uid.search(/Excel/i) !== -1) {
-      return markup.replace(/\\\[(Api set:[^\]]+)\\\]/, `\\[ [$1](http://bing.com?type=excel) \\]`);
+      return markup.replace(/\\\[(API set:[^\]]+)\\\]/, `\\[ [$1](http://bing.com?type=excel) \\]`);
     }
     else if (uid.search(/OneNote/i) !== -1) {
-      return markup.replace(/\\\[(Api set:[^\]]+)\\\]/, `\\[ [$1](http://bing.com?type=onenote) \\]`);
+      return markup.replace(/\\\[(API set:[^\]]+)\\\]/, `\\[ [$1](http://bing.com?type=onenote) \\]`);
     }
     else if (uid.search(/Visio/i) !== -1) {
-      return markup.replace(/\\\[(Api set:[^\]]+)\\\]/, `\\[ [$1](http://bing.com?type=visio) \\]`);
+      return markup.replace(/\\\[(API set:[^\]]+)\\\]/, `\\[ [$1](http://bing.com?type=visio) \\]`);
     }
     else if (uid.search(/Outlook/i) !== -1) {
-      return markup.replace(/\\\[(Api set:[^\]]+)\\\]/, `\\[ [$1](http://bing.com?type=outlook) \\]`);
+      return markup.replace(/\\\[(API set:[^\]]+)\\\]/, `\\[ [$1](http://bing.com?type=outlook) \\]`);
     }
     else if (uid.search(/Word/i) !== -1) {
-      return markup.replace(/\\\[(Api set:[^\]]+)\\\]/, `\\[ [$1](http://bing.com?type=word) \\]`);
+      return markup.replace(/\\\[(API set:[^\]]+)\\\]/, `\\[ [$1](http://bing.com?type=word) \\]`);
     }
     else {
-      return markup.replace(/\\\[(Api set:[^\]]+)\\\]/, `\\[ [$1](http://bing.com) \\]`);
+      return markup.replace(/\\\[(API set:[^\]]+)\\\]/, `\\[ [$1](http://bing.com) \\]`);
     }
   }
 }

--- a/apps/api-documenter/src/yaml/OfficeYamlDocumenter.ts
+++ b/apps/api-documenter/src/yaml/OfficeYamlDocumenter.ts
@@ -93,7 +93,7 @@ export class OfficeYamlDocumenter extends YamlDocumenter {
     else if (uid.search(/Word/i) !== -1) {
       return markup.replace(/\\\[(Api set:[^\]]+)\\\]/, `\\[ [$1](http://bing.com?type=word) \\]`);
     }
-    else if (uid.search(/OneNotel/i) !== -1) {
+    else if (uid.search(/OneNote/i) !== -1) {
       return markup.replace(/\\\[(Api set:[^\]]+)\\\]/, `\\[ [$1](http://bing.com?type=onenote) \\]`);
     }
     else if (uid.search(/Visio/i) !== -1) {

--- a/apps/api-documenter/src/yaml/OfficeYamlDocumenter.ts
+++ b/apps/api-documenter/src/yaml/OfficeYamlDocumenter.ts
@@ -63,26 +63,47 @@ export class OfficeYamlDocumenter extends YamlDocumenter {
         yamlItem.remarks = '';
       }
 
-      yamlItem.remarks += '\n\n## Snippets\n';
+      yamlItem.remarks += '\n\n#### Examples\n';
       for (const snippet of snippets) {
-        yamlItem.remarks += '\n```typescript\n' + snippet + '\n```\n';
+        if (snippet.search(/await/) == -1) {
+          yamlItem.remarks += '\n```javascript\n' + snippet + '\n```\n';
+        } else {
+          yamlItem.remarks += '\n```typescript\n' + snippet + '\n```\n';
+        }
       }
     }
 
     if (yamlItem.summary) {
-      yamlItem.summary = this._fixupApiSet(yamlItem.summary);
+      yamlItem.summary = this._fixupApiSet(yamlItem.summary, yamlItem.uid);
     }
     if (yamlItem.remarks) {
-      yamlItem.remarks = this._fixupApiSet(yamlItem.remarks);
+      yamlItem.remarks = this._fixupApiSet(yamlItem.remarks, yamlItem.uid);
     }
   }
 
-  private _fixupApiSet(markup: string): string {
+  private _fixupApiSet(markup: string, uid: string): string {
     // Search for a pattern such as this:
     // \[Api set: ExcelApi 1.1\]
     //
     // Hyperlink it like this:
-    // \[ [Api set: ExcelApi 1.1](http://bing.com) \]
-    return markup.replace(/\\\[(Api set:[^\]]+)\\\]/, `\\[ [$1](http://bing.com) \\]`);
+    // \[ [Api set: ExcelApi 1.1](http://bing.com?type=excel) \]
+    if (uid.search(/Excel/i) !== -1) {
+      return markup.replace(/\\\[(Api set:[^\]]+)\\\]/, `\\[ [$1](http://bing.com?type=excel) \\]`);
+    }
+    else if (uid.search(/Word/i) !== -1) {
+      return markup.replace(/\\\[(Api set:[^\]]+)\\\]/, `\\[ [$1](http://bing.com?type=word) \\]`);
+    }
+    else if (uid.search(/OneNotel/i) !== -1) {
+      return markup.replace(/\\\[(Api set:[^\]]+)\\\]/, `\\[ [$1](http://bing.com?type=onenote) \\]`);
+    }
+    else if (uid.search(/Visio/i) !== -1) {
+      return markup.replace(/\\\[(Api set:[^\]]+)\\\]/, `\\[ [$1](http://bing.com?type=visio) \\]`);
+    }
+    else if (uid.search(/Outlook/i) !== -1) {
+      return markup.replace(/\\\[(Api set:[^\]]+)\\\]/, `\\[ [$1](http://bing.com?type=outlook) \\]`);
+    }
+    else {
+      return markup.replace(/\\\[(Api set:[^\]]+)\\\]/, `\\[ [$1](http://bing.com) \\]`);
+    }
   }
 }

--- a/apps/api-documenter/src/yaml/OfficeYamlDocumenter.ts
+++ b/apps/api-documenter/src/yaml/OfficeYamlDocumenter.ts
@@ -65,7 +65,7 @@ export class OfficeYamlDocumenter extends YamlDocumenter {
 
       yamlItem.remarks += '\n\n#### Examples\n';
       for (const snippet of snippets) {
-        if (snippet.search(/await/) == -1) {
+        if (snippet.search(/await/) === -1) {
           yamlItem.remarks += '\n```javascript\n' + snippet + '\n```\n';
         } else {
           yamlItem.remarks += '\n```typescript\n' + snippet + '\n```\n';
@@ -87,23 +87,18 @@ export class OfficeYamlDocumenter extends YamlDocumenter {
     //
     // Hyperlink it like this:
     // \[ [API set: ExcelApi 1.1](http://bing.com?type=excel) \]
-    markup = markup.replace(/Api/, "API");
+    markup = markup.replace(/Api/, 'API');
     if (uid.search(/Excel/i) !== -1) {
       return markup.replace(/\\\[(API set:[^\]]+)\\\]/, `\\[ [$1](http://bing.com?type=excel) \\]`);
-    }
-    else if (uid.search(/OneNote/i) !== -1) {
+    } else if (uid.search(/OneNote/i) !== -1) {
       return markup.replace(/\\\[(API set:[^\]]+)\\\]/, `\\[ [$1](http://bing.com?type=onenote) \\]`);
-    }
-    else if (uid.search(/Visio/i) !== -1) {
+    } else if (uid.search(/Visio/i) !== -1) {
       return markup.replace(/\\\[(API set:[^\]]+)\\\]/, `\\[ [$1](http://bing.com?type=visio) \\]`);
-    }
-    else if (uid.search(/Outlook/i) !== -1) {
+    } else if (uid.search(/Outlook/i) !== -1) {
       return markup.replace(/\\\[(API set:[^\]]+)\\\]/, `\\[ [$1](http://bing.com?type=outlook) \\]`);
-    }
-    else if (uid.search(/Word/i) !== -1) {
+    } else if (uid.search(/Word/i) !== -1) {
       return markup.replace(/\\\[(API set:[^\]]+)\\\]/, `\\[ [$1](http://bing.com?type=word) \\]`);
-    }
-    else {
+    } else {
       return markup.replace(/\\\[(API set:[^\]]+)\\\]/, `\\[ [$1](http://bing.com) \\]`);
     }
   }

--- a/common/changes/@microsoft/api-documenter/kbrandl-patch-1_2018-03-21-12-52.json
+++ b/common/changes/@microsoft/api-documenter/kbrandl-patch-1_2018-03-21-12-52.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-documenter",
+      "comment": "Change heading for code snippets section from `## Snippets` to `#### Examples`.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/api-documenter",
+  "email": "kibrandl@microsoft.com"
+}

--- a/common/changes/@microsoft/api-documenter/kbrandl-patch-1_2018-03-21-12-52.json
+++ b/common/changes/@microsoft/api-documenter/kbrandl-patch-1_2018-03-21-12-52.json
@@ -7,5 +7,5 @@
     }
   ],
   "packageName": "@microsoft/api-documenter",
-  "email": "kibrandl@microsoft.com"
+  "email": "kibrandl@users.noreply.github.com"
 }

--- a/common/changes/@microsoft/api-documenter/kbrandl-patch-1_2018-03-21-12-53.json
+++ b/common/changes/@microsoft/api-documenter/kbrandl-patch-1_2018-03-21-12-53.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-documenter",
+      "comment": "Customize the `API Set #.#` hyperlink target by host. ",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/api-documenter",
+  "email": "kibrandl@microsoft.com"
+}

--- a/common/changes/@microsoft/api-documenter/kbrandl-patch-1_2018-03-21-12-53.json
+++ b/common/changes/@microsoft/api-documenter/kbrandl-patch-1_2018-03-21-12-53.json
@@ -7,5 +7,5 @@
     }
   ],
   "packageName": "@microsoft/api-documenter",
-  "email": "kibrandl@microsoft.com"
+  "email": "kibrandl@users.noreply.github.com"
 }

--- a/common/changes/@microsoft/api-documenter/kbrandl-patch-1_2018-03-21-12-54.json
+++ b/common/changes/@microsoft/api-documenter/kbrandl-patch-1_2018-03-21-12-54.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-documenter",
+      "comment": "Designate proper language for each code snippet (TypeScript or JavaScript).",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/api-documenter",
+  "email": "kibrandl@microsoft.com"
+}

--- a/common/changes/@microsoft/api-documenter/kbrandl-patch-1_2018-03-21-12-54.json
+++ b/common/changes/@microsoft/api-documenter/kbrandl-patch-1_2018-03-21-12-54.json
@@ -7,5 +7,5 @@
     }
   ],
   "packageName": "@microsoft/api-documenter",
-  "email": "kibrandl@microsoft.com"
+  "email": "kibrandl@users.noreply.github.com"
 }


### PR DESCRIPTION
- Use `#### Examples` heading for code snippets section (instead of `## Snippets`).
- Designate proper language for each code snippet (TypeScript or JavaScript).
- Customize the `API Set #.#` hyperlink target by host. 