### PR TITLE
Adding new findLast option to ISetWebpackPublicPathOptions

### DIFF
--- a/common/changes/@microsoft/set-webpack-public-path-plugin/mamooty-findLast_2018-03-29-23-09.json
+++ b/common/changes/@microsoft/set-webpack-public-path-plugin/mamooty-findLast_2018-03-29-23-09.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/set-webpack-public-path-plugin",
+      "comment": "Adding new option to ISetWebpackPublicPathOptions, called findLast",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@microsoft/set-webpack-public-path-plugin",
+  "email": "mamooty@microsoft.com"
+}

--- a/common/reviews/api/set-webpack-public-path-plugin.api.ts
+++ b/common/reviews/api/set-webpack-public-path-plugin.api.ts
@@ -3,6 +3,7 @@ export function getGlobalRegisterCode(debug?: boolean): string;
 
 // @public
 interface ISetWebpackPublicPathOptions {
+  findLast?: boolean;
   getPostProcessScript?: (varName: string) => string;
   publicPath?: string;
   regexVariable?: string;

--- a/common/reviews/api/set-webpack-public-path-plugin.api.ts
+++ b/common/reviews/api/set-webpack-public-path-plugin.api.ts
@@ -3,8 +3,8 @@ export function getGlobalRegisterCode(debug?: boolean): string;
 
 // @public
 interface ISetWebpackPublicPathOptions {
-  findLast?: boolean;
   getPostProcessScript?: (varName: string) => string;
+  preferLastFoundScript?: boolean;
   publicPath?: string;
   regexVariable?: string;
   systemJs?: boolean;

--- a/webpack/set-webpack-public-path-plugin/README.md
+++ b/webpack/set-webpack-public-path-plugin/README.md
@@ -121,9 +121,10 @@ the public path variable will have `/assets/` appended to the found path.
 
 Note that the existing value of the variable already ends in a slash (`/`).
 
-#### `findLast = false`
+#### `preferLastFoundScript = false`
 
 If true, find the last script matching the regexVariable (if it is set). If false, find the first matching script.
+This can be useful if there are multiple scripts loaded in the DOM that match the regexVariable.
 
 # SystemJS Caveat
 

--- a/webpack/set-webpack-public-path-plugin/README.md
+++ b/webpack/set-webpack-public-path-plugin/README.md
@@ -121,6 +121,10 @@ the public path variable will have `/assets/` appended to the found path.
 
 Note that the existing value of the variable already ends in a slash (`/`).
 
+#### `findLast = false`
+
+If true, find the last script matching the regexVariable (if it is set). If false, find the first matching script.
+
 # SystemJS Caveat
 
 When modules are loaded with SystemJS (and with the , `scriptLoad: true` meta option) `<script src="..."></script>`

--- a/webpack/set-webpack-public-path-plugin/src/SetPublicPathPlugin.ts
+++ b/webpack/set-webpack-public-path-plugin/src/SetPublicPathPlugin.ts
@@ -51,6 +51,11 @@ export interface ISetWebpackPublicPathOptions {
    * See the README for more information.
    */
   getPostProcessScript?: (varName: string) => string;
+
+  /**
+   * If true, find the last script matching the regexVariable (if it is set). If false, find the first matching script.
+   */
+  findLast?: boolean;
 }
 
 /**

--- a/webpack/set-webpack-public-path-plugin/src/SetPublicPathPlugin.ts
+++ b/webpack/set-webpack-public-path-plugin/src/SetPublicPathPlugin.ts
@@ -54,8 +54,9 @@ export interface ISetWebpackPublicPathOptions {
 
   /**
    * If true, find the last script matching the regexVariable (if it is set). If false, find the first matching script.
+   * This can be useful if there are multiple scripts loaded in the DOM that match the regexVariable.
    */
-  findLast?: boolean;
+  preferLastFoundScript?: boolean;
 }
 
 /**

--- a/webpack/set-webpack-public-path-plugin/src/codeGenerator.ts
+++ b/webpack/set-webpack-public-path-plugin/src/codeGenerator.ts
@@ -55,7 +55,7 @@ export function getSetPublicPathCode(options: IInternalOptions, emitWarning: (wa
       `    var path = scripts[i].getAttribute('src');`,
       '    if (path && path.match(regex)) {',
       `      ${varName} = path.substring(0, path.lastIndexOf('/') + 1);`,
-      '      break;',
+      ...(options.findLast ? [] : ['      break;']),
       '    }',
       '  }',
       '}',
@@ -64,7 +64,7 @@ export function getSetPublicPathCode(options: IInternalOptions, emitWarning: (wa
       `  for (var global in ${registryVariableName}) {`,
       '    if (global && global.match(regex)) {',
       `      ${varName} = global.substring(0, global.lastIndexOf('/') + 1);`,
-      '      break;',
+      ...(options.findLast ? [] : ['      break;']),
       '    }',
       '  }',
       '}'

--- a/webpack/set-webpack-public-path-plugin/src/codeGenerator.ts
+++ b/webpack/set-webpack-public-path-plugin/src/codeGenerator.ts
@@ -55,7 +55,7 @@ export function getSetPublicPathCode(options: IInternalOptions, emitWarning: (wa
       `    var path = scripts[i].getAttribute('src');`,
       '    if (path && path.match(regex)) {',
       `      ${varName} = path.substring(0, path.lastIndexOf('/') + 1);`,
-      ...(options.findLast ? [] : ['      break;']),
+      ...(options.preferLastFoundScript ? [] : ['      break;']),
       '    }',
       '  }',
       '}',
@@ -64,7 +64,7 @@ export function getSetPublicPathCode(options: IInternalOptions, emitWarning: (wa
       `  for (var global in ${registryVariableName}) {`,
       '    if (global && global.match(regex)) {',
       `      ${varName} = global.substring(0, global.lastIndexOf('/') + 1);`,
-      ...(options.findLast ? [] : ['      break;']),
+      ...(options.preferLastFoundScript ? [] : ['      break;']),
       '    }',
       '  }',
       '}'


### PR DESCRIPTION
Adding new option to ISetWebpackPublicPathOptions, called preferLastFoundScript. This allows for finding the last matching script instead of the first