### PR TITLE
[rush] Fix an issue creating the "common/local-rush" symlink

### DIFF
--- a/apps/rush-lib/src/cli/logic/InstallManager.ts
+++ b/apps/rush-lib/src/cli/logic/InstallManager.ts
@@ -237,7 +237,7 @@ export class InstallManager {
       try {
         fsx.unlinkSync(localPackageManagerToolFolder);
       } catch (error) {
-        if (error.code !== 'NOENT') {
+        if (error.code !== 'ENOENT') {
           throw error;
         }
       }

--- a/apps/rush-lib/src/cli/logic/InstallManager.ts
+++ b/apps/rush-lib/src/cli/logic/InstallManager.ts
@@ -228,11 +228,20 @@ export class InstallManager {
       // Example: "C:\MyRepo\common\temp\pnpm-local"
       const localPackageManagerToolFolder: string =
         path.join(this._rushConfiguration.commonTempFolder, `${packageManager}-local`);
-      if (fsx.existsSync(localPackageManagerToolFolder)) {
-        fsx.unlinkSync(localPackageManagerToolFolder);
-      }
+
       console.log(os.EOL + 'Symlinking "' + localPackageManagerToolFolder + '"');
       console.log('  --> "' + packageManagerToolFolder + '"');
+
+      // We cannot use fsx.existsSync() to test the existence of a symlink, because it will
+      // return false for broken symlinks.  There is no way to test without catching an exception.
+      try {
+        fsx.unlinkSync(localPackageManagerToolFolder);
+      } catch (error) {
+        if (error.code !== 'NOENT') {
+          throw error;
+        }
+      }
+
       fsx.symlinkSync(packageManagerToolFolder, localPackageManagerToolFolder, 'junction');
 
       lock.release();

--- a/common/changes/@microsoft/rush/pgonzal-fix-install-symlink-issue_2018-05-04-02-19.json
+++ b/common/changes/@microsoft/rush/pgonzal-fix-install-symlink-issue_2018-05-04-02-19.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Fix an issue where the common/local-rush symlink sometimes failed to be recreated",
+      "packageName": "@microsoft/rush",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "pgonzal@users.noreply.github.com"
+}


### PR DESCRIPTION
If the symlink was a broken link (e.g. because the person had deleted their `~/.rush` folder), then Rush failed to create it again.  The person would have to manually delete it.