### PR TITLE
Fix mutability on this._projectTsConfig

### DIFF
--- a/common/changes/@microsoft/gulp-core-build-typescript/GolaWaya_2018-06-21-20-19.json
+++ b/common/changes/@microsoft/gulp-core-build-typescript/GolaWaya_2018-06-21-20-19.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/gulp-core-build-typescript",
+      "comment": "Fixed mutation on tsConfigFile resulting in tslint error",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/gulp-core-build-typescript",
+  "email": "GolaWaya@users.noreply.github.com"
+}

--- a/core-build/gulp-core-build-typescript/src/TypeScriptConfiguration.ts
+++ b/core-build/gulp-core-build-typescript/src/TypeScriptConfiguration.ts
@@ -38,7 +38,7 @@ export class TypeScriptConfiguration {
    */
   public static getGulpTypescriptOptions(buildConfig: IBuildConfig): ITsConfigFile<ts.Settings> {
     const file: ITsConfigFile<ts.Settings> = assign({}, this.getTsConfigFile(buildConfig));
-    assign(file.compilerOptions, {
+    file.compilerOptions = assign({}, file.compilerOptions, {
       rootDir: buildConfig.rootPath,
       typescript: this.getTypescriptCompiler()
     });


### PR DESCRIPTION
Changed getGulpTypescriptOptions to prevent accidental mutation of compilerOptions object in immutable this._projectTsConfig resulting in an error in tslint when executing tslint and typescript tasks multiple times in a row within the same parent task (such as in a watch). #712 