### PR TITLE
Create different tarballs based on release type

### DIFF
--- a/apps/rush-lib/src/cli/actions/PublishAction.ts
+++ b/apps/rush-lib/src/cli/actions/PublishAction.ts
@@ -135,7 +135,7 @@ export default class PublishAction extends BaseRushAction {
       parameterLongName: '--release-type',
       argumentName: 'RELEASE_TYPE',
       description:
-      `This parameter is used with --pack parameter to provide release type for the tarballs. ` +
+      `This parameter is used with --pack parameter to provide release type for the generated tarballs. ` +
       `The default value is 'internal'. The valid values include 'public', 'beta', 'internal'`
     });
     // End of NPM pack tarball related parameters
@@ -367,6 +367,7 @@ export default class PublishAction extends BaseRushAction {
     const env: { [key: string]: string | undefined } = PublishUtilities.getEnvArgs();
 
     if (this._releaseType.value && this._releaseType.value !== 'internal') {
+      // a temporary workaround. Will replace it with npm or rush hooks.
       this._updateAPIFile(packageName, project);
     }
 

--- a/apps/rush-lib/src/cli/actions/PublishAction.ts
+++ b/apps/rush-lib/src/cli/actions/PublishAction.ts
@@ -368,6 +368,9 @@ export default class PublishAction extends BaseRushAction {
 
     if (this._releaseType.value && this._releaseType.value !== 'internal') {
       // a temporary workaround. Will replace it with npm or rush hooks.
+      if (this._releaseType.value !== 'public' && this._releaseType.value !== 'beta') {
+        throw new Error(`Invalid release type "${this._releaseType.value}"`);
+      }
       this._updateAPIFile(packageName, project);
     }
 

--- a/common/changes/@microsoft/rush/qz2017-tarball_update_2018-04-24-01-07.json
+++ b/common/changes/@microsoft/rush/qz2017-tarball_update_2018-04-24-01-07.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Add --release-type parameter to \"rush publish\" to be able to create different tarballs based on release type",
+      "packageName": "@microsoft/rush",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "qz2017@users.noreply.github.com"
+}


### PR DESCRIPTION
Added --release-type to "rush publish" so that different tarball file get created based on release type.