### PR TITLE
[rush] Fix issue with cleaning "rush-recycler" on macOS

### DIFF
--- a/common/changes/@microsoft/rush/pgonzal-rush-mac-recycler_2018-04-17-00-54.json
+++ b/common/changes/@microsoft/rush/pgonzal-rush-mac-recycler_2018-04-17-00-54.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Fix a problem where the \"rush-recycler\" folder was not getting cleaned on macOS",
+      "packageName": "@microsoft/rush",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "pgonzal@users.noreply.github.com"
+}


### PR DESCRIPTION
`AsyncRecycler.deleteAll()` is supposed to clean out the "common/temp/rush-recycler" folder.  At some point we had a regression for macOS.  The problem is that `child_process.spawn()` does not use a shell, so the "*" filename wildcard was not getting expanded.  This PR fixes that issue.