### PR TITLE
[rush] Add support for RUSH_PREVIEW_VERSION environment variable

### DIFF
--- a/apps/rush-lib/src/cli/logic/InstallManager.ts
+++ b/apps/rush-lib/src/cli/logic/InstallManager.ts
@@ -181,11 +181,11 @@ export class InstallManager {
    */
   public ensureLocalPackageManager(forceReinstall: boolean): Promise<void> {
     // Example: "C:\Users\YourName\.rush"
-    const rushHomeFolder: string = path.join(this._rushConfiguration.homeFolder, '.rush');
+    const rushUserFolder: string = this._rushConfiguration.rushUserFolder;
 
-    if (!fsx.existsSync(rushHomeFolder)) {
-      console.log('Creating ' + rushHomeFolder);
-      fsx.mkdirSync(rushHomeFolder);
+    if (!fsx.existsSync(rushUserFolder)) {
+      console.log('Creating ' + rushUserFolder);
+      fsx.mkdirSync(rushUserFolder);
     }
 
     const packageManager: PackageManager = this._rushConfiguration.packageManager;
@@ -193,14 +193,14 @@ export class InstallManager {
 
     const packageManagerAndVersion: string = `${packageManager}-${packageManagerVersion}`;
     // Example: "C:\Users\YourName\.rush\pnpm-1.2.3"
-    const packageManagerToolFolder: string = path.join(rushHomeFolder, packageManagerAndVersion);
+    const packageManagerToolFolder: string = path.join(rushUserFolder, packageManagerAndVersion);
 
     const packageManagerMarker: LastInstallFlag = new LastInstallFlag(packageManagerToolFolder, {
       node: process.versions.node
     });
 
     console.log(`Trying to acquire lock for ${packageManagerAndVersion}`);
-    return LockFile.acquire(rushHomeFolder, packageManagerAndVersion).then((lock: LockFile) => {
+    return LockFile.acquire(rushUserFolder, packageManagerAndVersion).then((lock: LockFile) => {
       console.log(`Acquired lock for ${packageManagerAndVersion}`);
 
       if (!packageManagerMarker.isValid() || forceReinstall || lock.dirtyWhenAcquired) {

--- a/apps/rush-lib/src/data/EnvironmentConfiguration.ts
+++ b/apps/rush-lib/src/data/EnvironmentConfiguration.ts
@@ -5,6 +5,7 @@ import * as os from 'os';
 
 /**
  * Names of environment variables used by Rush.
+ * @public
  */
 export const enum EnvironmentVariableNames {
   /**
@@ -58,6 +59,9 @@ export class EnvironmentConfiguration {
             EnvironmentConfiguration._rushTempFolderOverride = value;
             break;
 
+          case EnvironmentVariableNames.RUSH_PREVIEW_VERSION:
+            // Handled by @microsoft/rush front end
+            break;
           default:
             unknownEnvVariables.push(envVarName);
             break;

--- a/apps/rush-lib/src/data/EnvironmentConfiguration.ts
+++ b/apps/rush-lib/src/data/EnvironmentConfiguration.ts
@@ -4,6 +4,24 @@
 import * as os from 'os';
 
 /**
+ * Names of environment variables used by Rush.
+ */
+export const enum EnvironmentVariableNames {
+  /**
+   * This variable overrides the temporary folder used by Rush.
+   * The default value is "common/temp" under the repoistory root.
+   */
+  RUSH_TEMP_FOLDER = 'RUSH_TEMP_FOLDER',
+
+  /**
+   * This variable overrides the version of Rush that will be installed by
+   * the version selector.  The default value is determined by the "rushVersion"
+   * field from rush.json.
+   */
+  RUSH_PREVIEW_VERSION = 'RUSH_PREVIEW_VERSION'
+}
+
+/**
  * Provides Rush-specific environment variable data. All Rush environment variables must start with "RUSH_". This class
  * is designed to be used by RushConfiguration.
  *
@@ -36,7 +54,7 @@ export class EnvironmentConfiguration {
         // Environment variables are only case-insensitive on Windows
         const normalizedEnvVarName: string = os.platform() === 'win32' ? envVarName.toUpperCase() : envVarName;
         switch (normalizedEnvVarName) {
-          case 'RUSH_TEMP_FOLDER':
+          case EnvironmentVariableNames.RUSH_TEMP_FOLDER:
             EnvironmentConfiguration._rushTempFolderOverride = value;
             break;
 

--- a/apps/rush-lib/src/data/RushConfiguration.ts
+++ b/apps/rush-lib/src/data/RushConfiguration.ts
@@ -14,6 +14,7 @@ import { EventHooks } from './EventHooks';
 import { VersionPolicyConfiguration } from './VersionPolicyConfiguration';
 import { EnvironmentConfiguration } from './EnvironmentConfiguration';
 import { CommonVersionsConfiguration } from './CommonVersionsConfiguration';
+import { Utilities } from '../utilities/Utilities';
 
 const MINIMUM_SUPPORTED_RUSH_JSON_VERSION: string = '0.0.0';
 
@@ -125,7 +126,6 @@ export class RushConfiguration {
   private _npmTmpFolder: string;
   private _committedShrinkwrapFilename: string;
   private _tempShrinkwrapFilename: string;
-  private _homeFolder: string;
   private _rushUserFolder: string;
   private _rushLinkJsonFilename: string;
   private _packageManagerToolVersion: string;
@@ -244,21 +244,6 @@ export class RushConfiguration {
     }
 
     return undefined;
-  }
-
-  /**
-   * Get the user's home directory. On windows this looks something like "C:\users\username\" and on UNIX
-   * this looks something like "/usr/username/"
-   */
-  public static getHomeDirectory(): string {
-    const unresolvedUserFolder: string | undefined
-      = process.env[(process.platform === 'win32') ? 'USERPROFILE' : 'HOME'];
-    const homeFolder: string = path.resolve(unresolvedUserFolder);
-    if (!fsx.existsSync(homeFolder)) {
-      throw new Error('Unable to determine the current user\'s home directory');
-    }
-
-    return homeFolder;
   }
 
   /**
@@ -455,14 +440,6 @@ export class RushConfiguration {
    */
   public get tempShrinkwrapFilename(): string {
     return this._tempShrinkwrapFilename;
-  }
-
-  /**
-   * The absolute path to the home directory for the current user.  On Windows,
-   * it would be something like "C:\Users\YourName".
-   */
-  public get homeFolder(): string {
-    return this._homeFolder;
   }
 
   /**
@@ -687,8 +664,7 @@ export class RushConfiguration {
     this._pnpmStoreFolder = path.resolve(path.join(this._commonTempFolder, 'pnpm-store'));
 
     this._changesFolder = path.join(this._commonFolder, RushConstants.changeFilesFolderName);
-    this._homeFolder = RushConfiguration.getHomeDirectory();
-    this._rushUserFolder = path.join(this._homeFolder, '.rush');
+    this._rushUserFolder = path.join(Utilities.getHomeDirectory(), '.rush');
 
     this._rushLinkJsonFilename = path.join(this._commonTempFolder, 'rush-link.json');
 

--- a/apps/rush-lib/src/index.ts
+++ b/apps/rush-lib/src/index.ts
@@ -16,6 +16,10 @@ export {
 } from './data/RushConfiguration';
 
 export {
+  EnvironmentVariableNames
+} from './data/EnvironmentConfiguration';
+
+export {
   RushConfigurationProject
 } from './data/RushConfigurationProject';
 

--- a/apps/rush-lib/src/utilities/Utilities.ts
+++ b/apps/rush-lib/src/utilities/Utilities.ts
@@ -22,6 +22,21 @@ export interface IEnvironment {
  */
 export class Utilities {
   /**
+   * Get the user's home directory. On windows this looks something like "C:\users\username\" and on UNIX
+   * this looks something like "/usr/username/"
+   */
+  public static getHomeDirectory(): string {
+    const unresolvedUserFolder: string | undefined
+      = process.env[(process.platform === 'win32') ? 'USERPROFILE' : 'HOME'];
+    const homeFolder: string = path.resolve(unresolvedUserFolder);
+    if (!fsx.existsSync(homeFolder)) {
+      throw new Error('Unable to determine the current user\'s home directory');
+    }
+
+    return homeFolder;
+  }
+
+  /**
    * NodeJS equivalent of performance.now().
    */
   public static getTimeInMs(): number {

--- a/apps/rush/src/MinimalRushConfiguration.ts
+++ b/apps/rush/src/MinimalRushConfiguration.ts
@@ -15,7 +15,6 @@ interface IMinimalRushConfigurationJson {
  */
 export class MinimalRushConfiguration {
   private _rushVersion: string;
-  private _homeFolder: string;
 
   public static loadFromDefaultLocation(): MinimalRushConfiguration | undefined {
     const rushJsonLocation: string | undefined = RushConfiguration.tryFindRushJsonLocation();
@@ -37,7 +36,6 @@ export class MinimalRushConfiguration {
 
   private constructor(minimalRushConfigurationJson: IMinimalRushConfigurationJson) {
     this._rushVersion = minimalRushConfigurationJson.rushVersion || minimalRushConfigurationJson.rushMinimumVersion;
-    this._homeFolder = RushConfiguration.getHomeDirectory();
   }
 
   /**
@@ -47,13 +45,5 @@ export class MinimalRushConfiguration {
    */
   public get rushVersion(): string {
     return this._rushVersion;
-  }
-
-  /**
-   * The absolute path to the home directory for the current user. On Windows, it would be something
-   *  like "C:\Users\YourName".
-   */
-  public get homeFolder(): string {
-    return this._homeFolder;
   }
 }

--- a/apps/rush/src/RushVersionSelector.ts
+++ b/apps/rush/src/RushVersionSelector.ts
@@ -16,8 +16,8 @@ export class RushVersionSelector {
   private _rushDirectory: string;
   private _currentPackageVersion: string;
 
-  constructor(homeDirectory: string, currentPackageVersion: string) {
-    this._rushDirectory = path.join(homeDirectory, '.rush');
+  constructor(currentPackageVersion: string) {
+    this._rushDirectory = path.join(Utilities.getHomeDirectory(), '.rush');
     this._currentPackageVersion = currentPackageVersion;
   }
 

--- a/apps/rush/src/start.ts
+++ b/apps/rush/src/start.ts
@@ -49,31 +49,46 @@ let rushVersionToLoad: string | undefined = undefined;
 
 const previewVersion: string | undefined = process.env[EnvironmentVariableNames.RUSH_PREVIEW_VERSION];
 
+function padEnd(s: string, length: number): string {
+  let result: string = s;
+  while (result.length < length) {
+    result += ' ';
+  }
+  return result;
+}
+
 if (previewVersion) {
   if (!semver.valid(previewVersion, false)) {
-    console.error(colors.red(`Invalid value for RUSH_PREVIEW_VERSION: "${previewVersion}"`));
+    console.error(colors.red(`Invalid value for RUSH_PREVIEW_VERSION environment variable: "${previewVersion}"`));
     process.exit(1);
   }
 
   rushVersionToLoad = previewVersion;
 
-  console.error(colors.yellow(
-    os.EOL +
-    `* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *` + os.EOL +
-    `  WARNING! THE "RUSH_PREVIEW_VERSION" ENVIRONMENT VARIABLE IS SET.` + os.EOL + os.EOL +
-    `  You are previewing Rush version:        ${previewVersion}`));
+  const lines: string[] = [];
+  lines.push(
+    `*********************************************************************`,
+    `* WARNING! THE "RUSH_PREVIEW_VERSION" ENVIRONMENT VARIABLE IS SET.  *`,
+    `*                                                                   *`,
+    `* You are previewing Rush version:        ${padEnd(previewVersion, 25)} *`
+  );
 
   if (configuration) {
-    console.error(colors.yellow(
-      `  The rush.json configuration asks for:   ${configuration.rushVersion}`));
+    lines.push(
+      `* The rush.json configuration asks for:   ${padEnd(configuration.rushVersion, 25)} *`
+    );
   }
 
-  console.error(colors.yellow(os.EOL +
-    `  To restore the normal behavior, unset the RUSH_PREVIEW_VERSION` + os.EOL +
-    `  environment variable.` + os.EOL +
-    `* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *` +
-    os.EOL
-  ));
+  lines.push(
+    `*                                                                   *`,
+    `* To restore the normal behavior, unset the RUSH_PREVIEW_VERSION    *`,
+    `* environment variable.                                             *`,
+    `*********************************************************************`
+  );
+
+  console.error(lines
+    .map(line => colors.black(colors.bgYellow(line)))
+    .join(os.EOL));
 
 } else if (configuration) {
   rushVersionToLoad = configuration.rushVersion;

--- a/common/changes/@microsoft/rush/pgonzal-rush-preview-variable_2018-05-11-23-39.json
+++ b/common/changes/@microsoft/rush/pgonzal-rush-preview-variable_2018-05-11-23-39.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Remove unused RushConfiguration.homeFolder API",
+      "packageName": "@microsoft/rush",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush/pgonzal-rush-preview-variable_2018-05-12-00-20.json
+++ b/common/changes/@microsoft/rush/pgonzal-rush-preview-variable_2018-05-12-00-20.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Add RUSH_PREVIEW_VERSION environment variable for piloting new versions of Rush",
+      "packageName": "@microsoft/rush",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/reviews/api/rush-lib.api.ts
+++ b/common/reviews/api/rush-lib.api.ts
@@ -174,11 +174,9 @@ class RushConfiguration {
   readonly eventHooks: EventHooks;
   findProjectByShorthandName(shorthandProjectName: string): RushConfigurationProject | undefined;
   findProjectByTempName(tempProjectName: string): RushConfigurationProject | undefined;
-  static getHomeDirectory(): string;
   getProjectByName(projectName: string): RushConfigurationProject | undefined;
   readonly gitAllowedEmailRegExps: string[];
   readonly gitSampleEmail: string;
-  readonly homeFolder: string;
   readonly hotfixChangeEnabled: boolean;
   static loadFromConfigurationFile(rushJsonFilename: string): RushConfiguration;
   // (undocumented)

--- a/common/reviews/api/rush-lib.api.ts
+++ b/common/reviews/api/rush-lib.api.ts
@@ -93,6 +93,12 @@ class CommonVersionsConfiguration {
   readonly xstitchPreferredVersions: Map<string, string>;
 }
 
+// @public
+enum EnvironmentVariableNames {
+  RUSH_PREVIEW_VERSION = "RUSH_PREVIEW_VERSION",
+  RUSH_TEMP_FOLDER = "RUSH_TEMP_FOLDER"
+}
+
 // @beta
 enum Event {
   postRushBuild = 4,


### PR DESCRIPTION
To test out a new Rush version, developers can now set an environment variable RUSH_PREVIEW_VERSION.

Rush will display a warning banner like this:

```
* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
  WARNING! THE "RUSH_PREVIEW_VERSION" ENVIRONMENT VARIABLE IS SET.

  You are previewing Rush version:        5.0.0-dev.16
  The rush.json configuration asks for:   5.0.0-dev.17

  To restore the normal behavior, unset the RUSH_PREVIEW_VERSION
  environment variable.
* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
```