### PR TITLE
[rush] Fix an issue where .npmrc was not honored when Rush was invoked via an NPM lifecycle script

### DIFF
--- a/apps/rush-lib/src/cli/actions/BaseRushAction.ts
+++ b/apps/rush-lib/src/cli/actions/BaseRushAction.ts
@@ -73,7 +73,8 @@ export abstract class BaseRushAction extends CommandLineAction {
 
   protected get eventHooksManager(): EventHooksManager {
     if (!this._eventHooksManager) {
-      this._eventHooksManager = new EventHooksManager(this.rushConfiguration.eventHooks);
+      this._eventHooksManager = new EventHooksManager(this.rushConfiguration.eventHooks,
+        this.rushConfiguration.commonTempFolder);
     }
     return this._eventHooksManager;
   }

--- a/apps/rush-lib/src/cli/logic/EventHooksManager.ts
+++ b/apps/rush-lib/src/cli/logic/EventHooksManager.ts
@@ -11,9 +11,11 @@ import { Stopwatch } from '../../utilities/Stopwatch';
 
 export default class EventHooksManager {
   private _eventHooks: EventHooks;
+  private _commonTempFolder: string;
 
-  public constructor(eventHooks: EventHooks) {
+  public constructor(eventHooks: EventHooks, commonTempFolder: string) {
     this._eventHooks = eventHooks;
+    this._commonTempFolder = commonTempFolder;
   }
 
   public handle(event: Event, isDebug: boolean = false): void {
@@ -26,9 +28,9 @@ export default class EventHooksManager {
       console.log(os.EOL + colors.green(`Executing event hooks for ${Event[event]}`));
       scripts.forEach((script) => {
         try {
-          Utilities.executeShellCommand(script,
+          Utilities.executeLifecycleCommand(script,
             process.cwd(),
-            undefined,
+            this._commonTempFolder,
             true
           );
         } catch (error) {

--- a/apps/rush-lib/src/cli/logic/EventHooksManager.ts
+++ b/apps/rush-lib/src/cli/logic/EventHooksManager.ts
@@ -28,7 +28,7 @@ export default class EventHooksManager {
         try {
           Utilities.executeShellCommand(script,
             process.cwd(),
-            process.env,
+            undefined,
             true
           );
         } catch (error) {

--- a/apps/rush-lib/src/cli/logic/InstallManager.ts
+++ b/apps/rush-lib/src/cli/logic/InstallManager.ts
@@ -630,7 +630,7 @@ export default class InstallManager {
               + ` in ${this._rushConfiguration.commonTempFolder}`);
             const args: string[] = ['prune'];
             this.pushConfigurationArgs(args);
-            Utilities.executeCommandWithRetry(packageManagerFilename, args, MAX_INSTALL_ATTEMPTS,
+            Utilities.executeCommandWithRetry(MAX_INSTALL_ATTEMPTS, packageManagerFilename, args,
               this._rushConfiguration.commonTempFolder);
           }
 
@@ -677,10 +677,10 @@ export default class InstallManager {
       console.log(os.EOL + colors.bold(`Running "${this._rushConfiguration.packageManager} install" in`
         + ` ${this._rushConfiguration.commonTempFolder}`) + os.EOL);
 
-      Utilities.executeCommandWithRetry(packageManagerFilename,
+      Utilities.executeCommandWithRetry(MAX_INSTALL_ATTEMPTS, packageManagerFilename,
         installArgs,
-        MAX_INSTALL_ATTEMPTS,
         this._rushConfiguration.commonTempFolder,
+        undefined,
         false, () => {
           if (this._rushConfiguration.packageManager === 'pnpm') {
             // If there is a failure in pnpm, it is possible that it left the

--- a/apps/rush-lib/src/cli/logic/PublishUtilities.ts
+++ b/apps/rush-lib/src/cli/logic/PublishUtilities.ts
@@ -18,7 +18,7 @@ import {
   ChangeType
 } from '../../data/ChangeManagement';
 import RushConfigurationProject from '../../data/RushConfigurationProject';
-import Utilities from '../../utilities/Utilities';
+import Utilities, { IEnvironment } from '../../utilities/Utilities';
 import { execSync } from 'child_process';
 import PrereleaseToken from './PrereleaseToken';
 import ChangeFiles from './ChangeFiles';
@@ -185,18 +185,13 @@ export default class PublishUtilities {
     command: string,
     args: string[] = [],
     workingDirectory: string = process.cwd(),
-    env?: { [key: string]: string | undefined }
+    environment?: IEnvironment
   ): void {
 
     let relativeDirectory: string = path.relative(process.cwd(), workingDirectory);
-    const envArgs: { [key: string]: string | undefined } = PublishUtilities.getEnvArgs();
 
     if (relativeDirectory) {
       relativeDirectory = `(${relativeDirectory})`;
-    }
-
-    if (env) {
-      Object.keys(env).forEach((name: string) => envArgs[name] = env[name]);
     }
 
     console.log(
@@ -208,8 +203,8 @@ export default class PublishUtilities {
         command,
         args,
         workingDirectory,
-        false,
-        env);
+        environment,
+        false);
     }
   }
 

--- a/apps/rush-lib/src/cli/taskRunner/ProjectTask.ts
+++ b/apps/rush-lib/src/cli/taskRunner/ProjectTask.ts
@@ -4,6 +4,7 @@
 import * as child_process from 'child_process';
 import * as fsx from 'fs-extra';
 import * as path from 'path';
+import * as process from 'process';
 import { JsonFile, Text } from '@microsoft/node-core-library';
 import { ITaskWriter } from '@microsoft/stream-collator';
 import { IPackageDeps } from '@microsoft/package-deps-hash';
@@ -149,7 +150,7 @@ export default class ProjectTask implements ITaskDefinition {
 
         writer.writeLine(normalizedTaskCommand);
         const task: child_process.ChildProcess =
-          Utilities.executeShellCommandAsync(normalizedTaskCommand, projectFolder, process.env, true);
+          Utilities.executeShellCommandAsync(normalizedTaskCommand, projectFolder, undefined, true);
 
         // Hook into events, in order to get live streaming of build log
         task.stdout.on('data', (data: string) => {

--- a/apps/rush-lib/src/cli/taskRunner/ProjectTask.ts
+++ b/apps/rush-lib/src/cli/taskRunner/ProjectTask.ts
@@ -150,7 +150,8 @@ export default class ProjectTask implements ITaskDefinition {
 
         writer.writeLine(normalizedTaskCommand);
         const task: child_process.ChildProcess =
-          Utilities.executeShellCommandAsync(normalizedTaskCommand, projectFolder, undefined, true);
+          Utilities.executeLifecycleCommandAsync(normalizedTaskCommand, projectFolder,
+            this._rushConfiguration.commonTempFolder, true);
 
         // Hook into events, in order to get live streaming of build log
         task.stdout.on('data', (data: string) => {

--- a/apps/rush-lib/src/cli/test/Cli.test.ts
+++ b/apps/rush-lib/src/cli/test/Cli.test.ts
@@ -14,7 +14,7 @@ describe('CLI', () => {
     const startPath: string = path.resolve(path.join(__dirname, '../../start.js'));
 
     assert.doesNotThrow(() => {
-      Utilities.executeCommand('node', [ startPath ], workingDir, true);
+      Utilities.executeCommand('node', [ startPath ], workingDir, undefined, true);
     }, 'rush -h is broken');
   });
 });

--- a/apps/rush-lib/src/utilities/Utilities.ts
+++ b/apps/rush-lib/src/utilities/Utilities.ts
@@ -418,14 +418,14 @@ export default class Utilities {
       initialEnvironment = process.env;
     }
     const environment: {} = {};
-    for (const key of Object.getOwnPropertyNames(process.env)) {
+    for (const key of Object.getOwnPropertyNames(initialEnvironment)) {
       const normalizedKey: string = os.platform() === 'win32'
         ? key.toUpperCase() : key;
 
       // If Rush itself was invoked inside a lifecycle script, this may be set and would interfere
       // with Rush's installations.  If we actually want it, we will set it explicitly below.
       if (normalizedKey === 'INIT_CWD') {
-        break;
+        continue;
       }
 
       // When NPM invokes a lifecycle event, it copies its entire configuration into environment
@@ -435,7 +435,7 @@ export default class Utilities {
       // NOTE: Longer term we should clean out the entire environment and use rush.json to bring
       // back specific environment variables that the repo maintainer has determined to be safe.
       if (normalizedKey.match(/^NPM_CONFIG_/)) {
-        break;
+        continue;
       }
 
       environment[key] = initialEnvironment[key];

--- a/common/changes/@microsoft/rush/pgonzal-issue-12356_2018-04-25-20-03.json
+++ b/common/changes/@microsoft/rush/pgonzal-issue-12356_2018-04-25-20-03.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Fix an issue where Rush's .npmrc configuration was not honored when spawned via an NPM lifecycle script; in general the process environment is now more isolated",
+      "packageName": "@microsoft/rush",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "pgonzal@users.noreply.github.com"
+}


### PR DESCRIPTION
This is a fix for Issue #621.  The problem was that NPM sometimes sets environment variables that pollute Rush's process and cause it to behave differently.  This is bad, because one of Rush's goals is for its operations to have deterministic results on any developer PC.

The fixes:
- Refactor the (still somewhat crufty) command spawning utilities to consistently support customizing the environment
- Update Rush's core utilities to scrub the environment before executing commands
- Correctly set the INIT_CWD variable for Rush's own lifecycle events