### PR TITLE
[api-extractor] Allow nested namespaces in permissive mode

### DIFF
--- a/apps/api-extractor/src/ast/AstFunction.ts
+++ b/apps/api-extractor/src/ast/AstFunction.ts
@@ -2,6 +2,8 @@
 // See LICENSE in the project root for license information.
 
 import * as ts from 'typescript';
+import { Text } from '@microsoft/node-core-library';
+
 import { AstItem, AstItemKind, IAstItemOptions } from './AstItem';
 import { AstParameter } from './AstParameter';
 import { TypeScriptHelpers } from '../utils/TypeScriptHelpers';
@@ -40,7 +42,7 @@ export class AstFunction extends AstItem {
 
     // Return type
     if (methodDeclaration.type) {
-      this.returnType = methodDeclaration.type.getText();
+      this.returnType = Text.convertToLf(methodDeclaration.type.getText());
     } else {
       this.hasIncompleteTypes = true;
       this.returnType = 'any';

--- a/apps/api-extractor/src/ast/AstMember.ts
+++ b/apps/api-extractor/src/ast/AstMember.ts
@@ -2,6 +2,7 @@
 // See LICENSE in the project root for license information.
 
 import * as ts from 'typescript';
+import { Text } from '@microsoft/node-core-library';
 import { AstItem, IAstItemOptions } from './AstItem';
 import { AstStructuredType } from './AstStructuredType';
 import { PrettyPrinter } from '../utils/PrettyPrinter';
@@ -104,7 +105,7 @@ export class AstMember extends AstItem {
       result += this.isOptional ? '?' : '';
       result += ':';
       result += !this.typeLiteral && property && property.type ? ` ${property.type};` : '';
-      return result;
+      return Text.convertToLf(result);
     } else {
       return PrettyPrinter.getDeclarationSummary(this.declaration);
     }

--- a/apps/api-extractor/src/ast/AstMethod.ts
+++ b/apps/api-extractor/src/ast/AstMethod.ts
@@ -2,6 +2,8 @@
 // See LICENSE in the project root for license information.
 
 import * as ts from 'typescript';
+import { Text } from '@microsoft/node-core-library';
+
 import { IParsedPackageName } from '@microsoft/node-core-library';
 import { AstItem, AstItemKind, IAstItemOptions } from './AstItem';
 import { AstMember } from './AstMember';
@@ -51,7 +53,7 @@ export class AstMethod extends AstMember {
     // Return type
     if (this.kind !== AstItemKind.Constructor) {
       if (methodDeclaration.type) {
-        this.returnType = methodDeclaration.type.getText();
+        this.returnType = Text.convertToLf(methodDeclaration.type.getText());
       } else {
         this.returnType = 'any';
         this.hasIncompleteTypes = true;

--- a/apps/api-extractor/src/ast/AstModule.ts
+++ b/apps/api-extractor/src/ast/AstModule.ts
@@ -37,7 +37,7 @@ export abstract class AstModule extends AstItemContainer {
 
       if (followedSymbol.flags & (ts.SymbolFlags.Class | ts.SymbolFlags.Interface)) {
         this.addMemberItem(new AstStructuredType(options));
-      } else if (followedSymbol.flags & ts.SymbolFlags.ValueModule) {
+      } else if (followedSymbol.flags & (ts.SymbolFlags.ValueModule | ts.SymbolFlags.NamespaceModule)) {
         this.addMemberItem(new AstNamespace(options)); // tslint:disable-line:no-use-before-declare
       } else if (followedSymbol.flags & ts.SymbolFlags.Function) {
         this.addMemberItem(new AstFunction(options));

--- a/apps/api-extractor/src/ast/AstParameter.ts
+++ b/apps/api-extractor/src/ast/AstParameter.ts
@@ -2,6 +2,8 @@
 // See LICENSE in the project root for license information.
 
 import * as ts from 'typescript';
+import { Text } from '@microsoft/node-core-library';
+
 import { AstItem, AstItemKind, IAstItemOptions } from './AstItem';
 
 /**
@@ -24,7 +26,7 @@ export class AstParameter extends AstItem {
     const parameterDeclaration: ts.ParameterDeclaration = options.declaration as ts.ParameterDeclaration;
     this.isOptional = !!parameterDeclaration.questionToken || !!parameterDeclaration.initializer;
     if (parameterDeclaration.type) {
-      this.type = parameterDeclaration.type.getText();
+      this.type = Text.convertToLf(parameterDeclaration.type.getText());
     } else {
       this.hasIncompleteTypes = true;
       this.type = 'any';

--- a/apps/api-extractor/src/ast/AstProperty.ts
+++ b/apps/api-extractor/src/ast/AstProperty.ts
@@ -2,6 +2,7 @@
 // See LICENSE in the project root for license information.
 
 import * as ts from 'typescript';
+import { Text } from '@microsoft/node-core-library';
 
 import { AstItemKind, IAstItemOptions } from './AstItem';
 import { AstMember } from './AstMember';
@@ -21,7 +22,7 @@ export class AstProperty extends AstMember {
 
     const declaration: ts.PropertyDeclaration = options.declaration as ts.PropertyDeclaration;
     if (declaration.type) {
-      this.type = declaration.type.getText();
+      this.type = Text.convertToLf(declaration.type.getText());
     } else {
       this.hasIncompleteTypes = true;
       this.type = 'any';

--- a/apps/api-extractor/src/ast/AstStructuredType.ts
+++ b/apps/api-extractor/src/ast/AstStructuredType.ts
@@ -4,6 +4,8 @@
 /* tslint:disable:no-bitwise */
 
 import * as ts from 'typescript';
+import { Text } from '@microsoft/node-core-library';
+
 import { ReleaseTag } from '../aedoc/ReleaseTag';
 import { Markup } from '../markup/Markup';
 import { AstMethod } from './AstMethod';
@@ -157,7 +159,7 @@ export class AstStructuredType extends AstItemContainer {
           .join(', ');
       }
     }
-    return result;
+    return Text.convertToLf(result);
   }
 
   protected onCompleteInitialization(): void {

--- a/apps/api-extractor/src/utils/PrettyPrinter.ts
+++ b/apps/api-extractor/src/utils/PrettyPrinter.ts
@@ -4,6 +4,7 @@
 /* tslint:disable:no-bitwise */
 
 import * as ts from 'typescript';
+import { Text } from '@microsoft/node-core-library';
 
 import { Span } from './Span';
 
@@ -74,7 +75,7 @@ export class PrettyPrinter {
       }
     });
 
-    return rootSpan.getModifiedText();
+    return Text.convertToLf(rootSpan.getModifiedText());
   }
 
   /**

--- a/common/changes/@microsoft/api-extractor/pgonzal-ae-nested-namespaces_2018-06-19-02-49.json
+++ b/common/changes/@microsoft/api-extractor/pgonzal-ae-nested-namespaces_2018-06-19-02-49.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor",
+      "comment": "For namespaceSupport=permissive, allow arbitrary nesting of namespaces",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/api-extractor/pgonzal-ae-nested-namespaces_2018-06-19-03-08.json
+++ b/common/changes/@microsoft/api-extractor/pgonzal-ae-nested-namespaces_2018-06-19-03-08.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor",
+      "comment": "Fix an issue where multi-line type literals sometimes had inconsistent newlines in the *.api.json file",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor",
+  "email": "pgonzal@users.noreply.github.com"
+}


### PR DESCRIPTION
When `namespaceSupport=permissive` is specified in the configuration, allow arbitrary nesting of namespaces.