### PR TITLE
Respect process environment when executing "Rush publish"

### DIFF
--- a/apps/rush-lib/src/cli/logic/PublishUtilities.ts
+++ b/apps/rush-lib/src/cli/logic/PublishUtilities.ts
@@ -204,7 +204,8 @@ export class PublishUtilities {
         args,
         workingDirectory,
         environment,
-        false);
+        false,
+        true);
     }
   }
 

--- a/apps/rush-lib/src/utilities/Utilities.ts
+++ b/apps/rush-lib/src/utilities/Utilities.ts
@@ -200,11 +200,15 @@ export class Utilities {
    * The current directory will be set to the specified workingDirectory.
    */
   public static executeCommand(command: string, args: string[], workingDirectory: string,
-    environment?: IEnvironment, suppressOutput: boolean = false): void {
+    environment?: IEnvironment, suppressOutput: boolean = false,
+    keepEnvironment: boolean = false
+  ): void {
 
     Utilities._executeCommandInternal(command, args, workingDirectory,
       suppressOutput ? undefined : [0, 1, 2],
-      environment);
+      environment,
+      keepEnvironment
+    );
   }
 
   /**
@@ -212,11 +216,16 @@ export class Utilities {
    * The current directory will be set to the specified workingDirectory.
    */
   public static executeCommandAndCaptureOutput(command: string, args: string[], workingDirectory: string,
-    environment?: IEnvironment): string {
+    environment?: IEnvironment,
+    keepEnvironment: boolean = false
+  ): string {
 
     const  result: child_process.SpawnSyncReturns<Buffer>
       = Utilities._executeCommandInternal(command, args, workingDirectory,
-        ['pipe', 'pipe', 'pipe'], environment);
+        ['pipe', 'pipe', 'pipe'],
+        environment,
+        keepEnvironment
+      );
 
     return result.stdout.toString();
   }
@@ -460,13 +469,15 @@ export class Utilities {
   private static _executeCommandInternal(
     command: string, args: string[], workingDirectory: string,
     stdio: (string|number)[] | undefined,
-    environment?: IEnvironment): child_process.SpawnSyncReturns<Buffer> {
+    environment?: IEnvironment,
+    keepEnvironment: boolean = false
+  ): child_process.SpawnSyncReturns<Buffer> {
 
     const options: child_process.SpawnSyncOptions = {
       cwd: workingDirectory,
       shell: true,
       stdio: stdio,
-      env: Utilities._createEnvironmentForRushCommand('', environment)
+      env: keepEnvironment ? environment : Utilities._createEnvironmentForRushCommand('', environment)
     };
 
     // This is needed since we specify shell=true below.

--- a/apps/rush-lib/src/utilities/Utilities.ts
+++ b/apps/rush-lib/src/utilities/Utilities.ts
@@ -216,16 +216,11 @@ export class Utilities {
    * The current directory will be set to the specified workingDirectory.
    */
   public static executeCommandAndCaptureOutput(command: string, args: string[], workingDirectory: string,
-    environment?: IEnvironment,
-    keepEnvironment: boolean = false
-  ): string {
+    environment?: IEnvironment): string {
 
     const  result: child_process.SpawnSyncReturns<Buffer>
       = Utilities._executeCommandInternal(command, args, workingDirectory,
-        ['pipe', 'pipe', 'pipe'],
-        environment,
-        keepEnvironment
-      );
+        ['pipe', 'pipe', 'pipe'], environment);
 
     return result.stdout.toString();
   }

--- a/common/changes/@microsoft/rush/qz2017-publish_env_2018-05-01-23-53.json
+++ b/common/changes/@microsoft/rush/qz2017-publish_env_2018-05-01-23-53.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Respect process environment when executing \"Rush publish\"",
+      "packageName": "@microsoft/rush",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "qz2017@users.noreply.github.com"
+}


### PR DESCRIPTION
Rush publish normally needs a special set of npm configuration values. If we do not want to add all those variables as Rush parameters yet, we need "Rush publish" to be able to use the process environment variables. 