### PR TITLE
Add allowedAlternativeVersions logic

### DIFF
--- a/apps/rush-lib/src/cli/actions/CheckAction.ts
+++ b/apps/rush-lib/src/cli/actions/CheckAction.ts
@@ -41,7 +41,10 @@ export default class CheckAction extends BaseRushAction {
       packageJson: { dependencies: allPreferredVersions }
     } as RushConfigurationProject);
 
-    const mismatchFinder: VersionMismatchFinder = new VersionMismatchFinder(this.rushConfiguration.projects);
+    const mismatchFinder: VersionMismatchFinder = new VersionMismatchFinder(
+      this.rushConfiguration.projects,
+      this.rushConfiguration.commonVersions.allowedAlternativeVersions
+    );
 
     // Iterate over the list. For any dependency with mismatching versions, print the projects
     mismatchFinder.getMismatches().forEach((dependency: string) => {

--- a/apps/rush-lib/src/cli/actions/VersionAction.ts
+++ b/apps/rush-lib/src/cli/actions/VersionAction.ts
@@ -123,7 +123,10 @@ export default class VersionAction extends BaseRushAction {
     // Load the config from file to avoid using inconsistent in-memory data.
     const rushConfig: RushConfiguration =
       RushConfiguration.loadFromConfigurationFile(this.rushConfiguration.rushJsonFile);
-    const mismatchFinder: VersionMismatchFinder = new VersionMismatchFinder(rushConfig.projects);
+    const mismatchFinder: VersionMismatchFinder = new VersionMismatchFinder(
+      rushConfig.projects,
+      rushConfig.commonVersions.allowedAlternativeVersions
+    );
     if (mismatchFinder.numberOfMismatches) {
       throw new Error('Unable to finish version bump because inconsistencies were encountered.' +
         ' Run \"rush check\" to find more details.');

--- a/apps/rush-lib/src/data/VersionMismatchFinder.ts
+++ b/apps/rush-lib/src/data/VersionMismatchFinder.ts
@@ -18,10 +18,10 @@ export class VersionMismatchFinder {
   private _mismatches: Map<string, Map<string, string[]>>;
   private _projects: RushConfigurationProject[];
 
-  constructor(projects: RushConfigurationProject[], allowedAlternativeVersions:  Map<string, ReadonlyArray<string>>) {
+  constructor(projects: RushConfigurationProject[], allowedAlternativeVersions?:  Map<string, ReadonlyArray<string>>) {
     this._projects = projects;
     this._mismatches = new Map<string, Map<string, string[]>>();
-    this._allowedAlternativeVersion = allowedAlternativeVersions;
+    this._allowedAlternativeVersion = allowedAlternativeVersions || new Map<string, ReadonlyArray<string>>();
     this._analyze();
   }
 

--- a/apps/rush-lib/src/data/VersionMismatchFinder.ts
+++ b/apps/rush-lib/src/data/VersionMismatchFinder.ts
@@ -14,12 +14,14 @@ export class VersionMismatchFinder {
   *   }
   * }
   */
+  private _allowedAlternativeVersion:  Map<string, ReadonlyArray<string>>;
   private _mismatches: Map<string, Map<string, string[]>>;
   private _projects: RushConfigurationProject[];
 
-  constructor(projects: RushConfigurationProject[]) {
+  constructor(projects: RushConfigurationProject[], allowedAlternativeVersions:  Map<string, ReadonlyArray<string>>) {
     this._projects = projects;
     this._mismatches = new Map<string, Map<string, string[]>>();
+    this._allowedAlternativeVersion = allowedAlternativeVersions;
     this._analyze();
   }
 
@@ -82,6 +84,9 @@ export class VersionMismatchFinder {
       Object.keys(dependencyMap).forEach((dependency: string) => {
         if (!exclude || !exclude.has(dependency)) {
           const version: string = dependencyMap[dependency];
+          if (this._isVersionAllowedAlternative(dependency, version)) {
+            return;
+          }
           if (!this._mismatches.has(dependency)) {
             this._mismatches.set(dependency, new Map<string, string[]>());
           }
@@ -95,6 +100,17 @@ export class VersionMismatchFinder {
         }
       });
     }
+  }
+
+  private _isVersionAllowedAlternative(
+    dependency: string,
+    version: string): boolean {
+
+    const allowedAlternatives: ReadonlyArray<string> | undefined = this._allowedAlternativeVersion.get(dependency);
+    if (allowedAlternatives && allowedAlternatives.indexOf(version) > -1) {
+      return true;
+    }
+    return false;
   }
 
   // tslint:disable-next-line:no-any

--- a/apps/rush-lib/src/data/VersionMismatchFinder.ts
+++ b/apps/rush-lib/src/data/VersionMismatchFinder.ts
@@ -107,10 +107,7 @@ export class VersionMismatchFinder {
     version: string): boolean {
 
     const allowedAlternatives: ReadonlyArray<string> | undefined = this._allowedAlternativeVersion.get(dependency);
-    if (allowedAlternatives && allowedAlternatives.indexOf(version) > -1) {
-      return true;
-    }
-    return false;
+    return Boolean(allowedAlternatives && allowedAlternatives.indexOf(version) > -1);
   }
 
   // tslint:disable-next-line:no-any

--- a/apps/rush-lib/src/data/test/VersionMismatchFinder.test.ts
+++ b/apps/rush-lib/src/data/test/VersionMismatchFinder.test.ts
@@ -8,8 +8,6 @@ import RushConfigurationProject from '../RushConfigurationProject';
 import { VersionMismatchFinder } from '../VersionMismatchFinder';
 
 describe('VersionMismatchFinder', () => {
-  const emptyAlternatives: Map<string, ReadonlyArray<string>> = new Map<string, ReadonlyArray<string>>();
-
   it('finds no mismatches if there are none', (done: MochaDone) => {
     const projects: RushConfigurationProject[] = [
       {
@@ -33,7 +31,7 @@ describe('VersionMismatchFinder', () => {
         cyclicDependencyProjects: new Set<string>()
       }
     ] as any as RushConfigurationProject[]; // tslint:disable-line:no-any
-    const mismatchFinder: VersionMismatchFinder = new VersionMismatchFinder(projects, emptyAlternatives);
+    const mismatchFinder: VersionMismatchFinder = new VersionMismatchFinder(projects);
     assert.isNumber(mismatchFinder.numberOfMismatches);
     assert.equal(mismatchFinder.numberOfMismatches, 0);
     assert.equal(mismatchFinder.getMismatches().length, 0);
@@ -63,7 +61,7 @@ describe('VersionMismatchFinder', () => {
         cyclicDependencyProjects: new Set<string>()
       }
     ] as any as RushConfigurationProject[]; // tslint:disable-line:no-any
-    const mismatchFinder: VersionMismatchFinder = new VersionMismatchFinder(projects, emptyAlternatives);
+    const mismatchFinder: VersionMismatchFinder = new VersionMismatchFinder(projects);
     assert.isNumber(mismatchFinder.numberOfMismatches);
     assert.equal(mismatchFinder.numberOfMismatches, 1);
     assert.equal(mismatchFinder.getMismatches().length, 1);
@@ -97,7 +95,7 @@ describe('VersionMismatchFinder', () => {
         cyclicDependencyProjects: new Set<string>()
       }
     ] as any as RushConfigurationProject[]; // tslint:disable-line:no-any
-    const mismatchFinder: VersionMismatchFinder = new VersionMismatchFinder(projects, emptyAlternatives);
+    const mismatchFinder: VersionMismatchFinder = new VersionMismatchFinder(projects);
     assert.isNumber(mismatchFinder.numberOfMismatches);
     assert.equal(mismatchFinder.numberOfMismatches, 0);
     assert.equal(mismatchFinder.getMismatches().length, 0);
@@ -127,7 +125,7 @@ describe('VersionMismatchFinder', () => {
         cyclicDependencyProjects: new Set<string>()
       }
     ] as any as RushConfigurationProject[]; // tslint:disable-line:no-any
-    const mismatchFinder: VersionMismatchFinder = new VersionMismatchFinder(projects, emptyAlternatives);
+    const mismatchFinder: VersionMismatchFinder = new VersionMismatchFinder(projects);
     assert.equal(mismatchFinder.getVersionsOfMismatch('@types/foobar'), undefined);
     assert.equal(mismatchFinder.getConsumersOfMismatch('@types/fobar', '2.0.0'), undefined);
     assert.equal(mismatchFinder.getConsumersOfMismatch('@types/foo', '9.9.9'), undefined);
@@ -177,7 +175,7 @@ describe('VersionMismatchFinder', () => {
         cyclicDependencyProjects: new Set<string>()
       }
     ] as any as RushConfigurationProject[]; // tslint:disable-line:no-any
-    const mismatchFinder: VersionMismatchFinder = new VersionMismatchFinder(projects, emptyAlternatives);
+    const mismatchFinder: VersionMismatchFinder = new VersionMismatchFinder(projects);
     assert.isNumber(mismatchFinder.numberOfMismatches);
     assert.equal(mismatchFinder.numberOfMismatches, 2);
     assert.equal(mismatchFinder.getMismatches().length, 2);
@@ -224,7 +222,7 @@ describe('VersionMismatchFinder', () => {
         cyclicDependencyProjects: new Set<string>()
       }
     ] as any as RushConfigurationProject[]; // tslint:disable-line:no-any
-    const mismatchFinder: VersionMismatchFinder = new VersionMismatchFinder(projects, emptyAlternatives);
+    const mismatchFinder: VersionMismatchFinder = new VersionMismatchFinder(projects);
     assert.isNumber(mismatchFinder.numberOfMismatches);
     assert.equal(mismatchFinder.numberOfMismatches, 1);
     assert.equal(mismatchFinder.getMismatches().length, 1);
@@ -259,7 +257,7 @@ describe('VersionMismatchFinder', () => {
         cyclicDependencyProjects: new Set<string>()
       }
     ] as any as RushConfigurationProject[]; // tslint:disable-line:no-any
-    const mismatchFinder: VersionMismatchFinder = new VersionMismatchFinder(projects, emptyAlternatives);
+    const mismatchFinder: VersionMismatchFinder = new VersionMismatchFinder(projects);
     assert.isNumber(mismatchFinder.numberOfMismatches);
     assert.equal(mismatchFinder.numberOfMismatches, 1);
     assert.equal(mismatchFinder.getMismatches().length, 1);
@@ -293,7 +291,7 @@ describe('VersionMismatchFinder', () => {
         cyclicDependencyProjects: new Set<string>()
       }
     ] as any as RushConfigurationProject[]; // tslint:disable-line:no-any
-    const mismatchFinder: VersionMismatchFinder = new VersionMismatchFinder(projects, emptyAlternatives);
+    const mismatchFinder: VersionMismatchFinder = new VersionMismatchFinder(projects);
     assert.isNumber(mismatchFinder.numberOfMismatches);
     assert.equal(mismatchFinder.numberOfMismatches, 0);
     done();
@@ -322,7 +320,7 @@ describe('VersionMismatchFinder', () => {
         cyclicDependencyProjects: new Set<string>()
       }
     ] as any as RushConfigurationProject[]; // tslint:disable-line:no-any
-    const mismatchFinder: VersionMismatchFinder = new VersionMismatchFinder(projects, emptyAlternatives);
+    const mismatchFinder: VersionMismatchFinder = new VersionMismatchFinder(projects);
     assert.isNumber(mismatchFinder.numberOfMismatches);
     assert.equal(mismatchFinder.numberOfMismatches, 1);
     assert.equal(mismatchFinder.getMismatches().length, 1);

--- a/apps/rush-lib/src/data/test/VersionMismatchFinder.test.ts
+++ b/apps/rush-lib/src/data/test/VersionMismatchFinder.test.ts
@@ -8,6 +8,7 @@ import RushConfigurationProject from '../RushConfigurationProject';
 import { VersionMismatchFinder } from '../VersionMismatchFinder';
 
 describe('VersionMismatchFinder', () => {
+  const emptyAlternatives: Map<string, ReadonlyArray<string>> = new Map<string, ReadonlyArray<string>>();
 
   it('finds no mismatches if there are none', (done: MochaDone) => {
     const projects: RushConfigurationProject[] = [
@@ -32,7 +33,7 @@ describe('VersionMismatchFinder', () => {
         cyclicDependencyProjects: new Set<string>()
       }
     ] as any as RushConfigurationProject[]; // tslint:disable-line:no-any
-    const mismatchFinder: VersionMismatchFinder = new VersionMismatchFinder(projects);
+    const mismatchFinder: VersionMismatchFinder = new VersionMismatchFinder(projects, emptyAlternatives);
     assert.isNumber(mismatchFinder.numberOfMismatches);
     assert.equal(mismatchFinder.numberOfMismatches, 0);
     assert.equal(mismatchFinder.getMismatches().length, 0);
@@ -62,7 +63,7 @@ describe('VersionMismatchFinder', () => {
         cyclicDependencyProjects: new Set<string>()
       }
     ] as any as RushConfigurationProject[]; // tslint:disable-line:no-any
-    const mismatchFinder: VersionMismatchFinder = new VersionMismatchFinder(projects);
+    const mismatchFinder: VersionMismatchFinder = new VersionMismatchFinder(projects, emptyAlternatives);
     assert.isNumber(mismatchFinder.numberOfMismatches);
     assert.equal(mismatchFinder.numberOfMismatches, 1);
     assert.equal(mismatchFinder.getMismatches().length, 1);
@@ -96,7 +97,7 @@ describe('VersionMismatchFinder', () => {
         cyclicDependencyProjects: new Set<string>()
       }
     ] as any as RushConfigurationProject[]; // tslint:disable-line:no-any
-    const mismatchFinder: VersionMismatchFinder = new VersionMismatchFinder(projects);
+    const mismatchFinder: VersionMismatchFinder = new VersionMismatchFinder(projects, emptyAlternatives);
     assert.isNumber(mismatchFinder.numberOfMismatches);
     assert.equal(mismatchFinder.numberOfMismatches, 0);
     assert.equal(mismatchFinder.getMismatches().length, 0);
@@ -126,7 +127,7 @@ describe('VersionMismatchFinder', () => {
         cyclicDependencyProjects: new Set<string>()
       }
     ] as any as RushConfigurationProject[]; // tslint:disable-line:no-any
-    const mismatchFinder: VersionMismatchFinder = new VersionMismatchFinder(projects);
+    const mismatchFinder: VersionMismatchFinder = new VersionMismatchFinder(projects, emptyAlternatives);
     assert.equal(mismatchFinder.getVersionsOfMismatch('@types/foobar'), undefined);
     assert.equal(mismatchFinder.getConsumersOfMismatch('@types/fobar', '2.0.0'), undefined);
     assert.equal(mismatchFinder.getConsumersOfMismatch('@types/foo', '9.9.9'), undefined);
@@ -176,7 +177,7 @@ describe('VersionMismatchFinder', () => {
         cyclicDependencyProjects: new Set<string>()
       }
     ] as any as RushConfigurationProject[]; // tslint:disable-line:no-any
-    const mismatchFinder: VersionMismatchFinder = new VersionMismatchFinder(projects);
+    const mismatchFinder: VersionMismatchFinder = new VersionMismatchFinder(projects, emptyAlternatives);
     assert.isNumber(mismatchFinder.numberOfMismatches);
     assert.equal(mismatchFinder.numberOfMismatches, 2);
     assert.equal(mismatchFinder.getMismatches().length, 2);
@@ -223,7 +224,7 @@ describe('VersionMismatchFinder', () => {
         cyclicDependencyProjects: new Set<string>()
       }
     ] as any as RushConfigurationProject[]; // tslint:disable-line:no-any
-    const mismatchFinder: VersionMismatchFinder = new VersionMismatchFinder(projects);
+    const mismatchFinder: VersionMismatchFinder = new VersionMismatchFinder(projects, emptyAlternatives);
     assert.isNumber(mismatchFinder.numberOfMismatches);
     assert.equal(mismatchFinder.numberOfMismatches, 1);
     assert.equal(mismatchFinder.getMismatches().length, 1);
@@ -258,7 +259,7 @@ describe('VersionMismatchFinder', () => {
         cyclicDependencyProjects: new Set<string>()
       }
     ] as any as RushConfigurationProject[]; // tslint:disable-line:no-any
-    const mismatchFinder: VersionMismatchFinder = new VersionMismatchFinder(projects);
+    const mismatchFinder: VersionMismatchFinder = new VersionMismatchFinder(projects, emptyAlternatives);
     assert.isNumber(mismatchFinder.numberOfMismatches);
     assert.equal(mismatchFinder.numberOfMismatches, 1);
     assert.equal(mismatchFinder.getMismatches().length, 1);
@@ -292,7 +293,7 @@ describe('VersionMismatchFinder', () => {
         cyclicDependencyProjects: new Set<string>()
       }
     ] as any as RushConfigurationProject[]; // tslint:disable-line:no-any
-    const mismatchFinder: VersionMismatchFinder = new VersionMismatchFinder(projects);
+    const mismatchFinder: VersionMismatchFinder = new VersionMismatchFinder(projects, emptyAlternatives);
     assert.isNumber(mismatchFinder.numberOfMismatches);
     assert.equal(mismatchFinder.numberOfMismatches, 0);
     done();
@@ -321,7 +322,7 @@ describe('VersionMismatchFinder', () => {
         cyclicDependencyProjects: new Set<string>()
       }
     ] as any as RushConfigurationProject[]; // tslint:disable-line:no-any
-    const mismatchFinder: VersionMismatchFinder = new VersionMismatchFinder(projects);
+    const mismatchFinder: VersionMismatchFinder = new VersionMismatchFinder(projects, emptyAlternatives);
     assert.isNumber(mismatchFinder.numberOfMismatches);
     assert.equal(mismatchFinder.numberOfMismatches, 1);
     assert.equal(mismatchFinder.getMismatches().length, 1);
@@ -329,6 +330,38 @@ describe('VersionMismatchFinder', () => {
     assert.includeMembers(mismatchFinder.getVersionsOfMismatch('@types/foo')!, ['2.0.0', '1.2.3']);
     assert.equal(mismatchFinder.getConsumersOfMismatch('@types/foo', '2.0.0'), 'B');
     assert.equal(mismatchFinder.getConsumersOfMismatch('@types/foo', '1.2.3'), 'A');
+    done();
+  });
+
+  it('allows alternative versions', (done: MochaDone) => {
+    const projects: RushConfigurationProject[] = [
+      {
+        packageName: 'A',
+        packageJson: {
+          dependencies: {
+            '@types/foo': '1.2.3',
+            'karma': '0.0.1'
+          }
+        },
+        cyclicDependencyProjects: new Set<string>()
+      },
+      {
+        packageName: 'B',
+        packageJson: {
+          dependencies: {
+            '@types/foo': '2.0.0',
+            'karma': '0.0.1'
+          }
+        },
+        cyclicDependencyProjects: new Set<string>()
+      }
+    ] as any as RushConfigurationProject[]; // tslint:disable-line:no-any
+    const alternatives: Map<string, ReadonlyArray<string>> = new Map<string, ReadonlyArray<string>>();
+    alternatives.set('@types/foo', ['2.0.0']);
+    const mismatchFinder: VersionMismatchFinder = new VersionMismatchFinder(projects, alternatives);
+    assert.isNumber(mismatchFinder.numberOfMismatches);
+    assert.equal(mismatchFinder.numberOfMismatches, 0);
+    assert.equal(mismatchFinder.getMismatches().length, 0);
     done();
   });
 });

--- a/common/changes/@microsoft/rush/benkaiser-allowedAlternativeVersions_2018-04-09-18-28.json
+++ b/common/changes/@microsoft/rush/benkaiser-allowedAlternativeVersions_2018-04-09-18-28.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Implement allowedAlternativeVersions",
+      "packageName": "@microsoft/rush",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "benkaiser@users.noreply.github.com"
+}


### PR DESCRIPTION
There are certain cases where we want to exclude specific projects
versions from rush check, for example testing out new versions of
a library in one project whilst keeping the existing older version in
another project. With this option we can now set explicit version
exceptions (allowedAlternativeVersions) without skipping rush check
entirely for a given project.