### PR TITLE
[rush] Create "node_modules/.bin" launchers for locally linked dependencies

### DIFF
--- a/apps/rush-lib/package.json
+++ b/apps/rush-lib/package.json
@@ -25,6 +25,8 @@
     "@microsoft/package-deps-hash": "2.2.31",
     "@microsoft/stream-collator": "2.2.31",
     "@microsoft/ts-command-line": "3.1.1",
+    "@pnpm/link-bins": "~1.0.1",
+    "@pnpm/logger": "~1.0.1",
     "builtins": "~1.0.3",
     "colors": "~1.2.1",
     "fs-extra": "~0.26.7",

--- a/apps/rush-lib/src/cli/logic/pnpm/PnpmLinkManager.ts
+++ b/apps/rush-lib/src/cli/logic/pnpm/PnpmLinkManager.ts
@@ -36,7 +36,7 @@ export class PnpmLinkManager extends BaseLinkManager {
       for (const rushProject of this._rushConfiguration.projects) {
         promise = promise.then(() => {
           console.log(os.EOL + 'LINKING: ' + rushProject.packageName);
-          this._linkProject(rushProject, rushLinkJson);
+          return this._linkProject(rushProject, rushLinkJson);
         });
       }
 

--- a/apps/rush-lib/src/cli/logic/pnpm/PnpmLinkManager.ts
+++ b/apps/rush-lib/src/cli/logic/pnpm/PnpmLinkManager.ts
@@ -5,6 +5,7 @@ import * as fsx from 'fs-extra';
 import * as os from 'os';
 import * as path from 'path';
 import uriEncode = require('strict-uri-encode');
+import pnpmLinkBins from '@pnpm/link-bins';
 
 import {
   JsonFile,
@@ -14,8 +15,7 @@ import {
 } from '@microsoft/node-core-library';
 
 import {
-  BaseLinkManager,
-  SymlinkKind
+  BaseLinkManager
 } from '../base/BaseLinkManager';
 import { BasePackage } from '../base/BasePackage';
 import { RushConstants } from '../../../RushConstants';
@@ -31,15 +31,19 @@ export class PnpmLinkManager extends BaseLinkManager {
     try {
       const rushLinkJson: IRushLinkJson = { localLinks: {} };
 
+      let promise: Promise<void> = Promise.resolve();
+
       for (const rushProject of this._rushConfiguration.projects) {
-        console.log(os.EOL + 'LINKING: ' + rushProject.packageName);
-        this._linkProject(rushProject, rushLinkJson);
+        promise = promise.then(() => {
+          console.log(os.EOL + 'LINKING: ' + rushProject.packageName);
+          this._linkProject(rushProject, rushLinkJson);
+        });
       }
 
-      console.log(`Writing "${this._rushConfiguration.rushLinkJsonFilename}"`);
-      JsonFile.save(rushLinkJson, this._rushConfiguration.rushLinkJsonFilename);
-
-      return Promise.resolve();
+      return promise.then(() => {
+        console.log(`Writing "${this._rushConfiguration.rushLinkJsonFilename}"`);
+        JsonFile.save(rushLinkJson, this._rushConfiguration.rushLinkJsonFilename);
+      });
     } catch (error) {
       return Promise.reject(error);
     }
@@ -52,7 +56,7 @@ export class PnpmLinkManager extends BaseLinkManager {
    */
   private _linkProject(
     project: RushConfigurationProject,
-    rushLinkJson: IRushLinkJson): void {
+    rushLinkJson: IRushLinkJson): Promise<void> {
 
     // first, read the temp package.json information
 
@@ -204,11 +208,11 @@ export class PnpmLinkManager extends BaseLinkManager {
     PnpmLinkManager._createSymlinksForTopLevelProject(localPackage);
 
     // Also symlink the ".bin" folder
-    const commonBinFolder: string = path.join(this._rushConfiguration.commonTempFolder, 'node_modules', '.bin');
+    const projectFolder: string = path.join(localPackage.folderPath, 'node_modules');
     const projectBinFolder: string = path.join(localPackage.folderPath, 'node_modules', '.bin');
 
-    if (fsx.existsSync(commonBinFolder)) {
-      PnpmLinkManager._createSymlink(commonBinFolder, projectBinFolder, SymlinkKind.Directory);
-    }
+    // Return type is Promise<void[]> because the API returns Promise.all()
+    return pnpmLinkBins(projectFolder, projectBinFolder)
+      .then(() => { /* empty block */ });
   }
 }

--- a/common/changes/@microsoft/rush/pgonzal-better-bin-links_2018-04-04-01-49.json
+++ b/common/changes/@microsoft/rush/pgonzal-better-bin-links_2018-04-04-01-49.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Improve \"rush link\" to create node_modules/.bin launchers for local project dependencies (not just installed external dependencies)",
+      "packageName": "@microsoft/rush",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/config/rush/nonbrowser-approved-packages.json
+++ b/common/config/rush/nonbrowser-approved-packages.json
@@ -78,6 +78,14 @@
       "allowedCategories": [ "libraries", "tests" ]
     },
     {
+      "name": "@pnpm/link-bins",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
+      "name": "@pnpm/logger",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
       "name": "api-extractor-test-01",
       "allowedCategories": [ "tests" ]
     },

--- a/common/config/rush/shrinkwrap.yaml
+++ b/common/config/rush/shrinkwrap.yaml
@@ -1,5 +1,7 @@
 dependencies:
   '@microsoft/node-library-build': 4.3.28
+  '@pnpm/link-bins': 1.0.1
+  '@pnpm/logger': 1.0.1
   '@rush-temp/api-documenter': 'file:projects/api-documenter.tgz'
   '@rush-temp/api-extractor': 'file:projects/api-extractor.tgz'
   '@rush-temp/api-extractor-test-01': 'file:projects/api-extractor-test-01.tgz'
@@ -107,7 +109,7 @@ dependencies:
   gulp-typescript: 3.1.7
   gulp-util: 3.0.8
   inquirer: 1.2.3
-  istanbul-instrumenter-loader: 3.0.0
+  istanbul-instrumenter-loader: 3.0.1
   jest: 21.2.1
   jest-cli: 21.2.1
   jest-environment-jsdom: 21.2.1
@@ -129,7 +131,7 @@ dependencies:
   merge2: 1.0.3
   minimatch: 3.0.4
   mocha: 3.4.2
-  node-forge: 0.7.4
+  node-forge: 0.7.5
   node-notifier: 5.0.2
   npm-package-arg: 5.1.2
   object-assign: 4.1.1
@@ -311,6 +313,77 @@ packages:
     dev: false
     resolution:
       integrity: sha1-I8JxXmpc6QsiFJ5f1GxWxN6BpPU=
+  /@pnpm/link-bins/1.0.1:
+    dependencies:
+      '@pnpm/package-bins': 1.0.0
+      '@pnpm/types': 1.7.0
+      '@types/mz': 0.0.32
+      '@types/ramda': 0.25.21
+      '@zkochan/cmd-shim': 2.2.4
+      arr-flatten: 1.1.0
+      is-windows: 1.0.2
+      mkdirp-promise: 5.0.1
+      mz: 2.7.0
+      normalize-path: 2.1.1
+      p-filter: 1.0.0
+      ramda: 0.25.0
+      read-package-json: 2.0.13
+    dev: false
+    engines:
+      node: '>=4'
+    peerDependencies:
+      '@pnpm/logger': ^1.0.0
+    resolution:
+      integrity: sha512-6hHV7qwIxYizwpSfcSR5A/ChBkTdJYVvAxB70WYbdbj6Wc0enS2sOSuFWO8yhOUDpzBph6T+qTWYeZrlpFTqzA==
+  /@pnpm/link-bins/1.0.1/@pnpm!logger@1.0.1:
+    dependencies:
+      '@pnpm/logger': 1.0.1
+      '@pnpm/package-bins': 1.0.0
+      '@pnpm/types': 1.7.0
+      '@types/mz': 0.0.32
+      '@types/ramda': 0.25.21
+      '@zkochan/cmd-shim': 2.2.4
+      arr-flatten: 1.1.0
+      is-windows: 1.0.2
+      mkdirp-promise: 5.0.1
+      mz: 2.7.0
+      normalize-path: 2.1.1
+      p-filter: 1.0.0
+      ramda: 0.25.0
+      read-package-json: 2.0.13
+    dev: false
+    engines:
+      node: '>=4'
+    id: registry.npmjs.org/@pnpm/link-bins/1.0.1
+    peerDependencies:
+      '@pnpm/logger': ^1.0.0
+    resolution:
+      integrity: sha512-6hHV7qwIxYizwpSfcSR5A/ChBkTdJYVvAxB70WYbdbj6Wc0enS2sOSuFWO8yhOUDpzBph6T+qTWYeZrlpFTqzA==
+  /@pnpm/logger/1.0.1:
+    dependencies:
+      '@types/node': 9.6.2
+      bole: 3.0.2
+      ndjson: 1.5.0
+    dev: false
+    engines:
+      node: '>=4'
+    resolution:
+      integrity: sha512-23FWOXgCkJ9q73mIqS5H/x98uaZcvO7ov/nt0HZGgLci3MHsqBgEfh3UzZiLZIxlxmA3XoUp4fgbjM7S96pBRg==
+  /@pnpm/package-bins/1.0.0:
+    dependencies:
+      '@pnpm/types': 1.7.0
+      '@types/mz': 0.0.32
+      mz: 2.7.0
+      p-filter: 1.0.0
+    dev: false
+    engines:
+      node: '>=4'
+    resolution:
+      integrity: sha512-ZqVfIXK3r5AsP5VAhPHrhf3isF+T4yEuUpJTF9T03oFTJ9LBnkKvx8F7P7biKEManxSGOkSpNoIBdsura9pY5Q==
+  /@pnpm/types/1.7.0:
+    dev: false
+    resolution:
+      integrity: sha512-pn7g4uxcofWTNG/cxmKvkMK2lxr4OUIhrQDrEVYEdVhW0WkWztsHkFrYjFgfNzPbYu3ITlB3T6aSVjCoJQTOlw==
   /@types/argparse/1.0.33:
     dev: false
     resolution:
@@ -440,6 +513,12 @@ packages:
     dev: false
     resolution:
       integrity: sha1-jBiPbjTC58Px0BJ9kI1aNuWmDck=
+  /@types/mz/0.0.32:
+    dependencies:
+      '@types/node': 8.5.8
+    dev: false
+    resolution:
+      integrity: sha512-cy3yebKhrHuOcrJGkfwNHhpTXQLgmXSv1BX+4p32j+VUQ6aP2eJ5cL7OvGcAQx75fCTFaAIIAKewvqL+iwSd4g==
   /@types/node-forge/0.6.8:
     dev: false
     resolution:
@@ -454,6 +533,10 @@ packages:
     dev: false
     resolution:
       integrity: sha512-8KmlRxwbKZfjUHFIt3q8TF5S2B+/E5BaAoo/3mgc5h6FJzqxXkCK/VMetO+IRDtwtU6HUvovHMBn+XRj7SV9Qg==
+  /@types/node/9.6.2:
+    dev: false
+    resolution:
+      integrity: sha512-UWkRY9X7RQHp5OhhRIIka58/gVVycL1zHZu0OTsT5LI86ABaMOSbUjAl+b0FeDhQcxclrkyft3kW5QWdMRs8wQ==
   /@types/orchestrator/0.0.30:
     dependencies:
       '@types/q': 0.0.32
@@ -464,6 +547,10 @@ packages:
     dev: false
     resolution:
       integrity: sha1-vShOV8hPEyXacCur/IKlMoGQwMU=
+  /@types/ramda/0.25.21:
+    dev: false
+    resolution:
+      integrity: sha512-y4Dx3t+EA5Y+s87cwUoIzo0Tsj9z7QCu4gaXrdFln4wQRgk9igBskEEe7gZ0PG8dSXtQb29oA3RS//3XquHdiw==
   /@types/rimraf/0.0.28:
     dev: false
     resolution:
@@ -535,6 +622,16 @@ packages:
     dev: false
     resolution:
       integrity: sha1-LrHQCl5Ow/pYx2r94S4YK2bcXBw=
+  /@zkochan/cmd-shim/2.2.4:
+    dependencies:
+      is-windows: 1.0.2
+      mkdirp-promise: 5.0.1
+      mz: 2.7.0
+    dev: false
+    engines:
+      node: '>=4'
+    resolution:
+      integrity: sha512-BDy1oz6aFYyY73618IkXzJzFghnXwVZDc3SVa6MVKTrrk4RgubahAF5yKK+Mx4a78tfO0OHeZnJKPs0pNy5uNA==
   /abab/1.0.4:
     dev: false
     resolution:
@@ -699,6 +796,10 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-qCJQ3bABXponyoLoLqYDu/pF768=
+  /any-promise/1.3.0:
+    dev: false
+    resolution:
+      integrity: sha1-q8av7tzqUugJzcA3au0845Y10X8=
   /anymatch/1.3.2:
     dependencies:
       micromatch: 2.3.11
@@ -924,16 +1025,16 @@ packages:
       node: '>= 0.4.0'
     resolution:
       integrity: sha1-lfE2KbEsOlGl0hWr3OKqnzL4B3M=
-  /atob/2.0.3:
+  /atob/2.1.0:
     dev: false
     engines:
       node: '>= 0.4.0'
     resolution:
-      integrity: sha1-GcenYEc3dEaPILLS0DNyrX1Mv10=
+      integrity: sha512-SuiKH8vbsOyCALjA/+EINmt/Kdl+TQPrtFgW7XZZcwtryFu9e5kQoX3bjCW6mIvGH1fbeAZZuvwGR5IlBRznGw==
   /autoprefixer/6.3.7:
     dependencies:
       browserslist: 1.3.6
-      caniuse-db: 1.0.30000820
+      caniuse-db: 1.0.30000823
       normalize-range: 0.1.2
       num2fraction: 1.2.2
       postcss: 5.2.18
@@ -1049,7 +1150,7 @@ packages:
     dependencies:
       babel-core: 6.26.0
       babel-runtime: 6.26.0
-      core-js: 2.5.3
+      core-js: 2.5.4
       home-or-tmp: 2.0.0
       lodash: 4.17.5
       mkdirp: 0.5.1
@@ -1059,7 +1160,7 @@ packages:
       integrity: sha1-btAhFz4vy0htestFxgCahW9kcHE=
   /babel-runtime/6.26.0:
     dependencies:
-      core-js: 2.5.3
+      core-js: 2.5.4
       regenerator-runtime: 0.11.1
     dev: false
     resolution:
@@ -1231,7 +1332,7 @@ packages:
       content-type: 1.0.4
       debug: 2.6.9
       depd: 1.1.2
-      http-errors: 1.6.2
+      http-errors: 1.6.3
       iconv-lite: 0.4.19
       on-finished: 2.3.0
       qs: 6.5.1
@@ -1242,6 +1343,13 @@ packages:
       node: '>= 0.8'
     resolution:
       integrity: sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=
+  /bole/3.0.2:
+    dependencies:
+      fast-safe-stringify: 1.1.13
+      individual: 3.0.0
+    dev: false
+    resolution:
+      integrity: sha1-vIpIPKlASdqbg3wa0Rzf6+5uBRQ=
   /boom/2.10.1:
     dependencies:
       hoek: 2.16.3
@@ -1324,7 +1432,7 @@ packages:
     dev: false
     resolution:
       integrity: sha1-81HTKWnTL6XXpVZxVCY9korjvR8=
-  /browserify-aes/1.1.1:
+  /browserify-aes/1.2.0:
     dependencies:
       buffer-xor: 1.0.3
       cipher-base: 1.0.4
@@ -1334,10 +1442,10 @@ packages:
       safe-buffer: 5.1.1
     dev: false
     resolution:
-      integrity: sha512-UGnTYAnB2a3YuYKIRy1/4FB2HdM866E0qC46JXvVTYKlBlZlnvfpSfY6OKfXZAkv70eJ2a1SqzpAo5CRhZGDFg==
+      integrity: sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==
   /browserify-cipher/1.0.0:
     dependencies:
-      browserify-aes: 1.1.1
+      browserify-aes: 1.2.0
       browserify-des: 1.0.0
       evp_bytestokey: 1.0.3
     dev: false
@@ -1378,7 +1486,7 @@ packages:
       integrity: sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==
   /browserslist/1.3.6:
     dependencies:
-      caniuse-db: 1.0.30000820
+      caniuse-db: 1.0.30000823
     dev: false
     resolution:
       integrity: sha1-lS/0jVZGPTtTj4XvL46t39KEsTM=
@@ -1500,10 +1608,10 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=
-  /caniuse-db/1.0.30000820:
+  /caniuse-db/1.0.30000823:
     dev: false
     resolution:
-      integrity: sha1-fCDiXOoXaLJhtyT4LjpqJTqqFGg=
+      integrity: sha1-5o5fjHB4PvQFnS6g3oH1UWUdpvw=
   /caseless/0.11.0:
     dev: false
     resolution:
@@ -1866,10 +1974,10 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
-  /core-js/2.5.3:
+  /core-js/2.5.4:
     dev: false
     resolution:
-      integrity: sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4=
+      integrity: sha1-8si/GB8qgLkvNgEhQpzmOi8K6uA=
   /core-util-is/1.0.2:
     dev: false
     resolution:
@@ -2022,7 +2130,7 @@ packages:
       integrity: sha1-XQKkaFCt8bSjF5RqOSj8y1v9BCU=
   /d/1.0.0:
     dependencies:
-      es5-ext: 0.10.41
+      es5-ext: 0.10.42
     dev: false
     resolution:
       integrity: sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=
@@ -2058,14 +2166,14 @@ packages:
       node: '>=0.11.0'
     resolution:
       integrity: sha512-gpacYo8FBZh3INBp2KOtrQp9kCO5faHvOmEZx3/cZTr3Mm8/kAYs7/Ws3E3OAH0ApBNK6Y6N+7+Dka2Zn2Fldw==
-  /debug-fabulous/1.0.0:
+  /debug-fabulous/1.1.0:
     dependencies:
       debug: 3.1.0
       memoizee: 0.4.12
       object-assign: 4.1.1
     dev: false
     resolution:
-      integrity: sha512-dsd50qQ1atDeurcxL7XOjPp4nZCGZzWIONDujDXzl1atSyC3hMbZD+v6440etw+Vt0Pr8ce4TQzHfX3KZM05Mw==
+      integrity: sha512-GZqvGIgKNlUnHUPQhepnUZFIMoi3dgZKQBzKDeL2g7oJF9SNAji/AAu36dusFUas0O+pae74lNeoIPHqXWDkLg==
   /debug/2.2.0:
     dependencies:
       ms: 0.7.1
@@ -2428,18 +2536,18 @@ packages:
     dev: false
     resolution:
       integrity: sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=
-  /es5-ext/0.10.41:
+  /es5-ext/0.10.42:
     dependencies:
       es6-iterator: 2.0.3
       es6-symbol: 3.1.1
       next-tick: 1.0.0
     dev: false
     resolution:
-      integrity: sha512-MYK02wXfwTMie5TEJWPolgOsXEmz7wKCQaGzgmRjZOoV6VLG8I5dSv2bn6AOClXhK64gnSQTQ9W9MKvx87J4gw==
+      integrity: sha512-AJxO1rmPe1bDEfSR6TJ/FgMFYuTBhR5R57KW58iCkYACMyFbrkqVyzXSurYoScDGvgyMpk7uRF/lPUPPTmsRSA==
   /es6-iterator/2.0.3:
     dependencies:
       d: 1.0.0
-      es5-ext: 0.10.41
+      es5-ext: 0.10.42
       es6-symbol: 3.1.1
     dev: false
     resolution:
@@ -2447,7 +2555,7 @@ packages:
   /es6-map/0.1.5:
     dependencies:
       d: 1.0.0
-      es5-ext: 0.10.41
+      es5-ext: 0.10.42
       es6-iterator: 2.0.3
       es6-set: 0.1.5
       es6-symbol: 3.1.1
@@ -2462,7 +2570,7 @@ packages:
   /es6-set/0.1.5:
     dependencies:
       d: 1.0.0
-      es5-ext: 0.10.41
+      es5-ext: 0.10.42
       es6-iterator: 2.0.3
       es6-symbol: 3.1.1
       event-emitter: 0.3.5
@@ -2472,14 +2580,14 @@ packages:
   /es6-symbol/3.1.1:
     dependencies:
       d: 1.0.0
-      es5-ext: 0.10.41
+      es5-ext: 0.10.42
     dev: false
     resolution:
       integrity: sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=
   /es6-weak-map/2.0.2:
     dependencies:
       d: 1.0.0
-      es5-ext: 0.10.41
+      es5-ext: 0.10.42
       es6-iterator: 2.0.3
       es6-symbol: 3.1.1
     dev: false
@@ -2622,7 +2730,7 @@ packages:
   /event-emitter/0.3.5:
     dependencies:
       d: 1.0.0
-      es5-ext: 0.10.41
+      es5-ext: 0.10.42
     dev: false
     resolution:
       integrity: sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=
@@ -2895,6 +3003,10 @@ packages:
     dev: false
     resolution:
       integrity: sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
+  /fast-safe-stringify/1.1.13:
+    dev: false
+    resolution:
+      integrity: sha1-oB6c2cnkkXFcmKdaQtXwu9EH/3Y=
   /fastparse/1.1.1:
     dev: false
     resolution:
@@ -3737,7 +3849,7 @@ packages:
       acorn: 5.5.3
       convert-source-map: 1.5.1
       css: 2.2.1
-      debug-fabulous: 1.0.0
+      debug-fabulous: 1.1.0
       detect-newline: 2.1.0
       graceful-fs: 4.1.11
       source-map: 0.6.1
@@ -4086,7 +4198,7 @@ packages:
   /http-errors/1.3.1:
     dependencies:
       inherits: 2.0.3
-      statuses: 1.4.0
+      statuses: 1.5.0
     dev: false
     engines:
       node: '>= 0.6'
@@ -4097,12 +4209,23 @@ packages:
       depd: 1.1.1
       inherits: 2.0.3
       setprototypeof: 1.0.3
-      statuses: 1.4.0
+      statuses: 1.5.0
     dev: false
     engines:
       node: '>= 0.6'
     resolution:
       integrity: sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=
+  /http-errors/1.6.3:
+    dependencies:
+      depd: 1.1.2
+      inherits: 2.0.3
+      setprototypeof: 1.1.0
+      statuses: 1.5.0
+    dev: false
+    engines:
+      node: '>= 0.6'
+    resolution:
+      integrity: sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=
   /http-parser-js/0.4.11:
     dev: false
     resolution:
@@ -4184,6 +4307,10 @@ packages:
     dev: false
     resolution:
       integrity: sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10=
+  /individual/3.0.0:
+    dev: false
+    resolution:
+      integrity: sha1-58pPhfiVewGHNPKFdQ3CLsL5hi0=
   /inflight/1.0.6:
     dependencies:
       once: 1.4.0
@@ -4640,7 +4767,7 @@ packages:
     dev: false
     resolution:
       integrity: sha512-duj6AlLcsWNwUpfyfHt0nWIeRiZpuShnP40YTxOGQgtaN8fd6JYSxsvxUphTDy8V5MfDXo4s/xVCIIvVCO808g==
-  /istanbul-instrumenter-loader/3.0.0:
+  /istanbul-instrumenter-loader/3.0.1:
     dependencies:
       convert-source-map: 1.5.1
       istanbul-lib-instrument: 1.10.1
@@ -4648,11 +4775,11 @@ packages:
       schema-utils: 0.3.0
     dev: false
     engines:
-      node: '>= 4.3 < 5.0.0 || >= 5.10'
+      node: '>= 4.8 < 5.0.0 || >= 5.10'
     peerDependencies:
-      webpack: ^2.0.0 || ^3.0.0
+      webpack: ^2.0.0 || ^3.0.0 || ^4.0.0
     resolution:
-      integrity: sha512-alLSEFX06ApU75sm5oWcaVNaiss/bgMRiWTct3g0P0ZZTKjR+6QiCcuVOKDI1kWJgwHEnIXsv/dWm783kPpmtw==
+      integrity: sha512-a5SPObZgS0jB/ixaKSMdn6n/gXSrK2S6q/UfRJBT3e6gQmVjwZROTODQsYW5ZNwOu78hG62Y3fWlebaVOL0C+w==
   /istanbul-instrumenter-loader/3.0.1/webpack@3.6.0:
     dependencies:
       convert-source-map: 1.5.1
@@ -5076,10 +5203,10 @@ packages:
     dev: false
     resolution:
       integrity: sha512-QLPs8Dj7lnf3e3QYS1zkCo+4ZwqOiF9d/nZnYozTISxXWCfNs9yuky5rJw4/W34s7POaNlbZmQGaB5NiXCbP4w==
-  /json-parse-better-errors/1.0.1:
+  /json-parse-better-errors/1.0.2:
     dev: false
     resolution:
-      integrity: sha512-xyQpxeWWMKyJps9CuGJYeng6ssI5bpqS9ltQpdVQ90t4ql6NdnxFKh95JcRt2cun/DjMVNrdjniLPuMA69xmCw==
+      integrity: sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==
   /json-schema-traverse/0.3.1:
     dev: false
     resolution:
@@ -5244,7 +5371,7 @@ packages:
       chokidar: 1.7.0
       colors: 1.2.1
       connect: 3.6.6
-      core-js: 2.5.3
+      core-js: 2.5.4
       di: 0.0.1
       dom-serialize: 2.2.1
       expand-braces: 0.1.2
@@ -5764,7 +5891,7 @@ packages:
       integrity: sha512-wgeVXhrDwAWnIF/yZARsFnMBtdFXOg1b8RIrhilp+0iDYN4mdQcNZElDZ0e4B64BhaxeQ5zN7PMyvu7we1kPeQ==
   /lru-queue/0.1.0:
     dependencies:
-      es5-ext: 0.10.41
+      es5-ext: 0.10.42
     dev: false
     resolution:
       integrity: sha1-Jzi9nw089PhEkMVzbEhpmsYyzaM=
@@ -5842,7 +5969,7 @@ packages:
   /memoizee/0.4.12:
     dependencies:
       d: 1.0.0
-      es5-ext: 0.10.41
+      es5-ext: 0.10.42
       es6-weak-map: 2.0.2
       event-emitter: 0.3.5
       is-promise: 2.1.0
@@ -6058,6 +6185,14 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==
+  /mkdirp-promise/5.0.1:
+    dependencies:
+      mkdirp: 0.5.1
+    dev: false
+    engines:
+      node: '>=4'
+    resolution:
+      integrity: sha1-6bj2jlUsaKnBcTuEiD96HdA5uKE=
   /mkdirp/0.3.0:
     dev: false
     resolution:
@@ -6140,6 +6275,14 @@ packages:
     dev: false
     resolution:
       integrity: sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=
+  /mz/2.7.0:
+    dependencies:
+      any-promise: 1.3.0
+      object-assign: 4.1.1
+      thenify-all: 1.6.0
+    dev: false
+    resolution:
+      integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==
   /nan/2.10.0:
     dev: false
     resolution:
@@ -6164,6 +6307,7 @@ packages:
     resolution:
       integrity: sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==
   /natives/1.1.2:
+    deprecated: 'This module relies on Node.js''s internals and will break at some point. Do not use it, and update to graceful-fs@4.x.'
     dev: false
     resolution:
       integrity: sha512-5bRASydE1gu6zPOenLN043++J8xj1Ob7ArkfdYO3JN4DF5rDmG7bMoiybkTyD+GnXQEMixVeDHMzuqm6kpBmiA==
@@ -6171,6 +6315,15 @@ packages:
     dev: false
     resolution:
       integrity: sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
+  /ndjson/1.5.0:
+    dependencies:
+      json-stringify-safe: 5.0.1
+      minimist: 1.2.0
+      split2: 2.2.0
+      through2: 2.0.3
+    dev: false
+    resolution:
+      integrity: sha1-rmA7NrE0vOw0e0UkIrC/mNWDLsg=
   /negotiator/0.6.1:
     dev: false
     engines:
@@ -6185,10 +6338,10 @@ packages:
     dev: false
     resolution:
       integrity: sha1-yobR/ogoFpsBICCOPchCS524NCw=
-  /node-forge/0.7.4:
+  /node-forge/0.7.5:
     dev: false
     resolution:
-      integrity: sha512-8Df0906+tq/omxuCZD6PqhPaQDYuyJ1d+VITgxoIA8zvQd1ru+nMJcDChHH324MWitIgbVkAkQoGEEVJNpn/PA==
+      integrity: sha512-MmbQJ2MTESTjt3Gi/3yG1wGpIMhUfcIypUCGtTizFR9IiccFwxSpfp0vtIZlkFclEqERemxfnSdZEMR9VqqEFQ==
   /node-gyp/3.6.2:
     dependencies:
       fstream: 1.0.11
@@ -6232,7 +6385,7 @@ packages:
       readable-stream: 2.3.5
       stream-browserify: 2.0.1
       stream-http: 2.8.1
-      string_decoder: 1.1.0
+      string_decoder: 1.1.1
       timers-browserify: 2.0.6
       tty-browserify: 0.0.0
       url: 0.11.0
@@ -6582,6 +6735,14 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha512-RVbZPLso8+jFeq1MfNvgXtCRED2raz/dKpacfTNxsx6pLEpEomM7gah6VeHSYV3+vo0OAi4MkArtQcWWXuQoyw==
+  /p-filter/1.0.0:
+    dependencies:
+      p-map: 1.2.0
+    dev: false
+    engines:
+      node: '>=4'
+    resolution:
+      integrity: sha1-Yp0xcVAgnI/VCLoTdxPvS7kg6ds=
   /p-finally/1.0.0:
     dev: false
     engines:
@@ -6604,6 +6765,12 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=
+  /p-map/1.2.0:
+    dev: false
+    engines:
+      node: '>=4'
+    resolution:
+      integrity: sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==
   /p-try/1.0.0:
     dev: false
     engines:
@@ -6617,7 +6784,7 @@ packages:
   /parse-asn1/5.1.0:
     dependencies:
       asn1.js: 4.10.1
-      browserify-aes: 1.1.1
+      browserify-aes: 1.2.0
       create-hash: 1.1.3
       evp_bytestokey: 1.0.3
       pbkdf2: 3.0.14
@@ -7084,6 +7251,10 @@ packages:
       node: '>=0.4.x'
     resolution:
       integrity: sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=
+  /ramda/0.25.0:
+    dev: false
+    resolution:
+      integrity: sha512-GXpfrYVPwx3K7RQ6aYT8KPS8XViSXUVJT1ONhoKPE9VAleW42YE+U+8VEyGWt41EnEQW7gwecYJriTI0pKoecQ==
   /randomatic/1.1.7:
     dependencies:
       is-number: 3.0.0
@@ -7142,7 +7313,7 @@ packages:
   /read-package-json/2.0.13:
     dependencies:
       glob: 7.1.2
-      json-parse-better-errors: 1.0.1
+      json-parse-better-errors: 1.0.2
       normalize-package-data: 2.4.0
       slash: 1.0.0
     dev: false
@@ -7627,7 +7798,7 @@ packages:
       escape-html: 1.0.3
       etag: 1.8.1
       fresh: 0.5.2
-      http-errors: 1.6.2
+      http-errors: 1.6.3
       mime: 1.4.1
       ms: 2.0.0
       on-finished: 2.3.0
@@ -7650,7 +7821,7 @@ packages:
       batch: 0.6.1
       debug: 2.6.9
       escape-html: 1.0.3
-      http-errors: 1.6.2
+      http-errors: 1.6.3
       mime-types: 2.1.18
       parseurl: 1.3.2
     dev: false
@@ -7889,7 +8060,7 @@ packages:
       integrity: sha1-YQ9hIqRFuN1RU1oqcbeD38Ekh2E=
   /source-map-resolve/0.5.1:
     dependencies:
-      atob: 2.0.3
+      atob: 2.1.0
       decode-uri-component: 0.2.0
       resolve-url: 0.2.1
       source-map-url: 0.4.0
@@ -8003,6 +8174,12 @@ packages:
     dev: false
     resolution:
       integrity: sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=
+  /split2/2.2.0:
+    dependencies:
+      through2: 2.0.3
+    dev: false
+    resolution:
+      integrity: sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==
   /sprintf-js/1.0.3:
     dev: false
     resolution:
@@ -8048,6 +8225,12 @@ packages:
       node: '>= 0.6'
     resolution:
       integrity: sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==
+  /statuses/1.5.0:
+    dev: false
+    engines:
+      node: '>= 0.6'
+    resolution:
+      integrity: sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=
   /stdout-stream/1.4.0:
     dependencies:
       readable-stream: 2.3.5
@@ -8133,12 +8316,12 @@ packages:
     dev: false
     resolution:
       integrity: sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==
-  /string_decoder/1.1.0:
+  /string_decoder/1.1.1:
     dependencies:
       safe-buffer: 5.1.1
     dev: false
     resolution:
-      integrity: sha512-8zQpRF6juocE69ae7CSPmYEGJe4VCXwP6S6dxUWI7i53Gwv54/ec41fiUA+X7BPGGv7fRSQJjBQVa0gomGaOgg==
+      integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==
   /stringstream/0.0.5:
     dev: false
     resolution:
@@ -8349,6 +8532,20 @@ packages:
     dev: false
     resolution:
       integrity: sha1-ZUhjk+4fK7A5pgy7oFsLaL2VAdI=
+  /thenify-all/1.6.0:
+    dependencies:
+      thenify: 3.3.0
+    dev: false
+    engines:
+      node: '>=0.8'
+    resolution:
+      integrity: sha1-GhkY1ALY/D+Y+/I02wvMjMEOlyY=
+  /thenify/3.3.0:
+    dependencies:
+      any-promise: 1.3.0
+    dev: false
+    resolution:
+      integrity: sha1-5p44obq+lpsBCCB5eLn2K4hgSDk=
   /throat/4.1.0:
     dev: false
     resolution:
@@ -8426,7 +8623,7 @@ packages:
       integrity: sha512-HQ3nbYRAowdVd0ckGFvmJPPCOH/CHleFN/Y0YQCX1DVaB7t+KFvisuyN09fuP8Jtp1CpfSh8O8bMkHbdbPe6Pw==
   /timers-ext/0.1.5:
     dependencies:
-      es5-ext: 0.10.41
+      es5-ext: 0.10.42
       next-tick: 1.0.0
     dev: false
     resolution:
@@ -8557,7 +8754,7 @@ packages:
       integrity: sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ==
   /tslint-microsoft-contrib/5.0.3:
     dependencies:
-      tsutils: 2.22.2
+      tsutils: 2.26.0
     dev: false
     peerDependencies:
       tslint: ^5.1.0
@@ -8567,7 +8764,7 @@ packages:
   /tslint-microsoft-contrib/5.0.3/tslint@5.9.1+typescript@2.4.2:
     dependencies:
       tslint: /tslint/5.9.1/typescript@2.4.2
-      tsutils: /tsutils/2.22.2/typescript@2.4.2
+      tsutils: /tsutils/2.26.0/typescript@2.4.2
       typescript: 2.4.2
     dev: false
     id: registry.npmjs.org/tslint-microsoft-contrib/5.0.3
@@ -8589,7 +8786,7 @@ packages:
       resolve: 1.6.0
       semver: 5.3.0
       tslib: 1.9.0
-      tsutils: 2.22.2
+      tsutils: 2.26.0
     dev: false
     engines:
       node: '>=4.8.0'
@@ -8610,7 +8807,7 @@ packages:
       resolve: 1.6.0
       semver: 5.3.0
       tslib: 1.9.0
-      tsutils: /tsutils/2.22.2/typescript@2.4.2
+      tsutils: /tsutils/2.26.0/typescript@2.4.2
       typescript: 2.4.2
     dev: false
     engines:
@@ -8620,24 +8817,24 @@ packages:
       typescript: '>=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev'
     resolution:
       integrity: sha1-ElX4ej/1frCw4fDmEKi0dIBGya4=
-  /tsutils/2.22.2:
+  /tsutils/2.26.0:
     dependencies:
       tslib: 1.9.0
     dev: false
     peerDependencies:
-      typescript: '>=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev'
+      typescript: '>=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >= 2.10.0-dev'
     resolution:
-      integrity: sha512-u06FUSulCJ+Y8a2ftuqZN6kIGqdP2yJjUPEngXqmdPND4UQfb04igcotH+dw+IFr417yP6muCLE8/5/Qlfnx0w==
-  /tsutils/2.22.2/typescript@2.4.2:
+      integrity: sha512-hXUttgxeaZ/uPP/dpeiWUHbP5h744mPrfN2YFFtcZzd7vBRPBP6Knr0Mt6Bd+5SntMn8/1r6IGFeYPDSBIIPpg==
+  /tsutils/2.26.0/typescript@2.4.2:
     dependencies:
       tslib: 1.9.0
       typescript: 2.4.2
     dev: false
-    id: registry.npmjs.org/tsutils/2.22.2
+    id: registry.npmjs.org/tsutils/2.26.0
     peerDependencies:
-      typescript: '>=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev'
+      typescript: '>=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >= 2.10.0-dev'
     resolution:
-      integrity: sha512-u06FUSulCJ+Y8a2ftuqZN6kIGqdP2yJjUPEngXqmdPND4UQfb04igcotH+dw+IFr417yP6muCLE8/5/Qlfnx0w==
+      integrity: sha512-hXUttgxeaZ/uPP/dpeiWUHbP5h744mPrfN2YFFtcZzd7vBRPBP6Knr0Mt6Bd+5SntMn8/1r6IGFeYPDSBIIPpg==
   /tty-browserify/0.0.0:
     dev: false
     resolution:
@@ -9362,7 +9559,7 @@ packages:
     dev: false
     name: '@rush-temp/api-documenter'
     resolution:
-      integrity: sha512-W8CY04UcgYtm5SfNoC6Okdj1PL2y/zgWdS7SwJMJFXIPKGLrrkxsQMWGS3jq0CMyqfSaiKKU9NZ27bTs8hCRsQ==
+      integrity: sha512-Ec7lLeFwFDU5gux9X5Y2ptJp8gTpxKoNyqhoHmFg2mfdVG/Ixya67KCZn/yaO76YEZlKUbRBYgfdP6TLyucn0w==
       tarball: 'file:projects/api-documenter.tgz'
     version: 0.0.0
   'file:projects/api-extractor-test-01.tgz':
@@ -9374,7 +9571,7 @@ packages:
     dev: false
     name: '@rush-temp/api-extractor-test-01'
     resolution:
-      integrity: sha512-Zm26mNPSfiEvSMRmtaCL++8gL/Jq/6fRKvu9tkAyVEdY+xaGv0tcv4U5CX3rFa4pUeSPt+fm55Eb0ATbMjDO8Q==
+      integrity: sha512-VVC1na65aa8fhQQrplX6yYy3BKt5TuSmix8KrMgmz2O7Lmg2tvbmlBmpy9I7l33SbrpHSgFsy76TTNOxrhd4uw==
       tarball: 'file:projects/api-extractor-test-01.tgz'
     version: 0.0.0
   'file:projects/api-extractor-test-02.tgz':
@@ -9387,7 +9584,7 @@ packages:
     dev: false
     name: '@rush-temp/api-extractor-test-02'
     resolution:
-      integrity: sha512-obDkEh9VD7PvJqWPeflwaRpCHvDdPux06y0dTlcYEyMH5MCbMbhE8IZ7efC2XtQ1nln6ln2UvA7MTHWsR9wLkA==
+      integrity: sha512-O2zQivgREj7bc/6cxvZhvFw4hf7ZZura9maY2B7/8OneR/gs0tsRm9sTqR0Kmpv8tEb9BPZWu404nK9ZuPrE2w==
       tarball: 'file:projects/api-extractor-test-02.tgz'
     version: 0.0.0
   'file:projects/api-extractor-test-03.tgz':
@@ -9399,7 +9596,7 @@ packages:
     dev: false
     name: '@rush-temp/api-extractor-test-03'
     resolution:
-      integrity: sha512-XoWS/V5sQfM7gE7D/DjGI1hoEbgPLT4N5JTFA6oB/Y8pghGLMjyYK9iFN4QH2rKI0NDUw+M75W+ygOmAkrX44A==
+      integrity: sha512-Ohdp5zR9CZ3C2KLuLUvTf/srLQjbhQyhq24BMmX3vaKF/Q4a0PfT4X526eWRL4NaRZh690Y4ymNc94b9rLc5qg==
       tarball: 'file:projects/api-extractor-test-03.tgz'
     version: 0.0.0
   'file:projects/api-extractor-test-04.tgz':
@@ -9409,7 +9606,7 @@ packages:
     dev: false
     name: '@rush-temp/api-extractor-test-04'
     resolution:
-      integrity: sha512-tBg8OQvL47iB9CNpzC9DiV9+QMJtJvp8N79CXSn4VfWUahWhmSnIovL8EsUjXXuzr6VnGtHyuc+v3p8zJ5HEfQ==
+      integrity: sha512-Y6ORTuDwyuIMhMhWdJvj8kDCdodxm6Tw7N/eqYz/q76FSZMOBSCtJRX2ERm2CgzfNrEz/bQVpeO+0nQcmuXNuA==
       tarball: 'file:projects/api-extractor-test-04.tgz'
     version: 0.0.0
   'file:projects/api-extractor.tgz':
@@ -9430,7 +9627,7 @@ packages:
     dev: false
     name: '@rush-temp/api-extractor'
     resolution:
-      integrity: sha512-VhY4E1yYQhrbjh68LEqQ0/15Mp0TorDTzpP64H649r51q2CAZKhWfMNU7kmm6OT35radXlPnbAN9nwPEP4ut8g==
+      integrity: sha512-20MJWRLE/g78nOBgQfKUy9YlZGfLnzT/AX+8H2P3+f3x9Zd05VXhqEyEeyPOGFsjXPczSUoarEuGPsoxjiWzbQ==
       tarball: 'file:projects/api-extractor.tgz'
     version: 0.0.0
   'file:projects/gulp-core-build-karma.tgz':
@@ -9462,7 +9659,7 @@ packages:
     dev: false
     name: '@rush-temp/gulp-core-build-karma'
     resolution:
-      integrity: sha512-d66xDT7JzmWOYnpw2YlSFjhsEi6ivGpOQccIf/NoPSSjeyt4kb5XPOFisUPibhXb+9cpoTVaEacH9vnmpIwkRg==
+      integrity: sha512-m9oMFRd3Nwq8vSR8zP9m15oG9Bhzlbxb7an8/yvMB9lzD9+F8mDHpn+VKe2oIrBWvGOWDJOmP3OuOcBwg5oysQ==
       tarball: 'file:projects/gulp-core-build-karma.tgz'
     version: 0.0.0
   'file:projects/gulp-core-build-mocha.tgz':
@@ -9481,7 +9678,7 @@ packages:
     dev: false
     name: '@rush-temp/gulp-core-build-mocha'
     resolution:
-      integrity: sha512-0itpZ3PqhzoGu1NDooEc0MffPTSrc2mmhNO4FnPvk1DA0+3WDBgVBbDkfARixFN4/zWXXuJfzoJ2r6d2ea2sdg==
+      integrity: sha512-Ugaks1GJL2PXJNytKGYtbS+J+Ok4PXWGSHLEPrWz13ep1dQeXfCyqDOO7uOA9fe1fP1UL42G04sAJSA4eUwveQ==
       tarball: 'file:projects/gulp-core-build-mocha.tgz'
     version: 0.0.0
   'file:projects/gulp-core-build-sass.tgz':
@@ -9510,7 +9707,7 @@ packages:
     dev: false
     name: '@rush-temp/gulp-core-build-sass'
     resolution:
-      integrity: sha512-Z6M3u+VTUYe9cJ5b0xQuvdG4d7K+uLwmKPfWSb70wZjwaeFFzNHH9GIJ9PEawVu9wlaLvHp9nDVTEI48wTWvIg==
+      integrity: sha512-ZGuO7WS4EWfOoEbN1PAA8XGkcW3/3WAPKez2Rcxy3nLTUt2qtLxfk/EAbEWV7suZdH0QpFZAiEiFJI8YuXzxRA==
       tarball: 'file:projects/gulp-core-build-sass.tgz'
     version: 0.0.0
   'file:projects/gulp-core-build-serve.tgz':
@@ -9535,12 +9732,12 @@ packages:
       gulp-connect: 5.5.0
       gulp-open: 2.0.0
       gulp-util: 3.0.8
-      node-forge: 0.7.4
+      node-forge: 0.7.5
       sudo: 1.0.3
     dev: false
     name: '@rush-temp/gulp-core-build-serve'
     resolution:
-      integrity: sha512-IdEt6qeLV0gu1COjzjj82dUO5KfqA9lpR8ytJRnwqKfqtqOF5VfLMTerHzkvUGgatIrOMSTzdQ1uXhXd8uS39Q==
+      integrity: sha512-9g8CFywF/KRICq3ZPXAwVO9P8l3dsP5ixh45XPApLFd0JunblK+TYx5+P5X2APzTLlFN9GzN5EpFLVKCw0YUAQ==
       tarball: 'file:projects/gulp-core-build-serve.tgz'
     version: 0.0.0
   'file:projects/gulp-core-build-typescript.tgz':
@@ -9575,7 +9772,7 @@ packages:
     dev: false
     name: '@rush-temp/gulp-core-build-typescript'
     resolution:
-      integrity: sha512-3dkRrfV+yw9JHp0XgIh40YaDeyyOzFT06ySV0Msr4QxFXQN38mV6rLRUWEaYbSbQ+YF95RdSH1txMuQGyKiVjQ==
+      integrity: sha512-CaN+viCjwflc5saebKGIOe3DSb6BKOlcx/8S5UweOutyHddS9NgztAtKMY6G07ioQ/5VuGHZ7VNnVani41y0UA==
       tarball: 'file:projects/gulp-core-build-typescript.tgz'
     version: 0.0.0
   'file:projects/gulp-core-build-webpack.tgz':
@@ -9596,7 +9793,7 @@ packages:
     dev: false
     name: '@rush-temp/gulp-core-build-webpack'
     resolution:
-      integrity: sha512-3UcsA8sngaFJnEXPPyc2rv04ZednKWMAZUfOZ0cK5+4fguTmyKjYDqOShV06prJlfEaM21HBdjOZ9X0R3GFKBQ==
+      integrity: sha512-w9wTpKkJRk9191KO78crk4cWs4KndY196vxwpdEYN9WFnAL65ntPl8CJxhiD6Z/AA+4pUASXsB+2ErnKrRyrPA==
       tarball: 'file:projects/gulp-core-build-webpack.tgz'
     version: 0.0.0
   'file:projects/gulp-core-build.tgz':
@@ -9648,7 +9845,7 @@ packages:
     dev: false
     name: '@rush-temp/gulp-core-build'
     resolution:
-      integrity: sha512-gw/HA+pCyTYMBB7W31ke9F4joyNBFl6atnmtSyevjXauhpJXRNJe2bc7AU1pMoULRSNxcgI9KqQKAhNguoKn5w==
+      integrity: sha512-dmd9FI3FGkZQtjqhDaUgV55qjqVqXx/O9wR/cn8yMPfHnBGOAv/NCMuruGe9Lj3zVl8s7Gx6tvJkyQaOxJ/Zaw==
       tarball: 'file:projects/gulp-core-build.tgz'
     version: 0.0.0
   'file:projects/load-themed-styles.tgz':
@@ -9661,7 +9858,7 @@ packages:
     dev: false
     name: '@rush-temp/load-themed-styles'
     resolution:
-      integrity: sha512-BG50w3ZJp4dqQitH6gr8bEinM4BgYzXmPEURDXJaZZXU8fX1+QHf7/BT7NcXl8k+0y/UScSEXaZfK0veNyjFng==
+      integrity: sha512-fDUQrn/XOghMusB5uggYaMgi17UHfnj+24y7SKUF4LihWuyvOv0HzXSJMz5HvrNvOeLJtMdW/NQra7p9ihWwIg==
       tarball: 'file:projects/load-themed-styles.tgz'
     version: 0.0.0
   'file:projects/loader-load-themed-styles.tgz':
@@ -9677,7 +9874,7 @@ packages:
     dev: false
     name: '@rush-temp/loader-load-themed-styles'
     resolution:
-      integrity: sha512-h+2VkZf9btYqYmIEGPcnJSmu7qOETnydKFQr4nL9c0ZTovyKiRLpz1BUEyZHD4cKcCqlc6kHlW08PC/E9eC0aA==
+      integrity: sha512-+9BOtw6ySVev5o1JnuLOmeC+w/J8GrY85mXaYPF/fOreONr6/X/F9qnLnJnui4jqj4PoxJK/ykf9jBCti2eEJw==
       tarball: 'file:projects/loader-load-themed-styles.tgz'
     version: 0.0.0
   'file:projects/loader-raw-script.tgz':
@@ -9691,7 +9888,7 @@ packages:
     dev: false
     name: '@rush-temp/loader-raw-script'
     resolution:
-      integrity: sha512-Ti5z6ccXdc5+rbJMbv9md9kPNpHNFQitNZ4WKYHaU4/6eytSJPIGeAhjF5m2mgRetUNCMC/1ncgfrpbU5Lsgxw==
+      integrity: sha512-H9pyTj/H3KX6pEWqcKOvRRHLP7U1kaY2pRPgwzNot1Je1t6FSOUxzAVlW3tUj0iKoNIh5e0h5BLEN6CjTTsyjQ==
       tarball: 'file:projects/loader-raw-script.tgz'
     version: 0.0.0
   'file:projects/loader-set-webpack-public-path.tgz':
@@ -9707,7 +9904,7 @@ packages:
     dev: false
     name: '@rush-temp/loader-set-webpack-public-path'
     resolution:
-      integrity: sha512-QPISzX8UzhhqEFvmTCAcIfWxCpo936uS6v+CpYZYara9u/u71Fl7iQjm/04Wj0zagCtHGyT+66Gk127jICkVtQ==
+      integrity: sha512-OvpB8L5SREa3PscW0bgkcl7bBKOhh6crCvzMWICvPaIPQgngLqZAtytxnunbSa5O8+AVMwtWQ843UtkCb1ilyg==
       tarball: 'file:projects/loader-set-webpack-public-path.tgz'
     version: 0.0.0
   'file:projects/node-core-library.tgz':
@@ -9727,7 +9924,7 @@ packages:
     dev: false
     name: '@rush-temp/node-core-library'
     resolution:
-      integrity: sha512-q2PAooC5K4h/oeTmAzkQvGy6RjSZhgldmHwdXQC0DLK+OFGbOw9HZyXwxM+qWCDbj9cn4kPQVTU1PojRmoA3cQ==
+      integrity: sha512-NcIGS84R160EELvxx880p201XoZKkv7koX0cJO+/Gxk7sMICN4zj8khz7g69LWPjbgBQ/qyFSJncV23AkFVycA==
       tarball: 'file:projects/node-core-library.tgz'
     version: 0.0.0
   'file:projects/node-library-build.tgz':
@@ -9738,7 +9935,7 @@ packages:
     dev: false
     name: '@rush-temp/node-library-build'
     resolution:
-      integrity: sha512-7CKZLQxUlIXe501XNKlPKslrCsw4/Jx6tdI9keKBAft2t9qo4o92SbU9JT98pTXKzf6m9qeyop5StSFxxhHskQ==
+      integrity: sha512-tMIggY8aWpT2h/ePvtnU+WQMTJe6iZFT34dAW8LXkxzLgn4pyARnqPX7+dwVqfKpJGPHpLFwk6ys2TfQqwl/Gg==
       tarball: 'file:projects/node-library-build.tgz'
     version: 0.0.0
   'file:projects/package-deps-hash.tgz':
@@ -9751,7 +9948,7 @@ packages:
     dev: false
     name: '@rush-temp/package-deps-hash'
     resolution:
-      integrity: sha512-NNcTzMGCQ3xWeZNYxWcAnfVPx/+1HIvmED7RDogoIU7+aCqLy0t4FyvC7PJwhCxJX+0KBkXkSzO8wjOyEKZwaw==
+      integrity: sha512-uNvOomNMHRdIGcHbRKlJPbEIAICA2f/Hd9ryvlrT7zp+QRcDt/Vd/cScZCRtJWsFm46asH8XlziY+rE5NIvrpg==
       tarball: 'file:projects/package-deps-hash.tgz'
     version: 0.0.0
   'file:projects/resolve-chunk-plugin.tgz':
@@ -9765,11 +9962,13 @@ packages:
     dev: false
     name: '@rush-temp/resolve-chunk-plugin'
     resolution:
-      integrity: sha512-ABy19x6onE7HWCd6w/Eyi5bNmdYeVEhUSw1mH9n9YbMZWC5MoKILCEHGmq4CZV4elCHCUWqn6la04S8nrt1Hsg==
+      integrity: sha512-NpmeDHudGd+nyYzyIrxf+ECO4XSw9HWSX9uXjs6y6/7j5iTg7g6/vNGyzp0wgwIrxiAKzXrtb3QYpY4eT/Ra8w==
       tarball: 'file:projects/resolve-chunk-plugin.tgz'
     version: 0.0.0
   'file:projects/rush-lib.tgz':
     dependencies:
+      '@pnpm/link-bins': /@pnpm/link-bins/1.0.1/@pnpm!logger@1.0.1
+      '@pnpm/logger': 1.0.1
       '@types/chai': 3.4.34
       '@types/fs-extra': 0.0.37
       '@types/glob': 5.0.30
@@ -9808,7 +10007,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-lib'
     resolution:
-      integrity: sha512-00n7hfbRQ/ZvHqziSnyCMASqCb7BX/6I2tORioRbX9smQ2X9nlKVkGAVHfwHfwm+KOsTQiq8XRmzdsJVJwuhqA==
+      integrity: sha512-DfD1PIVjLMqtEkHyJhwO1B0zw7YFE95NceO5x+UfUzSbYmyQgNcN5sml2k/mbNN77zSyKJifr+m7T47jhz/w3Q==
       tarball: 'file:projects/rush-lib.tgz'
     version: 0.0.0
   'file:projects/rush.tgz':
@@ -9828,7 +10027,7 @@ packages:
     dev: false
     name: '@rush-temp/rush'
     resolution:
-      integrity: sha512-Ux1PfiYZLwvAlYHvH2JBr089JAnuF5yoNVrFSASSn+MQ6cnTDUDekQKW/UoRmdRDFEBXzc0TTJsNvWVT5NgE1A==
+      integrity: sha512-aXr7e0ri2xneWH1z9SuWTryXkJRB/1oKa0dUS3S1H4zP1f954xhgVwyQRlysN3R9b78nD3h0ZA2aDEf7Yl8g1Q==
       tarball: 'file:projects/rush.tgz'
     version: 0.0.0
   'file:projects/set-webpack-public-path-plugin.tgz':
@@ -9847,7 +10046,7 @@ packages:
     dev: false
     name: '@rush-temp/set-webpack-public-path-plugin'
     resolution:
-      integrity: sha512-AR6xqrQTJIgDg4dwRlJeowkYMSvMNrW9E1x/TDk6lePpVkuVBfLEC2XILV4ZiXb+2t73Q2mKMnKIOG0ob2jd4A==
+      integrity: sha512-O7vw96Li31bnaEpBZPJc+nbA4rFBuzZAKueRckpYxpRlE7ghrtVldd9x28mhDQmYFNs0yPesHOQAkLgmxFk4RA==
       tarball: 'file:projects/set-webpack-public-path-plugin.tgz'
     version: 0.0.0
   'file:projects/stream-collator.tgz':
@@ -9862,7 +10061,7 @@ packages:
     dev: false
     name: '@rush-temp/stream-collator'
     resolution:
-      integrity: sha512-uyi+CA6BNxjM70PXliJ8K2GV8zM4DU8X1pf1H3yrW7xPrfRS4LQlW6B9b7s+LYQdVa9J/ELImBLj2+EAu0AXeg==
+      integrity: sha512-O339zEhVP61KOHqAjgPcw0RPa/hwlWnjq5icHFooL2Mf+PSr3mZSr9cibEgxFLWbTyuztQ0CogkVDQX320Q1cg==
       tarball: 'file:projects/stream-collator.tgz'
     version: 0.0.0
   'file:projects/ts-command-line.tgz':
@@ -9878,7 +10077,7 @@ packages:
     dev: false
     name: '@rush-temp/ts-command-line'
     resolution:
-      integrity: sha512-V3wOeyr6GvdjzMQmUIcgxOJvfxW8JleltmibF9oCpmkBSE82stJTrNEVRuLGVTM5Dc5klWYfFrdFztkUoWOuZw==
+      integrity: sha512-anPyjFW8tk3NzJLkmRtNFhuQfXvJrV87aJ6Qx9kNvE+XKVEZk1q2T6ia0qGDNglpEqFSxjqCX7BNJPexRENhnA==
       tarball: 'file:projects/ts-command-line.tgz'
     version: 0.0.0
   'file:projects/web-library-build-test.tgz':
@@ -9891,7 +10090,7 @@ packages:
     dev: false
     name: '@rush-temp/web-library-build-test'
     resolution:
-      integrity: sha512-wj00h9hm0PRbUgwKO2mJJTDMe9+UhQdEPeO8jCqrnrgUvOe3V+Gp1ZF9eiYpGFsMSmigBScK7BS3G4NWnwKdYA==
+      integrity: sha512-XMgXm0ZTMqbEsvFAe3gijE3OHD8emYLC164rs8S8bxNJSUDdefWvt/sQMLzxb//PwucL4PUxUyjcXLnicyDQFw==
       tarball: 'file:projects/web-library-build-test.tgz'
     version: 0.0.0
   'file:projects/web-library-build.tgz':
@@ -9903,7 +10102,7 @@ packages:
     dev: false
     name: '@rush-temp/web-library-build'
     resolution:
-      integrity: sha512-gnhft2CpnMiPKWMk5cXfzNhjgwfZ1q7C9F8nLrV2HGQEPv5qhqxPC1UYDo6rVtpU+3aUp/tstPcOtsMMTJC0NQ==
+      integrity: sha512-0Gkhopds9jEH+9fghc0uMBrzDS/awc6dqX/SHtGglc+q5g/2GMBkMN1l6h4klcuKKRu9DI8rSN0s2+Q/cCF3yw==
       tarball: 'file:projects/web-library-build.tgz'
     version: 0.0.0
 registry: 'https://registry.npmjs.org/'
@@ -9911,6 +10110,8 @@ shrinkwrapMinorVersion: 4
 shrinkwrapVersion: 3
 specifiers:
   '@microsoft/node-library-build': 4.3.28
+  '@pnpm/link-bins': ~1.0.1
+  '@pnpm/logger': ~1.0.1
   '@rush-temp/api-documenter': 'file:./projects/api-documenter.tgz'
   '@rush-temp/api-extractor': 'file:./projects/api-extractor.tgz'
   '@rush-temp/api-extractor-test-01': 'file:./projects/api-extractor-test-01.tgz'


### PR DESCRIPTION
For example, the **api-extractor** project is a command line tool with a `bin/api-extractor` folder.  Whenever it gets installed, the package manager will normally create a `node_modules/.bin/api-extractor.cmd` launcher to invoke this scriptl.

However, suppose that another local project in this repo is symlinked to the **api-extractor** project by Rush.  When `rush link` creates the local **node_modules/.bin** folder, it is currently just a symlink to `common/temp/node_modules/.bin` which only contains launchers for external dependencies.  So the `api-extractor` command-line won't work.

This PR fixes that, by using `@pnpm/link-bins` to create launchers individually for each project.  This also enables a scenario where two different projects depend on different versions of a command-line tool.