### PR TITLE
[rush] Add "rushx" binary for project-specific commands

### DIFF
--- a/apps/rush-lib/src/Rush.ts
+++ b/apps/rush-lib/src/Rush.ts
@@ -8,10 +8,11 @@ import { IPackageJson } from '@microsoft/node-core-library';
 
 import { RushCommandLineParser } from './cli/actions/RushCommandLineParser';
 import { RushConstants } from './RushConstants';
+import { RushX } from './RushX';
 import { CommandLineMigrationAdvisor } from './cli/actions/CommandLineMigrationAdvisor';
 
 /**
- * Operations involving the rush tool and its operation.
+ * General operations for the Rush engine.
  *
  * @public
  */
@@ -19,8 +20,9 @@ export class Rush {
   private static _version: string;
 
   /**
-   * Executes the Rush CLI. This is expected to be called by the @microsoft/rush package, which acts as a version
-   *  manager for the Rush tool. The rush-lib API is exposed through the index.ts/js file.
+   * This API is used by the @microsoft/rush front end to launch the "rush" command-line.
+   * Third-party tools should not use this API.  Instead, they should execute the "rush" binary
+   * and start a new NodeJS process.
    *
    * @param launcherVersion - The version of the @microsoft/rush wrapper used to call invoke the CLI.
    * @param isManaged - True if the tool was invoked from within a project with a rush.json file, otherwise false. We
@@ -43,6 +45,20 @@ export class Rush {
 
     const parser: RushCommandLineParser = new RushCommandLineParser();
     parser.execute();
+  }
+
+  /**
+   * This API is used by the @microsoft/rush front end to launch the "rushx" command-line.
+   * Third-party tools should not use this API.  Instead, they should execute the "rushx" binary
+   * and start a new NodeJS process.
+   *
+   * @param launcherVersion - The version of the @microsoft/rush wrapper used to call invoke the CLI.
+   * @param isManaged - True if the tool was invoked from within a project with a rush.json file, otherwise false. We
+   *  consider a project without a rush.json to be "unmanaged" and we'll print that to the command line when
+   *  the tool is executed. This is mainly used for debugging purposes.
+   */
+  public static launchRushX(launcherVersion: string, isManaged: boolean): void {
+    RushX.launch(launcherVersion, isManaged);
   }
 
   /**

--- a/apps/rush-lib/src/Rush.ts
+++ b/apps/rush-lib/src/Rush.ts
@@ -30,12 +30,7 @@ export class Rush {
    *  the tool is executed. This is mainly used for debugging purposes.
    */
   public static launch(launcherVersion: string, isManaged: boolean): void {
-    console.log(
-      EOL +
-      colors.bold(`Rush Multi-Project Build Tool ${Rush.version}` + colors.yellow(isManaged ? '' : ' (unmanaged)')) +
-      colors.cyan(` - ${RushConstants.rushWebSiteUrl}`) +
-      EOL
-    );
+    Rush._printStartupBanner(isManaged);
 
     if (!CommandLineMigrationAdvisor.checkArgv(process.argv)) {
       // The migration advisor recognized an obsolete command-line
@@ -58,7 +53,9 @@ export class Rush {
    *  the tool is executed. This is mainly used for debugging purposes.
    */
   public static launchRushX(launcherVersion: string, isManaged: boolean): void {
-    RushX.launch(launcherVersion, isManaged);
+    Rush._printStartupBanner(isManaged);
+
+    RushX.launchRushX(launcherVersion, isManaged);
   }
 
   /**
@@ -74,5 +71,14 @@ export class Rush {
     }
 
     return Rush._version;
+  }
+
+  private static _printStartupBanner(isManaged: boolean): void {
+    console.log(
+      EOL +
+      colors.bold(`Rush Multi-Project Build Tool ${Rush.version}` + colors.yellow(isManaged ? '' : ' (unmanaged)')) +
+      colors.cyan(` - ${RushConstants.rushWebSiteUrl}`) +
+      EOL
+    );
   }
 }

--- a/apps/rush-lib/src/RushX.ts
+++ b/apps/rush-lib/src/RushX.ts
@@ -12,7 +12,7 @@ import {
   Text,
   IPackageJsonScriptTable
  } from '@microsoft/node-core-library';
-import { Utilities } from '../lib/utilities/Utilities';
+import { Utilities } from './utilities/Utilities';
 
 /**
  * Parses the "scripts" section from package.json

--- a/apps/rush-lib/src/RushX.ts
+++ b/apps/rush-lib/src/RushX.ts
@@ -67,14 +67,20 @@ export class RushX {
 
       const packageFolder: string = path.dirname(packageJsonFilePath);
 
-      const result: child_process.SpawnSyncReturns<Buffer> = Utilities.executeLifecycleCommand(
+      const result: child_process.ChildProcess = Utilities.executeLifecycleCommandAsync(
         scriptBody,
         packageFolder,
         packageFolder
       );
 
-      // Return the exit code of the child process
-      process.exitCode = result.status;
+      result.on('close', (code) => {
+        if (code) {
+          console.log(colors.red(`The script failed with exit code ${code}`));
+        }
+
+        // Pass along the exit code of the child process
+        process.exitCode = code || 0;
+      });
     } catch (error) {
       console.log(colors.red('Error: ' + error.message));
     }

--- a/apps/rush-lib/src/RushX.ts
+++ b/apps/rush-lib/src/RushX.ts
@@ -1,8 +1,88 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
+import * as colors from 'colors';
+import * as os from 'os';
+import {
+  PackageJsonLookup,
+  IPackageJson,
+  Text,
+  IPackageJsonScriptTable
+ } from '@microsoft/node-core-library';
+
 export class RushX {
-  public static launch(launcherVersion: string, isManaged: boolean): void {
-    console.log('invoking rushx');
+
+  public static launchRushX(launcherVersion: string, isManaged: boolean): void {
+    try {
+      // Find the governing package.json for this folder:
+      const packageJsonLookup: PackageJsonLookup = new PackageJsonLookup();
+
+      const packageJsonFilePath: string | undefined = packageJsonLookup.tryGetPackageJsonFilePathFor(process.cwd());
+      if (!packageJsonFilePath) {
+        console.log(colors.red('This command should be used inside a project folder.'));
+        console.log(`Unable to find a package.json file in the current working directory or any of its parents.`);
+        process.exitCode = 1;
+        return;
+      }
+
+      const packageJson: IPackageJson = packageJsonLookup.loadPackageJson(packageJsonFilePath);
+
+      // 0 = node.exe
+      // 1 = rushx
+      const args: string[] = process.argv.slice(2);
+
+      if (args.length === 0 || args[0][0] === '-') {
+        RushX._showUsage(packageJson);
+        process.exitCode = 1;
+        return;
+      }
+
+      const command: string = args[0];
+      console.log('Execute: ' + command);
+
+    } catch (error) {
+      console.log(colors.red('Error: ' + error.message));
+    }
+  }
+
+  private static _showUsage(packageJson: IPackageJson): void {
+    console.log('usage: rushx [-h]');
+    console.log('       rushx <command> ...' + os.EOL);
+
+    console.log('Optional arguments:');
+    console.log('  -h, --help            Show this help message and exit.' + os.EOL);
+
+    const scripts: IPackageJsonScriptTable = packageJson.scripts || { };
+    if (Object.keys(scripts).length > 0) {
+      console.log(`Project commands for ${colors.cyan(packageJson.name)}:`);
+
+      // Calculate the length of the longest script name, for formatting
+      let maxLength: number = 0;
+      for (const scriptName of Object.keys(scripts)) {
+        maxLength = Math.max(maxLength, scriptName.length);
+      }
+
+      let warning: string | undefined = undefined;
+
+      for (const scriptName of Object.keys(scripts)) {
+        if (scriptName[0] === '-' || scriptName.length === 0) {
+          if (!warning) {
+            warning = scriptName;
+          }
+        } else {
+          console.log('  '
+          + colors.cyan(Text.padEnd(scriptName + ':', maxLength + 2))
+          + JSON.stringify(scripts[scriptName]));
+        }
+      }
+
+      if (warning) {
+        console.log(os.EOL + colors.yellow('Warning: The "scripts" table in the package.json file'
+          + ` defines a script with an unsupported name: "${warning}"`));
+      }
+    } else {
+      console.log(colors.yellow('Warning: No commands are defined yet for this project.'));
+      console.log('You can define a command by adding a "scripts" table to the project\'s package.json file.');
+    }
   }
 }

--- a/apps/rush-lib/src/RushX.ts
+++ b/apps/rush-lib/src/RushX.ts
@@ -54,7 +54,8 @@ export class RushX {
 
         const availableCommands: string[] = Object.keys(scripts);
         if (availableCommands.length > 0) {
-          console.log(os.EOL + 'Available commands are: ' + availableCommands.map(x => `"${x}"`).join(', '));
+          console.log(os.EOL + 'Available commands for this project are: '
+            + availableCommands.map(x => `"${x}"`).join(', '));
         }
 
         console.log(`Use ${colors.yellow('"rushx --help"')} for more information.`);
@@ -104,9 +105,20 @@ export class RushX {
             warning = command;
           }
         } else {
-          console.log('  '
-          + colors.cyan(Text.padEnd(command + ':', maxLength + 2))
-          + JSON.stringify(scripts[command]));
+          const escapedScriptBody: string = JSON.stringify(scripts[command]);
+
+          // The length of the string e.g. "  command: "
+          const firstPartLength: number = 2 + maxLength + 2;
+          // The length for truncating the escaped escapedScriptBody so it doesn't wrap
+          // to the next line
+          const truncateLength: number = Math.max(0, Utilities.getConsoleWidth() - firstPartLength) - 1;
+
+          console.log(
+            // Example: "  command: "
+            '  ' + colors.cyan(Text.padEnd(command + ':', maxLength + 2))
+            // Example: "do some thin..."
+            + Text.truncateWithEllipsis(escapedScriptBody, truncateLength)
+          );
         }
       }
 

--- a/apps/rush-lib/src/RushX.ts
+++ b/apps/rush-lib/src/RushX.ts
@@ -1,18 +1,27 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
+import * as child_process from 'child_process';
 import * as colors from 'colors';
 import * as os from 'os';
+import * as path from 'path';
+
 import {
   PackageJsonLookup,
   IPackageJson,
   Text,
   IPackageJsonScriptTable
  } from '@microsoft/node-core-library';
+import { Utilities } from '../lib/utilities/Utilities';
 
 export class RushX {
 
   public static launchRushX(launcherVersion: string, isManaged: boolean): void {
+    // NodeJS can sometimes accidentally terminate with a zero exit code  (e.g. for an uncaught
+    // promise exception), so we start with the assumption that the exit code is 1
+    // and set it to 0 only on success.
+    process.exitCode = 1;
+
     try {
       // Find the governing package.json for this folder:
       const packageJsonLookup: PackageJsonLookup = new PackageJsonLookup();
@@ -21,7 +30,6 @@ export class RushX {
       if (!packageJsonFilePath) {
         console.log(colors.red('This command should be used inside a project folder.'));
         console.log(`Unable to find a package.json file in the current working directory or any of its parents.`);
-        process.exitCode = 1;
         return;
       }
 
@@ -33,13 +41,39 @@ export class RushX {
 
       if (args.length === 0 || args[0][0] === '-') {
         RushX._showUsage(packageJson);
-        process.exitCode = 1;
         return;
       }
 
       const command: string = args[0];
-      console.log('Execute: ' + command);
 
+      const scripts: IPackageJsonScriptTable = packageJson.scripts || { };
+
+      if (!Object.hasOwnProperty.call(scripts, command)) {
+        console.log(colors.red(`Error: The command "${command}" is not defined in the`
+          + ` package.json file for this project.`));
+
+        const availableCommands: string[] = Object.keys(scripts);
+        if (availableCommands.length > 0) {
+          console.log(os.EOL + 'Available commands are: ' + availableCommands.map(x => `"${x}"`).join(', '));
+        }
+
+        console.log(`Use ${colors.yellow('"rushx --help"')} for more information.`);
+        return;
+      }
+
+      const scriptBody: string = scripts[command];
+      console.log('Executing: ' + JSON.stringify(scriptBody) + os.EOL);
+
+      const packageFolder: string = path.basename(packageJsonFilePath);
+
+      const result: child_process.SpawnSyncReturns<Buffer> = Utilities.executeLifecycleCommand(
+        scriptBody,
+        packageFolder,
+        packageFolder
+      );
+
+      // Return the exit code of the child process
+      process.exitCode = result.status;
     } catch (error) {
       console.log(colors.red('Error: ' + error.message));
     }
@@ -58,21 +92,21 @@ export class RushX {
 
       // Calculate the length of the longest script name, for formatting
       let maxLength: number = 0;
-      for (const scriptName of Object.keys(scripts)) {
-        maxLength = Math.max(maxLength, scriptName.length);
+      for (const command of Object.keys(scripts)) {
+        maxLength = Math.max(maxLength, command.length);
       }
 
       let warning: string | undefined = undefined;
 
-      for (const scriptName of Object.keys(scripts)) {
-        if (scriptName[0] === '-' || scriptName.length === 0) {
+      for (const command of Object.keys(scripts)) {
+        if (command[0] === '-' || command.length === 0) {
           if (!warning) {
-            warning = scriptName;
+            warning = command;
           }
         } else {
           console.log('  '
-          + colors.cyan(Text.padEnd(scriptName + ':', maxLength + 2))
-          + JSON.stringify(scripts[scriptName]));
+          + colors.cyan(Text.padEnd(command + ':', maxLength + 2))
+          + JSON.stringify(scripts[command]));
         }
       }
 

--- a/apps/rush-lib/src/RushX.ts
+++ b/apps/rush-lib/src/RushX.ts
@@ -1,0 +1,8 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+export class RushX {
+  public static launch(launcherVersion: string, isManaged: boolean): void {
+    console.log('invoking rushx');
+  }
+}

--- a/apps/rush-lib/src/RushX.ts
+++ b/apps/rush-lib/src/RushX.ts
@@ -65,7 +65,7 @@ export class RushX {
       const scriptBody: string = scripts[command];
       console.log('Executing: ' + JSON.stringify(scriptBody) + os.EOL);
 
-      const packageFolder: string = path.basename(packageJsonFilePath);
+      const packageFolder: string = path.dirname(packageJsonFilePath);
 
       const result: child_process.SpawnSyncReturns<Buffer> = Utilities.executeLifecycleCommand(
         scriptBody,

--- a/apps/rush-lib/src/index.ts
+++ b/apps/rush-lib/src/index.ts
@@ -62,7 +62,4 @@ export {
   VersionPolicyConfiguration
 } from './data/VersionPolicyConfiguration';
 
-/**
- * @internal
- */
 export { Rush } from './Rush';

--- a/apps/rush-lib/src/utilities/Utilities.ts
+++ b/apps/rush-lib/src/utilities/Utilities.ts
@@ -327,7 +327,7 @@ export class Utilities {
    * @param workingDirectory - working directory for running this command
    * @param initCwd = the folder containing a local .npmrc, which will be used
    *        for the INIT_CWD environment variable
-   * @param environment - environment variables for running this command
+   * @param captureOutput - if true, map stdio to 'pipe' instead of the parent process's streams
    * @beta
    */
   public static executeLifecycleCommand(
@@ -367,7 +367,7 @@ export class Utilities {
    * @param workingDirectory - working directory for running this command
    * @param initCwd = the folder containing a local .npmrc, which will be used
    *        for the INIT_CWD environment variable
-   * @param environment - environment variables for running this command
+   * @param captureOutput - if true, map stdio to 'pipe' instead of the parent process's streams
    * @beta
    */
   public static executeLifecycleCommandAsync(

--- a/apps/rush/bin/rushx
+++ b/apps/rush/bin/rushx
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+require('../lib/start.js')

--- a/apps/rush/src/RushCommandSelector.ts
+++ b/apps/rush/src/RushCommandSelector.ts
@@ -3,10 +3,17 @@
 
 import * as colors from 'colors';
 import * as path from 'path';
-import * as myRushLib from '@microsoft/rush-lib';
+import * as rushLib from '@microsoft/rush-lib';
 
 type CommandName = 'rush' | 'rushx' | undefined;
 
+/**
+ * Both "rush" and "rushx" share the same src/start.ts entry point.  This makes it
+ * a little easier for them to share all the same startup checks and version selector
+ * logic.  RushCommandSelector looks at argv to determine whether we're doing "rush"
+ * or "rushx" behavior, and then invokes the appropriate entry point in the selected
+ * @microsoft/rush-lib.
+ */
 export class RushCommandSelector {
   public static failIfNotInvokedAsRush(version: string): void {
     if (RushCommandSelector._getCommandName() === 'rushx') {
@@ -16,8 +23,8 @@ export class RushCommandSelector {
   }
 
   // tslint:disable-next-line:no-any
-  public static execute(launcherVersion: string, isManaged: boolean, rushLib: any): void {
-    const Rush: typeof myRushLib.Rush = rushLib.Rush;
+  public static execute(launcherVersion: string, isManaged: boolean, selectedRushLib: any): void {
+    const Rush: typeof rushLib.Rush = selectedRushLib.Rush;
 
     if (!Rush) {
       // This should be impossible unless we somehow loaded an unexpected version

--- a/apps/rush/src/RushCommandSelector.ts
+++ b/apps/rush/src/RushCommandSelector.ts
@@ -1,0 +1,58 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import * as colors from 'colors';
+import * as path from 'path';
+import * as myRushLib from '@microsoft/rush-lib';
+
+type CommandName = 'rush' | 'rushx' | undefined;
+
+export class RushCommandSelector {
+  public static failIfNotInvokedAsRush(version: string): void {
+    if (RushCommandSelector._getCommandName() === 'rushx') {
+      RushCommandSelector._failWithError(`This repository is using Rush version ${version}`
+        + ` which does not support the "rushx" command`);
+    }
+  }
+
+  // tslint:disable-next-line:no-any
+  public static execute(launcherVersion: string, isManaged: boolean, rushLib: any): void {
+    const Rush: typeof myRushLib.Rush = rushLib.Rush;
+
+    if (!Rush) {
+      // This should be impossible unless we somehow loaded an unexpected version
+      RushCommandSelector._failWithError(`Unable to find the "Rush" entry point in @microsoft/rush-lib`);
+    }
+
+    if (RushCommandSelector._getCommandName() === 'rushx') {
+      if (!Rush.launchRushX) {
+        RushCommandSelector._failWithError(`This repository is using Rush version ${Rush.version}`
+          + ` which does not support the "rushx" command`);
+      }
+      Rush.launchRushX(launcherVersion, isManaged);
+    } else {
+      Rush.launch(launcherVersion, isManaged);
+    }
+  }
+
+  private static _failWithError(message: string): never {
+    console.log(colors.red(message));
+    return process.exit(1);
+  }
+
+  private static _getCommandName(): CommandName {
+    if (process.argv.length >= 2) {
+      // Example:
+      // argv[0]: "C:\\Program Files\\nodejs\\node.exe"
+      // argv[1]: "C:\\Program Files\\nodejs\\node_modules\\@microsoft\\rush\\bin\\rushx"
+      const basename: string = path.basename(process.argv[1]).toUpperCase();
+      if (basename === 'RUSHX') {
+        return 'rushx';
+      }
+      if (basename === 'RUSH') {
+        return 'rush';
+      }
+    }
+    return undefined;
+  }
+}

--- a/apps/rush/src/start.ts
+++ b/apps/rush/src/start.ts
@@ -35,7 +35,7 @@ else if (!semver.satisfies(nodeVersion, '^6.9.0')
 }
 
 import * as path from 'path';
-import { JsonFile, IPackageJson } from '@microsoft/node-core-library';
+import { JsonFile, IPackageJson, Text } from '@microsoft/node-core-library';
 import { EnvironmentVariableNames } from '@microsoft/rush-lib';
 import * as rushLib from '@microsoft/rush-lib';
 
@@ -51,14 +51,6 @@ let rushVersionToLoad: string | undefined = undefined;
 
 const previewVersion: string | undefined = process.env[EnvironmentVariableNames.RUSH_PREVIEW_VERSION];
 
-function padEnd(s: string, length: number): string {
-  let result: string = s;
-  while (result.length < length) {
-    result += ' ';
-  }
-  return result;
-}
-
 if (previewVersion) {
   if (!semver.valid(previewVersion, false)) {
     console.error(colors.red(`Invalid value for RUSH_PREVIEW_VERSION environment variable: "${previewVersion}"`));
@@ -72,12 +64,12 @@ if (previewVersion) {
     `*********************************************************************`,
     `* WARNING! THE "RUSH_PREVIEW_VERSION" ENVIRONMENT VARIABLE IS SET.  *`,
     `*                                                                   *`,
-    `* You are previewing Rush version:        ${padEnd(previewVersion, 25)} *`
+    `* You are previewing Rush version:        ${Text.padEnd(previewVersion, 25)} *`
   );
 
   if (configuration) {
     lines.push(
-      `* The rush.json configuration asks for:   ${padEnd(configuration.rushVersion, 25)} *`
+      `* The rush.json configuration asks for:   ${Text.padEnd(configuration.rushVersion, 25)} *`
     );
   }
 

--- a/apps/rush/src/start.ts
+++ b/apps/rush/src/start.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
+// The minimal set of imports that are safe even for ancient NodeJS versions:
 import * as colors from 'colors';
 import * as os from 'os';
 import * as semver from 'semver';
@@ -35,11 +36,12 @@ else if (!semver.satisfies(nodeVersion, '^6.9.0')
 
 import * as path from 'path';
 import { JsonFile, IPackageJson } from '@microsoft/node-core-library';
+import { EnvironmentVariableNames } from '@microsoft/rush-lib';
+import * as rushLib from '@microsoft/rush-lib';
 
-import { Rush, EnvironmentVariableNames } from '@microsoft/rush-lib';
-
-import { MinimalRushConfiguration } from './MinimalRushConfiguration';
+import { RushCommandSelector } from './RushCommandSelector';
 import { RushVersionSelector } from './RushVersionSelector';
+import { MinimalRushConfiguration } from './MinimalRushConfiguration';
 
 // Load the configuration
 const configuration: MinimalRushConfiguration | undefined = MinimalRushConfiguration.loadFromDefaultLocation();
@@ -114,5 +116,5 @@ if (rushVersionToLoad && rushVersionToLoad !== currentPackageJson.version) {
   // Rush is "managed" if its version and configuration are dictated by a repo's rush.json
   const isManaged: boolean = !!configuration;
 
-  Rush.launch(currentPackageJson.version, isManaged);
+  RushCommandSelector.execute(currentPackageJson.version, isManaged, rushLib);
 }

--- a/common/changes/@microsoft/node-core-library/pgonzal-rushx_2018-06-06-19-20.json
+++ b/common/changes/@microsoft/node-core-library/pgonzal-rushx_2018-06-06-19-20.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/node-core-library",
+      "comment": "Add Text.truncateWithEllipsis() API",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@microsoft/node-core-library",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush/pgonzal-rushx_2018-06-06-19-20.json
+++ b/common/changes/@microsoft/rush/pgonzal-rushx_2018-06-06-19-20.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Add \"rushx\" binary for single-project commands",
+      "packageName": "@microsoft/rush",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/reviews/api/node-core-library.api.ts
+++ b/common/reviews/api/node-core-library.api.ts
@@ -179,6 +179,7 @@ class ProtectableMap<K, V> {
 class Text {
   static convertToCrLf(input: string): string;
   static convertToLf(input: string): string;
+  static padEnd(s: string, minimumLength: number): string;
   static replaceAll(input: string, searchValue: string, replaceValue: string): string;
 }
 

--- a/common/reviews/api/node-core-library.api.ts
+++ b/common/reviews/api/node-core-library.api.ts
@@ -181,5 +181,6 @@ class Text {
   static convertToLf(input: string): string;
   static padEnd(s: string, minimumLength: number): string;
   static replaceAll(input: string, searchValue: string, replaceValue: string): string;
+  static truncateWithEllipsis(s: string, maximumLength: number): string;
 }
 

--- a/common/reviews/api/rush-lib.api.ts
+++ b/common/reviews/api/rush-lib.api.ts
@@ -163,6 +163,7 @@ class LockStepVersionPolicy extends VersionPolicy {
 // @public
 class Rush {
   static launch(launcherVersion: string, isManaged: boolean): void;
+  static launchRushX(launcherVersion: string, isManaged: boolean): void;
   // @public
   static readonly version: string;
 }

--- a/libraries/node-core-library/src/Text.ts
+++ b/libraries/node-core-library/src/Text.ts
@@ -51,4 +51,23 @@ export class Text {
     }
     return result;
   }
+
+  /**
+   * If the string is longer than maximumLength characters, truncate it to that length
+   * using "..." to indicate the truncation.
+   *
+   * @remarks
+   * For example truncateWithEllipsis('1234578', 5) would produce '12...'.
+   */
+  public static truncateWithEllipsis(s: string, maximumLength: number): string {
+    if (s.length < maximumLength) {
+      return s;
+    }
+
+    if (s.length < 4) {
+      return s.substring(0, maximumLength);
+    }
+
+    return s.substring(0, maximumLength-3) + '...';
+  }
 }

--- a/libraries/node-core-library/src/Text.ts
+++ b/libraries/node-core-library/src/Text.ts
@@ -38,4 +38,17 @@ export class Text {
     return input.replace(Text._newLineRegEx, '\n');
   }
 
+  /**
+   * Append spaces to the end of a string to ensure the result has a minimum length.
+   * @remarks
+   * If the string length already exceeds the minimum length, then the string is unchanged.
+   * The string is not truncated.
+   */
+  public static padEnd(s: string, minimumLength: number): string {
+    let result: string = s;
+    while (result.length < minimumLength) {
+      result += ' ';
+    }
+    return result;
+  }
 }

--- a/libraries/node-core-library/src/Text.ts
+++ b/libraries/node-core-library/src/Text.ts
@@ -60,11 +60,15 @@ export class Text {
    * For example truncateWithEllipsis('1234578', 5) would produce '12...'.
    */
   public static truncateWithEllipsis(s: string, maximumLength: number): string {
+    if (maximumLength < 0) {
+      throw new Error('The maximumLength cannot be a negative number');
+    }
+
     if (s.length <= maximumLength) {
       return s;
     }
 
-    if (s.length < 4) {
+    if (s.length <= 3) {
       return s.substring(0, maximumLength);
     }
 

--- a/libraries/node-core-library/src/Text.ts
+++ b/libraries/node-core-library/src/Text.ts
@@ -60,7 +60,7 @@ export class Text {
    * For example truncateWithEllipsis('1234578', 5) would produce '12...'.
    */
   public static truncateWithEllipsis(s: string, maximumLength: number): string {
-    if (s.length < maximumLength) {
+    if (s.length <= maximumLength) {
       return s;
     }
 
@@ -68,6 +68,6 @@ export class Text {
       return s.substring(0, maximumLength);
     }
 
-    return s.substring(0, maximumLength-3) + '...';
+    return s.substring(0, maximumLength - 3) + '...';
   }
 }

--- a/libraries/node-core-library/src/test/Text.test.ts
+++ b/libraries/node-core-library/src/test/Text.test.ts
@@ -14,6 +14,9 @@ describe('Text', () => {
     assert.equal(Text.padEnd('123456', 5),  '123456');
   });
   it('Text.truncateWithEllipsis()', () => {
+    assert.throws(() => { Text.truncateWithEllipsis('123', -1); });
+    assert.equal(Text.truncateWithEllipsis('123', 0),     '');
+
     assert.equal(Text.truncateWithEllipsis('', 2),        '');
     assert.equal(Text.truncateWithEllipsis('1', 2),       '1');
     assert.equal(Text.truncateWithEllipsis('12', 2),      '12');

--- a/libraries/node-core-library/src/test/Text.test.ts
+++ b/libraries/node-core-library/src/test/Text.test.ts
@@ -13,4 +13,15 @@ describe('Text', () => {
     assert.equal(Text.padEnd('12345', 5),   '12345');
     assert.equal(Text.padEnd('123456', 5),  '123456');
   });
+  it('Text.truncateWithEllipsis()', () => {
+    assert.equal(Text.truncateWithEllipsis('', 2),        '');
+    assert.equal(Text.truncateWithEllipsis('1', 2),       '1');
+    assert.equal(Text.truncateWithEllipsis('12', 2),      '12');
+    assert.equal(Text.truncateWithEllipsis('123', 2),     '12');
+
+    assert.equal(Text.truncateWithEllipsis('123', 5),     '123');
+    assert.equal(Text.truncateWithEllipsis('1234', 5),    '1234');
+    assert.equal(Text.truncateWithEllipsis('12345', 5),   '12345');
+    assert.equal(Text.truncateWithEllipsis('123456', 5),  '12...');
+  });
 });

--- a/libraries/node-core-library/src/test/Text.test.ts
+++ b/libraries/node-core-library/src/test/Text.test.ts
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+/// <reference types='mocha' />
+
+import { Text } from '../Text';
+import { assert } from 'chai';
+
+describe('Text', () => {
+  it('Text.padEnd()', () => {
+    assert.equal(Text.padEnd('', 5),        '     ');
+    assert.equal(Text.padEnd('123', 5),     '123  ');
+    assert.equal(Text.padEnd('12345', 5),   '12345');
+    assert.equal(Text.padEnd('123456', 5),  '123456');
+  });
+});


### PR DESCRIPTION
Rush 5 will distinguish 3 types of commands:
1. "global" commands that execute once for the whole repo
2. "bulk" commands that are executed separately in each project folder
3. "project" commands, that only affect a single project

This PR addresses #<!-- -->3  and our approach is a separate command line "rushx".