### PR TITLE
Add a `libESNextFolder` option

### DIFF
--- a/common/changes/@microsoft/gulp-core-build-typescript/lib-esnext_2018-03-21-18-42.json
+++ b/common/changes/@microsoft/gulp-core-build-typescript/lib-esnext_2018-03-21-18-42.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/gulp-core-build-typescript",
+      "comment": "Add a `libESNextFolder` option",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@microsoft/gulp-core-build-typescript",
+  "email": "elliottsj@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/gulp-core-build/lib-esnext_2018-03-21-18-42.json
+++ b/common/changes/@microsoft/gulp-core-build/lib-esnext_2018-03-21-18-42.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/gulp-core-build",
+      "comment": "Add a `libESNextFolder` option",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@microsoft/gulp-core-build",
+  "email": "elliottsj@users.noreply.github.com"
+}

--- a/common/reviews/api/gulp-core-build.api.ts
+++ b/common/reviews/api/gulp-core-build.api.ts
@@ -113,6 +113,7 @@ interface IBuildConfig {
   jestEnabled?: boolean;
   libAMDFolder?: string;
   libES6Folder?: string;
+  libESNextFolder?: string;
   libFolder: string;
   onTaskEnd?: (taskName: string, duration: number[], error?: any) => void;
   onTaskStart?: (taskName: string) => void;

--- a/common/reviews/api/node-library-build.api.ts
+++ b/common/reviews/api/node-library-build.api.ts
@@ -121,6 +121,7 @@ interface IBuildConfig {
   jestEnabled?: boolean;
   libAMDFolder?: string;
   libES6Folder?: string;
+  libESNextFolder?: string;
   libFolder: string;
   onTaskEnd?: (taskName: string, duration: number[], error?: any) => void;
   onTaskStart?: (taskName: string) => void;

--- a/common/reviews/api/web-library-build.api.ts
+++ b/common/reviews/api/web-library-build.api.ts
@@ -121,6 +121,7 @@ interface IBuildConfig {
   jestEnabled?: boolean;
   libAMDFolder?: string;
   libES6Folder?: string;
+  libESNextFolder?: string;
   libFolder: string;
   onTaskEnd?: (taskName: string, duration: number[], error?: any) => void;
   onTaskStart?: (taskName: string) => void;

--- a/core-build/gulp-core-build/src/IBuildConfig.ts
+++ b/core-build/gulp-core-build/src/IBuildConfig.ts
@@ -54,6 +54,11 @@ export interface IBuildConfig {
   libES6Folder?: string;
 
   /**
+   * Unbundled esnext modules folder, which can be optionally set to cause build tasks to output esnext modules.
+   */
+  libESNextFolder?: string;
+
+  /**
    * Dist folder, which includes all bundled resources which would be copied to a CDN for the project.
    */
   distFolder: string;

--- a/core-build/gulp-core-build/src/index.ts
+++ b/core-build/gulp-core-build/src/index.ts
@@ -69,6 +69,7 @@ let _buildConfig: IBuildConfig = {
   srcFolder: 'src',
   distFolder: path.join(packageFolder, 'dist'),
   libAMDFolder: undefined,
+  libESNextFolder: undefined,
   libFolder: path.join(packageFolder, 'lib'),
   tempFolder: 'temp',
   properties: {},


### PR DESCRIPTION
This option allows projects to emit modules to the specified directory
using `module: 'esnext'`.

Fixes #576 