### PR TITLE
Fix logging warnings in TypeScript config

### DIFF
--- a/common/changes/@microsoft/gulp-core-build-typescript/fix-typescript-config-log-warning_2018-04-08-20-55.json
+++ b/common/changes/@microsoft/gulp-core-build-typescript/fix-typescript-config-log-warning_2018-04-08-20-55.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/gulp-core-build-typescript",
+      "comment": "Fix logging warnings in TypeScript config",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/gulp-core-build-typescript",
+  "email": "elliottsj@users.noreply.github.com"
+}

--- a/core-build/gulp-core-build-typescript/src/TypeScriptTask.ts
+++ b/core-build/gulp-core-build-typescript/src/TypeScriptTask.ts
@@ -167,7 +167,7 @@ export class TypeScriptTask extends GulpTask<ITypeScriptTaskConfig> {
       compilerOptions = lodash.merge({}, compilerOptions, this.taskConfig.configurationAddons);
     }
 
-    TypeScriptConfiguration.fixupSettings(compilerOptions, this.logWarning);
+    TypeScriptConfiguration.fixupSettings(compilerOptions, this.logWarning.bind(this));
 
     this._tsProject = this._tsProject || ts.createProject(compilerOptions);
 


### PR DESCRIPTION
Previously, TypeScriptConfiguration did not correctly log warnings since
the `this.logWarning` function passed by TypeScriptTask lost its binding
to `TypeScriptTask` when passed to TypeScriptConfiguration:

```
TypeError: Cannot read property 'name' of undefined
    at logWarning (.../node_modules/@microsoft/gulp-core-build/lib/tasks/GulpTask.js:114:45)
    at Function.fixupSettings (.../node_modules/@microsoft/gulp-core-build-typescript/lib/TypeScriptConfiguration.js:94:13)
    at TypeScriptTask.executeTask (.../node_modules/@microsoft/gulp-core-build-typescript/lib/TypeScriptTask.js:73:59)
    at Promise (.../node_modules/@microsoft/gulp-core-build/lib/tasks/GulpTask.js:173:31)
    at new Promise (<anonymous>)
    at TypeScriptTask.execute (.../node_modules/@microsoft/gulp-core-build/lib/tasks/GulpTask.js:165:16)
    at _executeTask (.../node_modules/@microsoft/gulp-core-build/lib/index.js:341:44)
    at output.then (.../node_modules/@microsoft/gulp-core-build/lib/index.js:253:44)
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:188:7)
```

This is fixed by explicitly binding `logWarning` to `this`.