### PR TITLE
[rush] Support execution of lifecycle scripts containing Unix slashes on Windows OS

### DIFF
--- a/apps/rush-lib/src/cli/taskRunner/ProjectTask.ts
+++ b/apps/rush-lib/src/cli/taskRunner/ProjectTask.ts
@@ -265,8 +265,8 @@ function _areShallowEqual(object1: Object, object2: Object, writer: ITaskWriter)
  * actually complains.
  */
 export function convertSlashesForWindows(command: string): string {
-  // Match everything up to the first space, "&" or quote
-  const commandRegExp: RegExp = /^([^\s&"]+)(.*)$/;
+  // Match everything up to the first space, "&", "|", "<", ">", or quote
+  const commandRegExp: RegExp = /^([^\s&|<>"]+)(.*)$/;
   const match: RegExpMatchArray | null = commandRegExp.exec(command);
   if (match) {
     // Example input: "bin/blarg --path ./config/blah.json && a/b"

--- a/apps/rush-lib/src/cli/taskRunner/ProjectTask.ts
+++ b/apps/rush-lib/src/cli/taskRunner/ProjectTask.ts
@@ -251,18 +251,24 @@ function _areShallowEqual(object1: Object, object2: Object, writer: ITaskWriter)
 
 /**
  * When running a command from the "scripts" block in package.json, if the command
- * contains Unix-style path slashes, the package managers will convert the slashes
- * to backslashes for the Windows OS.  This is a complicated heuristic.  For example,
- * we want to convert "node_modules/bin/this && ./scripts/that" to
- * "node_modules\bin\this && .\scripts\that" but we don't want to convert
- * the slashes in  "cmd.exe /c blah".  NPM and PNPM use npm-lifecycle for this,
- * but it unfortunately has a dependency on the entire node-gyp kitchen sink.
- * Yarn has a simplified implementation in fix-cmd-win-slashes.js, but it's not
- * exposed as a library.
+ * contains Unix-style path slashes, for Windows the package managers will convert slashes
+ * to backslashes.  This is a complicated heuristic.  For example,  we need to convert
+ * "node_modules/bin/this && ./scripts/that" to "node_modules\bin\this && .\scripts\that",
+ * but we don't want to convert any of  the slashes in "cmd.exe /c echo a/b".  NPM and PNPM
+ * use npm-lifecycle for this, but it unfortunately has a dependency on the entire node-gyp
+ * kitchen sink.  Yarn has a simplified implementation in fix-cmd-win-slashes.js, but it's
+ * not exposed as a library.
  *
- * Since the "&&" and quoting edge cases are mostly deprecated for Rush projects,
- * we will just do something very basic for now.  We can improve it later if someone
- * actually complains.
+ * Here we just do something very basic, because the syntax edge cases are mostly deprecated
+ * for modern projects.  We could improve this implementation if someone complains.
+ *
+ * However NPM's whole scripting concept is misguided:  They start by inviting people to write
+ * shell scripts that try to target wildly different shell languages (e.g. cmd.exe and Bash).
+ * Even the path slashes aren't consistent, so they use complicated heuristics to convert
+ * Bash syntax to cmd.exe (but not if you're using Bash on Windows!).  These workarounds are
+ * really complicated, to the point where you could probably implement a small portable
+ * shell language with less code.  (Or simply tell people to put their scripts in conventional
+ * script files, which is what we advocate.)
  */
 export function convertSlashesForWindows(command: string): string {
   // Match everything up to the first space, "&", "|", "<", ">", or quote

--- a/apps/rush-lib/src/cli/taskRunner/test/ProjectTask.test.ts
+++ b/apps/rush-lib/src/cli/taskRunner/test/ProjectTask.test.ts
@@ -8,6 +8,8 @@ import { convertSlashesForWindows } from '../ProjectTask';
 
 describe('convertSlashesForWindows()', () => {
   it('converted inputs', () => {
+    assert.equal(convertSlashesForWindows('./node_modules/.bin/tslint -c config/tslint.json'),
+      '.\\node_modules\\.bin\\tslint -c config/tslint.json');
     assert.equal(convertSlashesForWindows('/blah/bleep&&/bloop'), '\\blah\\bleep&&/bloop');
     assert.equal(convertSlashesForWindows('/blah/bleep'), '\\blah\\bleep');
     assert.equal(convertSlashesForWindows('/blah/bleep --path a/b'), '\\blah\\bleep --path a/b');

--- a/apps/rush-lib/src/cli/taskRunner/test/ProjectTask.test.ts
+++ b/apps/rush-lib/src/cli/taskRunner/test/ProjectTask.test.ts
@@ -11,9 +11,13 @@ describe('convertSlashesForWindows()', () => {
     assert.equal(convertSlashesForWindows('/blah/bleep&&/bloop'), '\\blah\\bleep&&/bloop');
     assert.equal(convertSlashesForWindows('/blah/bleep'), '\\blah\\bleep');
     assert.equal(convertSlashesForWindows('/blah/bleep --path a/b'), '\\blah\\bleep --path a/b');
+    assert.equal(convertSlashesForWindows('/blah/bleep>output.log'), '\\blah\\bleep>output.log');
+    assert.equal(convertSlashesForWindows('/blah/bleep<input.json'), '\\blah\\bleep<input.json');
+    assert.equal(convertSlashesForWindows('/blah/bleep|/blah/bloop'), '\\blah\\bleep|/blah/bloop');
   });
   it('ignored inputs', () => {
-    assert.equal(convertSlashesForWindows('C:\\blah/bleep && /bloop'), 'C:\\blah/bleep && /bloop');
+    assert.equal(convertSlashesForWindows('/blah\\bleep && /bloop'), '/blah\\bleep && /bloop');
+    assert.equal(convertSlashesForWindows('cmd.exe /c blah'), 'cmd.exe /c blah');
     assert.equal(convertSlashesForWindows('"/blah/bleep"'), '"/blah/bleep"');
   });
 });

--- a/apps/rush-lib/src/cli/taskRunner/test/ProjectTask.test.ts
+++ b/apps/rush-lib/src/cli/taskRunner/test/ProjectTask.test.ts
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+// <reference types='mocha' />
+import { assert } from 'chai';
+
+import { convertSlashesForWindows } from '../ProjectTask';
+
+describe('convertSlashesForWindows()', () => {
+  it('converted inputs', () => {
+    assert.equal(convertSlashesForWindows('/blah/bleep&&/bloop'), '\\blah\\bleep&&/bloop');
+    assert.equal(convertSlashesForWindows('/blah/bleep'), '\\blah\\bleep');
+    assert.equal(convertSlashesForWindows('/blah/bleep --path a/b'), '\\blah\\bleep --path a/b');
+  });
+  it('ignored inputs', () => {
+    assert.equal(convertSlashesForWindows('C:\\blah/bleep && /bloop'), 'C:\\blah/bleep && /bloop');
+    assert.equal(convertSlashesForWindows('"/blah/bleep"'), '"/blah/bleep"');
+  });
+});

--- a/common/changes/@microsoft/rush/pgonzal-rush-windows-slashes_2018-04-05-00-42.json
+++ b/common/changes/@microsoft/rush/pgonzal-rush-windows-slashes_2018-04-05-00-42.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Improve lifecycle script execution to support Unix slashes in the command name when running on Windows",
+      "packageName": "@microsoft/rush",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "pgonzal@users.noreply.github.com"
+}


### PR DESCRIPTION
When running a command from the "scripts" block in package.json, if the command contains Unix-style path slashes, the package managers will convert the slashes to backslashes for the Windows OS.  This is a complicated heuristic.  For example, we want to convert `"node_modules/bin/this && ./scripts/that"` to `"node_modules\bin\this && .\scripts\that"` but we don't want to convert the slashes in  `"cmd.exe /c blah"`.  NPM and PNPM use npm-lifecycle for this, but it unfortunately has a dependency on the entire node-gyp kitchen sink. Yarn has a simplified implementation in fix-cmd-win-slashes.js, but it's not exposed as a library.

Since the "&&" and quoting edge cases are mostly deprecated for Rush projects, we will just do something very basic for now.  We can improve it later if someone actually complains.