### PR TITLE
[api-extractor] Add AEDoc tags for @sealed/@virtual/@override

### DIFF
--- a/apps/api-documenter/src/yaml/YamlDocumenter.ts
+++ b/apps/api-documenter/src/yaml/YamlDocumenter.ts
@@ -16,7 +16,8 @@ import {
   IApiEnumMember,
   IApiClass,
   IApiInterface,
-  Markup
+  Markup,
+  ApiItem
 } from '@microsoft/api-extractor';
 
 import { DocItemSet, DocItem, DocItemKind, IDocItemSetResolveResult } from '../utils/DocItemSet';
@@ -300,6 +301,20 @@ export class YamlDocumenter {
     if (apiStructure.implements) {
       yamlItem.implements = [ apiStructure.implements ];
     }
+
+    if (apiStructure.isSealed) {
+      let sealedMessage: string;
+      if (docItem.kind === DocItemKind.Class) {
+        sealedMessage = 'This class is marked as `@sealed`. Subclasses should not extend it.';
+      } else {
+        sealedMessage = 'This interface is marked as `@sealed`. Other interfaces should not extend it.';
+      }
+      if (!yamlItem.remarks) {
+        yamlItem.remarks = sealedMessage;
+      } else {
+        yamlItem.remarks += sealedMessage + '\n\n' + yamlItem.remarks;
+      }
+    }
   }
 
   private _populateYamlMethod(yamlItem: Partial<IYamlItem>, docItem: DocItem): void {
@@ -307,7 +322,7 @@ export class YamlDocumenter {
     yamlItem.name = Utilities.getConciseSignature(docItem.name, apiMethod);
 
     const syntax: IYamlSyntax = {
-      content: apiMethod.signature
+      content: this._formatCommentedAnnotations(apiMethod.signature, apiMethod)
     };
     yamlItem.syntax = syntax;
 
@@ -343,8 +358,9 @@ export class YamlDocumenter {
     const apiProperty: IApiProperty = docItem.apiItem as IApiProperty;
 
     const syntax: IYamlSyntax = {
-      content: apiProperty.signature
+      content: this._formatCommentedAnnotations(apiProperty.signature, apiProperty)
     };
+
     yamlItem.syntax = syntax;
 
     if (apiProperty.type) {
@@ -395,6 +411,27 @@ export class YamlDocumenter {
     if (schema) {
       schema.validateObject(dataObject, filePath);
     }
+  }
+
+  // Prepends a string such as "/** @sealed @override */" to an item signature where appropriate.
+  private _formatCommentedAnnotations(signature: string, apiItem: ApiItem): string {
+    const apiItemTags: { isSealed?: boolean, isVirtual?: boolean, isOverride?: boolean }
+      = apiItem as any; // tslint:disable-line:no-any
+
+    const annotations: string[] = [];
+    if (apiItemTags.isSealed) {
+      annotations.push('@sealed');
+    }
+    if (apiItemTags.isVirtual) {
+      annotations.push('@virtual');
+    }
+    if (apiItemTags.isOverride) {
+      annotations.push('@override');
+    }
+    if (annotations.length === 0) {
+      return signature;
+    }
+    return '/** ' + annotations.join(' ') + ' */\n' + signature;
   }
 
   /**

--- a/apps/api-documenter/src/yaml/YamlDocumenter.ts
+++ b/apps/api-documenter/src/yaml/YamlDocumenter.ts
@@ -16,8 +16,7 @@ import {
   IApiEnumMember,
   IApiClass,
   IApiInterface,
-  Markup,
-  ApiItem
+  Markup
 } from '@microsoft/api-extractor';
 
 import { DocItemSet, DocItem, DocItemKind, IDocItemSetResolveResult } from '../utils/DocItemSet';
@@ -414,18 +413,15 @@ export class YamlDocumenter {
   }
 
   // Prepends a string such as "/** @sealed @override */" to an item signature where appropriate.
-  private _formatCommentedAnnotations(signature: string, apiItem: ApiItem): string {
-    const apiItemTags: { isSealed?: boolean, isVirtual?: boolean, isOverride?: boolean }
-      = apiItem as any; // tslint:disable-line:no-any
-
+  private _formatCommentedAnnotations(signature: string, apiItem: IApiMethod | IApiProperty): string {
     const annotations: string[] = [];
-    if (apiItemTags.isSealed) {
+    if (apiItem.isSealed) {
       annotations.push('@sealed');
     }
-    if (apiItemTags.isVirtual) {
+    if (apiItem.isVirtual) {
       annotations.push('@virtual');
     }
-    if (apiItemTags.isOverride) {
+    if (apiItem.isOverride) {
       annotations.push('@override');
     }
     if (annotations.length === 0) {

--- a/apps/api-documenter/src/yaml/YamlDocumenter.ts
+++ b/apps/api-documenter/src/yaml/YamlDocumenter.ts
@@ -312,7 +312,7 @@ export class YamlDocumenter {
       if (!yamlItem.remarks) {
         yamlItem.remarks = sealedMessage;
       } else {
-        yamlItem.remarks += sealedMessage + '\n\n' + yamlItem.remarks;
+        yamlItem.remarks = sealedMessage + '\n\n' + yamlItem.remarks;
       }
     }
   }

--- a/apps/api-extractor/src/aedoc/ApiDocumentation.ts
+++ b/apps/api-extractor/src/aedoc/ApiDocumentation.ts
@@ -184,6 +184,11 @@ export class ApiDocumentation {
     this.reportError = errorLogger;
     this.parameters = {};
     this.warnings = warnings;
+
+    this.isSealed = false;
+    this.isVirtual = false;
+    this.isOverride = false;
+
     this._parseDocs();
   }
 

--- a/apps/api-extractor/src/aedoc/ApiDocumentation.ts
+++ b/apps/api-extractor/src/aedoc/ApiDocumentation.ts
@@ -41,12 +41,6 @@ export interface IAedocParameter {
 }
 
 export class ApiDocumentation {
-  /**
-   * Match AEDoc block tags and inline tags
-   * Example "@a @b@c d@e @f {whatever} {@link a} { @something } \@g" => ["@a", "@f", "{@link a}", "{ @something }"]
-   */
-  public static readonly _aedocTagsRegex: RegExp = /{\s*@(\\{|\\}|[^{}])*}|(?:^|\s)(\@[a-z_]+)(?=\s|$)/gi;
-
   // For guidance about using these tags, please see this documentation:
   // https://github.com/Microsoft/web-build-tools/wiki/API-Extractor-~-AEDoc-tags
   private static _allowedRegularAedocTags: string[] = [
@@ -78,21 +72,6 @@ export class ApiDocumentation {
    * Example: "This is a summary. \{\@link a\} \@remarks These are remarks."
    */
   public originalAedoc: string;
-
-  /**
-   * The docComment text string split into an array of ITokenItems.  The tokens are essentially either
-   * AEDoc tags (which start with the "@" character) or substrings containing the
-   * remaining text.  The array can be empty, but not undefined.
-   * Example:
-   * docComment       = "Example Function\n@returns the number of items\n@internal  "
-   * docCommentTokens = [
-   *  {tokenType: 'text', parameter: 'Example Function\n'},
-   *  {tokenType: '\@returns', parameter: ''}
-   *  {tokenType: 'text', parameter: 'the number of items\n'}
-   *  {tokenType: '@internal', parameter: ''}
-   * ];
-   */
-  public docCommentTokens: Token[];
 
    /**
    * docCommentTokens that are parsed into Doc Elements.
@@ -131,23 +110,17 @@ export class ApiDocumentation {
    * True if the "\@preapproved" tag was specified.
    * Indicates that this internal API is exempt from further reviews.
    */
-  public preapproved?: boolean;
+  public preapproved: boolean | undefined;
 
   /**
    * True if the "\@packagedocumentation" tag was specified.
    */
-  public isPackageDocumentation?: boolean;
+  public isPackageDocumentation: boolean | undefined;
 
-  public deprecated?: string;
-  public internalremarks?: string;
-  public paramDocs?: Map<string, string>;
-  public returns?: string;
-  public see?: string[];
-  public isDocBeta?: boolean;
-  public isDocInherited?: boolean;
-  public isDocInheritedDeprecated?: boolean;
-  public isOverride?: boolean;
-  public hasReadOnlyTag?: boolean;
+  public isDocBeta: boolean | undefined;
+  public isDocInherited: boolean | undefined;
+  public isDocInheritedDeprecated: boolean | undefined;
+  public hasReadOnlyTag: boolean | undefined;
   public warnings: string[];
 
   /**

--- a/apps/api-extractor/src/aedoc/ApiDocumentation.ts
+++ b/apps/api-extractor/src/aedoc/ApiDocumentation.ts
@@ -50,6 +50,7 @@ export class ApiDocumentation {
     '@betadocumentation',
     '@internal',
     '@internalremarks',
+    '@override',
     '@packagedocumentation',
     '@param',
     '@preapproved',
@@ -57,7 +58,9 @@ export class ApiDocumentation {
     '@returns',
     '@deprecated',
     '@readonly',
-    '@remarks'
+    '@remarks',
+    '@sealed',
+    '@virtual'
   ];
 
   private static _allowedInlineAedocTags: string[] = [
@@ -122,6 +125,21 @@ export class ApiDocumentation {
   public isDocInheritedDeprecated: boolean | undefined;
   public hasReadOnlyTag: boolean | undefined;
   public warnings: string[];
+
+  /**
+   * Whether the "\@sealed" AEDoc tag was specified.
+   */
+  public isSealed: boolean;
+
+  /**
+   * Whether the "\@virtual" AEDoc tag was specified.
+   */
+  public isVirtual: boolean;
+
+  /**
+   * Whether the "\@override" AEDoc tag was specified.
+   */
+  public isOverride: boolean;
 
   /**
    * A function type interface that abstracts away resolving
@@ -275,6 +293,18 @@ export class ApiDocumentation {
           case '@betadocumentation':
             tokenizer.getToken();
             this.isDocBeta = true;
+            break;
+          case '@sealed':
+            tokenizer.getToken();
+            this.isSealed = true;
+            break;
+         case '@virtual':
+            tokenizer.getToken();
+            this.isVirtual = true;
+            break;
+          case '@override':
+            tokenizer.getToken();
+            this.isOverride = true;
             break;
           default:
             tokenizer.getToken();

--- a/apps/api-extractor/src/aedoc/ApiDocumentation.ts
+++ b/apps/api-extractor/src/aedoc/ApiDocumentation.ts
@@ -350,6 +350,14 @@ export class ApiDocumentation {
       this.reportError('The @preapproved tag may only be applied to @internal definitions');
       this.preapproved = false;
     }
+
+    if (this.isSealed && this.isVirtual) {
+      this.reportError('The @sealed and @virtual tags may not be used together');
+    }
+
+    if (this.isVirtual && this.isOverride) {
+      this.reportError('The @virtual and @override tags may not be used together');
+    }
   }
 
   protected _parseParam(tokenizer: Tokenizer): IAedocParameter | undefined {

--- a/apps/api-extractor/src/api/ApiItem.ts
+++ b/apps/api-extractor/src/api/ApiItem.ts
@@ -157,6 +157,21 @@ export interface IApiProperty extends IApiBaseDefinition {
   isStatic: boolean;
 
   /**
+   * Indicates that the item was marked as "\@sealed" and must not be extended.
+   */
+  isSealed: boolean;
+
+  /**
+   * Indicates that the item was marked as "\@virtual" and may be extended.
+   */
+  isVirtual: boolean;
+
+  /**
+   * Indicates that the item was marked as "\@override" and is overriding a base definition.
+   */
+  isOverride: boolean;
+
+  /**
    * The data type of this property
    */
   type: string;
@@ -191,6 +206,21 @@ export interface IApiMethod extends IApiBaseDefinition {
    * for a class member, whether it is static
    */
   isStatic: boolean;
+
+  /**
+   * Indicates that the item was marked as "\@sealed" and must not be extended.
+   */
+  isSealed: boolean;
+
+  /**
+   * Indicates that the item was marked as "\@virtual" and may be extended.
+   */
+  isVirtual: boolean;
+
+  /**
+   * Indicates that the item was marked as "\@override" and is overriding a base definition.
+   */
+  isOverride: boolean;
 
   /**
    * a mapping of parameter name to IApiParameter
@@ -246,6 +276,21 @@ export interface IApiConstructor extends IApiBaseDefinition {
   signature: string;
 
   /**
+   * Indicates that the item was marked as "\@sealed" and must not be extended.
+   */
+  isSealed: boolean;
+
+  /**
+   * Indicates that the item was marked as "\@virtual" and may be extended.
+   */
+  isVirtual: boolean;
+
+  /**
+   * Indicates that the item was marked as "\@override" and is overriding a base definition.
+   */
+  isOverride: boolean;
+
+  /**
    * parameters of the function
    */
   parameters: IApiNameMap<IApiParameter>;
@@ -279,6 +324,11 @@ export interface IApiClass extends IApiBaseDefinition {
    * Generic type parameters for this class
    */
   typeParameters?: string[];
+
+  /**
+   * Indicates that the item was marked as "\@sealed" and must not be extended.
+   */
+  isSealed: boolean;
 }
 
 /**
@@ -336,6 +386,11 @@ export interface IApiInterface extends IApiBaseDefinition {
    * Generic type parameters for this interface
    */
   typeParameters?: string[];
+
+  /**
+   * Indicates that the item was marked as "\@sealed" and must not be extended.
+   */
+  isSealed: boolean;
 }
 
 /**

--- a/apps/api-extractor/src/api/api-json.schema.json
+++ b/apps/api-extractor/src/api/api-json.schema.json
@@ -421,6 +421,18 @@
           "description": "If present, indicates that the item is deprecated and describes the recommended alternative",
           "type": "array",
           "items": { "$ref": "#/definitions/markupBasicElement" }
+        },
+        "isSealed": {
+          "description": "If present, indicates that the item was marked as \"@sealed\" and must not be extended",
+          "type": "boolean"
+        },
+        "isVirtual": {
+          "description": "If present, indicates that the item was marked as \"@virtual\" and may be extended",
+          "type": "boolean"
+        },
+        "isOverride": {
+          "description": "If present, indicates that the item was marked as \"@override\" and is overriding a base definition",
+          "type": "boolean"
         }
       },
       "additionalProperties": false,
@@ -480,6 +492,18 @@
           "description": "If present, indicates that the item is deprecated and describes the recommended alternative",
           "type": "array",
           "items": { "$ref": "#/definitions/markupBasicElement" }
+        },
+        "isSealed": {
+          "description": "If present, indicates that the item was marked as \"@sealed\" and must not be extended",
+          "type": "boolean"
+        },
+        "isVirtual": {
+          "description": "If present, indicates that the item was marked as \"@virtual\" and may be extended",
+          "type": "boolean"
+        },
+        "isOverride": {
+          "description": "If present, indicates that the item was marked as \"@override\" and is overriding a base definition",
+          "type": "boolean"
         }
       },
       "additionalProperties": false,
@@ -633,6 +657,18 @@
           "description": "If present, indicates that the item is deprecated and describes the recommended alternative",
           "type": "array",
           "items": { "$ref": "#/definitions/markupBasicElement" }
+        },
+        "isSealed": {
+          "description": "If present, indicates that the item was marked as \"@sealed\" and must not be extended",
+          "type": "boolean"
+        },
+        "isVirtual": {
+          "description": "If present, indicates that the item was marked as \"@virtual\" and may be extended",
+          "type": "boolean"
+        },
+        "isOverride": {
+          "description": "If present, indicates that the item was marked as \"@override\" and is overriding a base definition",
+          "type": "boolean"
         }
       },
       "additionalProperties": false,
@@ -791,6 +827,10 @@
           "description": "If present, indicates that the item is deprecated and describes the recommended alternative",
           "type": "array",
           "items": { "$ref": "#/definitions/markupBasicElement" }
+        },
+        "isSealed": {
+          "description": "If present, indicates that the item was marked as \"@sealed\" and must not be extended",
+          "type": "boolean"
         }
       },
       "additionalProperties": false,
@@ -943,6 +983,10 @@
           "description": "If present, indicates that the item is deprecated and describes the recommended alternative",
           "type": "array",
           "items": { "$ref": "#/definitions/markupBasicElement" }
+        },
+        "isSealed": {
+          "description": "If present, indicates that the item was marked as \"@sealed\" and must not be extended",
+          "type": "boolean"
         }
       },
       "additionalProperties": false,

--- a/apps/api-extractor/src/generators/ApiFileGenerator.ts
+++ b/apps/api-extractor/src/generators/ApiFileGenerator.ts
@@ -190,41 +190,47 @@ export class ApiFileGenerator extends AstItemVisitor {
     if (astItem instanceof AstPackage && !astItem.documentation.summary.length) {
       lines.push('(No @packagedocumentation comment for this package)');
     } else {
-      let footer: string = '';
+      const footerParts: string[] = [];
       switch (astItem.documentation.releaseTag) {
         case ReleaseTag.Internal:
-          footer += '@internal';
+          footerParts.push('@internal');
           break;
         case ReleaseTag.Alpha:
-          footer += '@alpha';
+          footerParts.push('@alpha');
           break;
         case ReleaseTag.Beta:
-          footer += '@beta';
+          footerParts.push('@beta');
           break;
         case ReleaseTag.Public:
-          footer += '@public';
+          footerParts.push('@public');
           break;
+      }
+
+      if (astItem.documentation.isSealed) {
+        footerParts.push('@sealed');
+      }
+
+      if (astItem.documentation.isVirtual) {
+        footerParts.push('@virtual');
+      }
+
+      if (astItem.documentation.isSealed) {
+        footerParts.push('@override');
       }
 
       // deprecatedMessage is initialized by default,
       // this ensures it has contents before adding '@deprecated'
       if (astItem.documentation.deprecatedMessage.length > 0) {
-        if (footer) {
-          footer += ' ';
-        }
-        footer += '@deprecated';
+        footerParts.push('@deprecated');
       }
 
       // If we are anywhere inside a TypeLiteral, _insideTypeLiteral is greater than 0
       if (this._insideTypeLiteral === 0 && astItem.needsDocumentation) {
-        if (footer) {
-          footer += ' ';
-        }
-        footer += '(undocumented)';
+        footerParts.push('(undocumented)');
       }
 
-      if (footer) {
-        lines.push(footer);
+      if (footerParts.length > 0) {
+        lines.push(footerParts.join(' '));
       }
     }
 

--- a/apps/api-extractor/src/generators/ApiFileGenerator.ts
+++ b/apps/api-extractor/src/generators/ApiFileGenerator.ts
@@ -214,7 +214,7 @@ export class ApiFileGenerator extends AstItemVisitor {
         footerParts.push('@virtual');
       }
 
-      if (astItem.documentation.isSealed) {
+      if (astItem.documentation.isOverride) {
         footerParts.push('@override');
       }
 

--- a/apps/api-extractor/src/generators/ApiJsonGenerator.ts
+++ b/apps/api-extractor/src/generators/ApiJsonGenerator.ts
@@ -95,6 +95,13 @@ export class ApiJsonGenerator extends AstItemVisitor {
       remarks: astStructuredType.documentation.remarks || [],
       isBeta: astStructuredType.inheritedReleaseTag === ReleaseTag.Beta
     };
+
+    // Type literals don't support isSealed
+    if (astStructuredType.kind === AstItemKind.Class || astStructuredType.kind === AstItemKind.Interface) {
+      // tslint:disable-next-line:no-any
+      (structureNode as any).isSealed = !!astStructuredType.documentation.isSealed;
+    }
+
     refObject![astStructuredType.name] = structureNode;
 
     ApiJsonGenerator._methodCounter = 0;
@@ -242,7 +249,10 @@ export class ApiJsonGenerator extends AstItemVisitor {
       deprecatedMessage: astProperty.inheritedDeprecatedMessage || [],
       summary: astProperty.documentation.summary || [],
       remarks: astProperty.documentation.remarks || [],
-      isBeta: astProperty.inheritedReleaseTag === ReleaseTag.Beta
+      isBeta: astProperty.inheritedReleaseTag === ReleaseTag.Beta,
+      isSealed: !!astProperty.documentation.isSealed,
+      isVirtual: !!astProperty.documentation.isVirtual,
+      isOverride: !!astProperty.documentation.isOverride
     };
 
     refObject![astProperty.name] = newNode;
@@ -295,8 +305,11 @@ export class ApiJsonGenerator extends AstItemVisitor {
         deprecatedMessage: astMethod.inheritedDeprecatedMessage || [],
         summary: astMethod.documentation.summary || [],
         remarks: astMethod.documentation.remarks || [],
-        isBeta: astMethod.inheritedReleaseTag === ReleaseTag.Beta
-      };
+        isBeta: astMethod.inheritedReleaseTag === ReleaseTag.Beta,
+        isSealed: !!astMethod.documentation.isSealed,
+        isVirtual: !!astMethod.documentation.isVirtual,
+        isOverride: !!astMethod.documentation.isOverride
+        };
     }
 
     refObject![astMethod.name] = newNode;

--- a/common/changes/@microsoft/api-documenter/pgonzal-aedoc-decorators_2018-05-14-22-55.json
+++ b/common/changes/@microsoft/api-documenter/pgonzal-aedoc-decorators_2018-05-14-22-55.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-documenter",
+      "comment": "Add support for new AEDoc tags @sealed, @virtual, and @override",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@microsoft/api-documenter",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/api-extractor/pgonzal-aedoc-decorators_2018-05-14-22-54.json
+++ b/common/changes/@microsoft/api-extractor/pgonzal-aedoc-decorators_2018-05-14-22-54.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor",
+      "comment": "Add support for new AEDoc tags @sealed, @virtual, and @override",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/reviews/api/api-extractor.api.ts
+++ b/common/reviews/api/api-extractor.api.ts
@@ -49,6 +49,7 @@ interface IApiBaseDefinition {
 interface IApiClass extends IApiBaseDefinition {
   extends?: string;
   implements?: string;
+  isSealed: boolean;
   kind: 'class';
   members: IApiNameMap<ApiMember>;
   typeParameters?: string[];
@@ -56,6 +57,9 @@ interface IApiClass extends IApiBaseDefinition {
 
 // @alpha
 interface IApiConstructor extends IApiBaseDefinition {
+  isOverride: boolean;
+  isSealed: boolean;
+  isVirtual: boolean;
   kind: 'constructor';
   parameters: IApiNameMap<IApiParameter>;
   signature: string;
@@ -87,6 +91,7 @@ interface IApiFunction extends IApiBaseDefinition {
 interface IApiInterface extends IApiBaseDefinition {
   extends?: string;
   implements?: string;
+  isSealed: boolean;
   kind: 'interface';
   members: IApiNameMap<ApiMember>;
   typeParameters?: string[];
@@ -104,7 +109,10 @@ interface IApiItemReference {
 interface IApiMethod extends IApiBaseDefinition {
   accessModifier: ApiAccessModifier;
   isOptional: boolean;
+  isOverride: boolean;
+  isSealed: boolean;
   isStatic: boolean;
+  isVirtual: boolean;
   kind: 'method';
   parameters: IApiNameMap<IApiParameter>;
   returnValue: IApiReturnValue;
@@ -148,8 +156,11 @@ interface IApiParameter {
 // @alpha
 interface IApiProperty extends IApiBaseDefinition {
   isOptional: boolean;
+  isOverride: boolean;
   isReadOnly: boolean;
+  isSealed: boolean;
   isStatic: boolean;
+  isVirtual: boolean;
   kind: 'property';
   signature: string;
   type: string;


### PR DESCRIPTION
We are replacing the @sealed/@virtual/@override with AEDoc tags, because decorators don't show up in the *.d.ts files that customers see.