### PR TITLE
Allow "rush version --ensure-version-policy" to update policy version directly

### DIFF
--- a/apps/rush-lib/src/cli/actions/VersionAction.ts
+++ b/apps/rush-lib/src/cli/actions/VersionAction.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import * as semver from 'semver';
 import { IPackageJson } from '@microsoft/node-core-library';
 import {
   CommandLineFlagParameter,
@@ -68,7 +67,6 @@ export default class VersionAction extends BaseRushAction {
     });
     this._versionPolicy = this.defineStringParameter({
       parameterLongName: '--version-policy',
-      parameterShortName: '-p',
       argumentName: 'POLICY',
       description: 'The name of the version policy'
     });
@@ -126,7 +124,7 @@ export default class VersionAction extends BaseRushAction {
     }
     if (this._versionPolicy.value) {
       this.rushConfiguration.versionPolicyConfiguration.update(this._versionPolicy.value,
-        new semver.SemVer(this._overwriteVersion.value));
+        this._overwriteVersion.value);
     } else {
       throw new Error('Missing --version-policy parameter to specify which version policy should be overwritten.');
     }

--- a/apps/rush-lib/src/cli/logic/VersionManager.ts
+++ b/apps/rush-lib/src/cli/logic/VersionManager.ts
@@ -45,9 +45,10 @@ export class VersionManager {
    * This method does not commit changes.
    * @param versionPolicyName -- version policy name
    * @param shouldCommit -- should update files to disk
+   * @param force -- update even when project version is higher than policy version.
    */
-  public ensure(versionPolicyName?: string, shouldCommit?: boolean): void {
-    this._ensure(versionPolicyName, shouldCommit);
+  public ensure(versionPolicyName?: string, shouldCommit?: boolean, force?: boolean): void {
+    this._ensure(versionPolicyName, shouldCommit, force);
   }
 
   /**
@@ -95,8 +96,8 @@ export class VersionManager {
     return this._changeFiles;
   }
 
-  private _ensure(versionPolicyName?: string, shouldCommit?: boolean): void {
-    this._updateVersionsByPolicy(versionPolicyName);
+  private _ensure(versionPolicyName?: string, shouldCommit?: boolean, force?: boolean): void {
+    this._updateVersionsByPolicy(versionPolicyName, force);
 
     // Update all dependencies if needed.
     this._updateDependencies();
@@ -126,7 +127,7 @@ export class VersionManager {
     return lockStepProjectNames;
   }
 
-  private _updateVersionsByPolicy(versionPolicyName?: string): void {
+  private _updateVersionsByPolicy(versionPolicyName?: string, force?: boolean): void {
     // Update versions based on version policy
     this._rushConfiguration.projects.forEach(rushProject => {
       const projectVersionPolicyName: string | undefined = rushProject.versionPolicyName;
@@ -134,7 +135,7 @@ export class VersionManager {
           (!versionPolicyName || projectVersionPolicyName === versionPolicyName)) {
         const versionPolicy: VersionPolicy = this._versionPolicyConfiguration.getVersionPolicy(
           projectVersionPolicyName);
-        const updatedProject: IPackageJson | undefined = versionPolicy.ensure(rushProject.packageJson);
+        const updatedProject: IPackageJson | undefined = versionPolicy.ensure(rushProject.packageJson, force);
         if (updatedProject) {
           this._updatedProjects.set(updatedProject.name, updatedProject);
           // No need to create an entry for prerelease version bump.

--- a/apps/rush-lib/src/data/VersionPolicy.ts
+++ b/apps/rush-lib/src/data/VersionPolicy.ts
@@ -218,6 +218,18 @@ export class LockStepVersionPolicy extends VersionPolicy {
   }
 
   /**
+   * Updates the version of the policy directly with a new value
+   * @param newVersion - New version
+   */
+  public update(newVersion: semver.SemVer): boolean {
+    if (!newVersion || this._version === newVersion) {
+      return false;
+    }
+    this._version = newVersion;
+    return true;
+  }
+
+  /**
    * Validates the specified version and throws if the version does not satisfy lockstep version.
    *
    * @param versionString - version string

--- a/apps/rush-lib/src/data/VersionPolicy.ts
+++ b/apps/rush-lib/src/data/VersionPolicy.ts
@@ -219,9 +219,10 @@ export class LockStepVersionPolicy extends VersionPolicy {
 
   /**
    * Updates the version of the policy directly with a new value
-   * @param newVersion - New version
+   * @param newVersionString - New version
    */
-  public update(newVersion: semver.SemVer): boolean {
+  public update(newVersionString: string): boolean {
+    const newVersion: semver.SemVer = new semver.SemVer(newVersionString);
     if (!newVersion || this._version === newVersion) {
       return false;
     }

--- a/apps/rush-lib/src/data/VersionPolicy.ts
+++ b/apps/rush-lib/src/data/VersionPolicy.ts
@@ -99,8 +99,9 @@ export abstract class VersionPolicy {
    * Returns an updated package json that satisfies the policy.
    *
    * @param project - package json
+   * @param force - force update even when the project version is higher than the policy version.
    */
-  public abstract ensure(project: IPackageJson): IPackageJson | undefined;
+  public abstract ensure(project: IPackageJson, force?: boolean): IPackageJson | undefined;
 
   /**
    * Bumps version based on the policy
@@ -150,8 +151,8 @@ export class LockStepVersionPolicy extends VersionPolicy {
   /**
    * The value of the lockstep version
    */
-  public get version(): semver.SemVer {
-    return this._version;
+  public get version(): string {
+    return this._version.format();
   }
 
   /**
@@ -180,7 +181,7 @@ export class LockStepVersionPolicy extends VersionPolicy {
     const json: ILockStepVersionJson = {
       policyName: this.policyName,
       definitionName: VersionPolicyDefinitionName[this.definitionName],
-      version: this.version.format(),
+      version: this.version,
       nextBump: BumpType[this.nextBump]
     };
     if (this._mainProject) {
@@ -193,13 +194,14 @@ export class LockStepVersionPolicy extends VersionPolicy {
    * Returns an updated package json that satisfies the version policy.
    *
    * @param project - input package json
+   * @param force - force update even when the project version is higher than the policy version.
    */
-  public ensure(project: IPackageJson): IPackageJson | undefined {
+  public ensure(project: IPackageJson, force?: boolean): IPackageJson | undefined {
     const packageVersion: semver.SemVer = new semver.SemVer(project.version);
     const compareResult: number = packageVersion.compare(this._version);
     if (compareResult === 0) {
       return undefined;
-    } else if (compareResult > 0) {
+    } else if (compareResult > 0 && !force) {
       const errorMessage: string = `Version ${project.version} in package ${project.name}`
         + ` is higher than locked version ${this._version.format()}.`;
       throw new Error(errorMessage);
@@ -214,7 +216,7 @@ export class LockStepVersionPolicy extends VersionPolicy {
    * @param identifier - Prerelease identifier if bump type is prerelease.
    */
   public bump(bumpType?: BumpType, identifier?: string): void {
-    this.version.inc(this._getReleaseType(bumpType || this.nextBump), identifier);
+    this._version.inc(this._getReleaseType(bumpType || this.nextBump), identifier);
   }
 
   /**
@@ -238,7 +240,7 @@ export class LockStepVersionPolicy extends VersionPolicy {
    */
   public validate(versionString: string, packageName: string): void {
     const versionToTest: semver.SemVer = new semver.SemVer(versionString, false);
-    if (this.version.compare(versionToTest) !== 0) {
+    if (this._version.compare(versionToTest) !== 0) {
       throw new Error(`Invalid version ${versionString} in ${packageName}`);
     }
   }
@@ -297,8 +299,9 @@ export class IndividualVersionPolicy extends VersionPolicy {
    * Returns an updated package json that satisfies the version policy.
    *
    * @param project - input package json
+   * @param force - force update even when the project version is higher than the policy version.
    */
-  public ensure(project: IPackageJson): IPackageJson | undefined {
+  public ensure(project: IPackageJson, force?: boolean): IPackageJson | undefined {
     if (this.lockedMajor) {
       const version: semver.SemVer = new semver.SemVer(project.version);
       if (version.major < this.lockedMajor) {

--- a/apps/rush-lib/src/data/VersionPolicyConfiguration.ts
+++ b/apps/rush-lib/src/data/VersionPolicyConfiguration.ts
@@ -3,7 +3,6 @@
 
 import * as path from 'path';
 import * as fsx from 'fs-extra';
-import * as semver from 'semver';
 import { JsonFile, JsonSchema } from '@microsoft/node-core-library';
 
 import { VersionPolicy, BumpType, LockStepVersionPolicy } from './VersionPolicy';
@@ -125,11 +124,11 @@ export class VersionPolicyConfiguration {
    * @param newVersion - new version
    */
   public update(versionPolicyName: string,
-    newVersion: semver.SemVer
+    newVersion: string
   ): void {
     const policy: VersionPolicy | undefined = this.versionPolicies.get(versionPolicyName);
     if (!policy || !policy.isLockstepped) {
-      throw new Error(`Lockstep Version policy with name ${versionPolicyName} cannot be found`);
+      throw new Error(`Lockstep Version policy with name "${versionPolicyName}" cannot be found`);
     }
     const lockStepVersionPolicy: LockStepVersionPolicy = policy as LockStepVersionPolicy;
     if (lockStepVersionPolicy.update(newVersion)) {

--- a/apps/rush-lib/src/data/VersionPolicyConfiguration.ts
+++ b/apps/rush-lib/src/data/VersionPolicyConfiguration.ts
@@ -3,6 +3,7 @@
 
 import * as path from 'path';
 import * as fsx from 'fs-extra';
+import * as semver from 'semver';
 import { JsonFile, JsonSchema } from '@microsoft/node-core-library';
 
 import { VersionPolicy, BumpType, LockStepVersionPolicy } from './VersionPolicy';
@@ -115,12 +116,24 @@ export class VersionPolicyConfiguration {
         }
       });
     }
-    const versionPolicyJson: IVersionPolicyJson[] = [];
-    this.versionPolicies.forEach((versionPolicy) => {
-      versionPolicyJson.push(versionPolicy._json);
-    });
-    if (shouldCommit) {
-      JsonFile.save(versionPolicyJson, this._jsonFileName);
+    this._saveFile(!!shouldCommit);
+  }
+
+  /**
+   * Updates the version directly for the specified version policy
+   * @param versionPolicyName - version policy name
+   * @param newVersion - new version
+   */
+  public update(versionPolicyName: string,
+    newVersion: semver.SemVer
+  ): void {
+    const policy: VersionPolicy | undefined = this.versionPolicies.get(versionPolicyName);
+    if (!policy || !policy.isLockstepped) {
+      throw new Error(`Lockstep Version policy with name ${versionPolicyName} cannot be found`);
+    }
+    const lockStepVersionPolicy: LockStepVersionPolicy = policy as LockStepVersionPolicy;
+    if (lockStepVersionPolicy.update(newVersion)) {
+      this._saveFile(true);
     }
   }
 
@@ -137,5 +150,15 @@ export class VersionPolicyConfiguration {
         this._versionPolicies.set(policy.policyName, policy);
       }
     });
+  }
+
+  private _saveFile(shouldCommit: boolean): void {
+    const versionPolicyJson: IVersionPolicyJson[] = [];
+    this.versionPolicies.forEach((versionPolicy) => {
+      versionPolicyJson.push(versionPolicy._json);
+    });
+    if (shouldCommit) {
+      JsonFile.save(versionPolicyJson, this._jsonFileName);
+    }
   }
 }

--- a/apps/rush-lib/src/data/test/VersionPolicy.test.ts
+++ b/apps/rush-lib/src/data/test/VersionPolicy.test.ts
@@ -28,7 +28,7 @@ describe('VersionPolicy', () => {
     it('loads configuration.', () => {
       assert.isTrue(versionPolicy instanceof LockStepVersionPolicy, 'versionPolicy is a LockStepVersionPolicy');
       const lockStepVersionPolicy: LockStepVersionPolicy = versionPolicy as LockStepVersionPolicy;
-      assert.equal(lockStepVersionPolicy.version.format(), '1.1.0');
+      assert.equal(lockStepVersionPolicy.version, '1.1.0');
       assert.equal(lockStepVersionPolicy.nextBump, BumpType.patch);
     });
 
@@ -64,17 +64,30 @@ describe('VersionPolicy', () => {
       });
     });
 
+    it('update version with force if version is higher than the locked step version', () => {
+      const lockStepVersionPolicy: LockStepVersionPolicy = versionPolicy as LockStepVersionPolicy;
+      const originalPackageJson: IPackageJson = {
+        name: 'a',
+        version: '2.1.0'
+      };
+      const expectedPackageJson: IPackageJson = {
+        name: 'a',
+        version: '1.1.0'
+      };
+      assert.deepEqual(lockStepVersionPolicy.ensure(originalPackageJson, true), expectedPackageJson);
+    });
+
     it('bumps version for preminor release', () => {
       const lockStepVersionPolicy: LockStepVersionPolicy = versionPolicy as LockStepVersionPolicy;
       lockStepVersionPolicy.bump(BumpType.preminor, 'pr');
-      assert.equal(lockStepVersionPolicy.version.format(), '1.2.0-pr.0');
+      assert.equal(lockStepVersionPolicy.version, '1.2.0-pr.0');
       assert.equal(lockStepVersionPolicy.nextBump, BumpType.patch);
     });
 
     it('bumps version for minor release', () => {
       const lockStepVersionPolicy: LockStepVersionPolicy = versionPolicy as LockStepVersionPolicy;
       lockStepVersionPolicy.bump(BumpType.minor);
-      assert.equal(lockStepVersionPolicy.version.format(), '1.2.0');
+      assert.equal(lockStepVersionPolicy.version, '1.2.0');
       assert.equal(lockStepVersionPolicy.nextBump, BumpType.patch);
     });
 
@@ -82,7 +95,7 @@ describe('VersionPolicy', () => {
       const lockStepVersionPolicy: LockStepVersionPolicy = versionPolicy as LockStepVersionPolicy;
       const newVersion: string = '1.5.6-beta.0';
       lockStepVersionPolicy.update(newVersion);
-      assert.equal(lockStepVersionPolicy.version.version, newVersion);
+      assert.equal(lockStepVersionPolicy.version, newVersion);
     });
   });
 

--- a/apps/rush-lib/src/data/test/VersionPolicy.test.ts
+++ b/apps/rush-lib/src/data/test/VersionPolicy.test.ts
@@ -5,7 +5,6 @@
 
 import * as path from 'path';
 import { assert } from 'chai';
-import * as semver from 'semver';
 import { IPackageJson } from '@microsoft/node-core-library';
 
 import { VersionPolicyConfiguration } from '../VersionPolicyConfiguration';
@@ -81,9 +80,9 @@ describe('VersionPolicy', () => {
 
     it('can update version directly', () => {
       const lockStepVersionPolicy: LockStepVersionPolicy = versionPolicy as LockStepVersionPolicy;
-      const newVersion: semver.SemVer = new semver.SemVer('1.5.6-beta.0');
+      const newVersion: string = '1.5.6-beta.0';
       lockStepVersionPolicy.update(newVersion);
-      assert.deepEqual(lockStepVersionPolicy.version, newVersion);
+      assert.equal(lockStepVersionPolicy.version.version, newVersion);
     });
   });
 

--- a/apps/rush-lib/src/data/test/VersionPolicy.test.ts
+++ b/apps/rush-lib/src/data/test/VersionPolicy.test.ts
@@ -5,6 +5,7 @@
 
 import * as path from 'path';
 import { assert } from 'chai';
+import * as semver from 'semver';
 import { IPackageJson } from '@microsoft/node-core-library';
 
 import { VersionPolicyConfiguration } from '../VersionPolicyConfiguration';
@@ -19,7 +20,11 @@ describe('VersionPolicy', () => {
   describe('LockStepVersion', () => {
     const filename: string = path.resolve(__dirname, 'jsonFiles', 'rushWithLockVersion.json');
     const versionPolicyConfig: VersionPolicyConfiguration = new VersionPolicyConfiguration(filename);
-    const versionPolicy: VersionPolicy = versionPolicyConfig.getVersionPolicy('testPolicy1');
+    let versionPolicy: VersionPolicy;
+
+    beforeEach(() => {
+      versionPolicy = versionPolicyConfig.getVersionPolicy('testPolicy1');
+    });
 
     it('loads configuration.', () => {
       assert.isTrue(versionPolicy instanceof LockStepVersionPolicy, 'versionPolicy is a LockStepVersionPolicy');
@@ -72,6 +77,13 @@ describe('VersionPolicy', () => {
       lockStepVersionPolicy.bump(BumpType.minor);
       assert.equal(lockStepVersionPolicy.version.format(), '1.2.0');
       assert.equal(lockStepVersionPolicy.nextBump, BumpType.patch);
+    });
+
+    it('can update version directly', () => {
+      const lockStepVersionPolicy: LockStepVersionPolicy = versionPolicy as LockStepVersionPolicy;
+      const newVersion: semver.SemVer = new semver.SemVer('1.5.6-beta.0');
+      lockStepVersionPolicy.update(newVersion);
+      assert.deepEqual(lockStepVersionPolicy.version, newVersion);
     });
   });
 

--- a/common/changes/@microsoft/rush/qz2017-update_version_2018-04-23-21-25.json
+++ b/common/changes/@microsoft/rush/qz2017-update_version_2018-04-23-21-25.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Allow \\\"rush version --ensure-version-policy\\\" to update policy version directly. ",
+      "packageName": "@microsoft/rush",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "qz2017@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush/qz2017-update_version_2018-04-23-21-25.json
+++ b/common/changes/@microsoft/rush/qz2017-update_version_2018-04-23-21-25.json
@@ -1,7 +1,7 @@
 {
   "changes": [
     {
-      "comment": "Allow \\\"rush version --ensure-version-policy\\\" to update policy version directly. ",
+      "comment": "Allow \"rush version --ensure-version-policy\" to update policy version directly. ",
       "packageName": "@microsoft/rush",
       "type": "none"
     }

--- a/common/reviews/api/rush-lib.api.ts
+++ b/common/reviews/api/rush-lib.api.ts
@@ -132,7 +132,7 @@ class IndividualVersionPolicy extends VersionPolicy {
   // @internal
   readonly _json: IIndividualVersionJson;
   bump(bumpType?: BumpType, identifier?: string): void;
-  ensure(project: IPackageJson): IPackageJson | undefined;
+  ensure(project: IPackageJson, force?: boolean): IPackageJson | undefined;
   readonly lockedMajor: number | undefined;
   validate(versionString: string, packageName: string): void;
 }
@@ -146,12 +146,12 @@ class LockStepVersionPolicy extends VersionPolicy {
   // @internal
   readonly _json: ILockStepVersionJson;
   bump(bumpType?: BumpType, identifier?: string): void;
-  ensure(project: IPackageJson): IPackageJson | undefined;
+  ensure(project: IPackageJson, force?: boolean): IPackageJson | undefined;
   readonly mainProject: string | undefined;
   readonly nextBump: BumpType;
   update(newVersionString: string): boolean;
   validate(versionString: string, packageName: string): void;
-  readonly version: semver.SemVer;
+  readonly version: string;
 }
 
 // @public
@@ -241,7 +241,7 @@ class VersionPolicy {
   readonly _json: IVersionPolicyJson;
   abstract bump(bumpType?: BumpType, identifier?: string): void;
   readonly definitionName: VersionPolicyDefinitionName;
-  abstract ensure(project: IPackageJson): IPackageJson | undefined;
+  abstract ensure(project: IPackageJson, force?: boolean): IPackageJson | undefined;
   readonly isLockstepped: boolean;
   // WARNING: Because this definition is explicitly marked as @internal, an underscore prefix ("_") should be added to its name
   // WARNING: The type "IVersionPolicyJson" needs to be exported by the package (e.g. added to index.ts)

--- a/common/reviews/api/rush-lib.api.ts
+++ b/common/reviews/api/rush-lib.api.ts
@@ -149,6 +149,7 @@ class LockStepVersionPolicy extends VersionPolicy {
   ensure(project: IPackageJson): IPackageJson | undefined;
   readonly mainProject: string | undefined;
   readonly nextBump: BumpType;
+  update(newVersion: semver.SemVer): boolean;
   validate(versionString: string, packageName: string): void;
   readonly version: semver.SemVer;
 }
@@ -256,6 +257,7 @@ class VersionPolicyConfiguration {
   constructor(jsonFileName: string);
   bump(versionPolicyName?: string, bumpType?: BumpType, identifier?: string, shouldCommit?: boolean): void;
   getVersionPolicy(policyName: string): VersionPolicy;
+  update(versionPolicyName: string, newVersion: semver.SemVer): void;
   validate(projectsByName: Map<string, RushConfigurationProject>): void;
   readonly versionPolicies: Map<string, VersionPolicy>;
 }

--- a/common/reviews/api/rush-lib.api.ts
+++ b/common/reviews/api/rush-lib.api.ts
@@ -149,7 +149,7 @@ class LockStepVersionPolicy extends VersionPolicy {
   ensure(project: IPackageJson): IPackageJson | undefined;
   readonly mainProject: string | undefined;
   readonly nextBump: BumpType;
-  update(newVersion: semver.SemVer): boolean;
+  update(newVersionString: string): boolean;
   validate(versionString: string, packageName: string): void;
   readonly version: semver.SemVer;
 }
@@ -257,7 +257,7 @@ class VersionPolicyConfiguration {
   constructor(jsonFileName: string);
   bump(versionPolicyName?: string, bumpType?: BumpType, identifier?: string, shouldCommit?: boolean): void;
   getVersionPolicy(policyName: string): VersionPolicy;
-  update(versionPolicyName: string, newVersion: semver.SemVer): void;
+  update(versionPolicyName: string, newVersion: string): void;
   validate(projectsByName: Map<string, RushConfigurationProject>): void;
   readonly versionPolicies: Map<string, VersionPolicy>;
 }


### PR DESCRIPTION
It can be useful when the policy version needs to be reset to a different value.