### PR TITLE
Fix to handle pnpm relative\absolute dependency path version

### DIFF
--- a/apps/rush-lib/src/cli/logic/base/BaseShrinkwrapFile.ts
+++ b/apps/rush-lib/src/cli/logic/base/BaseShrinkwrapFile.ts
@@ -93,13 +93,17 @@ export abstract class BaseShrinkwrapFile {
     return result;
   }
 
+  protected checkValidVersionRange(dependencyVersion: string, versionRange: string) : boolean {
+    // If it's a SemVer pattern, then require that the shrinkwrapped version must be compatible
+    return semver.satisfies(dependencyVersion, versionRange);
+  }
+
   private _checkDependencyVerson(dependencyName: string, versionRange: string, dependencyVersion: string): boolean {
     const result: npmPackageArg.IResult = npmPackageArg.resolve(dependencyName, versionRange);
     switch (result.type) {
       case 'version':
       case 'range':
-        // If it's a SemVer pattern, then require that the shrinkwrapped version must be compatible
-        return semver.satisfies(dependencyVersion, versionRange);
+        return this.checkValidVersionRange(dependencyVersion, versionRange);
       default:
         // Only warn once for each spec
         if (!this._alreadyWarnedSpecs.has(result.rawSpec)) {

--- a/apps/rush-lib/src/cli/logic/base/BaseShrinkwrapFile.ts
+++ b/apps/rush-lib/src/cli/logic/base/BaseShrinkwrapFile.ts
@@ -93,7 +93,7 @@ export abstract class BaseShrinkwrapFile {
     return result;
   }
 
-  protected checkValidVersionRange(dependencyVersion: string, versionRange: string) : boolean {
+  protected checkValidVersionRange(dependencyVersion: string, versionRange: string): boolean {
     // If it's a SemVer pattern, then require that the shrinkwrapped version must be compatible
     return semver.satisfies(dependencyVersion, versionRange);
   }

--- a/apps/rush-lib/src/cli/logic/pnpm/PnpmShrinkwrapFile.ts
+++ b/apps/rush-lib/src/cli/logic/pnpm/PnpmShrinkwrapFile.ts
@@ -199,9 +199,8 @@ export class PnpmShrinkwrapFile extends BaseShrinkwrapFile {
   }
 
   protected checkValidVersionRange(dependencyVersion: string, versionRange: string): boolean { // override
-    // dependencyVersion could be of two formats:
-    // 1. (d*).(d*).(d*)
-    // 2. <path>(d*).(d*).(d*) for example /foo/1.0.0
+    // dependencyVersion could be a relattive or absolute path, for those cases we
+    // need to extract the version from the end of the path.
     return super.checkValidVersionRange(dependencyVersion.split('/').pop()!, versionRange);
   }
 

--- a/apps/rush-lib/src/cli/logic/pnpm/PnpmShrinkwrapFile.ts
+++ b/apps/rush-lib/src/cli/logic/pnpm/PnpmShrinkwrapFile.ts
@@ -95,6 +95,11 @@ export function extractVersionFromPnpmVersionSpecifier(version: string): string 
     if (versionParts.length === 5 && isScoped) {
       extractedVersion = versionParts[3]; // e.g. "3.1.1"
     }
+
+    // e.g. "path.pkgs.visualstudio.com/@scope/depame/1.4.0"
+    if (!extractedVersion && versionParts[versionParts.length - 1].match(/^(\d*)\.(\d*)\.(\d*)/)) {
+      extractedVersion = versionParts[versionParts.length - 1];
+    }
   }
 
   return extractedVersion;
@@ -256,6 +261,7 @@ export class PnpmShrinkwrapFile extends BaseShrinkwrapFile {
     // B - a peer dep version (e.g. "/gulp-karma/0.0.5/karma@0.13.22"
     //                           or "/@ms/sp-client-utilities/3.1.1/foo@13.1.0"
     //                           or "/sinon-chai/2.8.0/chai@3.5.0+sinon@1.17.7")
+    // C -The dependency path is relative or absolute (e.g., /foo/1.0.0)
 
     // check to see if this is the special style of specifiers
     // e.g.:  "/gulp-karma/0.0.5/karma@0.13.22" or
@@ -274,5 +280,12 @@ export class PnpmShrinkwrapFile extends BaseShrinkwrapFile {
     } else {
       return undefined;
     }
+  }
+
+  protected checkValidVersionRange(dependencyVersion: string, versionRange: string) : boolean {
+    // dependencyVersion could be of two formats:
+    // 1. (d*).(d*).(d*)
+    // 2. <path>(d*).(d*).(d*) for example /foo/1.0.0
+    return super.checkValidVersionRange(dependencyVersion.split('/').pop()!, versionRange);
   }
 }

--- a/apps/rush-lib/src/cli/logic/pnpm/PnpmShrinkwrapFile.ts
+++ b/apps/rush-lib/src/cli/logic/pnpm/PnpmShrinkwrapFile.ts
@@ -97,7 +97,7 @@ export function extractVersionFromPnpmVersionSpecifier(version: string): string 
     }
 
     // e.g. "path.pkgs.visualstudio.com/@scope/depame/1.4.0"
-    if (!extractedVersion && versionParts[versionParts.length - 1].match(/^(\d*)\.(\d*)\.(\d*)/)) {
+    if (!extractedVersion && semver.valid(versionParts[versionParts.length - 1]) !== null) {
       extractedVersion = versionParts[versionParts.length - 1];
     }
   }
@@ -198,6 +198,13 @@ export class PnpmShrinkwrapFile extends BaseShrinkwrapFile {
     return this._normalizeDependencyVersion(dependencyName, packageDescription.dependencies[dependencyName]);
   }
 
+  protected checkValidVersionRange(dependencyVersion: string, versionRange: string): boolean { // override
+    // dependencyVersion could be of two formats:
+    // 1. (d*).(d*).(d*)
+    // 2. <path>(d*).(d*).(d*) for example /foo/1.0.0
+    return super.checkValidVersionRange(dependencyVersion.split('/').pop()!, versionRange);
+  }
+
   private constructor(shrinkwrapJson: IShrinkwrapYaml) {
     super();
     this._shrinkwrapJson = shrinkwrapJson;
@@ -280,12 +287,5 @@ export class PnpmShrinkwrapFile extends BaseShrinkwrapFile {
     } else {
       return undefined;
     }
-  }
-
-  protected checkValidVersionRange(dependencyVersion: string, versionRange: string) : boolean {
-    // dependencyVersion could be of two formats:
-    // 1. (d*).(d*).(d*)
-    // 2. <path>(d*).(d*).(d*) for example /foo/1.0.0
-    return super.checkValidVersionRange(dependencyVersion.split('/').pop()!, versionRange);
   }
 }

--- a/apps/rush-lib/src/cli/logic/test/ShrinkwrapFile.test.ts
+++ b/apps/rush-lib/src/cli/logic/test/ShrinkwrapFile.test.ts
@@ -43,7 +43,8 @@ const shrinkwrapFile: BaseShrinkwrapFile = ShrinkwrapFileFactory.getShrinkwrapFi
     assert.isTrue(shrinkwrapFile.tryEnsureCompatibleDependency('jquery', '>=2.0.0 <3.0.0', '@rush-temp/project1'));
     assert.isTrue(shrinkwrapFile.tryEnsureCompatibleDependency('q', '~1.5.0', '@rush-temp/project2'));
     assert.isFalse(shrinkwrapFile.tryEnsureCompatibleDependency('left-pad', '~9.9.9', '@rush-temp/project1'));
-    assert.isTrue(shrinkwrapFile.tryEnsureCompatibleDependency('@scope/testDep', '>=1.0.0 < 2.0.0', '@rush-temp/project3'));
+    assert.isTrue(
+      shrinkwrapFile.tryEnsureCompatibleDependency('@scope/testDep', '>=1.0.0 <2.0.0', '@rush-temp/project3'));
   });
 
   it('extracts temp projects successfully', () => {
@@ -67,6 +68,11 @@ describe('extractVersionFromPnpmVersionSpecifier', () => {
   it('extracts a scoped peer dep', () => {
     assert.equal(extractVersionFromPnpmVersionSpecifier('/@ms/sp-client-utilities/3.1.1/foo@13.1.0'), '3.1.1');
   });
+  it('extracts relative versions', () => {
+    assert.equal(extractVersionFromPnpmVersionSpecifier('example.pkgs.visualstudio.com/@scope/testDep/1.0.0'), '1.0.0');
+    assert.equal(extractVersionFromPnpmVersionSpecifier(
+      'example.pkgs.visualstudio.com/@scope/testDep/1.2.3-beta.3'), '1.2.3-beta.3');
+  });
   it('handles bad cases', () => {
     assert.equal(extractVersionFromPnpmVersionSpecifier('/foo/gulp-karma/0.0.5/karma@0.13.22'), undefined);
     assert.equal(extractVersionFromPnpmVersionSpecifier('/@ms/3.1.1/foo@13.1.0'), undefined);
@@ -74,5 +80,6 @@ describe('extractVersionFromPnpmVersionSpecifier', () => {
     assert.equal(extractVersionFromPnpmVersionSpecifier('/'), undefined);
     assert.equal(extractVersionFromPnpmVersionSpecifier('//'), undefined);
     assert.equal(extractVersionFromPnpmVersionSpecifier('/@/'), undefined);
+    assert.equal(extractVersionFromPnpmVersionSpecifier('example.pkgs.visualstudio.com/@scope/testDep/'), undefined);
   });
 });

--- a/apps/rush-lib/src/cli/logic/test/ShrinkwrapFile.test.ts
+++ b/apps/rush-lib/src/cli/logic/test/ShrinkwrapFile.test.ts
@@ -43,6 +43,7 @@ const shrinkwrapFile: BaseShrinkwrapFile = ShrinkwrapFileFactory.getShrinkwrapFi
     assert.isTrue(shrinkwrapFile.tryEnsureCompatibleDependency('jquery', '>=2.0.0 <3.0.0', '@rush-temp/project1'));
     assert.isTrue(shrinkwrapFile.tryEnsureCompatibleDependency('q', '~1.5.0', '@rush-temp/project2'));
     assert.isFalse(shrinkwrapFile.tryEnsureCompatibleDependency('left-pad', '~9.9.9', '@rush-temp/project1'));
+    assert.isTrue(shrinkwrapFile.tryEnsureCompatibleDependency('@scope/testDep', '>=1.0.0 < 2.0.0', '@rush-temp/project3'));
   });
 
   it('extracts temp projects successfully', () => {

--- a/apps/rush-lib/src/cli/logic/test/shrinkwrapFile/shrinkwrap.yaml
+++ b/apps/rush-lib/src/cli/logic/test/shrinkwrapFile/shrinkwrap.yaml
@@ -15,6 +15,9 @@ packages:
   /left-pad/9.9.9:
     resolution:
       integrity: sha1-3QG6ydBtMObyGa7LglPunr3DCPE=
+  example.pkgs.visualstudio.com/@scope/testDep/1.0.0:
+    resolution:
+      integrity: sha1-3QG6ydBtMObyGa7LglPunr3DCPE=
   'file:projects/project1.tgz':
     dependencies:
       jquery: 2.9.9
@@ -25,6 +28,7 @@ packages:
   'file:projects/project3.tgz':
     dependencies:
       q: 1.5.3
+      '@scope/testDep': example.pkgs.visualstudio.com/@scope/testDep/1.0.0
 registry: 'http://localhost:4873/'
 shrinkwrapVersion: 3
 specifiers:

--- a/common/changes/@microsoft/rush/ddlbrena-pnpmVersionFix_2018-04-20-06-09.json
+++ b/common/changes/@microsoft/rush/ddlbrena-pnpmVersionFix_2018-04-20-06-09.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Fix to handle pnpm relative\\absolute dependency path version",
+      "packageName": "@microsoft/rush",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "ddlbrena@microsoft.com"
+}


### PR DESCRIPTION
Per https://github.com/pnpm/spec/blob/master/shrinkwrap/3.4.md Dependency versions can be relative or absolute (e.g., /foo/1.0.0 or registry.node-modules.io/foo/1.0.0).

PnpmShrinkwrapFile.ts cant handle this today. We get "Invalid Version" error due to _checkDependencyVersion in BaseShrinkWrapFile.js not being able to handle this format.

Also extractVersionFromPnpmVersionSpecifier() in PnpmShrinkwrapFile.ts needs to be able to handle this scenario.