### PR TITLE
[rush] Peer dependencies should be ignored by "rush check"

### DIFF
--- a/apps/rush-lib/src/data/VersionMismatchFinder.ts
+++ b/apps/rush-lib/src/data/VersionMismatchFinder.ts
@@ -50,12 +50,17 @@ export class VersionMismatchFinder {
   private _analyze(): void {
     this._projects.forEach((project: RushConfigurationProject) => {
       if (!project.skipRushCheck) {
+        // NOTE: We do not consider peer dependencies here.  The purpose of "rush check" is
+        // mainly to avoid side-by-side duplicates in the node_modules folder, whereas
+        // peer dependencies are just a compatibility statement that will be satisfied by a
+        // regular dependency.  (It might be useful for Rush to help people keep their peer dependency
+        // patterns consistent, but on the other hand different projects may have different
+        // levels of compatibility -- we should wait for someone to actually request this feature
+        // before we get into that.)
         this._addDependenciesToList(project.packageName,
           project.packageJson.dependencies, project.cyclicDependencyProjects);
         this._addDependenciesToList(project.packageName,
           project.packageJson.devDependencies, project.cyclicDependencyProjects);
-        this._addDependenciesToList(project.packageName,
-          project.packageJson.peerDependencies, project.cyclicDependencyProjects);
         this._addDependenciesToList(project.packageName,
           project.packageJson.optionalDependencies, project.cyclicDependencyProjects);
       }

--- a/apps/rush-lib/src/data/test/VersionMismatchFinder.test.ts
+++ b/apps/rush-lib/src/data/test/VersionMismatchFinder.test.ts
@@ -269,7 +269,7 @@ describe('VersionMismatchFinder', () => {
     done();
   });
 
-  it('checks peer dependencies', (done: MochaDone) => {
+  it('does not check peer dependencies', (done: MochaDone) => {
     const projects: RushConfigurationProject[] = [
       {
         packageName: 'A',
@@ -294,12 +294,7 @@ describe('VersionMismatchFinder', () => {
     ] as any as RushConfigurationProject[]; // tslint:disable-line:no-any
     const mismatchFinder: VersionMismatchFinder = new VersionMismatchFinder(projects);
     assert.isNumber(mismatchFinder.numberOfMismatches);
-    assert.equal(mismatchFinder.numberOfMismatches, 1);
-    assert.equal(mismatchFinder.getMismatches().length, 1);
-    assert.equal(mismatchFinder.getMismatches()[0], '@types/foo');
-    assert.includeMembers(mismatchFinder.getVersionsOfMismatch('@types/foo')!, ['2.0.0', '1.2.3']);
-    assert.equal(mismatchFinder.getConsumersOfMismatch('@types/foo', '2.0.0'), 'B');
-    assert.equal(mismatchFinder.getConsumersOfMismatch('@types/foo', '1.2.3'), 'A');
+    assert.equal(mismatchFinder.numberOfMismatches, 0);
     done();
   });
 

--- a/common/changes/@microsoft/rush/pgonzal-rush-check-skip-peers_2018-04-04-18-51.json
+++ b/common/changes/@microsoft/rush/pgonzal-rush-check-skip-peers_2018-04-04-18-51.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Improve \"rush check\" to ignore peer dependencies, since they don't need to be consistent with everything else (and generally won't be)",
+      "packageName": "@microsoft/rush",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "pgonzal@users.noreply.github.com"
+}


### PR DESCRIPTION
The purpose of "rush check" is mainly to avoid side-by-side duplicates in the node_modules folder.  Wheras peer dependencies are just a compatibility statement that will be satisfied by a regular dependency.  So "rush check" should not be processing the `peerDependencies` field at all.

> NOTE: It might be useful in the future for Rush to help people keep their peer dependency patterns consistent. But on the other hand, different projects within a repo may express different levels of compatibility for their peers. So we shouldn't try to handle this until someone actually requests it and provides a realistic use case.