### PR TITLE
[rush] Fix a regression where "rush install" printed an incorrect warning

### DIFF
--- a/apps/rush-lib/src/logic/InstallManager.ts
+++ b/apps/rush-lib/src/logic/InstallManager.ts
@@ -350,19 +350,12 @@ export class InstallManager {
       shrinkwrapIsUpToDate = false;
     }
 
-    // Find the implicitly preferred versions
-    // These are any first-level dependencies for which we only consume a single version range
-    // (e.g. every package that depends on react uses an identical specifier)
-    const allPreferredVersions: Map<string, string> =
-      InstallManager.collectImplicitlyPreferredVersions(this._rushConfiguration);
-
-    // Add in the explicitly preferred versions.
-    // Note that these take precedence over implicitly preferred versions.
-    MapExtensions.mergeFromMap(allPreferredVersions, this._rushConfiguration.commonVersions.getAllPreferredVersions());
+    const allExplicitPreferredVersions: Map<string, string> = this._rushConfiguration.commonVersions
+      .getAllPreferredVersions();
 
     if (shrinkwrapFile) {
-      // Check any preferred dependencies first
-      allPreferredVersions.forEach((version: string, dependency: string) => {
+      // Check any (explicitly) preferred dependencies first
+      allExplicitPreferredVersions.forEach((version: string, dependency: string) => {
         if (!shrinkwrapFile.hasCompatibleTopLevelDependency(dependency, version)) {
           console.log(colors.yellow(Utilities.wrapWords(
             `${os.EOL}The NPM shrinkwrap file does not provide "${dependency}"`
@@ -405,6 +398,16 @@ export class InstallManager {
       private: true,
       version: '0.0.0'
     };
+
+    // Find the implicitly preferred versions
+    // These are any first-level dependencies for which we only consume a single version range
+    // (e.g. every package that depends on react uses an identical specifier)
+    const allPreferredVersions: Map<string, string> =
+      InstallManager.collectImplicitlyPreferredVersions(this._rushConfiguration);
+
+    // Add in the explicitly preferred versions.
+    // Note that these take precedence over implicitly preferred versions.
+    MapExtensions.mergeFromMap(allPreferredVersions, allExplicitPreferredVersions);
 
     // Add any preferred versions to the top of the commonPackageJson
     // do this in alphabetical order for simpler debugging

--- a/common/changes/@microsoft/rush/pgonzal-fix-rush-warning_2018-06-13-18-40.json
+++ b/common/changes/@microsoft/rush/pgonzal-fix-rush-warning_2018-06-13-18-40.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@microsoft/rush",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/config/rush/shrinkwrap.yaml
+++ b/common/config/rush/shrinkwrap.yaml
@@ -164,20 +164,20 @@ dependencies:
   yargs: 4.6.0
   z-schema: 3.18.4
 packages:
-  /@babel/code-frame/7.0.0-beta.49:
+  /@babel/code-frame/7.0.0-beta.51:
     dependencies:
-      '@babel/highlight': 7.0.0-beta.49
+      '@babel/highlight': 7.0.0-beta.51
     dev: false
     resolution:
-      integrity: sha1-vs2AVIJzREDJ0TfkbXc0DmTX9Rs=
-  /@babel/highlight/7.0.0-beta.49:
+      integrity: sha1-vXHZsZKvl435FYKdOdQJRFZDmgw=
+  /@babel/highlight/7.0.0-beta.51:
     dependencies:
       chalk: 2.4.1
       esutils: 2.0.2
       js-tokens: 3.0.2
     dev: false
     resolution:
-      integrity: sha1-lr3GtD4TSCASumaRsQGEktOWIsw=
+      integrity: sha1-6IRK4loVlcz9QriWI7Q3bKBtIl0=
   /@gulp-sourcemaps/identity-map/1.0.1:
     dependencies:
       acorn: 5.6.2
@@ -752,15 +752,22 @@ packages:
       node: '>= 4.0.0'
     resolution:
       integrity: sha512-c+R/U5X+2zz2+UCrCFv6odQzJdoqI+YecuhnAJLa1zYaMc13zPfwMwZrr91Pd1DYNo/yPRbiM4WVf9whgwFsIg==
-  /ajv-keywords/3.2.0/ajv@6.5.0:
+  /ajv-keywords/3.2.0/ajv@6.5.1:
     dependencies:
-      ajv: 6.5.0
+      ajv: 6.5.1
     dev: false
     id: registry.npmjs.org/ajv-keywords/3.2.0
     peerDependencies:
       ajv: ^6.0.0
     resolution:
       integrity: sha1-6GuBnGAs+IIa1jdBNpjx3sAhhHo=
+  /ajv/4.11.8:
+    dependencies:
+      co: 4.6.0
+      json-stable-stringify: 1.0.1
+    dev: false
+    resolution:
+      integrity: sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=
   /ajv/5.2.2:
     dependencies:
       co: 4.6.0
@@ -770,15 +777,15 @@ packages:
     dev: false
     resolution:
       integrity: sha1-R8aNaehvXZUxA7AHSpQw3GPaXjk=
-  /ajv/6.5.0:
+  /ajv/6.5.1:
     dependencies:
       fast-deep-equal: 2.0.1
       fast-json-stable-stringify: 2.0.0
-      json-schema-traverse: 0.3.1
+      json-schema-traverse: 0.4.1
       uri-js: 4.2.2
     dev: false
     resolution:
-      integrity: sha512-VDUX1oSajablmiyFyED9L1DFndg0P9h7p1F+NO8FkIzei6EPrR6Zu1n18rd5P8PqaSRd/FrWv3G1TVBqpM83gA==
+      integrity: sha512-pgZos1vgOHDiC7gKNbZW8eKvCnNXARv2oqrGQT7Hzbq5Azp7aZG6DJzADnkuSq7RH6qkXp4J/m68yPX/2uBHyQ==
   /align-text/0.1.4:
     dependencies:
       kind-of: 3.2.2
@@ -855,7 +862,7 @@ packages:
       integrity: sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=
   /ansi-styles/3.2.1:
     dependencies:
-      color-convert: 1.9.1
+      color-convert: 1.9.2
     dev: false
     engines:
       node: '>=4'
@@ -1103,7 +1110,7 @@ packages:
   /autoprefixer/6.3.7:
     dependencies:
       browserslist: 1.3.6
-      caniuse-db: 1.0.30000850
+      caniuse-db: 1.0.30000853
       normalize-range: 0.1.2
       num2fraction: 1.2.2
       postcss: 5.2.18
@@ -1559,7 +1566,7 @@ packages:
       integrity: sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==
   /browserslist/1.3.6:
     dependencies:
-      caniuse-db: 1.0.30000850
+      caniuse-db: 1.0.30000853
     dev: false
     resolution:
       integrity: sha1-lS/0jVZGPTtTj4XvL46t39KEsTM=
@@ -1580,7 +1587,7 @@ packages:
   /buffer/4.9.1:
     dependencies:
       base64-js: 1.3.0
-      ieee754: 1.1.11
+      ieee754: 1.1.12
       isarray: 1.0.0
     dev: false
     resolution:
@@ -1681,10 +1688,10 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=
-  /caniuse-db/1.0.30000850:
+  /caniuse-db/1.0.30000853:
     dev: false
     resolution:
-      integrity: sha1-llyBZkFXbQhwm+4SJWoFUBZLldU=
+      integrity: sha1-MpAafWuTqH1Z8Iqu5H6o/27JD98=
   /capture-exit/1.2.0:
     dependencies:
       rsvp: 3.6.2
@@ -1895,16 +1902,16 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=
-  /color-convert/1.9.1:
+  /color-convert/1.9.2:
     dependencies:
-      color-name: 1.1.3
+      color-name: 1.1.1
     dev: false
     resolution:
-      integrity: sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==
-  /color-name/1.1.3:
+      integrity: sha512-3NUJZdhMhcdPn8vJ9v2UQJoH0qqoGUkYTgFEPZaPjEtwmmKUfNV46zZmgB2M5M4DCEQHMaCfWHCxiBflLm04Tg==
+  /color-name/1.1.1:
     dev: false
     resolution:
-      integrity: sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
+      integrity: sha1-SxQVMEz1ACjqgWQ2Q72C6gWANok=
   /color-support/1.1.3:
     dev: false
     resolution:
@@ -1951,10 +1958,10 @@ packages:
       node: '>= 0.6.x'
     resolution:
       integrity: sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=
-  /compare-versions/3.2.1:
+  /compare-versions/3.3.0:
     dev: false
     resolution:
-      integrity: sha512-2y2nHcopMG/NAyk6vWXlLs86XeM9sik4jmx1tKIgzMi9/RQ2eo758RGpxQO3ErihHmg0RlQITPqgz73y6s7quA==
+      integrity: sha512-MAAAIOdi2s4Gl6rZ76PNcUa9IOYB+5ICdT41o5uMRf09aEu/F9RK+qhe8RjXNPwcTjGV7KU7h2P/fljThFVqyQ==
   /component-bind/1.0.0:
     dev: false
     resolution:
@@ -2212,7 +2219,7 @@ packages:
     dependencies:
       abab: 1.0.4
       whatwg-mimetype: 2.1.0
-      whatwg-url: 6.4.1
+      whatwg-url: 6.5.0
     dev: false
     resolution:
       integrity: sha512-ai40PPQR0Fn1lD2PPie79CibnlMN2AYiDhwFX/rZHVsxbs5kNJSjegqXIprhouGXlRdEnfybva7kqRGnB6mypA==
@@ -2528,7 +2535,7 @@ packages:
     dependencies:
       bn.js: 4.11.8
       brorand: 1.1.0
-      hash.js: 1.1.3
+      hash.js: 1.1.4
       hmac-drbg: 1.0.1
       inherits: 2.0.3
       minimalistic-assert: 1.0.1
@@ -2727,6 +2734,19 @@ packages:
       node: '>=0.8.0'
     resolution:
       integrity: sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
+  /escodegen/1.10.0:
+    dependencies:
+      esprima: 3.1.3
+      estraverse: 4.2.0
+      esutils: 2.0.2
+      optionator: 0.8.2
+    dev: false
+    engines:
+      node: '>=4.0'
+    optionalDependencies:
+      source-map: 0.6.1
+    resolution:
+      integrity: sha512-fjUOf8johsv23WuIKdNQU4P9t9jhQ4Qzx6pC2uW890OloK3Zs1ZAoCNpg/2larNF501jLl3UNy0kIRcF6VI22g==
   /escodegen/1.7.1:
     dependencies:
       esprima: 1.2.5
@@ -2753,19 +2773,6 @@ packages:
       source-map: 0.2.0
     resolution:
       integrity: sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=
-  /escodegen/1.9.1:
-    dependencies:
-      esprima: 3.1.3
-      estraverse: 4.2.0
-      esutils: 2.0.2
-      optionator: 0.8.2
-    dev: false
-    engines:
-      node: '>=4.0'
-    optionalDependencies:
-      source-map: 0.6.1
-    resolution:
-      integrity: sha512-6hTjO1NAWkHnDk3OqQ4YrCuwwmGHL9S3nPlzBOUG/R44rda3wLNrfvQ5fkSGjyhHFKM7ALPKcKGrwvCLe0lC7Q==
   /escope/3.6.0:
     dependencies:
       es6-map: 0.1.5
@@ -4123,6 +4130,12 @@ packages:
       uglify-js: 2.8.29
     resolution:
       integrity: sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=
+  /har-schema/1.0.5:
+    dev: false
+    engines:
+      node: '>=4'
+    resolution:
+      integrity: sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=
   /har-schema/2.0.0:
     dev: false
     engines:
@@ -4140,6 +4153,15 @@ packages:
       node: '>=0.10'
     resolution:
       integrity: sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=
+  /har-validator/4.2.1:
+    dependencies:
+      ajv: 4.11.8
+      har-schema: 1.0.5
+    dev: false
+    engines:
+      node: '>=4'
+    resolution:
+      integrity: sha1-M0gdDxu/9gDdID11gSpqX7oALio=
   /har-validator/5.0.3:
     dependencies:
       ajv: 5.2.2
@@ -4257,13 +4279,13 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=
-  /hash.js/1.1.3:
+  /hash.js/1.1.4:
     dependencies:
       inherits: 2.0.3
       minimalistic-assert: 1.0.1
     dev: false
     resolution:
-      integrity: sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==
+      integrity: sha512-A6RlQvvZEtFS5fLU43IDu0QUmBy+fDO9VMdTXvufKwIkt/rFfvICAViCax5fbDO4zdNzaC3/27ZhKUok5bAJyw==
   /hasha/2.2.0:
     dependencies:
       is-stream: 1.1.0
@@ -4286,7 +4308,7 @@ packages:
       integrity: sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=
   /hmac-drbg/1.0.1:
     dependencies:
-      hash.js: 1.1.3
+      hash.js: 1.1.4
       minimalistic-assert: 1.0.1
       minimalistic-crypto-utils: 1.0.1
     dev: false
@@ -4431,10 +4453,10 @@ packages:
     dev: false
     resolution:
       integrity: sha1-Bupvg2ead0njhs/h/oEq5dsiPe0=
-  /ieee754/1.1.11:
+  /ieee754/1.1.12:
     dev: false
     resolution:
-      integrity: sha512-VhDzCKN7K8ufStx/CLj5/PDTMgph+qwN5Pkd5i0sGnVwk56zJ0lkT8Qzi1xqWLS0Wp29DgDtNeS7v8/wMoZeHg==
+      integrity: sha512-GguP+DRY+pJ3soyIiGPTvdiVXjZ+DbXOxGpXn3eMvNW4x4irjqXm4wHKscC+TfxSJ0yw/S1F24tqdMNsMZTiLA==
   /import-local/1.0.0:
     dependencies:
       pkg-dir: 2.0.0
@@ -4944,7 +4966,7 @@ packages:
   /istanbul-api/1.3.1:
     dependencies:
       async: 2.6.1
-      compare-versions: 3.2.1
+      compare-versions: 3.3.0
       fileset: 2.0.3
       istanbul-lib-coverage: 1.2.0
       istanbul-lib-hook: 1.2.1
@@ -5247,7 +5269,7 @@ packages:
       integrity: sha512-lsEHVaTnKzdAPR5t4B6OcxXo9Vy4K+kRRbG5gtddY8lBEC+Mlpvm1CJcsMESRjzUhzkz568exMV1hTB76nAKbA==
   /jest-message-util/22.4.3:
     dependencies:
-      '@babel/code-frame': 7.0.0-beta.49
+      '@babel/code-frame': 7.0.0-beta.51
       chalk: 2.4.1
       micromatch: 2.3.11
       slash: 1.0.0
@@ -5403,10 +5425,10 @@ packages:
       cssstyle: 0.3.1
       data-urls: 1.0.0
       domexception: 1.0.1
-      escodegen: 1.9.1
+      escodegen: 1.10.0
       html-encoding-sniffer: 1.0.2
       left-pad: 1.3.0
-      nwsapi: 2.0.2
+      nwsapi: 2.0.3
       parse5: 4.0.0
       pn: 1.1.0
       request: 2.87.0
@@ -5418,7 +5440,7 @@ packages:
       webidl-conversions: 4.0.2
       whatwg-encoding: 1.0.3
       whatwg-mimetype: 2.1.0
-      whatwg-url: 6.4.1
+      whatwg-url: 6.5.0
       ws: 4.1.0
       xml-name-validator: 3.0.0
     dev: false
@@ -5444,6 +5466,10 @@ packages:
     dev: false
     resolution:
       integrity: sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=
+  /json-schema-traverse/0.4.1:
+    dev: false
+    resolution:
+      integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
   /json-schema/0.2.3:
     dev: false
     resolution:
@@ -6592,17 +6618,16 @@ packages:
     dev: false
     resolution:
       integrity: sha512-MmbQJ2MTESTjt3Gi/3yG1wGpIMhUfcIypUCGtTizFR9IiccFwxSpfp0vtIZlkFclEqERemxfnSdZEMR9VqqEFQ==
-  /node-gyp/3.6.2:
+  /node-gyp/3.7.0:
     dependencies:
       fstream: 1.0.11
       glob: 7.0.6
       graceful-fs: 4.1.11
-      minimatch: 3.0.4
       mkdirp: 0.5.1
       nopt: 3.0.6
       npmlog: 4.1.2
       osenv: 0.1.5
-      request: 2.87.0
+      request: 2.81.0
       rimraf: 2.5.4
       semver: 5.3.0
       tar: 2.2.1
@@ -6611,7 +6636,7 @@ packages:
     engines:
       node: '>= 0.8.0'
     resolution:
-      integrity: sha1-m/vlRWIoYoSDjnUOrAUpWFP6HGA=
+      integrity: sha512-qDQE/Ft9xXP6zphwx4sD0t+VhwV7yFaloMpfbL2QnnDZcyaiakWlLdtFGGQfTAwpFHdpbRhRxVhIHN1OKAjgbg==
   /node-int64/0.4.0:
     dev: false
     resolution:
@@ -6677,7 +6702,7 @@ packages:
       meow: 3.7.0
       mkdirp: 0.5.1
       nan: 2.10.0
-      node-gyp: 3.6.2
+      node-gyp: 3.7.0
       npmlog: 4.1.2
       request: 2.79.0
       sass-graph: 2.2.4
@@ -6768,10 +6793,10 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=
-  /nwsapi/2.0.2:
+  /nwsapi/2.0.3:
     dev: false
     resolution:
-      integrity: sha512-wAvMV1QgoYPvqfcAmX1M86SyZA3SnNT6UNvjqO/pKHjIZzhMpPHjCTOWdOfkmUknjnvjDq09wDiBaHAzXSLiSA==
+      integrity: sha512-zFJF9lOpg2+uicP0BQKOAfIOqeTp/p8PC669mewxgRkR1hGjne8BMUHk4wpRS9o5Z0icA5Nv04HmGkW31KfMKw==
   /oauth-sign/0.8.2:
     dev: false
     resolution:
@@ -7235,6 +7260,10 @@ packages:
     dev: false
     resolution:
       integrity: sha1-elfrVQpng/kRUzH89GY9XI4AelA=
+  /performance-now/0.2.0:
+    dev: false
+    resolution:
+      integrity: sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=
   /performance-now/2.1.0:
     dev: false
     resolution:
@@ -7483,10 +7512,10 @@ packages:
     dev: false
     resolution:
       integrity: sha1-8FKijacOYYkX7wqKw0wa5aaChrM=
-  /psl/1.1.27:
+  /psl/1.1.28:
     dev: false
     resolution:
-      integrity: sha512-J8tJX5tAeEp9tQTI2w2aMZ6V1INuU4JmNaNPRuHAqjjVq3ZJ+jV3+tcT3ncgTnBxvwJy740IB/WZrxFus2VdMA==
+      integrity: sha512-+AqO1Ae+N/4r7Rvchrdm432afjT9hqJRyBN3DQv9At0tPz4hIFSGKbq64fN9dVoCow4oggIIax5/iONx0r9hZw==
   /public-encrypt/4.0.2:
     dependencies:
       bn.js: 4.11.8
@@ -7525,6 +7554,12 @@ packages:
       node: '>=0.6'
     resolution:
       integrity: sha1-51vV9uJoEioqDgvaYwslUMFmUCw=
+  /qs/6.4.0:
+    dev: false
+    engines:
+      node: '>=0.6'
+    resolution:
+      integrity: sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=
   /qs/6.5.1:
     dev: false
     engines:
@@ -7908,6 +7943,35 @@ packages:
       node: '>= 4'
     resolution:
       integrity: sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=
+  /request/2.81.0:
+    dependencies:
+      aws-sign2: 0.6.0
+      aws4: 1.7.0
+      caseless: 0.12.0
+      combined-stream: 1.0.6
+      extend: 3.0.1
+      forever-agent: 0.6.1
+      form-data: 2.1.4
+      har-validator: 4.2.1
+      hawk: 3.1.3
+      http-signature: 1.1.1
+      is-typedarray: 1.0.0
+      isstream: 0.1.2
+      json-stringify-safe: 5.0.1
+      mime-types: 2.1.18
+      oauth-sign: 0.8.2
+      performance-now: 0.2.0
+      qs: 6.4.0
+      safe-buffer: 5.1.2
+      stringstream: 0.0.6
+      tough-cookie: 2.3.4
+      tunnel-agent: 0.6.0
+      uuid: 3.2.1
+    dev: false
+    engines:
+      node: '>= 4'
+    resolution:
+      integrity: sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=
   /request/2.87.0:
     dependencies:
       aws-sign2: 0.7.0
@@ -8315,7 +8379,7 @@ packages:
       formatio: 1.1.1
       lolex: 1.3.2
       samsam: 1.1.2
-      util: 0.10.4
+      util: 0.11.0
     dev: false
     engines:
       node: '>=0.1.103'
@@ -9093,7 +9157,7 @@ packages:
       integrity: sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==
   /tough-cookie/2.4.2:
     dependencies:
-      psl: 1.1.27
+      psl: 1.1.28
       punycode: 1.4.1
     dev: false
     engines:
@@ -9425,6 +9489,12 @@ packages:
     dev: false
     resolution:
       integrity: sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==
+  /util/0.11.0:
+    dependencies:
+      inherits: 2.0.3
+    dev: false
+    resolution:
+      integrity: sha512-5n12uMzKCjvB2HPFHnbQSjaqAa98L5iIXmHrZCLavuZVe0qe/SJGbDGWlpaHk5lnBkWRDO+dRu1/PgmUYKPPTw==
   /utils-merge/1.0.1:
     dev: false
     engines:
@@ -9652,8 +9722,8 @@ packages:
     dependencies:
       acorn: 5.6.2
       acorn-dynamic-import: 2.0.2
-      ajv: 6.5.0
-      ajv-keywords: /ajv-keywords/3.2.0/ajv@6.5.0
+      ajv: 6.5.1
+      ajv-keywords: /ajv-keywords/3.2.0/ajv@6.5.1
       async: 2.6.1
       enhanced-resolve: 3.4.1
       escope: 3.6.0
@@ -9702,14 +9772,14 @@ packages:
     dev: false
     resolution:
       integrity: sha512-FKxhYLytBQiUKjkYteN71fAUA3g6KpNXoho1isLiLSB3N1G4F35Q5vUxWfKFhBwi5IWF27VE6WxhrnnC+m0Mew==
-  /whatwg-url/6.4.1:
+  /whatwg-url/6.5.0:
     dependencies:
       lodash.sortby: 4.7.0
       tr46: 1.0.1
       webidl-conversions: 4.0.2
     dev: false
     resolution:
-      integrity: sha512-FwygsxsXx27x6XXuExA/ox3Ktwcbf+OAvrKmLulotDAiO1Q6ixchPFaHYsis2zZBZSJTR0+dR+JVtf7MlbqZjw==
+      integrity: sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==
   /which-module/1.0.0:
     dev: false
     resolution:
@@ -9976,7 +10046,7 @@ packages:
     dev: false
     name: '@rush-temp/api-documenter'
     resolution:
-      integrity: sha512-wA3a4tS9fU1Glv0+ZHSYt76K5+hXAHWcd/ZIEe8NSHON9Db+f5DJRkgDUTKGAUg7Xep+myAJ6dp3fIkP8ZIEag==
+      integrity: sha512-QwhEEs6B1CuE2AE/GlpqwUxI8eX+UreXnpfhhTQuTOY0u+CL7AJxHNAGfPGkIm5bV7jusQ31/joR53KZP1Gb4A==
       tarball: 'file:projects/api-documenter.tgz'
     version: 0.0.0
   'file:projects/api-extractor-test-01.tgz':
@@ -9988,7 +10058,7 @@ packages:
     dev: false
     name: '@rush-temp/api-extractor-test-01'
     resolution:
-      integrity: sha512-aNdiFg6swmtdZ4994dZD8AlCDjVLAtl0hTepnWsk7+wnFbj88ZlMarpg4A+lh813/oVasJvlbqaIJq9vJEwz/Q==
+      integrity: sha512-Qb+lSYkbdZC47kh+PjaT62fZ2v5O/fTY0Hj0zZXmuX1GRHx+QZ6vapi2f6jmOJgIBHg5rITEHU0xEuMQ2uxBhw==
       tarball: 'file:projects/api-extractor-test-01.tgz'
     version: 0.0.0
   'file:projects/api-extractor-test-02.tgz':
@@ -10001,7 +10071,7 @@ packages:
     dev: false
     name: '@rush-temp/api-extractor-test-02'
     resolution:
-      integrity: sha512-0225l4IuXHAQumzqE1JbtOUzUTAP+ZlPZ+NhUzOBpW5AEXR+zXu0RMIvRp8AxuUBcqICkXyQ3KUgffM2VDMn9g==
+      integrity: sha512-C6tUCEEg3+FKeqjM7LFNlje2Kf7Wu4TuRGXhFpqVIlJT3cbFOpb1CBgifZp4ZoBmoQvqUY9ueHQwmUVm6gwVmQ==
       tarball: 'file:projects/api-extractor-test-02.tgz'
     version: 0.0.0
   'file:projects/api-extractor-test-03.tgz':
@@ -10023,7 +10093,7 @@ packages:
     dev: false
     name: '@rush-temp/api-extractor-test-04'
     resolution:
-      integrity: sha512-qJgk9kC3TZimupH4RWZG0tceORzgSc82YPSNxZI3RF3YMt3tzsUseaP79n4ZkwX3Iob6IX2kcv4FFLFVe/dkfA==
+      integrity: sha512-p24nNHI/7tfN8g3vcxx5pNxjzqk/1c/HDdMy8WFqles4GOtvgjf9Mozm2oQm7/UVk84SyeH/rKBPJXX6GDGbDQ==
       tarball: 'file:projects/api-extractor-test-04.tgz'
     version: 0.0.0
   'file:projects/api-extractor.tgz':
@@ -10044,7 +10114,7 @@ packages:
     dev: false
     name: '@rush-temp/api-extractor'
     resolution:
-      integrity: sha512-mTjuE7UFW2yrRHWq3+h6NVzs3WoCFE2DwhNrrSKc0wTBPefZaprFyO5l0YxjBO6XjjAqu550QVe6TzHD1Gz9nQ==
+      integrity: sha512-az8VjG6LnfFdPHJd1ebPYzLkrLnwhRJeUiLAhU6Jbo2BMijC3FacowYVvBgiDi8dILqwicK9Vejvh+z4vPcQrA==
       tarball: 'file:projects/api-extractor.tgz'
     version: 0.0.0
   'file:projects/gulp-core-build-karma.tgz':
@@ -10076,7 +10146,7 @@ packages:
     dev: false
     name: '@rush-temp/gulp-core-build-karma'
     resolution:
-      integrity: sha512-vhykKuW2sn9oAPhvLNQsQ8qb/XLObHdzqqckJHJO6bQUfJjOlW6pOV2eVnHpD3mNJ2eyWve7HnQdSu80btoZWQ==
+      integrity: sha512-+SZo1eQLLUzovQn5STe3yRA13nwXIqIHHlLY2g5JXxSdJoXFy7a/WStoUIoK0g1fqMTnzprciQ5zAIUucpY8HQ==
       tarball: 'file:projects/gulp-core-build-karma.tgz'
     version: 0.0.0
   'file:projects/gulp-core-build-mocha.tgz':
@@ -10095,7 +10165,7 @@ packages:
     dev: false
     name: '@rush-temp/gulp-core-build-mocha'
     resolution:
-      integrity: sha512-olibp9uSq8JBu3zACBNMTHTxcjRo1NT2ba0Tb2hzFpdJgYgPXUY8yzcIis+H6SPnCKBAB9wVis5NE1XaJHdGpA==
+      integrity: sha512-i80CBqbKItTNrmdcvLrFi30uicZnu5RCKVJl+oG5UO3SSKrrmu/QLTu4d0cx5VDdM/pU7Naxj5MY84EGRChPVQ==
       tarball: 'file:projects/gulp-core-build-mocha.tgz'
     version: 0.0.0
   'file:projects/gulp-core-build-sass.tgz':
@@ -10124,7 +10194,7 @@ packages:
     dev: false
     name: '@rush-temp/gulp-core-build-sass'
     resolution:
-      integrity: sha512-zGxz7mQKC34hqWAD6r4smCQklcl1PD6muqc1rZuWxjJbjLz9+eXAC/IW2g+8p2UWJ+k5/KTzDEEDa206FdrrCg==
+      integrity: sha512-y0f+obtAfz3P8EhhIuFCqujvuyvbUmFdof/oarSYDE7be+YgKNgjuzDaxhAJqfda9uE5UcakOhx9y5bOJqGg7g==
       tarball: 'file:projects/gulp-core-build-sass.tgz'
     version: 0.0.0
   'file:projects/gulp-core-build-serve.tgz':
@@ -10154,7 +10224,7 @@ packages:
     dev: false
     name: '@rush-temp/gulp-core-build-serve'
     resolution:
-      integrity: sha512-B46J4YfMVJuhOSaH/T2JYWNu6KAPS1xrW+1z7uN9OIwTeAEDdHi7SilU6AI/QlpOXlNsa2/ADOF839byOg0Gsg==
+      integrity: sha512-MvZ02fGqujOJvAwwOiBiXp+HwetrQIyt8GJ7IfGLjDTLC4FYcEqsF90Bb2xHAjqgzWxsT/FMAQwqseWYkbPolA==
       tarball: 'file:projects/gulp-core-build-serve.tgz'
     version: 0.0.0
   'file:projects/gulp-core-build-typescript.tgz':
@@ -10189,7 +10259,7 @@ packages:
     dev: false
     name: '@rush-temp/gulp-core-build-typescript'
     resolution:
-      integrity: sha512-RfWkmYUKUdPNNOoUW8k2hJsIVBLufaXNJSMPkhMMyLEI79pseA+0L0R3C8E16zaqTb7RiXeuccR1qY6aoKRnaw==
+      integrity: sha512-kJKI6mPTqfHfyVBsaL7uUZFgfQlsik2cJXj7QT+6hwvzyMH2IBce5/R4CU3JQr0l1R7LbPeJdXwz/mVcOe3a/A==
       tarball: 'file:projects/gulp-core-build-typescript.tgz'
     version: 0.0.0
   'file:projects/gulp-core-build-webpack.tgz':
@@ -10209,7 +10279,7 @@ packages:
     dev: false
     name: '@rush-temp/gulp-core-build-webpack'
     resolution:
-      integrity: sha512-/rO8tpjYHpkP3hNBUgKa6lG/6eADrlrsqadXPwqZ3fW8OSF03Tdg1WBHAHS+doojAfXUZFowHu9CYUHy0gPXFA==
+      integrity: sha512-4wCB8CCCLe5Kutcvxsm1SXbQORps4/RG1hzlNSwkRsIOxIv+0DW61+lHJ27WoQqVtIqRciFwD3y9SRfEgANmhQ==
       tarball: 'file:projects/gulp-core-build-webpack.tgz'
     version: 0.0.0
   'file:projects/gulp-core-build.tgz':
@@ -10261,7 +10331,7 @@ packages:
     dev: false
     name: '@rush-temp/gulp-core-build'
     resolution:
-      integrity: sha512-n/vLaI1pChVvcL4kVC/MSTS2KlnoCjwO9YvMs3MOvETymFoCYOEFJTCxZnjScVQchov3PCe8AWsVbUDimRvTXA==
+      integrity: sha512-Ur2IUBZXdLXAZ6IxgoHw9JOGDL3TEmYp5RvwVAncou5Q547y1X2c+LiPQJofaQZd6+OfiYgMhaGfhnbZS6r5Xg==
       tarball: 'file:projects/gulp-core-build.tgz'
     version: 0.0.0
   'file:projects/load-themed-styles.tgz':
@@ -10274,7 +10344,7 @@ packages:
     dev: false
     name: '@rush-temp/load-themed-styles'
     resolution:
-      integrity: sha512-sPOlToxPRUuxkm+pM0AFrdbM9Mqc+C2lyiQRhKztGVT/XkvxOjweHwh+mCx6NLyeGQKS8AL655hcgSW73kG5Ng==
+      integrity: sha512-ojXdn34b5L/jdjTyWcKyQmP2r4ikIUylJQerHVpCcmkj82RkeTMoJIx8nUXS2y0Vy6ZkzEHZnkskB4Kf/UwV/w==
       tarball: 'file:projects/load-themed-styles.tgz'
     version: 0.0.0
   'file:projects/loader-load-themed-styles.tgz':
@@ -10289,7 +10359,7 @@ packages:
     dev: false
     name: '@rush-temp/loader-load-themed-styles'
     resolution:
-      integrity: sha512-wYU/mKRiF+m2tXgI2SoX3So0xLzQ/1fzNl/pnMYbjEeiM/xh3PTlHzBY/FpAmB2C4u7KpReQD/4iSWDv6+WihQ==
+      integrity: sha512-T0y83oIo1ZUDqsJs5M+jmunCM0BiECekbX5rReJ/6e56zTX5ojjlyGBRBNTCEbjJjqKXTPRaO2xCihVy3xmsWg==
       tarball: 'file:projects/loader-load-themed-styles.tgz'
     version: 0.0.0
   'file:projects/loader-raw-script.tgz':
@@ -10303,7 +10373,7 @@ packages:
     dev: false
     name: '@rush-temp/loader-raw-script'
     resolution:
-      integrity: sha512-X0sr6Hc2zW/r2tijCH5iYWRR5qmuxPJNbkPEkog/6hHWRCuox/HkMux/uwMOWzVe3vYEOvtVtfEr4CnEgSQjtg==
+      integrity: sha512-UfJ2CYA15Pwg8hqG4cOBHVrEpsks/HhLzqHPwuZyzGVSBoEhE3sqCA4stXZdqAP8vlOIjCxwbxR1YIVFm4uD9Q==
       tarball: 'file:projects/loader-raw-script.tgz'
     version: 0.0.0
   'file:projects/loader-set-webpack-public-path.tgz':
@@ -10319,7 +10389,7 @@ packages:
     dev: false
     name: '@rush-temp/loader-set-webpack-public-path'
     resolution:
-      integrity: sha512-QnX564oUmkbQzJRJXHwAwAC49BJnaX0BU9M+BeJJehQLH7TD5Qg3fcEANyPjUyDe1ttkk2XMGOwLsL+C+ir3kQ==
+      integrity: sha512-rmNOdLhDeFNmBmtz8ifmgFpDiwdTdoammW2OGqYpDvyva0Um2rnt1HElOVFGtg55vz3L4+xAz8o+hvCgSAaZbw==
       tarball: 'file:projects/loader-set-webpack-public-path.tgz'
     version: 0.0.0
   'file:projects/node-core-library.tgz':
@@ -10350,7 +10420,7 @@ packages:
     dev: false
     name: '@rush-temp/node-library-build'
     resolution:
-      integrity: sha512-BJgJTTd8RK9WCjR8q3LHzCKkOUHE80TQfaPBkIy2W75rvffysnbBxiKT+8hlImsV8ry+L8cGjfkioWcLg4U+9Q==
+      integrity: sha512-mEiH1/rF1qiHEdTCHiOqwRfs3qtYg1sKxpWZiCtRolQ8kroYJQYF4xXzy3VJud4JqqHaB/Y3BqlnAP1lYNp/yQ==
       tarball: 'file:projects/node-library-build.tgz'
     version: 0.0.0
   'file:projects/package-deps-hash.tgz':
@@ -10363,7 +10433,7 @@ packages:
     dev: false
     name: '@rush-temp/package-deps-hash'
     resolution:
-      integrity: sha512-exDRyzFbKO7IHAWblVQIil0vM37jN8S6Dq1ttDAp6B9y+c41pUHEJRnZnEv5AmIeGMvX4S95PMEKGRWtcGJWYg==
+      integrity: sha512-aCaAMRA4HRTCilHacKOv9DuyM44483Fg+d49bUjliuyS/qR+GCbNAcuomx7OVk8792qwRVlSpJEAch4tHwfOaw==
       tarball: 'file:projects/package-deps-hash.tgz'
     version: 0.0.0
   'file:projects/resolve-chunk-plugin.tgz':
@@ -10376,7 +10446,7 @@ packages:
     dev: false
     name: '@rush-temp/resolve-chunk-plugin'
     resolution:
-      integrity: sha512-jNM0fnFsRmx4mYTD+BdZxe316UCtTZ0m3QTiuMMmvJP5wP9Pp1GNG8If+e/FcdNxFdnDldIUnlEvdReGwUXmFw==
+      integrity: sha512-wT+j1t/LffVdDv6kDognaOFWiz2imyAaZJm2eT8H4nMY0fgCmK8xowD9ziLF2UVL06T5gTdZdiRTbW1YHaanpQ==
       tarball: 'file:projects/resolve-chunk-plugin.tgz'
     version: 0.0.0
   'file:projects/rush-lib.tgz':
@@ -10419,7 +10489,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-lib'
     resolution:
-      integrity: sha512-3T9x2Rol/6Zul9u6nepVOdBLxmjCmisdbtpjrLykhR6tOXZ+UxRoqrfxnhHCBMJsiNndrSxpdNxQIaaoeugUKw==
+      integrity: sha512-J9B8QH9BORkXjq4Y0kRgcl/gqZylSfyHpsYWpljHxCBVUwOzwXu9iOEbkTYPMbyGKIj/aMcgN10MHYqCN9nn6A==
       tarball: 'file:projects/rush-lib.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler.tgz':
@@ -10430,7 +10500,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler'
     resolution:
-      integrity: sha512-LYd8Al4xtXS/B1yCXvDvKBaEOa+OoEXNTIe0DWlucHLxJlIyjyK8vPk82J/WbPYz9z174qMLP/qSNyR1KZQJ/g==
+      integrity: sha512-XIc9hQIvQevtoMocDJjHc80sbaIifLiYd5PECe9HEd3TCFWQpqRdT6SNiFg7Z+TaCReOf1H8q+MipysBF/qOnA==
       tarball: 'file:projects/rush-stack-compiler.tgz'
     version: 0.0.0
   'file:projects/rush-stack-library-test.tgz':
@@ -10451,7 +10521,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack'
     resolution:
-      integrity: sha512-a3kg8lgH4Y7LZa9Md37ga/95xYpCiE59D5pd17QAwTzGAdTilGs0Jzmwm3eC0gncaFgOCOwGaz88p8QVuLMY6Q==
+      integrity: sha512-5aS0c5SS5vWr3fdY6UXiM0ufC113bfLePUMwLPsFjLoDdJeRKLPQlhNms4hLnm0d/nxNB9ffy9aDj9IVyaKz8A==
       tarball: 'file:projects/rush-stack.tgz'
     version: 0.0.0
   'file:projects/rush.tgz':
@@ -10471,7 +10541,7 @@ packages:
     dev: false
     name: '@rush-temp/rush'
     resolution:
-      integrity: sha512-MpHP/Qz1g7aR9ej/AGuRKEThFzpWQoIRPGxETjgzTVwaIlqhew7mBvnhOeHAalQ3pYpiX3jaaqptjaXQjqUiFQ==
+      integrity: sha512-NqdD8zbQGKADa7DnqV23+nU9VS8uuYlBqRIbdiuB9nap/BgOG9OTiUxo0hjjh4o9il8b5ae400SfMycIJDiAyw==
       tarball: 'file:projects/rush.tgz'
     version: 0.0.0
   'file:projects/set-webpack-public-path-plugin.tgz':
@@ -10490,7 +10560,7 @@ packages:
     dev: false
     name: '@rush-temp/set-webpack-public-path-plugin'
     resolution:
-      integrity: sha512-FW2ios7f80Ths2NhTQqdcO4y6pjGlj/mWy5ThAaM8gMeE7psFhM7mQvErQBKhmqFgWPRQaaBiCEV488u7xdoOQ==
+      integrity: sha512-HMtDXv34M9Slq7SJf8br5TfbxAFlmleI5QmnA3Kv51ylIaHwaKMV37AM6oeK4NFmT0D3IoLGOX2jz5hD1enFBA==
       tarball: 'file:projects/set-webpack-public-path-plugin.tgz'
     version: 0.0.0
   'file:projects/stream-collator.tgz':
@@ -10505,7 +10575,7 @@ packages:
     dev: false
     name: '@rush-temp/stream-collator'
     resolution:
-      integrity: sha512-LwcifVJM9vgP+0wr21z1M0rXnU0nyhRgc6bmiKqrvMDrMR1/qJwKou0gP25RYj7OdHBzlc79vgJGB3OcNVsG7A==
+      integrity: sha512-Vrhwyk4JirI9JSJN5R3ijvah+HjWyGDsIFuJ+ObK9VD5vf9jaGP7jX+cFk75ESa8oCnOxJaIF07E77If7WpLmQ==
       tarball: 'file:projects/stream-collator.tgz'
     version: 0.0.0
   'file:projects/ts-command-line.tgz':
@@ -10533,7 +10603,7 @@ packages:
     dev: false
     name: '@rush-temp/web-library-build-test'
     resolution:
-      integrity: sha512-pUHtdVUkOvCa/BoX8S2w2eGY0cQLjBpDCr+3HE7qJ6PRrWqwKxoNpnv5dQzXqZ/fzPyMr5eDfhUBQQoeIJKiTw==
+      integrity: sha512-UOPkfDtVdwKrp6Axf+OgjoT7FiJL6xJV4HeYWJ2X5OM4o9iPu1xibNVXEyiaPWAWzy/4G6hb9cneHhDXbXnRNg==
       tarball: 'file:projects/web-library-build-test.tgz'
     version: 0.0.0
   'file:projects/web-library-build.tgz':
@@ -10545,7 +10615,7 @@ packages:
     dev: false
     name: '@rush-temp/web-library-build'
     resolution:
-      integrity: sha512-q6MVMS4Lveyvj1Iux2QaTOg16r9tOHuljIxjtM9/VTXZkYMjqp9oBGsum+6J1KXBRZnfSUjK/Ff71+LuMNQYNw==
+      integrity: sha512-tYDGNjr0iTh5TZwJ13t2nSnqCMH1Tbg3d+DghmxtxjVU2oHGCGZ4s5XKLZCZKCuNFrwo8K8eByR1G4lcR9iqAw==
       tarball: 'file:projects/web-library-build.tgz'
     version: 0.0.0
 registry: 'https://registry.npmjs.org/'

--- a/rush.json
+++ b/rush.json
@@ -1,6 +1,6 @@
 {
   "rushVersion": "5.0.0-dev.22",
-  "pnpmVersion": "2.2.1",
+  "pnpmVersion": "2.4.0",
   "nodeSupportedVersionRange": ">=6.9.0 <7.0.0 || >=8.9.4 <9.0.0",
 
   "projectFolderMinDepth": 2,


### PR DESCRIPTION
If a dependency was missing, "rush install" would print two warnings...

```
The NPM shrinkwrap file does not provide "react" (16.4.1) required by the preferred versions from common-versions.json
The NPM shrinkwrap file is missing "react" (16.4.1) required by "@microsoft/api-documenter".
Finished creating temporary modules (0.15 seconds)
```

...when only the second warning was correct.  This occurred because the implicit preferred version was being checked and reported the same way as an explicit setting in **common-versions.json**.