### PR TITLE
[api-extractor] Fix an issue where import statements were not being trimmed

### DIFF
--- a/apps/api-extractor/src/generators/dtsRollup/DtsRollupGenerator.ts
+++ b/apps/api-extractor/src/generators/dtsRollup/DtsRollupGenerator.ts
@@ -229,16 +229,20 @@ export class DtsRollupGenerator {
     // Emit the imports
     for (const dtsEntry of this._dtsEntries) {
       if (dtsEntry.astSymbol.astImport) {
-        const astImport: AstImport = dtsEntry.astSymbol.astImport;
 
-        if (astImport.exportName === '*') {
-          indentedWriter.write(`import * as ${dtsEntry.nameForEmit}`);
-        } else if (dtsEntry.nameForEmit !== astImport.exportName) {
-          indentedWriter.write(`import { ${astImport.exportName} as ${dtsEntry.nameForEmit} }`);
-        } else {
-          indentedWriter.write(`import { ${astImport.exportName} }`);
+        const releaseTag: ReleaseTag = this._getReleaseTagForAstSymbol(dtsEntry.astSymbol);
+        if (this._shouldIncludeReleaseTag(releaseTag, dtsKind)) {
+          const astImport: AstImport = dtsEntry.astSymbol.astImport;
+
+          if (astImport.exportName === '*') {
+            indentedWriter.write(`import * as ${dtsEntry.nameForEmit}`);
+          } else if (dtsEntry.nameForEmit !== astImport.exportName) {
+            indentedWriter.write(`import { ${astImport.exportName} as ${dtsEntry.nameForEmit} }`);
+          } else {
+            indentedWriter.write(`import { ${astImport.exportName} }`);
+          }
+          indentedWriter.writeLine(` from '${astImport.modulePath}';`);
         }
-        indentedWriter.writeLine(` from '${astImport.modulePath}';`);
       }
     }
 
@@ -247,7 +251,6 @@ export class DtsRollupGenerator {
       if (!dtsEntry.astSymbol.astImport) {
 
         const releaseTag: ReleaseTag = this._getReleaseTagForAstSymbol(dtsEntry.astSymbol);
-
         if (this._shouldIncludeReleaseTag(releaseTag, dtsKind)) {
 
           // Emit all the declarations for this entry

--- a/common/changes/@microsoft/api-extractor/pgonzal-ae-trimming-fix_2018-05-01-18-50.json
+++ b/common/changes/@microsoft/api-extractor/pgonzal-ae-trimming-fix_2018-05-01-18-50.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor",
+      "comment": "Fix an issue where the *.d.ts rollup trimming did not trim import statements",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor",
+  "email": "pgonzal@users.noreply.github.com"
+}


### PR DESCRIPTION
Fix a bug where import statements were not being trimmed.  For example:

```
import { Example } from 'example-lib';
```

If `Example` is marked as `@beta` in the other package, then for a public release this import statement should be excluded.