### PR TITLE
Eliminate default exports (pure refactor)

### DIFF
--- a/apps/rush-lib/src/Rush.ts
+++ b/apps/rush-lib/src/Rush.ts
@@ -6,7 +6,7 @@ import * as path from 'path';
 import * as colors from 'colors';
 import { IPackageJson } from '@microsoft/node-core-library';
 
-import RushCommandLineParser from './cli/actions/RushCommandLineParser';
+import { RushCommandLineParser } from './cli/actions/RushCommandLineParser';
 import { RushConstants } from './RushConstants';
 
 /**
@@ -14,7 +14,7 @@ import { RushConstants } from './RushConstants';
  *
  * @public
  */
-export default class Rush {
+export class Rush {
   private static _version: string;
 
   /**

--- a/apps/rush-lib/src/cli/actions/BaseRushAction.ts
+++ b/apps/rush-lib/src/cli/actions/BaseRushAction.ts
@@ -10,9 +10,9 @@ import {
 
 import { LockFile } from '@microsoft/node-core-library';
 
-import RushConfiguration from '../../data/RushConfiguration';
-import EventHooksManager from '../logic/EventHooksManager';
-import RushCommandLineParser from './RushCommandLineParser';
+import { RushConfiguration } from '../../data/RushConfiguration';
+import { EventHooksManager } from '../logic/EventHooksManager';
+import { RushCommandLineParser } from './RushCommandLineParser';
 
 export interface IRushCommandLineActionOptions extends ICommandLineActionOptions {
   /**

--- a/apps/rush-lib/src/cli/actions/ChangeAction.ts
+++ b/apps/rush-lib/src/cli/actions/ChangeAction.ts
@@ -14,16 +14,16 @@ import {
   CommandLineStringParameter
 } from '@microsoft/ts-command-line';
 
-import RushConfigurationProject from '../../data/RushConfigurationProject';
+import { RushConfigurationProject } from '../../data/RushConfigurationProject';
 import {
   IChangeFile,
   IChangeInfo
 } from '../../data/ChangeManagement';
-import VersionControl from '../../utilities/VersionControl';
+import { VersionControl } from '../../utilities/VersionControl';
 import { ChangeFile } from '../../data/ChangeFile';
 import { BaseRushAction } from './BaseRushAction';
-import RushCommandLineParser from './RushCommandLineParser';
-import ChangeFiles from '../logic/ChangeFiles';
+import { RushCommandLineParser } from './RushCommandLineParser';
+import { ChangeFiles } from '../logic/ChangeFiles';
 import {
   VersionPolicy,
   IndividualVersionPolicy,
@@ -31,7 +31,7 @@ import {
   VersionPolicyDefinitionName
 } from '../../data/VersionPolicy';
 
-export default class ChangeAction extends BaseRushAction {
+export class ChangeAction extends BaseRushAction {
   private _sortedProjectList: string[];
   private _changeFileData: Map<string, IChangeFile>;
   private _changeComments: Map<string, string[]>;

--- a/apps/rush-lib/src/cli/actions/CheckAction.ts
+++ b/apps/rush-lib/src/cli/actions/CheckAction.ts
@@ -3,13 +3,13 @@
 
 import * as colors from 'colors';
 
-import RushConfigurationProject from '../../data/RushConfigurationProject';
+import { RushConfigurationProject } from '../../data/RushConfigurationProject';
 import { RushConstants } from '../../RushConstants';
 import { VersionMismatchFinder } from '../../data/VersionMismatchFinder';
-import RushCommandLineParser from './RushCommandLineParser';
+import { RushCommandLineParser } from './RushCommandLineParser';
 import { BaseRushAction } from './BaseRushAction';
 
-export default class CheckAction extends BaseRushAction {
+export class CheckAction extends BaseRushAction {
   constructor(parser: RushCommandLineParser) {
     super({
       actionName: 'check',

--- a/apps/rush-lib/src/cli/actions/CustomCommandFactory.ts
+++ b/apps/rush-lib/src/cli/actions/CustomCommandFactory.ts
@@ -4,7 +4,7 @@ import {
   CustomOption
 } from '../../data/CommandLineConfiguration';
 
-import RushCommandLineParser from './RushCommandLineParser';
+import { RushCommandLineParser } from './RushCommandLineParser';
 import { CustomRushAction } from './CustomRushAction';
 
 /**

--- a/apps/rush-lib/src/cli/actions/CustomRushAction.ts
+++ b/apps/rush-lib/src/cli/actions/CustomRushAction.ts
@@ -22,7 +22,7 @@ import {
   ICommandLineActionOptions
 } from '@microsoft/ts-command-line';
 
-import RushCommandLineParser from './RushCommandLineParser';
+import { RushCommandLineParser } from './RushCommandLineParser';
 import { BaseRushAction } from './BaseRushAction';
 import { TaskSelector } from '../logic/TaskSelector';
 import { Stopwatch } from '../../utilities/Stopwatch';

--- a/apps/rush-lib/src/cli/actions/GenerateAction.ts
+++ b/apps/rush-lib/src/cli/actions/GenerateAction.ts
@@ -8,18 +8,18 @@ import * as fsx from 'fs-extra';
 import { CommandLineFlagParameter } from '@microsoft/ts-command-line';
 
 import { PackageManager } from '../../data/RushConfiguration';
-import Utilities from '../../utilities/Utilities';
+import { Utilities } from '../../utilities/Utilities';
 import { Stopwatch } from '../../utilities/Stopwatch';
-import InstallManager, { InstallType } from '../logic/InstallManager';
+import { InstallManager, InstallType } from '../logic/InstallManager';
 import { LinkManagerFactory } from '../logic/LinkManagerFactory';
 import { BaseLinkManager } from '../logic/base/BaseLinkManager';
-import RushCommandLineParser from './RushCommandLineParser';
+import { RushCommandLineParser } from './RushCommandLineParser';
 import { ApprovedPackagesChecker } from '../logic/ApprovedPackagesChecker';
 import { BaseShrinkwrapFile } from '../logic/base/BaseShrinkwrapFile';
 import { ShrinkwrapFileFactory } from '../logic/ShrinkwrapFileFactory';
 import { BaseRushAction } from './BaseRushAction';
 
-export default class GenerateAction extends BaseRushAction {
+export class GenerateAction extends BaseRushAction {
   private _lazyParameter: CommandLineFlagParameter;
   private _noLinkParameter: CommandLineFlagParameter;
   private _forceParameter: CommandLineFlagParameter;

--- a/apps/rush-lib/src/cli/actions/InstallAction.ts
+++ b/apps/rush-lib/src/cli/actions/InstallAction.ts
@@ -8,9 +8,9 @@ import { CommandLineFlagParameter } from '@microsoft/ts-command-line';
 
 import { Event } from '../../data/EventHooks';
 import { Stopwatch } from '../../utilities/Stopwatch';
-import RushCommandLineParser from './RushCommandLineParser';
-import GitPolicy from '../logic/GitPolicy';
-import InstallManager, { InstallType } from '../logic/InstallManager';
+import { RushCommandLineParser } from './RushCommandLineParser';
+import { GitPolicy } from '../logic/GitPolicy';
+import { InstallManager, InstallType } from '../logic/InstallManager';
 import { LinkManagerFactory } from '../logic/LinkManagerFactory';
 import { ShrinkwrapFileFactory } from '../logic/ShrinkwrapFileFactory';
 import { BaseLinkManager } from '../logic/base/BaseLinkManager';
@@ -18,7 +18,7 @@ import { BaseShrinkwrapFile } from '../logic/base/BaseShrinkwrapFile';
 import { ApprovedPackagesChecker } from '../logic/ApprovedPackagesChecker';
 import { BaseRushAction } from './BaseRushAction';
 
-export default class InstallAction extends BaseRushAction {
+export class InstallAction extends BaseRushAction {
   private _cleanInstall: CommandLineFlagParameter;
   private _cleanInstallFull: CommandLineFlagParameter;
   private _bypassPolicy: CommandLineFlagParameter;

--- a/apps/rush-lib/src/cli/actions/LinkAction.ts
+++ b/apps/rush-lib/src/cli/actions/LinkAction.ts
@@ -3,12 +3,12 @@
 
 import { CommandLineFlagParameter } from '@microsoft/ts-command-line';
 
-import RushCommandLineParser from './RushCommandLineParser';
+import { RushCommandLineParser } from './RushCommandLineParser';
 import { LinkManagerFactory } from '../logic/LinkManagerFactory';
 import { BaseLinkManager } from '../logic/base/BaseLinkManager';
 import { BaseRushAction } from './BaseRushAction';
 
-export default class LinkAction extends BaseRushAction {
+export class LinkAction extends BaseRushAction {
   private _force: CommandLineFlagParameter;
 
   constructor(parser: RushCommandLineParser) {

--- a/apps/rush-lib/src/cli/actions/PublishAction.ts
+++ b/apps/rush-lib/src/cli/actions/PublishAction.ts
@@ -14,20 +14,20 @@ import {
   IChangeInfo,
   ChangeType
 } from '../../data/ChangeManagement';
-import RushConfigurationProject from '../../data/RushConfigurationProject';
-import Npm from '../../utilities/Npm';
-import RushCommandLineParser from './RushCommandLineParser';
-import PublishUtilities from '../logic/PublishUtilities';
-import ChangelogGenerator from '../logic/ChangelogGenerator';
-import GitPolicy from '../logic/GitPolicy';
-import PrereleaseToken from '../logic/PrereleaseToken';
-import ChangeManager from '../logic/ChangeManager';
+import { RushConfigurationProject } from '../../data/RushConfigurationProject';
+import { Npm } from '../../utilities/Npm';
+import { RushCommandLineParser } from './RushCommandLineParser';
+import { PublishUtilities } from '../logic/PublishUtilities';
+import { ChangelogGenerator } from '../logic/ChangelogGenerator';
+import { GitPolicy } from '../logic/GitPolicy';
+import { PrereleaseToken } from '../logic/PrereleaseToken';
+import { ChangeManager } from '../logic/ChangeManager';
 import { BaseRushAction } from './BaseRushAction';
 import { Git } from '../logic/Git';
-import VersionControl from '../../utilities/VersionControl';
+import { VersionControl } from '../../utilities/VersionControl';
 import { JsonFile } from '@microsoft/node-core-library';
 
-export default class PublishAction extends BaseRushAction {
+export class PublishAction extends BaseRushAction {
   private _addCommitDetails: CommandLineFlagParameter;
   private _apply: CommandLineFlagParameter;
   private _includeAll: CommandLineFlagParameter;

--- a/apps/rush-lib/src/cli/actions/RushCommandLineParser.ts
+++ b/apps/rush-lib/src/cli/actions/RushCommandLineParser.ts
@@ -9,23 +9,23 @@ import { CommandLineParser, CommandLineFlagParameter } from '@microsoft/ts-comma
 
 import { RushConstants } from '../../RushConstants';
 import { CommandLineConfiguration } from '../../data/CommandLineConfiguration';
-import RushConfiguration from '../../data/RushConfiguration';
-import Utilities from '../../utilities/Utilities';
-import ChangeAction from './ChangeAction';
-import CheckAction from './CheckAction';
-import GenerateAction from './GenerateAction';
-import InstallAction from './InstallAction';
-import LinkAction from './LinkAction';
-import PublishAction from './PublishAction';
-import UnlinkAction from './UnlinkAction';
-import ScanAction from './ScanAction';
-import VersionAction from './VersionAction';
+import { RushConfiguration } from '../../data/RushConfiguration';
+import { Utilities } from '../../utilities/Utilities';
+import { ChangeAction } from './ChangeAction';
+import { CheckAction } from './CheckAction';
+import { GenerateAction } from './GenerateAction';
+import { InstallAction } from './InstallAction';
+import { LinkAction } from './LinkAction';
+import { PublishAction } from './PublishAction';
+import { UnlinkAction } from './UnlinkAction';
+import { ScanAction } from './ScanAction';
+import { VersionAction } from './VersionAction';
 import { CustomCommandFactory } from './CustomCommandFactory';
 import { CustomRushAction } from './CustomRushAction';
 
-import Telemetry from '../logic/Telemetry';
+import { Telemetry } from '../logic/Telemetry';
 
-export default class RushCommandLineParser extends CommandLineParser {
+export class RushCommandLineParser extends CommandLineParser {
   public telemetry: Telemetry | undefined;
   public rushConfiguration: RushConfiguration;
 

--- a/apps/rush-lib/src/cli/actions/ScanAction.ts
+++ b/apps/rush-lib/src/cli/actions/ScanAction.ts
@@ -7,10 +7,10 @@ import * as glob from 'glob';
 import * as path from 'path';
 import builtinPackageNames = require('builtins');
 
-import RushCommandLineParser from './RushCommandLineParser';
+import { RushCommandLineParser } from './RushCommandLineParser';
 import { BaseRushAction } from './BaseRushAction';
 
-export default class ScanAction extends BaseRushAction {
+export class ScanAction extends BaseRushAction {
   constructor(parser: RushCommandLineParser) {
     super({
       actionName: 'scan',

--- a/apps/rush-lib/src/cli/actions/UnlinkAction.ts
+++ b/apps/rush-lib/src/cli/actions/UnlinkAction.ts
@@ -5,11 +5,11 @@ import * as fsx from 'fs-extra';
 import * as os from 'os';
 import * as path from 'path';
 
-import Utilities from '../../utilities/Utilities';
-import RushCommandLineParser from './RushCommandLineParser';
+import { Utilities } from '../../utilities/Utilities';
+import { RushCommandLineParser } from './RushCommandLineParser';
 import { BaseRushAction } from './BaseRushAction';
 
-export default class UnlinkAction extends BaseRushAction {
+export class UnlinkAction extends BaseRushAction {
   constructor(parser: RushCommandLineParser) {
     super({
       actionName: 'unlink',

--- a/apps/rush-lib/src/cli/actions/VersionAction.ts
+++ b/apps/rush-lib/src/cli/actions/VersionAction.ts
@@ -10,17 +10,17 @@ import {
 
 import { BumpType, LockStepVersionPolicy } from '../../data/VersionPolicy';
 import { VersionPolicyConfiguration } from '../../data/VersionPolicyConfiguration';
-import RushConfiguration from '../../data/RushConfiguration';
-import Utilities from '../../utilities/Utilities';
-import VersionControl from '../../utilities/VersionControl';
+import { RushConfiguration } from '../../data/RushConfiguration';
+import { Utilities } from '../../utilities/Utilities';
+import { VersionControl } from '../../utilities/VersionControl';
 import { VersionMismatchFinder } from '../../data/VersionMismatchFinder';
-import RushCommandLineParser from './RushCommandLineParser';
-import GitPolicy from '../logic/GitPolicy';
+import { RushCommandLineParser } from './RushCommandLineParser';
+import { GitPolicy } from '../logic/GitPolicy';
 import { BaseRushAction } from './BaseRushAction';
 import { VersionManager } from '../logic/VersionManager';
 import { Git } from '../logic/Git';
 
-export default class VersionAction extends BaseRushAction {
+export class VersionAction extends BaseRushAction {
   private _ensureVersionPolicy: CommandLineFlagParameter;
   private _overrideVersion: CommandLineStringParameter;
   private _bumpVersion: CommandLineFlagParameter;

--- a/apps/rush-lib/src/cli/logic/ApprovedPackagesChecker.ts
+++ b/apps/rush-lib/src/cli/logic/ApprovedPackagesChecker.ts
@@ -4,8 +4,8 @@
 import { IPackageJson, PackageName } from '@microsoft/node-core-library';
 
 import { ApprovedPackagesPolicy } from '../../data/ApprovedPackagesPolicy';
-import RushConfiguration from '../../data/RushConfiguration';
-import RushConfigurationProject from '../../data/RushConfigurationProject';
+import { RushConfiguration } from '../../data/RushConfiguration';
+import { RushConfigurationProject } from '../../data/RushConfigurationProject';
 
 export class ApprovedPackagesChecker {
   /**

--- a/apps/rush-lib/src/cli/logic/ChangeFiles.ts
+++ b/apps/rush-lib/src/cli/logic/ChangeFiles.ts
@@ -5,7 +5,7 @@ import * as fsx from 'fs-extra';
 import { EOL } from 'os';
 import * as glob from 'glob';
 
-import Utilities from '../../utilities/Utilities';
+import { Utilities } from '../../utilities/Utilities';
 import { IChangeInfo } from '../../data/ChangeManagement';
 import { IChangelog } from '../../data/Changelog';
 
@@ -13,7 +13,7 @@ import { IChangelog } from '../../data/Changelog';
  * This class represents the collection of change files existing in the repo and provides operations
  * for those change files.
  */
-export default class ChangeFiles {
+export class ChangeFiles {
 
   /**
    * Change file path relative to changes folder.

--- a/apps/rush-lib/src/cli/logic/ChangeManager.ts
+++ b/apps/rush-lib/src/cli/logic/ChangeManager.ts
@@ -5,21 +5,19 @@ import { IPackageJson } from '@microsoft/node-core-library';
 
 import { IChangeInfo } from '../../data/ChangeManagement';
 import { IChangelog } from '../../data/Changelog';
-import RushConfiguration from '../../data/RushConfiguration';
-import RushConfigurationProject from '../../data/RushConfigurationProject';
+import { RushConfiguration } from '../../data/RushConfiguration';
+import { RushConfigurationProject } from '../../data/RushConfigurationProject';
 import { VersionPolicyConfiguration } from '../../data/VersionPolicyConfiguration';
-import PublishUtilities, {
-  IChangeInfoHash
-} from './PublishUtilities';
-import ChangeFiles from './ChangeFiles';
-import PrereleaseToken from './PrereleaseToken';
-import ChangelogGenerator from './ChangelogGenerator';
+import { PublishUtilities, IChangeInfoHash } from './PublishUtilities';
+import { ChangeFiles } from './ChangeFiles';
+import { PrereleaseToken } from './PrereleaseToken';
+import { ChangelogGenerator } from './ChangelogGenerator';
 
 /**
  * The class manages change files and controls how changes logged by change files
  * can be applied to package.json and change logs.
  */
-export default class ChangeManager {
+export class ChangeManager {
   private _prereleaseToken: PrereleaseToken;
   private _orderedChanges: IChangeInfo[];
   private _allPackages: Map<string, RushConfigurationProject>;

--- a/apps/rush-lib/src/cli/logic/ChangelogGenerator.ts
+++ b/apps/rush-lib/src/cli/logic/ChangelogGenerator.ts
@@ -6,7 +6,7 @@ import * as path from 'path';
 import * as semver from 'semver';
 
 import {
-  default as PublishUtilities,
+  PublishUtilities,
   IChangeInfoHash
 } from './PublishUtilities';
 import {
@@ -18,14 +18,14 @@ import {
   IChangeLogEntry,
   IChangeLogComment
 } from '../../data/Changelog';
-import RushConfigurationProject from '../../data/RushConfigurationProject';
-import RushConfiguration from '../../data/RushConfiguration';
+import { RushConfigurationProject } from '../../data/RushConfigurationProject';
+import { RushConfiguration } from '../../data/RushConfiguration';
 
 const CHANGELOG_JSON: string = 'CHANGELOG.json';
 const CHANGELOG_MD: string = 'CHANGELOG.md';
 const EOL: string = '\n';
 
-export default class ChangelogGenerator {
+export class ChangelogGenerator {
   /**
    * Updates the appropriate changelogs with the given changes.
    */

--- a/apps/rush-lib/src/cli/logic/EventHooksManager.ts
+++ b/apps/rush-lib/src/cli/logic/EventHooksManager.ts
@@ -4,12 +4,12 @@
 import * as os from 'os';
 import * as colors from 'colors';
 
-import EventHooks from '../../data/EventHooks';
-import Utilities from '../../utilities/Utilities';
+import { EventHooks } from '../../data/EventHooks';
+import { Utilities } from '../../utilities/Utilities';
 import { Event } from '../../data/EventHooks';
 import { Stopwatch } from '../../utilities/Stopwatch';
 
-export default class EventHooksManager {
+export class EventHooksManager {
   private _eventHooks: EventHooks;
   private _commonTempFolder: string;
 

--- a/apps/rush-lib/src/cli/logic/Git.ts
+++ b/apps/rush-lib/src/cli/logic/Git.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import PublishUtilities from './PublishUtilities';
+import { PublishUtilities } from './PublishUtilities';
 
 export class Git {
   private _targetBranch: string | undefined;

--- a/apps/rush-lib/src/cli/logic/GitPolicy.ts
+++ b/apps/rush-lib/src/cli/logic/GitPolicy.ts
@@ -4,10 +4,10 @@
 import * as os from 'os';
 import * as colors from 'colors';
 
-import RushConfiguration from '../../data/RushConfiguration';
-import Utilities from '../../utilities/Utilities';
+import { RushConfiguration } from '../../data/RushConfiguration';
+import { Utilities } from '../../utilities/Utilities';
 
-export default class GitPolicy {
+export class GitPolicy {
   public static check(rushConfiguration: RushConfiguration): boolean {
     if (rushConfiguration.gitAllowedEmailRegExps.length === 0) {
       return true;

--- a/apps/rush-lib/src/cli/logic/InstallManager.ts
+++ b/apps/rush-lib/src/cli/logic/InstallManager.ts
@@ -18,13 +18,11 @@ import {
   MapExtensions
 } from '@microsoft/node-core-library';
 
-import AsyncRecycler from '../../utilities/AsyncRecycler';
-import RushConfiguration, {
-  PackageManager
-} from '../../data/RushConfiguration';
-import RushConfigurationProject from '../../data/RushConfigurationProject';
+import { AsyncRecycler } from '../../utilities/AsyncRecycler';
+import { RushConfiguration, PackageManager } from '../../data/RushConfiguration';
+import { RushConfigurationProject } from '../../data/RushConfigurationProject';
 import { RushConstants } from '../../RushConstants';
-import Utilities from '../../utilities/Utilities';
+import { Utilities } from '../../utilities/Utilities';
 import { Stopwatch } from '../../utilities/Stopwatch';
 import { IRushTempPackageJson } from '../logic/base/BasePackage';
 import { BaseShrinkwrapFile } from '../logic/base/BaseShrinkwrapFile';
@@ -71,7 +69,7 @@ export enum InstallType {
 /**
  * This class implements common logic between "rush install" and "rush generate".
  */
-export default class InstallManager {
+export class InstallManager {
   private _rushConfiguration: RushConfiguration;
   private _commonNodeModulesMarker: LastInstallFlag;
   private _asyncRecycler: AsyncRecycler;

--- a/apps/rush-lib/src/cli/logic/LinkManagerFactory.ts
+++ b/apps/rush-lib/src/cli/logic/LinkManagerFactory.ts
@@ -1,4 +1,4 @@
-import RushConfiguration from '../../data/RushConfiguration';
+import { RushConfiguration } from '../../data/RushConfiguration';
 import { BaseLinkManager } from './base/BaseLinkManager';
 import { NpmLinkManager } from './npm/NpmLinkManager';
 import { PnpmLinkManager } from './pnpm/PnpmLinkManager';

--- a/apps/rush-lib/src/cli/logic/PackageChangeAnalyzer.ts
+++ b/apps/rush-lib/src/cli/logic/PackageChangeAnalyzer.ts
@@ -10,7 +10,7 @@ import {
 import { Path } from '@microsoft/node-core-library';
 
 import { RushConstants } from '../../RushConstants';
-import RushConfiguration from '../../data/RushConfiguration';
+import { RushConfiguration } from '../../data/RushConfiguration';
 
 export class PackageChangeAnalyzer {
   // Allow this function to be overwritten during unit tests

--- a/apps/rush-lib/src/cli/logic/PackageLookup.ts
+++ b/apps/rush-lib/src/cli/logic/PackageLookup.ts
@@ -3,7 +3,7 @@
 
 import { BasePackage } from './base/BasePackage';
 
-export default class PackageLookup {
+export class PackageLookup {
   private _packageMap: Map<string, BasePackage>;
 
   constructor() {

--- a/apps/rush-lib/src/cli/logic/PrereleaseToken.ts
+++ b/apps/rush-lib/src/cli/logic/PrereleaseToken.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-export default class PrereleaseToken {
+export class PrereleaseToken {
   private _name: string;
   private _prereleaseName: string | undefined;
   private _suffixName: string | undefined;

--- a/apps/rush-lib/src/cli/logic/PublishUtilities.ts
+++ b/apps/rush-lib/src/cli/logic/PublishUtilities.ts
@@ -17,18 +17,18 @@ import {
   IChangeInfo,
   ChangeType
 } from '../../data/ChangeManagement';
-import RushConfigurationProject from '../../data/RushConfigurationProject';
-import Utilities, { IEnvironment } from '../../utilities/Utilities';
+import { RushConfigurationProject } from '../../data/RushConfigurationProject';
+import { Utilities, IEnvironment } from '../../utilities/Utilities';
 import { execSync } from 'child_process';
-import PrereleaseToken from './PrereleaseToken';
-import ChangeFiles from './ChangeFiles';
-import RushConfiguration from '../../data/RushConfiguration';
+import { PrereleaseToken } from './PrereleaseToken';
+import { ChangeFiles } from './ChangeFiles';
+import { RushConfiguration } from '../../data/RushConfiguration';
 
 export interface IChangeInfoHash {
   [key: string]: IChangeInfo;
 }
 
-export default class PublishUtilities {
+export class PublishUtilities {
   /**
    * Finds change requests in the given folder.
    * @param changesPath Path to the changes folder.

--- a/apps/rush-lib/src/cli/logic/TaskSelector.ts
+++ b/apps/rush-lib/src/cli/logic/TaskSelector.ts
@@ -1,12 +1,12 @@
 import {
-  default as RushConfiguration,
+  RushConfiguration,
   IRushLinkJson
 } from '../../data/RushConfiguration';
-import { default as RushConfigurationProject } from '../../data/RushConfigurationProject';
+import { RushConfigurationProject } from '../../data/RushConfigurationProject';
 import { JsonFile } from '@microsoft/node-core-library';
 
-import TaskRunner from '../taskRunner/TaskRunner';
-import ProjectTask from '../taskRunner/ProjectTask';
+import { TaskRunner } from '../taskRunner/TaskRunner';
+import { ProjectTask } from '../taskRunner/ProjectTask';
 import { PackageChangeAnalyzer } from './PackageChangeAnalyzer';
 
 export interface ITaskSelectorConstructor {

--- a/apps/rush-lib/src/cli/logic/Telemetry.ts
+++ b/apps/rush-lib/src/cli/logic/Telemetry.ts
@@ -5,8 +5,8 @@ import * as path from 'path';
 import * as fsx from 'fs-extra';
 import { cloneDeep } from 'lodash';
 
-import RushConfiguration from '../../data/RushConfiguration';
-import Rush from '../../Rush';
+import { RushConfiguration } from '../../data/RushConfiguration';
+import { Rush } from '../../Rush';
 
 export interface ITelemetryData {
   name: string;
@@ -20,7 +20,7 @@ export interface ITelemetryData {
 
 const MAX_FILE_COUNT: number = 100;
 
-export default class Telemetry {
+export class Telemetry {
   private _enabled: boolean;
   private _store: ITelemetryData[];
   private _dataFolder: string;

--- a/apps/rush-lib/src/cli/logic/VersionManager.ts
+++ b/apps/rush-lib/src/cli/logic/VersionManager.ts
@@ -14,11 +14,11 @@ import {
 } from '../../data/VersionPolicy';
 import { ChangeFile } from '../../data/ChangeFile';
 import { ChangeType, IChangeInfo } from '../../data/ChangeManagement';
-import RushConfiguration from '../../data/RushConfiguration';
-import RushConfigurationProject from '../../data/RushConfigurationProject';
+import { RushConfiguration } from '../../data/RushConfiguration';
+import { RushConfigurationProject } from '../../data/RushConfigurationProject';
 import { VersionPolicyConfiguration } from '../../data/VersionPolicyConfiguration';
-import PublishUtilities from './PublishUtilities';
-import ChangeManager from './ChangeManager';
+import { PublishUtilities } from './PublishUtilities';
+import { ChangeManager } from './ChangeManager';
 
 export class VersionManager {
   private _versionPolicyConfiguration: VersionPolicyConfiguration;

--- a/apps/rush-lib/src/cli/logic/base/BaseLinkManager.ts
+++ b/apps/rush-lib/src/cli/logic/base/BaseLinkManager.ts
@@ -6,10 +6,8 @@ import * as fsx from 'fs-extra';
 import * as os from 'os';
 import * as path from 'path';
 
-import {
-  default as RushConfiguration
-} from '../../../data/RushConfiguration';
-import Utilities from '../../../utilities/Utilities';
+import { RushConfiguration } from '../../../data/RushConfiguration';
+import { Utilities } from '../../../utilities/Utilities';
 import { Stopwatch } from '../../../utilities/Stopwatch';
 import { BasePackage } from './BasePackage';
 

--- a/apps/rush-lib/src/cli/logic/npm/NpmLinkManager.ts
+++ b/apps/rush-lib/src/cli/logic/npm/NpmLinkManager.ts
@@ -13,14 +13,14 @@ import { JsonFile, PackageName } from '@microsoft/node-core-library';
 
 import { RushConstants } from '../../../RushConstants';
 import { IRushLinkJson } from '../../../data/RushConfiguration';
-import RushConfigurationProject from '../../../data/RushConfigurationProject';
-import Utilities from '../../../utilities/Utilities';
+import { RushConfigurationProject } from '../../../data/RushConfigurationProject';
+import { Utilities } from '../../../utilities/Utilities';
 import {
   NpmPackage,
   IResolveOrCreateResult,
   PackageDependencyKind
 } from './NpmPackage';
-import PackageLookup from '../PackageLookup';
+import { PackageLookup } from '../PackageLookup';
 import {
   BaseLinkManager,
   SymlinkKind

--- a/apps/rush-lib/src/cli/logic/pnpm/PnpmLinkManager.ts
+++ b/apps/rush-lib/src/cli/logic/pnpm/PnpmLinkManager.ts
@@ -20,7 +20,7 @@ import {
 import { BasePackage } from '../base/BasePackage';
 import { RushConstants } from '../../../RushConstants';
 import { IRushLinkJson } from '../../../data/RushConfiguration';
-import RushConfigurationProject from '../../../data/RushConfigurationProject';
+import { RushConfigurationProject } from '../../../data/RushConfigurationProject';
 
 // special flag for debugging, will print extra diagnostic information,
 // but comes with performance cost

--- a/apps/rush-lib/src/cli/logic/test/ChangeFiles.test.ts
+++ b/apps/rush-lib/src/cli/logic/test/ChangeFiles.test.ts
@@ -5,7 +5,7 @@ import { expect } from 'chai';
 import * as path from 'path';
 
 import { IChangelog } from '../../../data/Changelog';
-import ChangeFiles from '../ChangeFiles';
+import { ChangeFiles } from '../ChangeFiles';
 
 describe('ChangeFiles', () => {
   describe('getFiles', () => {

--- a/apps/rush-lib/src/cli/logic/test/ChangeManager.test.ts
+++ b/apps/rush-lib/src/cli/logic/test/ChangeManager.test.ts
@@ -4,9 +4,9 @@
 import { expect } from 'chai';
 import * as path from 'path';
 
-import RushConfiguration from '../../../data/RushConfiguration';
-import ChangeManager from '../ChangeManager';
-import PrereleaseToken from '../PrereleaseToken';
+import { RushConfiguration } from '../../../data/RushConfiguration';
+import { ChangeManager } from '../ChangeManager';
+import { PrereleaseToken } from '../PrereleaseToken';
 
 describe('ChangeManager', () => {
   const rushJsonFile: string = path.resolve(__dirname, 'packages', 'rush.json');

--- a/apps/rush-lib/src/cli/logic/test/ChangelogGenerator.test.ts
+++ b/apps/rush-lib/src/cli/logic/test/ChangelogGenerator.test.ts
@@ -5,9 +5,9 @@ import { expect } from 'chai';
 
 import { IChangelog } from '../../../data/Changelog';
 import { ChangeType } from '../../../data/ChangeManagement';
-import RushConfiguration from '../../../data/RushConfiguration';
-import RushConfigurationProject from '../../../data/RushConfigurationProject';
-import ChangelogGenerator from '../ChangelogGenerator';
+import { RushConfiguration } from '../../../data/RushConfiguration';
+import { RushConfigurationProject } from '../../../data/RushConfigurationProject';
+import { ChangelogGenerator } from '../ChangelogGenerator';
 import { IChangeInfoHash } from '../PublishUtilities';
 
 import * as path from 'path';

--- a/apps/rush-lib/src/cli/logic/test/PackageChangeAnalyzer.test.ts
+++ b/apps/rush-lib/src/cli/logic/test/PackageChangeAnalyzer.test.ts
@@ -5,7 +5,7 @@ import { expect } from 'chai';
 import * as path from 'path';
 
 import { PackageChangeAnalyzer } from '../PackageChangeAnalyzer';
-import RushConfiguration from '../../../data/RushConfiguration';
+import { RushConfiguration } from '../../../data/RushConfiguration';
 
 import {
   IPackageDeps

--- a/apps/rush-lib/src/cli/logic/test/PublishUtilities.test.ts
+++ b/apps/rush-lib/src/cli/logic/test/PublishUtilities.test.ts
@@ -8,13 +8,13 @@ import {
   IChangeInfo,
   ChangeType
 } from '../../../data/ChangeManagement';
-import RushConfiguration from '../../../data/RushConfiguration';
-import RushConfigurationProject from '../../../data/RushConfigurationProject';
+import { RushConfiguration } from '../../../data/RushConfiguration';
+import { RushConfigurationProject } from '../../../data/RushConfigurationProject';
 import {
-  default as PublishUtilities,
+  PublishUtilities,
   IChangeInfoHash
 } from '../PublishUtilities';
-import ChangeFiles from '../ChangeFiles';
+import { ChangeFiles } from '../ChangeFiles';
 
 /* tslint:disable:no-string-literal */
 

--- a/apps/rush-lib/src/cli/logic/test/Telemetry.test.ts
+++ b/apps/rush-lib/src/cli/logic/test/Telemetry.test.ts
@@ -4,10 +4,10 @@
 import { assert } from 'chai';
 import * as path from 'path';
 
-import RushConfiguration from '../../../data/RushConfiguration';
-import Rush from '../../../Rush';
+import { RushConfiguration } from '../../../data/RushConfiguration';
+import { Rush } from '../../../Rush';
 import {
-  default as Telemetry,
+  Telemetry,
   ITelemetryData
  } from '../Telemetry';
 

--- a/apps/rush-lib/src/cli/logic/test/VersionManager.test.ts
+++ b/apps/rush-lib/src/cli/logic/test/VersionManager.test.ts
@@ -8,7 +8,7 @@ import { IPackageJson } from '@microsoft/node-core-library';
 import { BumpType } from '../../../data/VersionPolicy';
 import { ChangeFile } from '../../../data/ChangeFile';
 import { ChangeType, IChangeInfo } from '../../../data/ChangeManagement';
-import RushConfiguration from '../../../data/RushConfiguration';
+import { RushConfiguration } from '../../../data/RushConfiguration';
 import { VersionManager } from '../VersionManager';
 
 function _getChanges(changeFiles: Map<string, ChangeFile>,

--- a/apps/rush-lib/src/cli/taskRunner/ITask.ts
+++ b/apps/rush-lib/src/cli/taskRunner/ITask.ts
@@ -5,7 +5,7 @@ import { ITaskWriter } from '@microsoft/stream-collator';
 
 import { Stopwatch } from '../../utilities/Stopwatch';
 import { TaskStatus } from './TaskStatus';
-import TaskError from './TaskError';
+import { TaskError } from './TaskError';
 
 /**
  * A definition for a task, an execute function returning a promise and a unique string name
@@ -97,4 +97,3 @@ export interface ITask extends ITaskDefinition {
    */
   stopwatch: Stopwatch;
 }
-export default ITask;

--- a/apps/rush-lib/src/cli/taskRunner/ProjectTask.ts
+++ b/apps/rush-lib/src/cli/taskRunner/ProjectTask.ts
@@ -9,12 +9,12 @@ import { JsonFile, Text } from '@microsoft/node-core-library';
 import { ITaskWriter } from '@microsoft/stream-collator';
 import { IPackageDeps } from '@microsoft/package-deps-hash';
 
-import RushConfiguration from '../../data/RushConfiguration';
-import RushConfigurationProject from '../../data/RushConfigurationProject';
+import { RushConfiguration } from '../../data/RushConfiguration';
+import { RushConfigurationProject } from '../../data/RushConfigurationProject';
 import { RushConstants } from '../../RushConstants';
-import Utilities from '../../utilities/Utilities';
+import { Utilities } from '../../utilities/Utilities';
 import { TaskStatus } from './TaskStatus';
-import TaskError from './TaskError';
+import { TaskError } from './TaskError';
 import { ITaskDefinition } from '../taskRunner/ITask';
 import {
   PackageChangeAnalyzer
@@ -37,7 +37,7 @@ export interface IProjectTaskOptions {
 /**
  * A TaskRunner task which cleans and builds a project
  */
-export default class ProjectTask implements ITaskDefinition {
+export class ProjectTask implements ITaskDefinition {
   public get name(): string {
     return this._rushProject.packageName;
   }

--- a/apps/rush-lib/src/cli/taskRunner/TaskError.ts
+++ b/apps/rush-lib/src/cli/taskRunner/TaskError.ts
@@ -5,7 +5,7 @@
  * Encapsulates information about an error
  * @public
  */
-export default class TaskError {
+export class TaskError {
   protected _type: string;
   protected _message: string;
 

--- a/apps/rush-lib/src/cli/taskRunner/TaskRunner.ts
+++ b/apps/rush-lib/src/cli/taskRunner/TaskRunner.ts
@@ -6,9 +6,9 @@ import * as os from 'os';
 import { Interleaver } from '@microsoft/stream-collator';
 
 import { Stopwatch } from '../../utilities/Stopwatch';
-import ITask, { ITaskDefinition } from './ITask';
+import { ITask, ITaskDefinition } from './ITask';
 import { TaskStatus } from './TaskStatus';
-import TaskError from './TaskError';
+import { TaskError } from './TaskError';
 
 /**
  * A class which manages the execution of a set of tasks with interdependencies.
@@ -19,7 +19,7 @@ import TaskError from './TaskError';
  * definitions must
  * @todo #168352: add unit tests
  */
-export default class TaskRunner {
+export class TaskRunner {
   private _tasks: Map<string, ITask>;
   private _changedProjectsOnly: boolean;
   private _buildQueue: ITask[];

--- a/apps/rush-lib/src/cli/test/Cli.test.ts
+++ b/apps/rush-lib/src/cli/test/Cli.test.ts
@@ -6,7 +6,7 @@
 import * as path from 'path';
 import { assert } from 'chai';
 
-import Utilities from '../../utilities/Utilities';
+import { Utilities } from '../../utilities/Utilities';
 
 describe('CLI', () => {
   it('should not fail when there is no rush.json', () => {

--- a/apps/rush-lib/src/data/ApprovedPackagesConfiguration.ts
+++ b/apps/rush-lib/src/data/ApprovedPackagesConfiguration.ts
@@ -6,7 +6,7 @@ import * as path from 'path';
 import * as os from 'os';
 import { JsonFile, JsonSchema, Text } from '@microsoft/node-core-library';
 
-import Utilities from '../utilities/Utilities';
+import { Utilities } from '../utilities/Utilities';
 
 /**
  * Part of IApprovedPackagesJson.

--- a/apps/rush-lib/src/data/ApprovedPackagesPolicy.ts
+++ b/apps/rush-lib/src/data/ApprovedPackagesPolicy.ts
@@ -5,7 +5,7 @@ import * as path from 'path';
 
 import { ApprovedPackagesConfiguration } from './ApprovedPackagesConfiguration';
 import { RushConstants } from '../RushConstants';
-import RushConfiguration, { IRushConfigurationJson, IApprovedPackagesPolicyJson } from './RushConfiguration';
+import { RushConfiguration, IRushConfigurationJson, IApprovedPackagesPolicyJson } from './RushConfiguration';
 
 /**
  * This is a helper object for RushConfiguration.

--- a/apps/rush-lib/src/data/ChangeFile.ts
+++ b/apps/rush-lib/src/data/ChangeFile.ts
@@ -5,7 +5,7 @@ import * as fsx from 'fs-extra';
 import * as path from 'path';
 import gitInfo = require('git-repo-info');
 
-import RushConfiguration from './RushConfiguration';
+import { RushConfiguration } from './RushConfiguration';
 import {
   IChangeFile,
   IChangeInfo

--- a/apps/rush-lib/src/data/EventHooks.ts
+++ b/apps/rush-lib/src/data/EventHooks.ts
@@ -32,7 +32,7 @@ export enum Event {
  * The actions are expressed as a command-line that is executed using the operating system shell.
  * @beta
  */
-export default class EventHooks {
+export class EventHooks {
   private _hooks: Map<Event, string[]>;
 
   /**

--- a/apps/rush-lib/src/data/RushConfiguration.ts
+++ b/apps/rush-lib/src/data/RushConfiguration.ts
@@ -6,11 +6,11 @@ import * as fsx from 'fs-extra';
 import * as semver from 'semver';
 import { JsonFile, JsonSchema, PackageName } from '@microsoft/node-core-library';
 
-import Rush from '../Rush';
-import RushConfigurationProject, { IRushConfigurationProjectJson } from './RushConfigurationProject';
+import { Rush } from '../Rush';
+import { RushConfigurationProject, IRushConfigurationProjectJson } from './RushConfigurationProject';
 import { RushConstants } from '../RushConstants';
 import { ApprovedPackagesPolicy } from './ApprovedPackagesPolicy';
-import EventHooks from './EventHooks';
+import { EventHooks } from './EventHooks';
 import { VersionPolicyConfiguration } from './VersionPolicyConfiguration';
 import { EnvironmentConfiguration } from './EnvironmentConfiguration';
 import { CommonVersionsConfiguration } from './CommonVersionsConfiguration';
@@ -110,7 +110,7 @@ export type PackageManager = 'pnpm' | 'npm';
  * configuration file.
  * @public
  */
-export default class RushConfiguration {
+export class RushConfiguration {
   private static _jsonSchema: JsonSchema = JsonSchema.fromFile(path.join(__dirname, '../schemas/rush.schema.json'));
 
   private _rushJsonFile: string;

--- a/apps/rush-lib/src/data/RushConfigurationProject.ts
+++ b/apps/rush-lib/src/data/RushConfigurationProject.ts
@@ -9,7 +9,7 @@ import {
   PackageName
 } from '@microsoft/node-core-library';
 
-import RushConfiguration from '../data/RushConfiguration';
+import { RushConfiguration } from '../data/RushConfiguration';
 import { VersionPolicy, LockStepVersionPolicy } from './VersionPolicy';
 
 /**
@@ -30,7 +30,7 @@ export interface IRushConfigurationProjectJson {
  * the Rush.json configuration file.
  * @public
  */
-export default class RushConfigurationProject {
+export class RushConfigurationProject {
   private _packageName: string;
   private _projectFolder: string;
   private _projectRelativeFolder: string;

--- a/apps/rush-lib/src/data/VersionMismatchFinder.ts
+++ b/apps/rush-lib/src/data/VersionMismatchFinder.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import RushConfigurationProject from './RushConfigurationProject';
+import { RushConfigurationProject } from './RushConfigurationProject';
 
 /**
  * @public

--- a/apps/rush-lib/src/data/VersionPolicyConfiguration.ts
+++ b/apps/rush-lib/src/data/VersionPolicyConfiguration.ts
@@ -6,7 +6,7 @@ import * as fsx from 'fs-extra';
 import { JsonFile, JsonSchema } from '@microsoft/node-core-library';
 
 import { VersionPolicy, BumpType, LockStepVersionPolicy } from './VersionPolicy';
-import RushConfigurationProject from './RushConfigurationProject';
+import { RushConfigurationProject } from './RushConfigurationProject';
 
 /**
  * @beta

--- a/apps/rush-lib/src/data/test/ChangeFile.test.ts
+++ b/apps/rush-lib/src/data/test/ChangeFile.test.ts
@@ -6,7 +6,7 @@ import * as path from 'path';
 import { assert } from 'chai';
 
 import { ChangeFile } from '../ChangeFile';
-import RushConfiguration from '../RushConfiguration';
+import { RushConfiguration } from '../RushConfiguration';
 import { ChangeType } from '../ChangeManagement';
 
 describe('ChangeFile', () => {

--- a/apps/rush-lib/src/data/test/EventHooks.test.ts
+++ b/apps/rush-lib/src/data/test/EventHooks.test.ts
@@ -5,8 +5,8 @@
 
 import { assert } from 'chai';
 import * as path from 'path';
-import RushConfiguration from '../RushConfiguration';
-import { Event, default as EventHooks } from '../EventHooks';
+import { RushConfiguration } from '../RushConfiguration';
+import { Event, EventHooks } from '../EventHooks';
 
 describe('EventHooks', () => {
   it('loads a post build hook from rush.json', () => {

--- a/apps/rush-lib/src/data/test/RushConfiguration.test.ts
+++ b/apps/rush-lib/src/data/test/RushConfiguration.test.ts
@@ -3,13 +3,14 @@
 
 /// <reference types='mocha' />
 
+import * as path from 'path';
+
 import { assert } from 'chai';
 import { Text } from '@microsoft/node-core-library';
-import RushConfiguration from '../RushConfiguration';
+import { RushConfiguration } from '../RushConfiguration';
 import { ApprovedPackagesPolicy } from '../ApprovedPackagesPolicy';
-import RushConfigurationProject from '../RushConfigurationProject';
-import * as path from 'path';
-import Utilities from '../../utilities/Utilities';
+import { RushConfigurationProject } from '../RushConfigurationProject';
+import { Utilities } from '../../utilities/Utilities';
 
 function normalizePathForComparison(pathToNormalize: string): string {
   return Text.replaceAll(pathToNormalize, '\\', '/').toUpperCase();

--- a/apps/rush-lib/src/data/test/VersionMismatchFinder.test.ts
+++ b/apps/rush-lib/src/data/test/VersionMismatchFinder.test.ts
@@ -4,7 +4,7 @@
 /// <reference types='mocha' />
 
 import { assert } from 'chai';
-import RushConfigurationProject from '../RushConfigurationProject';
+import { RushConfigurationProject } from '../RushConfigurationProject';
 import { VersionMismatchFinder } from '../VersionMismatchFinder';
 
 describe('VersionMismatchFinder', () => {

--- a/apps/rush-lib/src/index.ts
+++ b/apps/rush-lib/src/index.ts
@@ -11,12 +11,12 @@ export {
 } from './data/ApprovedPackagesPolicy';
 
 export {
-  default as RushConfiguration,
+  RushConfiguration,
   PackageManager
 } from './data/RushConfiguration';
 
 export {
-  default as RushConfigurationProject
+  RushConfigurationProject
 } from './data/RushConfigurationProject';
 
 export {
@@ -29,7 +29,7 @@ export {
 } from './data/CommonVersionsConfiguration';
 
 export {
-  default as EventHooks,
+  EventHooks,
   Event
 } from './data/EventHooks';
 
@@ -61,4 +61,4 @@ export {
 /**
  * @internal
  */
-export { default as Rush } from './Rush';
+export { Rush } from './Rush';

--- a/apps/rush-lib/src/start.ts
+++ b/apps/rush-lib/src/start.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import Rush from './Rush';
+import { Rush } from './Rush';
 
 Rush.launch(Rush.version, false);

--- a/apps/rush-lib/src/utilities/AsyncRecycler.ts
+++ b/apps/rush-lib/src/utilities/AsyncRecycler.ts
@@ -8,8 +8,8 @@ import * as fsx from 'fs-extra';
 
 import { Text } from '@microsoft/node-core-library';
 
-import RushConfiguration from '../data/RushConfiguration';
-import Utilities from './Utilities';
+import { RushConfiguration } from '../data/RushConfiguration';
+import { Utilities } from './Utilities';
 
 /**
  * For deleting large folders, AsyncRecycler is significantly faster than Utilities.dangerouslyDeletePath().
@@ -17,7 +17,7 @@ import Utilities from './Utilities';
  * background process to recursively delete that folder.
  * @public
  */
-export default class AsyncRecycler {
+export class AsyncRecycler {
   private _rushConfiguration: RushConfiguration;
   private _recyclerFolder: string;
   private _movedFolderCount: number;

--- a/apps/rush-lib/src/utilities/Npm.ts
+++ b/apps/rush-lib/src/utilities/Npm.ts
@@ -1,13 +1,13 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import Utilities from './Utilities';
+import { Utilities } from './Utilities';
 import * as semver from 'semver';
 
 /**
  * @public
  */
-export default class Npm {
+export class Npm {
   public static publishedVersions(
     packageName: string,
     cwd: string,

--- a/apps/rush-lib/src/utilities/Stopwatch.ts
+++ b/apps/rush-lib/src/utilities/Stopwatch.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import Utilities from './Utilities';
+import { Utilities } from './Utilities';
 
 /**
  * Used with the Stopwatch class.

--- a/apps/rush-lib/src/utilities/Utilities.ts
+++ b/apps/rush-lib/src/utilities/Utilities.ts
@@ -20,7 +20,7 @@ export interface IEnvironment {
 /**
  * @public
  */
-export default class Utilities {
+export class Utilities {
   /**
    * NodeJS equivalent of performance.now().
    */

--- a/apps/rush-lib/src/utilities/VersionControl.ts
+++ b/apps/rush-lib/src/utilities/VersionControl.ts
@@ -6,7 +6,7 @@ import * as child_process from 'child_process';
 /**
  * @public
  */
-export default class VersionControl {
+export class VersionControl {
   public static getChangedFolders(targetBranch?: string): Array<string | undefined> | undefined {
     const branchName: string = targetBranch ? targetBranch : 'origin/master';
     const output: string | undefined = child_process.execSync(`git diff ${branchName}... --dirstat=files,0`)

--- a/apps/rush-lib/src/utilities/test/Npm.test.ts
+++ b/apps/rush-lib/src/utilities/test/Npm.test.ts
@@ -3,11 +3,12 @@
 
 /// <reference types='mocha' />
 
-import { assert } from 'chai';
-import Npm from '../Npm';
 import * as process from 'process';
-import Utilities from '../Utilities';
 import * as sinon from 'sinon';
+
+import { assert } from 'chai';
+import { Npm } from '../Npm';
+import { Utilities } from '../Utilities';
 
 describe('npm', () => {
   const packageName: string = '@microsoft/rush-lib-never';

--- a/common/changes/@microsoft/gulp-core-build-serve/pgonzal-no-default-exports_2018-04-30-19-48.json
+++ b/common/changes/@microsoft/gulp-core-build-serve/pgonzal-no-default-exports_2018-04-30-19-48.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/gulp-core-build-serve",
+      "comment": "Internal refactoring to eliminate default exports",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/gulp-core-build-serve",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush/pgonzal-no-default-exports_2018-04-30-19-48.json
+++ b/common/changes/@microsoft/rush/pgonzal-no-default-exports_2018-04-30-19-48.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Internal refactoring to eliminate default exports",
+      "packageName": "@microsoft/rush",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/stream-collator/pgonzal-no-default-exports_2018-04-30-19-48.json
+++ b/common/changes/@microsoft/stream-collator/pgonzal-no-default-exports_2018-04-30-19-48.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/stream-collator",
+      "comment": "Internal refactoring to eliminate default exports",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/stream-collator",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/core-build/gulp-core-build-serve/src/CertificateStore.ts
+++ b/core-build/gulp-core-build-serve/src/CertificateStore.ts
@@ -7,7 +7,7 @@ import { homedir } from 'os';
 
 const encoding: string = 'utf8';
 
-export default class CertificateStore {
+export class CertificateStore {
   private static _instance: CertificateStore;
 
   public static get instance(): CertificateStore {

--- a/core-build/gulp-core-build-serve/src/TrustCertTask.ts
+++ b/core-build/gulp-core-build-serve/src/TrustCertTask.ts
@@ -12,7 +12,7 @@ import { ICertificate } from './certificates';
  *  trusted as a root cert in the keychain. On other platforms, the certificate is generated
  *  and signed, but the user must trust it manually.
  */
-export default class TrustCertTask extends GulpTask<void> {
+export class TrustCertTask extends GulpTask<void> {
   constructor() {
     super('trust-cert');
   }

--- a/core-build/gulp-core-build-serve/src/UntrustCertTask.ts
+++ b/core-build/gulp-core-build-serve/src/UntrustCertTask.ts
@@ -3,7 +3,7 @@
 
 import { GulpTask } from '@microsoft/gulp-core-build';
 import * as Gulp from 'gulp';
-import CertificateStoreType from './CertificateStore';
+import { CertificateStore } from './CertificateStore';
 
 /**
  * On Windows, this task removes the certificate with the expected serial number from the user's
@@ -12,7 +12,7 @@ import CertificateStoreType from './CertificateStore';
  *  other platforms, the user must untrust the certificate manually. On all platforms,
  *  the certificate and private key are deleted from the user's home directory.
  */
-export default class UntrustCertTask extends GulpTask<void> {
+export class UntrustCertTask extends GulpTask<void> {
   constructor() {
     super('untrust-cert');
   }
@@ -24,7 +24,7 @@ export default class UntrustCertTask extends GulpTask<void> {
     /* tslint:enable */
 
     const untrustCertResult: boolean = untrustCertificate(this);
-    const certificateStore: CertificateStoreType = CertificateStore.instance;
+    const certificateStore: CertificateStore = CertificateStore.instance;
 
     // Clear out the certificate store
     certificateStore.certificateData = undefined;

--- a/core-build/gulp-core-build-serve/src/certificates.ts
+++ b/core-build/gulp-core-build-serve/src/certificates.ts
@@ -13,7 +13,7 @@ import { EOL } from 'os';
 
 import { runSudoSync, ISudoSyncResult } from './sudoSync';
 
-import CertificateStore from './CertificateStore';
+import { CertificateStore } from './CertificateStore';
 
 const serialNumber: string = '731c321744e34650a202e3ef91c3c1b9';
 const friendlyName: string = 'gulp-core-build-serve Development Certificate';

--- a/core-build/gulp-core-build-serve/src/index.ts
+++ b/core-build/gulp-core-build-serve/src/index.ts
@@ -3,8 +3,8 @@
 
 import { ServeTask } from './ServeTask';
 import { ReloadTask } from './ReloadTask';
-import TrustCertTask from './TrustCertTask';
-import UntrustCertTask from './UntrustCertTask';
+import { TrustCertTask } from './TrustCertTask';
+import { UntrustCertTask } from './UntrustCertTask';
 
 export const serve: ServeTask = new ServeTask();
 export const reload: ReloadTask = new ReloadTask();

--- a/libraries/stream-collator/src/Interleaver.ts
+++ b/libraries/stream-collator/src/Interleaver.ts
@@ -41,7 +41,7 @@ enum ITaskOutputStream {
  *
  * @public
  */
-export default class Interleaver {
+export class Interleaver {
   private static _tasks: Map<string, ITaskWriterInfo> = new Map<string, ITaskWriterInfo>();
   private static _activeTask: string = undefined;
   private static _stdout: { write: (text: string) => void } = process.stdout;

--- a/libraries/stream-collator/src/index.ts
+++ b/libraries/stream-collator/src/index.ts
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-export { default as Interleaver } from './Interleaver';
+export { Interleaver } from './Interleaver';
 export { ITaskWriter as ITaskWriter } from './Interleaver';
-export { default as StreamCollator } from './next/StreamCollator';
-export { default as DualTaskStream } from './next/DualTaskStream';
-export { default as PersistentStream } from './next/PersistentStream';
+export { StreamCollator } from './next/StreamCollator';
+export { DualTaskStream } from './next/DualTaskStream';
+export { PersistentStream } from './next/PersistentStream';

--- a/libraries/stream-collator/src/next/DualTaskStream.ts
+++ b/libraries/stream-collator/src/next/DualTaskStream.ts
@@ -6,7 +6,7 @@
 import * as colors from 'colors';
 import * as stream from 'stream';
 
-import PersistentStream from './PersistentStream';
+import { PersistentStream } from './PersistentStream';
 
 /**
  * This is a special type of stream class which has two substreams (stderr and stdout), which you can write to.
@@ -15,7 +15,7 @@ import PersistentStream from './PersistentStream';
  *
  * @public
  */
-export default class DualTaskStream extends stream.Readable implements NodeJS.ReadableStream, NodeJS.EventEmitter {
+export class DualTaskStream extends stream.Readable implements NodeJS.ReadableStream, NodeJS.EventEmitter {
   public stdout: PersistentStream;
   public stderr: PersistentStream;
 

--- a/libraries/stream-collator/src/next/PersistentStream.ts
+++ b/libraries/stream-collator/src/next/PersistentStream.ts
@@ -10,7 +10,7 @@ import * as stream from 'stream';
  *
  * @public
  */
-export default class PersistentStream extends stream.Transform {
+export class PersistentStream extends stream.Transform {
   private _buffer: string[] = [];
 
   constructor(opts?: stream.TransformOptions) {

--- a/libraries/stream-collator/src/next/StreamCollator.ts
+++ b/libraries/stream-collator/src/next/StreamCollator.ts
@@ -35,7 +35,7 @@ class StreamInfo<T extends NodeJS.ReadableStream> {
  *
  * @public
  */
-export default class StreamCollator<T extends NodeJS.ReadableStream>
+export class StreamCollator<T extends NodeJS.ReadableStream>
   extends Stream.Readable implements NodeJS.ReadableStream {
   private _streams: StreamInfo<T>[] = [];
   private _activeStream: StreamInfo<T> = undefined;

--- a/libraries/stream-collator/src/next/test/DualTaskStream.test.ts
+++ b/libraries/stream-collator/src/next/test/DualTaskStream.test.ts
@@ -6,7 +6,7 @@
 import { assert } from 'chai';
 import * as colors from 'colors';
 
-import DualTaskStream from '../DualTaskStream';
+import { DualTaskStream } from '../DualTaskStream';
 
 const helloWorld: string = 'Hello, world!';
 

--- a/libraries/stream-collator/src/next/test/PersistentStream.test.ts
+++ b/libraries/stream-collator/src/next/test/PersistentStream.test.ts
@@ -4,7 +4,7 @@
 /// <reference types="mocha" />
 
 import { assert } from 'chai';
-import PersistentStream from '../PersistentStream';
+import { PersistentStream } from '../PersistentStream';
 
 describe('PersistentStream', () => {
   it('passes through unmodified values', (done: () => void) => {

--- a/libraries/stream-collator/src/next/test/StreamModerator.test.ts
+++ b/libraries/stream-collator/src/next/test/StreamModerator.test.ts
@@ -4,8 +4,8 @@
 /// <reference types="mocha" />
 
 import { assert } from 'chai';
-import StreamCollator from '../StreamCollator';
-import PersistentStream from '../PersistentStream';
+import { StreamCollator } from '../StreamCollator';
+import { PersistentStream } from '../PersistentStream';
 
 let collator: StreamCollator<NodeJS.ReadableStream>;
 let stdout: PersistentStream, taskA: PersistentStream, taskB: PersistentStream;

--- a/libraries/stream-collator/src/test/Interleaver.test.ts
+++ b/libraries/stream-collator/src/test/Interleaver.test.ts
@@ -6,7 +6,7 @@
 import { assert } from 'chai';
 import * as os from 'os';
 
-import Interleaver, { ITaskWriter } from '../Interleaver';
+import { Interleaver, ITaskWriter } from '../Interleaver';
 
 class StringStream {
   private _buffer: string[] = [];

--- a/rush.json
+++ b/rush.json
@@ -1,6 +1,6 @@
 {
-  "rushVersion": "5.0.0-dev.2",
-  "pnpmVersion": "1.35.10",
+  "rushVersion": "5.0.0-dev.9",
+  "pnpmVersion": "1.41.2",
   "nodeSupportedVersionRange": ">=6.9.0 <7.0.0 || >=8.9.4 <9.0.0",
 
   "projectFolderMinDepth": 1,


### PR DESCRIPTION
A while ago we deprecated the `export default` pattern.  This PR fixes up the last few projects that had not been updated yet.  This PR doesn't change the operational behavior of any project.