### PR TITLE
Pass the hostname from serve.json to gulpConnect.server()

### DIFF
--- a/common/changes/@microsoft/gulp-core-build-serve/ext-gulp-core-build-serve_2018-06-12-08-10.json
+++ b/common/changes/@microsoft/gulp-core-build-serve/ext-gulp-core-build-serve_2018-06-12-08-10.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/gulp-core-build-serve",
+      "comment": "Pass the hostname from serve.json to gulpConnect.server()",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/gulp-core-build-serve",
+  "email": "waldekmastykarz@users.noreply.github.com"
+}

--- a/core-build/gulp-core-build-serve/src/ServeTask.ts
+++ b/core-build/gulp-core-build-serve/src/ServeTask.ts
@@ -121,7 +121,7 @@ export class ServeTask<TExtendedConfig = {}> extends GulpTask<IServeTaskConfig &
     const openBrowser: boolean = (process.argv.indexOf('--nobrowser') === -1);
     const portArgumentIndex: number = process.argv.indexOf('--port');
     let { port, initialPage }: IServeTaskConfig = this.taskConfig;
-    const { api }: IServeTaskConfig = this.taskConfig;
+    const { api, hostname }: IServeTaskConfig = this.taskConfig;
     const { rootPath }: IBuildConfig = this.buildConfig;
     const httpsServerOptions: HttpsType.ServerOptions = this._loadHttpsServerOptions();
 
@@ -136,7 +136,8 @@ export class ServeTask<TExtendedConfig = {}> extends GulpTask<IServeTaskConfig &
       middleware: (): Function[] => [this._logRequestsMiddleware, this._enableCorsMiddleware],
       port: port,
       root: rootPath,
-      preferHttp1: true
+      preferHttp1: true,
+      host: hostname
     });
 
     // If an api is provided, spin it up.


### PR DESCRIPTION
Pass the `hostname` from `serve.json` to `gulpConnect.server()`.

Starting from v5.1.0, gulp-connect uses the `host` parameter to instantiate the server. If the `host` is not specified, it instantiate the serve on `localhost`. When used in a Docker container, localhost is not exposed outside the container. This fix makes it possible to use the `hostname` specified in `serve.json` with `gulpConnect.server()`.