### PR TITLE
[rush] Warn about phantom node_modules folders

### DIFF
--- a/apps/rush-lib/src/logic/SetupChecks.ts
+++ b/apps/rush-lib/src/logic/SetupChecks.ts
@@ -86,6 +86,7 @@ export class SetupChecks {
       for (const folder of phantomFolders) {
         console.log(colors.yellow(`"${folder}"`));
       }
+      console.log(); // add a newline
     }
   }
 

--- a/apps/rush-lib/src/logic/SetupChecks.ts
+++ b/apps/rush-lib/src/logic/SetupChecks.ts
@@ -2,10 +2,13 @@
 // See LICENSE in the project root for license information.
 
 import * as colors from 'colors';
+import * as path from 'path';
+import * as fsx from 'fs-extra';
 import * as semver from 'semver';
 import { RushConfiguration } from '../api/RushConfiguration';
 import { AlreadyReportedError } from '../utilities/AlreadyReportedError';
 import { Utilities } from '../utilities/Utilities';
+import { RushConstants } from '../api/RushConstants';
 
 // Refuses to run at all if the PNPM version is older than this, because there
 // are known bugs or missing features in earlier releases.
@@ -17,6 +20,12 @@ const MINIMUM_SUPPORTED_PNPM_VERSION: string = '2.1.0';
 
 /**
  * Validate that the developer's setup is good.
+ *
+ * These checks are invoked prior to the following commands:
+ * - rush install
+ * - rush update
+ * - rush build
+ * - rush rebuild
  */
 export class SetupChecks {
   public static validate(rushConfiguration: RushConfiguration): void {
@@ -30,6 +39,7 @@ export class SetupChecks {
   }
 
   private static _validate(rushConfiguration: RushConfiguration): string | undefined {
+    // Check for outdated tools
     if (rushConfiguration.packageManager === 'pnpm') {
       if (semver.lt(rushConfiguration.packageManagerToolVersion, MINIMUM_SUPPORTED_PNPM_VERSION)) {
         return `The rush.json file requests PNPM version `
@@ -42,6 +52,61 @@ export class SetupChecks {
           + rushConfiguration.packageManagerToolVersion
           + `, but NPM ${MINIMUM_SUPPORTED_NPM_VERSION} is the minimum supported by Rush.`;
       }
+    }
+
+    SetupChecks._checkForPhantomFolders(rushConfiguration);
+  }
+
+  private static _checkForPhantomFolders(rushConfiguration: RushConfiguration): void {
+    const phantomFolders: string[] = [];
+    const seenFolders: Set<string> = new Set<string>();
+
+    // Check from the real parent of the common/temp folder
+    const commonTempParent: string = path.dirname(fsx.realpathSync(rushConfiguration.commonTempFolder));
+    SetupChecks._collectPhantomFoldersRecursive(commonTempParent, phantomFolders, seenFolders);
+
+    // Check from the real folder containing rush.json
+    const realRushJsonFolder: string = fsx.realpathSync(rushConfiguration.rushJsonFolder);
+    SetupChecks._collectPhantomFoldersRecursive(realRushJsonFolder, phantomFolders, seenFolders);
+
+    if (phantomFolders.length > 0) {
+      if (phantomFolders.length === 1) {
+        console.log(colors.yellow(Utilities.wrapWords(
+          'Warning: A phantom "node_modules" folder was found. This defeats Rush\'s protection against'
+          + ' NPM phantom dependencies, and may cause confusing build errors. It\'s recommended to'
+          + ' delete this folder:'
+        )));
+      } else {
+        console.log(colors.yellow(Utilities.wrapWords(
+          'Warning: Phantom "node_modules" folders were found. This defeats Rush\'s protection against'
+          + ' NPM phantom dependencies, and may cause confusing build errors. It\'s recommended to'
+          + ' delete these folders:'
+        )));
+      }
+      for (const folder of phantomFolders) {
+        console.log(colors.yellow(`"${folder}"`));
+      }
+    }
+  }
+
+  private static _collectPhantomFoldersRecursive(folder: string, phantomFolders: string[],
+    seenFolders: Set<string>): void {
+
+    if (seenFolders.has(folder)) {
+      // Stop because we already analyzed this folder
+      return;
+    }
+    seenFolders.add(folder);
+
+    const nodeModulesFolder: string = path.join(folder, RushConstants.nodeModulesFolderName);
+    if (fsx.existsSync(nodeModulesFolder)) {
+      phantomFolders.push(nodeModulesFolder);
+    }
+
+    // Walk upwards until path.dirname() returns its own input, which means we reached the root
+    const parentFolder: string = path.dirname(folder);
+    if (parentFolder && parentFolder !== folder) {
+      SetupChecks._collectPhantomFoldersRecursive(parentFolder, phantomFolders, seenFolders);
     }
   }
 }

--- a/common/changes/@microsoft/rush/pgonzal-phantom-folder-check_2018-06-13-02-13.json
+++ b/common/changes/@microsoft/rush/pgonzal-phantom-folder-check_2018-06-13-02-13.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Rush now warns when phantom node_modules folders are found",
+      "packageName": "@microsoft/rush",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "pgonzal@users.noreply.github.com"
+}


### PR DESCRIPTION
This spring we've had several investigations of strange build errors that turned out to be NodeJS finding the wrong library in a stray `node_modules` folder.  Normally `require()` stops at the first match it finds, but for `@types` the TypeScript compiler seems to keep looking in other folders.

With this PR, Rush now warns about phantom `node_modules` folders.  For now the warning is purely informational and does not fail the operation.  Later once the **install-run.js** scenario is proven out, we will make it more strict.