### PR TITLE
Darren officeyamdocumenter apiset updates

### DIFF
--- a/apps/api-documenter/src/yaml/OfficeYamlDocumenter.ts
+++ b/apps/api-documenter/src/yaml/OfficeYamlDocumenter.ts
@@ -25,6 +25,16 @@ interface ISnippetsFile {
 export class OfficeYamlDocumenter extends YamlDocumenter {
   private _snippets: ISnippetsFile;
 
+  // Hash set of API set relative URLs.
+  private _apiSetUrls: any = {
+    "Excel": "/javascript/office/requirement-sets/excel-api-requirement-sets",
+    "OneNote": "/javascript/office/requirement-sets/onenote-api-requirement-sets",
+    "Visio": "/javascript/office/overview/visio-javascript-reference-overview",
+    "Outlook": "/javascript/office/requirement-sets/outlook-api-requirement-sets",
+    "Word": "/javascript/office/requirement-sets/word-api-requirement-sets",
+    "Default": "/javascript/office/javascript-api-for-office"
+  };
+
   public constructor(docItemSet: DocItemSet, inputFolder: string) {
     super(docItemSet);
 
@@ -89,18 +99,18 @@ export class OfficeYamlDocumenter extends YamlDocumenter {
     // Hyperlink it like this:
     // \[ [API set: ExcelApi 1.1](http://bing.com?type=excel) \]
     markup = markup.replace(/Api/, 'API');
-    if (uid.search(/Excel/i) !== -1) {
-      return markup.replace(/\\\[(API set:[^\]]+)\\\]/, `\\[ [$1](http://bing.com?type=excel) \\]`);
-    } else if (uid.search(/OneNote/i) !== -1) {
-      return markup.replace(/\\\[(API set:[^\]]+)\\\]/, `\\[ [$1](http://bing.com?type=onenote) \\]`);
-    } else if (uid.search(/Visio/i) !== -1) {
-      return markup.replace(/\\\[(API set:[^\]]+)\\\]/, `\\[ [$1](http://bing.com?type=visio) \\]`);
-    } else if (uid.search(/Outlook/i) !== -1) {
-      return markup.replace(/\\\[(API set:[^\]]+)\\\]/, `\\[ [$1](http://bing.com?type=outlook) \\]`);
-    } else if (uid.search(/Word/i) !== -1) {
-      return markup.replace(/\\\[(API set:[^\]]+)\\\]/, `\\[ [$1](http://bing.com?type=word) \\]`);
-    } else {
-      return markup.replace(/\\\[(API set:[^\]]+)\\\]/, `\\[ [$1](http://bing.com) \\]`);
-    }
+    return markup.replace(/\\\[(API set:[^\]]+)\\\]/, '\\[ [$1](' + this._getApiSetUrl(uid) + ') \\]');
   }
+
+  // Gets the link to the API set based on product context. Seeks a case-insensitve match in the hash set.
+  private _getApiSetUrl(uid: string) {
+    for (var key in this._apiSetUrls) {
+      let regexp = new RegExp(key, 'i');
+      if (regexp.test(uid)) {
+          return this._apiSetUrls[key];
+      }
+    }
+    return this._apiSetUrls["Default"]; // match not found.
+  }
+
 }

--- a/common/changes/@microsoft/api-documenter/darren-officeyamdocumenter-apiset-updates_2018-05-17-01-01.json
+++ b/common/changes/@microsoft/api-documenter/darren-officeyamdocumenter-apiset-updates_2018-05-17-01-01.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-documenter",
+      "comment": "Add hash set with API Set URLs",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/api-documenter",
+  "email": "darren@users.noreply.github.com"
+}


### PR DESCRIPTION
Refactored some logic in OfficeYamlDocumenter.ts extension, Api Set links go to valid relative locations based on product (or default location if product match not found).