### PR TITLE
[rush] When using PNPM, eliminate some troublesome workarounds for NPM bugs

### DIFF
--- a/apps/rush-lib/src/cli/logic/InstallManager.ts
+++ b/apps/rush-lib/src/cli/logic/InstallManager.ts
@@ -627,23 +627,23 @@ export default class InstallManager {
             this.pushConfigurationArgs(args);
             Utilities.executeCommandWithRetry(MAX_INSTALL_ATTEMPTS, packageManagerFilename, args,
               this._rushConfiguration.commonTempFolder);
-          }
 
-          // Delete the (installed image of) the temp projects, since "npm install" does not
-          // detect changes for "file:./" references.
-          // We recognize the temp projects by their names, which always start with "rush-".
+            // Delete the (installed image of) the temp projects, since "npm install" does not
+            // detect changes for "file:./" references.
+            // We recognize the temp projects by their names, which always start with "rush-".
 
-          // Example: "C:\MyRepo\common\temp\node_modules\@rush-temp"
-          const pathToDeleteWithoutStar: string = path.join(commonNodeModulesFolder, RushConstants.rushTempNpmScope);
-          console.log(`Deleting ${pathToDeleteWithoutStar}\\*`);
-          // Glob can't handle Windows paths
-          const normalizedpathToDeleteWithoutStar: string = Text.replaceAll(pathToDeleteWithoutStar, '\\', '/');
+            // Example: "C:\MyRepo\common\temp\node_modules\@rush-temp"
+            const pathToDeleteWithoutStar: string = path.join(commonNodeModulesFolder, RushConstants.rushTempNpmScope);
+            console.log(`Deleting ${pathToDeleteWithoutStar}\\*`);
+            // Glob can't handle Windows paths
+            const normalizedpathToDeleteWithoutStar: string = Text.replaceAll(pathToDeleteWithoutStar, '\\', '/');
 
-          // Example: "C:/MyRepo/common/temp/node_modules/@rush-temp/*"
-          for (const tempModulePath of glob.sync(globEscape(normalizedpathToDeleteWithoutStar) + '/*')) {
-            // We could potentially use AsyncRecycler here, but in practice these folders tend
-            // to be very small
-            Utilities.dangerouslyDeletePath(tempModulePath);
+            // Example: "C:/MyRepo/common/temp/node_modules/@rush-temp/*"
+            for (const tempModulePath of glob.sync(globEscape(normalizedpathToDeleteWithoutStar) + '/*')) {
+              // We could potentially use AsyncRecycler here, but in practice these folders tend
+              // to be very small
+              Utilities.dangerouslyDeletePath(tempModulePath);
+            }
           }
         }
       }

--- a/apps/rush-lib/src/cli/logic/InstallManager.ts
+++ b/apps/rush-lib/src/cli/logic/InstallManager.ts
@@ -693,7 +693,9 @@ export default class InstallManager {
           }
         });
 
-      this._fixupNpm5Regression();
+      if (this._rushConfiguration.packageManager === 'npm') {
+        this._fixupNpm5Regression();
+      }
 
       // Finally, create the marker file to indicate a successful install
       this._commonNodeModulesMarker.create();

--- a/common/changes/@microsoft/rush/pgonzal-rush-install-stability_2018-04-28-23-30.json
+++ b/common/changes/@microsoft/rush/pgonzal-rush-install-stability_2018-04-28-23-30.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "When using PNPM, remove some NPM bug workarounds that probably caused problems for \"pnpm install\"",
+      "packageName": "@microsoft/rush",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "pgonzal@users.noreply.github.com"
+}


### PR DESCRIPTION
When using NPM, "rush install" has workarounds for three NPM bugs:

- NPM doesn't detect changes to @rush-temp/*.tgz files
- NPM doesn't clean up @rush-temp projects
- NPM 5 generates a shrinkwrap file that can't be parsed by its own **read-package-tree** library

These workarounds seemed to be causing occasional issues for PNPM.  PNPM doesn't have any of these bugs, so this PR disables the workarounds when using PNPM.