### PR TITLE
[rush] Add a LockFile to avoid a race condition while bootstrapping rush-lib

### DIFF
--- a/apps/rush-lib/src/utilities/Utilities.ts
+++ b/apps/rush-lib/src/utilities/Utilities.ts
@@ -383,10 +383,8 @@ export class Utilities {
   ): void {
     if (fsx.existsSync(directory)) {
       console.log('Deleting old files from ' + directory);
-      Utilities.dangerouslyDeletePath(directory);
+      fsx.emptyDirSync(directory);
     }
-
-    Utilities.createFolderWithRetry(directory);
 
     const npmPackageJson: IPackageJson = {
       dependencies: {

--- a/apps/rush/src/start.ts
+++ b/apps/rush/src/start.ts
@@ -57,14 +57,16 @@ if (process.argv[2] === RUSH_PURGE_OPTION_NAME) {
   const currentPackageJson: IPackageJson = JsonFile.load(path.join(__dirname, '..', 'package.json'));
 
   // If we're inside a repo folder, and it's requesting a different version, then use the RushVersionManager to
-  //  install it
+  // install it
   if (configuration && configuration.rushVersion !== currentPackageJson.version) {
     const versionSelector: RushVersionSelector = new RushVersionSelector(
       configuration.homeFolder,
       currentPackageJson.version
     );
-    const rushWrapper: () => void = versionSelector.ensureRushVersionInstalled(configuration.rushVersion);
-    rushWrapper();
+    versionSelector.ensureRushVersionInstalled(configuration.rushVersion)
+      .catch((error: Error) => {
+        console.log(colors.red('Error: ' + error.message));
+      });
   } else {
     // Otherwise invoke the rush-lib that came with this rush package
     const isManaged: boolean = !!configuration && configuration.rushVersion === currentPackageJson.version;

--- a/common/changes/@microsoft/rush/pgonzal-rush-locking_2018-05-01-00-24.json
+++ b/common/changes/@microsoft/rush/pgonzal-rush-locking_2018-05-01-00-24.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Add a lock file to avoid race conditions when the Rush version selector is installing rush-lib",
+      "packageName": "@microsoft/rush",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "pgonzal@users.noreply.github.com"
+}


### PR DESCRIPTION
The Rush version selector installs the appropriate version of rush-lib in the global .rush folder, but there was no LockFile.  This could cause two simultaneous installations to overwrite each others' files.