### PR TITLE
[rush] Relax the rush.json version check for rush-lib

### DIFF
--- a/common/changes/@microsoft/rush/pgonzal-relax-version-check_2018-04-23-19-40.json
+++ b/common/changes/@microsoft/rush/pgonzal-relax-version-check_2018-04-23-19-40.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Relax the rush.json version check for rush-lib; future versions are now accepted as long as the major/minor parts match",
+      "packageName": "@microsoft/rush",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "pgonzal@users.noreply.github.com"
+}


### PR DESCRIPTION
Future versions are now accepted as long as the major/minor parts match.