### PR TITLE
Fix a couple issues to support Rush prereleases

### DIFF
--- a/apps/rush-lib/src/cli/logic/InstallManager.ts
+++ b/apps/rush-lib/src/cli/logic/InstallManager.ts
@@ -129,13 +129,13 @@ export default class InstallManager {
         // For each dependency, collectImplicitlyPreferredVersions() is collecting the set of all version specifiers
         // that appear across the repo.  If there is only one version specifier, then that's the "preferred" one.
         // However, there are a few cases where additional version specifiers can be safely ignored.
-        let shouldAffectPreferredVersions: boolean = true;
+        let ignoreVersion: boolean = false;
 
         // 1. If the version specifier was listed in "allowedAlternativeVersions", then it's never a candidate.
         //    (Even if it's the only version specifier anywhere in the repo, we still ignore it, because
         //    otherwise the rule would be difficult to explain.)
         if (alternativesForThisDependency.indexOf(versionSpecifier) > 0) {
-          shouldAffectPreferredVersions = false;
+          ignoreVersion = true;
         } else {
           // Is it a local project?
           const localProject: RushConfigurationProject | undefined = rushConfiguration.getProjectByName(dependency);
@@ -147,12 +147,12 @@ export default class InstallManager {
             // - if the local project was specified in "cyclicDependencyProjects" in rush.json
             if (semver.satisfies(localProject.packageJson.version, versionSpecifier)
               && !cyclicDependencies.has(dependency)) {
-              shouldAffectPreferredVersions = false;
+              ignoreVersion = true;
             }
           }
         }
 
-        if (shouldAffectPreferredVersions) {
+        if (!ignoreVersion) {
           InstallManager._updateVersionsForDependencies(versionsForDependencies, dependency, versionSpecifier);
         }
       });

--- a/apps/rush-lib/src/cli/logic/InstallManager.ts
+++ b/apps/rush-lib/src/cli/logic/InstallManager.ts
@@ -104,19 +104,6 @@ export default class InstallManager {
     return implicitlyPreferred;
   }
 
-  // tslint:disable-next-line:no-any
-  public static _keys<T>(data: Map<T, any>): Array<T> {
-    const keys: Array<T> = new Array<T>();
-
-    const iterator: Iterator<T> = data.keys();
-    let current: IteratorResult<T> = iterator.next();
-    while (!current.done) {
-      keys.push(current.value);
-      current = iterator.next();
-    }
-    return keys;
-  }
-
   // Helper for collectImplicitlyPreferredVersions()
   private static _updateVersionsForDependencies(versionsForDependencies: Map<string, Set<string>>,
     dependency: string, version: string): void {
@@ -353,9 +340,9 @@ export default class InstallManager {
 
     // Add any preferred versions to the top of the commonPackageJson
     // do this in alphabetical order for simpler debugging
-    InstallManager._keys(allPreferredVersions).sort().forEach((dependency: string) => {
+    for (const dependency of Array.from(allPreferredVersions.keys()).sort()) {
       commonPackageJson.dependencies![dependency] = allPreferredVersions.get(dependency)!;
-    });
+    }
 
     // To make the common/package.json file more readable, sort alphabetically
     // according to rushProject.tempProjectName instead of packageName.

--- a/apps/rush-lib/src/data/test/repo/rush-npm.json
+++ b/apps/rush-lib/src/data/test/repo/rush-npm.json
@@ -1,6 +1,6 @@
 {
   "npmVersion": "4.5.0",
-  "rushVersion": "2.5.0",
+  "rushVersion": "2.5.0-dev.123",
   "projectFolderMinDepth": 1,
   "projectFolderMaxDepth": 99,
   "hotfixChangeEnabled": true,

--- a/apps/rush-lib/src/schemas/rush.schema.json
+++ b/apps/rush-lib/src/schemas/rush.schema.json
@@ -12,7 +12,7 @@
         "npmVersion": {
           "description": "The version of the NPM tool to install.",
           "type": "string",
-          "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+          "pattern": "^[0-9]+\\.[0-9]+\\.[0-9a-zA-Z.+\\-]+$"
         }
       }
     },
@@ -23,7 +23,7 @@
         "pnpmVersion": {
           "description": "The version of the PNPM tool to install.",
           "type": "string",
-          "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+          "pattern": "^[0-9]+\\.[0-9]+\\.[0-9a-zA-Z.+\\-]+$"
         }
       }
     }
@@ -47,7 +47,7 @@
     "rushVersion": {
       "description": "The version of the Rush tool that will be used to build this repository.",
       "type": "string",
-      "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+      "pattern": "^[0-9]+\\.[0-9]+\\.[0-9a-zA-Z.+\\-]+$"
     },
     "nodeSupportedVersionRange": {
       "description": "A node-semver expression (e.g. \">=1.2.3 <2.0.0\", see https://github.com/npm/node-semver) indicating which versions of Node.js can safely be used to build this repository.  If omitted, no validation is performed.",

--- a/apps/rush-lib/src/schemas/version-policies.schema.json
+++ b/apps/rush-lib/src/schemas/version-policies.schema.json
@@ -27,7 +27,8 @@
         },
         "version": {
           "description": "Current version for projects with lockStepVersion policy",
-          "type":"string"
+          "type": "string",
+          "pattern": "^[0-9]+\\.[0-9]+\\.[0-9a-zA-Z.+\\-]+$"
         },
         "nextBump": {
           "description": "Type of next version bump",

--- a/common/changes/@microsoft/rush/pgonzal-fix-semver_2018-04-11-20-08.json
+++ b/common/changes/@microsoft/rush/pgonzal-fix-semver_2018-04-11-20-08.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Update rush.json schema to support prerelease versions of Rush",
+      "packageName": "@microsoft/rush",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "pgonzal@users.noreply.github.com"
+}


### PR DESCRIPTION
1. The rush.json schema didn't allow prerelease SemVer tags
2. Fix a regression from the (unpublished) "allowedAlternativeVersions" feature work