### PR TITLE
[rush-stack] Add support for --no-color

### DIFF
--- a/stack/rush-stack/src/cli/BuildAction.ts
+++ b/stack/rush-stack/src/cli/BuildAction.ts
@@ -20,6 +20,10 @@ export class BuildAction extends CommandLineAction {
       parameterLongName: '--production',
       description: 'used for production builds'
     });
+    this.defineFlagParameter({
+      parameterLongName: '--no-color',
+      description: ''
+    });
   }
 
   protected onExecute(): Promise<void> { // override


### PR DESCRIPTION
The publishing CI definition was providing "--no-color", which wasn't supported by the rush-stack command line.  This PR is a temporary workaround.  (An upcoming PR will make the command-line options dynamic.)