### PR TITLE
[rushell] Initial commit of shell tokenizer

### DIFF
--- a/libraries/rushell/src/ParseError.ts
+++ b/libraries/rushell/src/ParseError.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
 import { TextRange, ITextLocation } from './TextRange';
 
 /**

--- a/libraries/rushell/src/TextRange.ts
+++ b/libraries/rushell/src/TextRange.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
 /**
  * Text coordinates represented as a line number and column number.
  *

--- a/libraries/rushell/src/Tokenizer.ts
+++ b/libraries/rushell/src/Tokenizer.ts
@@ -1,0 +1,110 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import { TextRange } from './TextRange';
+
+export enum TokenKind {
+  // One or more spaces/tabs
+  Spaces,
+  // A single newline sequence such as CRLF or LF
+  NewLine,
+  // An unrecognized character
+  Other,
+  // The end of the input string
+  EndOfInput
+}
+
+export class Token {
+  public readonly kind: TokenKind;
+  public readonly range: TextRange;
+
+  public constructor(kind: TokenKind, range: TextRange) {
+    this.kind = kind;
+    this.range = range;
+  }
+
+  public toString(): string {
+    return this.range.toString();
+  }
+}
+
+export class Tokenizer {
+  public readonly input: TextRange;
+  private _currentIndex: number;
+
+  constructor(input: TextRange | string) {
+    if (typeof(input) === 'string') {
+      this.input = TextRange.fromString(input);
+    } else {
+      this.input = input;
+    }
+    this._currentIndex = this.input.pos;
+  }
+
+  public get currentIndex(): number {
+    return this._currentIndex;
+  }
+
+  public getToken(): Token {
+    const input: TextRange = this.input;
+
+    const startIndex: number = this._currentIndex;
+    let c: string | undefined = this._get();
+
+    // Reached end of input yet?
+    if (c === undefined) {
+      return new Token(TokenKind.EndOfInput, TextRange.empty);
+    }
+
+    // Is it a sequence of whitespace?
+    if (/[ \t]/.test(c)) {
+
+      while (Tokenizer._isSpace(this._peek())) {
+        this._get();
+      }
+
+      return new Token(TokenKind.Spaces, input.getNewRange(startIndex, this._currentIndex));
+    }
+
+    // Is it a newline?
+    if (c === '\r') {
+      if (this._peek() === '\n') {
+        this._get();
+      }
+      return new Token(TokenKind.NewLine, input.getNewRange(startIndex, this._currentIndex));
+    } else if (c === '\n') {
+      return new Token(TokenKind.NewLine, input.getNewRange(startIndex, this._currentIndex));
+    }
+
+    // Otherwise treat it as an "other" character
+    return new Token(TokenKind.Other, input.getNewRange(startIndex, this._currentIndex));
+  }
+
+  public getTokens(): Token[] {
+    const tokens: Token[] = [];
+    let token: Token = this.getToken();
+    while (token.kind !== TokenKind.EndOfInput) {
+      tokens.push(token);
+      token = this.getToken();
+    }
+    return tokens;
+  }
+
+  private _get(): string | undefined {
+    if (this._currentIndex >= this.input.end) {
+      return undefined;
+    }
+    return this.input.buffer[this._currentIndex++];
+  }
+
+  private _peek(): string | undefined {
+    if (this._currentIndex >= this.input.end) {
+      return undefined;
+    }
+    return this.input.buffer[this._currentIndex];
+  }
+
+  private static _isSpace(c: string | undefined): boolean {
+    return c === ' ' || c === '\t';
+  }
+}

--- a/libraries/rushell/src/Tokenizer.ts
+++ b/libraries/rushell/src/Tokenizer.ts
@@ -199,7 +199,7 @@ export class Tokenizer {
 
     // Is it the "&&" token?
     if (firstChar === '&') {
-      if (this._peek2() === '&') {
+      if (this._peekTwice() === '&') {
         this._get();
         this._get();
         return new Token(TokenKind.AndIf, input.getNewRange(startIndex, this._currentIndex));
@@ -221,6 +221,10 @@ export class Tokenizer {
     return tokens;
   }
 
+  /**
+   * Retrieve the next character in the input stream.
+   * @returns a string of length 1, or undefined if the end of input is reached
+   */
   private _get(): string | undefined {
     if (this._currentIndex >= this.input.end) {
       return undefined;
@@ -228,6 +232,10 @@ export class Tokenizer {
     return this.input.buffer[this._currentIndex++];
   }
 
+  /**
+   * Return the next character in the input stream, but don't advance the stream pointer.
+   * @returns a string of length 1, or undefined if the end of input is reached
+   */
   private _peek(): string | undefined {
     if (this._currentIndex >= this.input.end) {
       return undefined;
@@ -235,7 +243,11 @@ export class Tokenizer {
     return this.input.buffer[this._currentIndex];
   }
 
-  private _peek2(): string | undefined {
+  /**
+   * Return the character after the next character in the input stream, but don't advance the stream pointer.
+   * @returns a string of length 1, or undefined if the end of input is reached
+   */
+  private _peekTwice(): string | undefined {
     if (this._currentIndex + 1 >= this.input.end) {
       return undefined;
     }

--- a/libraries/rushell/src/Tokenizer.ts
+++ b/libraries/rushell/src/Tokenizer.ts
@@ -10,7 +10,7 @@ export enum TokenKind {
   // A single newline sequence such as CRLF or LF
   NewLine,
   // An unrecognized character
-  Other,
+  OtherCharacter,
   // A sequence of characters that doesn't contain any symbols with special meaning
   // Characters can be escaped, in which case the Token.text may differ from the
   // Token.range.toString()
@@ -63,6 +63,10 @@ export class Tokenizer {
   private _currentIndex: number;
 
   private static _isSpace(c: string | undefined): boolean {
+    // You can empirically test whether shell treats a given character as whitespace like this:
+    // echo $(echo -e a '\u0009' b)
+    // If you get "a b" it means the tab character (Unicode 0009) is being collapsed away.
+    // If you get "a   b" then the invisible character is being padded like a normal letter.
     return c === ' ' || c === '\t';
   }
 
@@ -208,7 +212,7 @@ export class Tokenizer {
 
     // Otherwise treat it as an "other" character
     this._get();
-    return new Token(TokenKind.Other, input.getNewRange(startIndex, this._currentIndex));
+    return new Token(TokenKind.OtherCharacter, input.getNewRange(startIndex, this._currentIndex));
   }
 
   public getTokens(): Token[] {

--- a/libraries/rushell/src/test/Tokenizer.test.ts
+++ b/libraries/rushell/src/test/Tokenizer.test.ts
@@ -6,7 +6,8 @@ import { Tokenizer, TokenKind } from '../Tokenizer';
 function escape(s: string): string {
   return s.replace(/\n/g, '[n]')
     .replace(/\r/g, '[r]')
-    .replace(/\t/g, '[t]');
+    .replace(/\t/g, '[t]')
+    .replace(/\\/g, '[b]');
 }
 
 function matchSnapshot(input: string): void {
@@ -17,11 +18,15 @@ function matchSnapshot(input: string): void {
   }).toMatchSnapshot();
 }
 
-test('empty inputs', () => {
+test('00: empty inputs', () => {
   matchSnapshot('');
   matchSnapshot('\r\n');
 });
 
-test('white space tokens', () => {
-  matchSnapshot('  abc   \r\ndef  \n  ghi\n\r  ');
+test('01: white space tokens', () => {
+  matchSnapshot(' \t abc   \r\ndef  \n  ghi\n\r  ');
+});
+
+test('02: text with escapes', () => {
+  matchSnapshot(' ab+56\\>qrst$(abc\\))');
 });

--- a/libraries/rushell/src/test/Tokenizer.test.ts
+++ b/libraries/rushell/src/test/Tokenizer.test.ts
@@ -17,10 +17,22 @@ function tokenize(input: string): Token[] {
 
 function matchSnapshot(input: string): void {
   const tokenizer: Tokenizer = new Tokenizer(input);
-  expect({
-    input: escape(tokenizer.input.toString()),
-    tokens: tokenizer.getTokens().map(x => [TokenKind[x.kind], escape(x.toString())])
-  }).toMatchSnapshot();
+
+  const reportedTokens = tokenizer.getTokens().map(
+    token => {
+      return {
+        kind: TokenKind[token.kind],
+        value: escape(token.toString())
+      }
+    }
+  );
+
+  expect(
+    {
+      input: escape(tokenizer.input.toString()),
+      tokens: reportedTokens
+    }
+  ).toMatchSnapshot();
 }
 
 test('00: empty inputs', () => {

--- a/libraries/rushell/src/test/Tokenizer.test.ts
+++ b/libraries/rushell/src/test/Tokenizer.test.ts
@@ -18,12 +18,12 @@ function tokenize(input: string): Token[] {
 function matchSnapshot(input: string): void {
   const tokenizer: Tokenizer = new Tokenizer(input);
 
-  const reportedTokens = tokenizer.getTokens().map(
+  const reportedTokens: { kind: string, value: string }[] = tokenizer.getTokens().map(
     token => {
       return {
         kind: TokenKind[token.kind],
         value: escape(token.toString())
-      }
+      };
     }
   );
 

--- a/libraries/rushell/src/test/Tokenizer.test.ts
+++ b/libraries/rushell/src/test/Tokenizer.test.ts
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import { Tokenizer, TokenKind } from '../Tokenizer';
+
+function escape(s: string): string {
+  return s.replace(/\n/g, '[n]')
+    .replace(/\r/g, '[r]')
+    .replace(/\t/g, '[t]');
+}
+
+function matchSnapshot(input: string): void {
+  const tokenizer = new Tokenizer(input);
+  expect({
+    input: escape(tokenizer.input.toString()),
+    tokens: tokenizer.getTokens().map(x => [TokenKind[x.kind], escape(x.toString())])
+  }).toMatchSnapshot();
+}
+
+test('empty inputs', () => {
+  matchSnapshot('');
+  matchSnapshot('\r\n');
+});
+
+test('white space tokens', () => {
+  matchSnapshot('  abc   \r\ndef  \n  ghi\n\r  ');
+});

--- a/libraries/rushell/src/test/Tokenizer.test.ts
+++ b/libraries/rushell/src/test/Tokenizer.test.ts
@@ -34,6 +34,7 @@ test('01: white space tokens', () => {
 
 test('02: text with escapes', () => {
   matchSnapshot(' ab+56\\>qrst(abc\\))');
+  expect(() => tokenize('Unterminated: \\')).toThrowError();
 });
 
 test('03: The && operator', () => {
@@ -48,4 +49,14 @@ test('04: dollar variables', () => {
   matchSnapshot('$ab$_90');
   expect(() => tokenize('$')).toThrowError();
   expect(() => tokenize('${abc}')).toThrowError();
+});
+
+test('05: double-quoted strings', () => {
+  matchSnapshot('what "is" is');
+  matchSnapshot('what"is"is');
+  matchSnapshot('what"is\\""is');
+  matchSnapshot('no C-style escapes: "\\t\\r\\n"');
+  expect(() => tokenize('Unterminated: "')).toThrowError();
+  expect(() => tokenize('Unterminated: "abc')).toThrowError();
+  expect(() => tokenize('Unterminated: "abc\\')).toThrowError();
 });

--- a/libraries/rushell/src/test/Tokenizer.test.ts
+++ b/libraries/rushell/src/test/Tokenizer.test.ts
@@ -30,3 +30,10 @@ test('01: white space tokens', () => {
 test('02: text with escapes', () => {
   matchSnapshot(' ab+56\\>qrst$(abc\\))');
 });
+
+test('03: The && operator', () => {
+  matchSnapshot('&&abc&&cde&&');
+  matchSnapshot('a&b');
+  matchSnapshot('&&');
+  matchSnapshot('&');
+});

--- a/libraries/rushell/src/test/Tokenizer.test.ts
+++ b/libraries/rushell/src/test/Tokenizer.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import { Tokenizer, TokenKind } from '../Tokenizer';
+import { Tokenizer, TokenKind, Token } from '../Tokenizer';
 
 function escape(s: string): string {
   return s.replace(/\n/g, '[n]')
@@ -10,8 +10,13 @@ function escape(s: string): string {
     .replace(/\\/g, '[b]');
 }
 
+function tokenize(input: string): Token[] {
+  const tokenizer: Tokenizer = new Tokenizer(input);
+  return tokenizer.getTokens();
+}
+
 function matchSnapshot(input: string): void {
-  const tokenizer = new Tokenizer(input);
+  const tokenizer: Tokenizer = new Tokenizer(input);
   expect({
     input: escape(tokenizer.input.toString()),
     tokens: tokenizer.getTokens().map(x => [TokenKind[x.kind], escape(x.toString())])
@@ -28,7 +33,7 @@ test('01: white space tokens', () => {
 });
 
 test('02: text with escapes', () => {
-  matchSnapshot(' ab+56\\>qrst$(abc\\))');
+  matchSnapshot(' ab+56\\>qrst(abc\\))');
 });
 
 test('03: The && operator', () => {
@@ -36,4 +41,11 @@ test('03: The && operator', () => {
   matchSnapshot('a&b');
   matchSnapshot('&&');
   matchSnapshot('&');
+});
+
+test('04: dollar variables', () => {
+  matchSnapshot('$abc123.456');
+  matchSnapshot('$ab$_90');
+  expect(() => tokenize('$')).toThrowError();
+  expect(() => tokenize('${abc}')).toThrowError();
 });

--- a/libraries/rushell/src/test/__snapshots__/Tokenizer.test.ts.snap
+++ b/libraries/rushell/src/test/__snapshots__/Tokenizer.test.ts.snap
@@ -114,3 +114,75 @@ Object {
   ],
 }
 `;
+
+exports[`03: The && operator 1`] = `
+Object {
+  "input": "&&abc&&cde&&",
+  "tokens": Array [
+    Array [
+      "AndIf",
+      "&&",
+    ],
+    Array [
+      "Text",
+      "abc",
+    ],
+    Array [
+      "AndIf",
+      "&&",
+    ],
+    Array [
+      "Text",
+      "cde",
+    ],
+    Array [
+      "AndIf",
+      "&&",
+    ],
+  ],
+}
+`;
+
+exports[`03: The && operator 2`] = `
+Object {
+  "input": "a&b",
+  "tokens": Array [
+    Array [
+      "Text",
+      "a",
+    ],
+    Array [
+      "Other",
+      "&",
+    ],
+    Array [
+      "Text",
+      "b",
+    ],
+  ],
+}
+`;
+
+exports[`03: The && operator 3`] = `
+Object {
+  "input": "&&",
+  "tokens": Array [
+    Array [
+      "AndIf",
+      "&&",
+    ],
+  ],
+}
+`;
+
+exports[`03: The && operator 4`] = `
+Object {
+  "input": "&",
+  "tokens": Array [
+    Array [
+      "Other",
+      "&",
+    ],
+  ],
+}
+`;

--- a/libraries/rushell/src/test/__snapshots__/Tokenizer.test.ts.snap
+++ b/libraries/rushell/src/test/__snapshots__/Tokenizer.test.ts.snap
@@ -88,7 +88,7 @@ Object {
       "value": "ab",
     },
     Object {
-      "kind": "Other",
+      "kind": "OtherCharacter",
       "value": "+",
     },
     Object {
@@ -96,7 +96,7 @@ Object {
       "value": "56>qrst",
     },
     Object {
-      "kind": "Other",
+      "kind": "OtherCharacter",
       "value": "(",
     },
     Object {
@@ -104,7 +104,7 @@ Object {
       "value": "abc)",
     },
     Object {
-      "kind": "Other",
+      "kind": "OtherCharacter",
       "value": ")",
     },
   ],
@@ -148,7 +148,7 @@ Object {
       "value": "a",
     },
     Object {
-      "kind": "Other",
+      "kind": "OtherCharacter",
       "value": "&",
     },
     Object {
@@ -176,7 +176,7 @@ Object {
   "input": "&",
   "tokens": Array [
     Object {
-      "kind": "Other",
+      "kind": "OtherCharacter",
       "value": "&",
     },
   ],
@@ -192,7 +192,7 @@ Object {
       "value": "abc123",
     },
     Object {
-      "kind": "Other",
+      "kind": "OtherCharacter",
       "value": ".",
     },
     Object {
@@ -304,7 +304,7 @@ Object {
       "value": "C",
     },
     Object {
-      "kind": "Other",
+      "kind": "OtherCharacter",
       "value": "-",
     },
     Object {
@@ -320,7 +320,7 @@ Object {
       "value": "escapes",
     },
     Object {
-      "kind": "Other",
+      "kind": "OtherCharacter",
       "value": ":",
     },
     Object {

--- a/libraries/rushell/src/test/__snapshots__/Tokenizer.test.ts.snap
+++ b/libraries/rushell/src/test/__snapshots__/Tokenizer.test.ts.snap
@@ -218,3 +218,119 @@ Object {
   ],
 }
 `;
+
+exports[`05: double-quoted strings 1`] = `
+Object {
+  "input": "what \\"is\\" is",
+  "tokens": Array [
+    Array [
+      "Text",
+      "what",
+    ],
+    Array [
+      "Spaces",
+      " ",
+    ],
+    Array [
+      "DoubleQuotedText",
+      "is",
+    ],
+    Array [
+      "Spaces",
+      " ",
+    ],
+    Array [
+      "Text",
+      "is",
+    ],
+  ],
+}
+`;
+
+exports[`05: double-quoted strings 2`] = `
+Object {
+  "input": "what\\"is\\"is",
+  "tokens": Array [
+    Array [
+      "Text",
+      "what",
+    ],
+    Array [
+      "DoubleQuotedText",
+      "is",
+    ],
+    Array [
+      "Text",
+      "is",
+    ],
+  ],
+}
+`;
+
+exports[`05: double-quoted strings 3`] = `
+Object {
+  "input": "what\\"is[b]\\"\\"is",
+  "tokens": Array [
+    Array [
+      "Text",
+      "what",
+    ],
+    Array [
+      "DoubleQuotedText",
+      "is\\"",
+    ],
+    Array [
+      "Text",
+      "is",
+    ],
+  ],
+}
+`;
+
+exports[`05: double-quoted strings 4`] = `
+Object {
+  "input": "no C-style escapes: \\"[b]t[b]r[b]n\\"",
+  "tokens": Array [
+    Array [
+      "Text",
+      "no",
+    ],
+    Array [
+      "Spaces",
+      " ",
+    ],
+    Array [
+      "Text",
+      "C",
+    ],
+    Array [
+      "Other",
+      "-",
+    ],
+    Array [
+      "Text",
+      "style",
+    ],
+    Array [
+      "Spaces",
+      " ",
+    ],
+    Array [
+      "Text",
+      "escapes",
+    ],
+    Array [
+      "Other",
+      ":",
+    ],
+    Array [
+      "Spaces",
+      " ",
+    ],
+    Array [
+      "DoubleQuotedText",
+      "trn",
+    ],
+  ],
+}
+`;

--- a/libraries/rushell/src/test/__snapshots__/Tokenizer.test.ts.snap
+++ b/libraries/rushell/src/test/__snapshots__/Tokenizer.test.ts.snap
@@ -21,23 +21,15 @@ Object {
 
 exports[`white space tokens 1`] = `
 Object {
-  "input": "  abc   [r][n]def  [n]  ghi[n][r]  ",
+  "input": " [t] abc   [r][n]def  [n]  ghi[n][r]  ",
   "tokens": Array [
     Array [
       "Spaces",
-      "  ",
+      " [t] ",
     ],
     Array [
-      "Other",
-      "a",
-    ],
-    Array [
-      "Other",
-      "b",
-    ],
-    Array [
-      "Other",
-      "c",
+      "Text",
+      "abc",
     ],
     Array [
       "Spaces",
@@ -48,16 +40,8 @@ Object {
       "[r][n]",
     ],
     Array [
-      "Other",
-      "d",
-    ],
-    Array [
-      "Other",
-      "e",
-    ],
-    Array [
-      "Other",
-      "f",
+      "Text",
+      "def",
     ],
     Array [
       "Spaces",
@@ -72,16 +56,8 @@ Object {
       "  ",
     ],
     Array [
-      "Other",
-      "g",
-    ],
-    Array [
-      "Other",
-      "h",
-    ],
-    Array [
-      "Other",
-      "i",
+      "Text",
+      "ghi",
     ],
     Array [
       "NewLine",

--- a/libraries/rushell/src/test/__snapshots__/Tokenizer.test.ts.snap
+++ b/libraries/rushell/src/test/__snapshots__/Tokenizer.test.ts.snap
@@ -1,0 +1,100 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`empty inputs 1`] = `
+Object {
+  "input": "",
+  "tokens": Array [],
+}
+`;
+
+exports[`empty inputs 2`] = `
+Object {
+  "input": "[r][n]",
+  "tokens": Array [
+    Array [
+      "NewLine",
+      "[r][n]",
+    ],
+  ],
+}
+`;
+
+exports[`white space tokens 1`] = `
+Object {
+  "input": "  abc   [r][n]def  [n]  ghi[n][r]  ",
+  "tokens": Array [
+    Array [
+      "Spaces",
+      "  ",
+    ],
+    Array [
+      "Other",
+      "a",
+    ],
+    Array [
+      "Other",
+      "b",
+    ],
+    Array [
+      "Other",
+      "c",
+    ],
+    Array [
+      "Spaces",
+      "   ",
+    ],
+    Array [
+      "NewLine",
+      "[r][n]",
+    ],
+    Array [
+      "Other",
+      "d",
+    ],
+    Array [
+      "Other",
+      "e",
+    ],
+    Array [
+      "Other",
+      "f",
+    ],
+    Array [
+      "Spaces",
+      "  ",
+    ],
+    Array [
+      "NewLine",
+      "[n]",
+    ],
+    Array [
+      "Spaces",
+      "  ",
+    ],
+    Array [
+      "Other",
+      "g",
+    ],
+    Array [
+      "Other",
+      "h",
+    ],
+    Array [
+      "Other",
+      "i",
+    ],
+    Array [
+      "NewLine",
+      "[n]",
+    ],
+    Array [
+      "NewLine",
+      "[r]",
+    ],
+    Array [
+      "Spaces",
+      "  ",
+    ],
+  ],
+}
+`;

--- a/libraries/rushell/src/test/__snapshots__/Tokenizer.test.ts.snap
+++ b/libraries/rushell/src/test/__snapshots__/Tokenizer.test.ts.snap
@@ -77,7 +77,7 @@ Object {
 
 exports[`02: text with escapes 1`] = `
 Object {
-  "input": " ab+56[b]>qrst$(abc[b]))",
+  "input": " ab+56[b]>qrst(abc[b]))",
   "tokens": Array [
     Array [
       "Spaces",
@@ -94,10 +94,6 @@ Object {
     Array [
       "Text",
       "56>qrst",
-    ],
-    Array [
-      "Other",
-      "$",
     ],
     Array [
       "Other",
@@ -182,6 +178,42 @@ Object {
     Array [
       "Other",
       "&",
+    ],
+  ],
+}
+`;
+
+exports[`04: dollar variables 1`] = `
+Object {
+  "input": "$abc123.456",
+  "tokens": Array [
+    Array [
+      "DollarVariable",
+      "abc123",
+    ],
+    Array [
+      "Other",
+      ".",
+    ],
+    Array [
+      "Text",
+      "456",
+    ],
+  ],
+}
+`;
+
+exports[`04: dollar variables 2`] = `
+Object {
+  "input": "$ab$_90",
+  "tokens": Array [
+    Array [
+      "DollarVariable",
+      "ab",
+    ],
+    Array [
+      "DollarVariable",
+      "_90",
     ],
   ],
 }

--- a/libraries/rushell/src/test/__snapshots__/Tokenizer.test.ts.snap
+++ b/libraries/rushell/src/test/__snapshots__/Tokenizer.test.ts.snap
@@ -11,10 +11,10 @@ exports[`00: empty inputs 2`] = `
 Object {
   "input": "[r][n]",
   "tokens": Array [
-    Array [
-      "NewLine",
-      "[r][n]",
-    ],
+    Object {
+      "kind": "NewLine",
+      "value": "[r][n]",
+    },
   ],
 }
 `;
@@ -23,54 +23,54 @@ exports[`01: white space tokens 1`] = `
 Object {
   "input": " [t] abc   [r][n]def  [n]  ghi[n][r]  ",
   "tokens": Array [
-    Array [
-      "Spaces",
-      " [t] ",
-    ],
-    Array [
-      "Text",
-      "abc",
-    ],
-    Array [
-      "Spaces",
-      "   ",
-    ],
-    Array [
-      "NewLine",
-      "[r][n]",
-    ],
-    Array [
-      "Text",
-      "def",
-    ],
-    Array [
-      "Spaces",
-      "  ",
-    ],
-    Array [
-      "NewLine",
-      "[n]",
-    ],
-    Array [
-      "Spaces",
-      "  ",
-    ],
-    Array [
-      "Text",
-      "ghi",
-    ],
-    Array [
-      "NewLine",
-      "[n]",
-    ],
-    Array [
-      "NewLine",
-      "[r]",
-    ],
-    Array [
-      "Spaces",
-      "  ",
-    ],
+    Object {
+      "kind": "Spaces",
+      "value": " [t] ",
+    },
+    Object {
+      "kind": "Text",
+      "value": "abc",
+    },
+    Object {
+      "kind": "Spaces",
+      "value": "   ",
+    },
+    Object {
+      "kind": "NewLine",
+      "value": "[r][n]",
+    },
+    Object {
+      "kind": "Text",
+      "value": "def",
+    },
+    Object {
+      "kind": "Spaces",
+      "value": "  ",
+    },
+    Object {
+      "kind": "NewLine",
+      "value": "[n]",
+    },
+    Object {
+      "kind": "Spaces",
+      "value": "  ",
+    },
+    Object {
+      "kind": "Text",
+      "value": "ghi",
+    },
+    Object {
+      "kind": "NewLine",
+      "value": "[n]",
+    },
+    Object {
+      "kind": "NewLine",
+      "value": "[r]",
+    },
+    Object {
+      "kind": "Spaces",
+      "value": "  ",
+    },
   ],
 }
 `;
@@ -79,34 +79,34 @@ exports[`02: text with escapes 1`] = `
 Object {
   "input": " ab+56[b]>qrst(abc[b]))",
   "tokens": Array [
-    Array [
-      "Spaces",
-      " ",
-    ],
-    Array [
-      "Text",
-      "ab",
-    ],
-    Array [
-      "Other",
-      "+",
-    ],
-    Array [
-      "Text",
-      "56>qrst",
-    ],
-    Array [
-      "Other",
-      "(",
-    ],
-    Array [
-      "Text",
-      "abc)",
-    ],
-    Array [
-      "Other",
-      ")",
-    ],
+    Object {
+      "kind": "Spaces",
+      "value": " ",
+    },
+    Object {
+      "kind": "Text",
+      "value": "ab",
+    },
+    Object {
+      "kind": "Other",
+      "value": "+",
+    },
+    Object {
+      "kind": "Text",
+      "value": "56>qrst",
+    },
+    Object {
+      "kind": "Other",
+      "value": "(",
+    },
+    Object {
+      "kind": "Text",
+      "value": "abc)",
+    },
+    Object {
+      "kind": "Other",
+      "value": ")",
+    },
   ],
 }
 `;
@@ -115,26 +115,26 @@ exports[`03: The && operator 1`] = `
 Object {
   "input": "&&abc&&cde&&",
   "tokens": Array [
-    Array [
-      "AndIf",
-      "&&",
-    ],
-    Array [
-      "Text",
-      "abc",
-    ],
-    Array [
-      "AndIf",
-      "&&",
-    ],
-    Array [
-      "Text",
-      "cde",
-    ],
-    Array [
-      "AndIf",
-      "&&",
-    ],
+    Object {
+      "kind": "AndIf",
+      "value": "&&",
+    },
+    Object {
+      "kind": "Text",
+      "value": "abc",
+    },
+    Object {
+      "kind": "AndIf",
+      "value": "&&",
+    },
+    Object {
+      "kind": "Text",
+      "value": "cde",
+    },
+    Object {
+      "kind": "AndIf",
+      "value": "&&",
+    },
   ],
 }
 `;
@@ -143,18 +143,18 @@ exports[`03: The && operator 2`] = `
 Object {
   "input": "a&b",
   "tokens": Array [
-    Array [
-      "Text",
-      "a",
-    ],
-    Array [
-      "Other",
-      "&",
-    ],
-    Array [
-      "Text",
-      "b",
-    ],
+    Object {
+      "kind": "Text",
+      "value": "a",
+    },
+    Object {
+      "kind": "Other",
+      "value": "&",
+    },
+    Object {
+      "kind": "Text",
+      "value": "b",
+    },
   ],
 }
 `;
@@ -163,10 +163,10 @@ exports[`03: The && operator 3`] = `
 Object {
   "input": "&&",
   "tokens": Array [
-    Array [
-      "AndIf",
-      "&&",
-    ],
+    Object {
+      "kind": "AndIf",
+      "value": "&&",
+    },
   ],
 }
 `;
@@ -175,10 +175,10 @@ exports[`03: The && operator 4`] = `
 Object {
   "input": "&",
   "tokens": Array [
-    Array [
-      "Other",
-      "&",
-    ],
+    Object {
+      "kind": "Other",
+      "value": "&",
+    },
   ],
 }
 `;
@@ -187,18 +187,18 @@ exports[`04: dollar variables 1`] = `
 Object {
   "input": "$abc123.456",
   "tokens": Array [
-    Array [
-      "DollarVariable",
-      "abc123",
-    ],
-    Array [
-      "Other",
-      ".",
-    ],
-    Array [
-      "Text",
-      "456",
-    ],
+    Object {
+      "kind": "DollarVariable",
+      "value": "abc123",
+    },
+    Object {
+      "kind": "Other",
+      "value": ".",
+    },
+    Object {
+      "kind": "Text",
+      "value": "456",
+    },
   ],
 }
 `;
@@ -207,14 +207,14 @@ exports[`04: dollar variables 2`] = `
 Object {
   "input": "$ab$_90",
   "tokens": Array [
-    Array [
-      "DollarVariable",
-      "ab",
-    ],
-    Array [
-      "DollarVariable",
-      "_90",
-    ],
+    Object {
+      "kind": "DollarVariable",
+      "value": "ab",
+    },
+    Object {
+      "kind": "DollarVariable",
+      "value": "_90",
+    },
   ],
 }
 `;
@@ -223,26 +223,26 @@ exports[`05: double-quoted strings 1`] = `
 Object {
   "input": "what \\"is\\" is",
   "tokens": Array [
-    Array [
-      "Text",
-      "what",
-    ],
-    Array [
-      "Spaces",
-      " ",
-    ],
-    Array [
-      "DoubleQuotedText",
-      "is",
-    ],
-    Array [
-      "Spaces",
-      " ",
-    ],
-    Array [
-      "Text",
-      "is",
-    ],
+    Object {
+      "kind": "Text",
+      "value": "what",
+    },
+    Object {
+      "kind": "Spaces",
+      "value": " ",
+    },
+    Object {
+      "kind": "DoubleQuotedText",
+      "value": "is",
+    },
+    Object {
+      "kind": "Spaces",
+      "value": " ",
+    },
+    Object {
+      "kind": "Text",
+      "value": "is",
+    },
   ],
 }
 `;
@@ -251,18 +251,18 @@ exports[`05: double-quoted strings 2`] = `
 Object {
   "input": "what\\"is\\"is",
   "tokens": Array [
-    Array [
-      "Text",
-      "what",
-    ],
-    Array [
-      "DoubleQuotedText",
-      "is",
-    ],
-    Array [
-      "Text",
-      "is",
-    ],
+    Object {
+      "kind": "Text",
+      "value": "what",
+    },
+    Object {
+      "kind": "DoubleQuotedText",
+      "value": "is",
+    },
+    Object {
+      "kind": "Text",
+      "value": "is",
+    },
   ],
 }
 `;
@@ -271,18 +271,18 @@ exports[`05: double-quoted strings 3`] = `
 Object {
   "input": "what\\"is[b]\\"\\"is",
   "tokens": Array [
-    Array [
-      "Text",
-      "what",
-    ],
-    Array [
-      "DoubleQuotedText",
-      "is\\"",
-    ],
-    Array [
-      "Text",
-      "is",
-    ],
+    Object {
+      "kind": "Text",
+      "value": "what",
+    },
+    Object {
+      "kind": "DoubleQuotedText",
+      "value": "is\\"",
+    },
+    Object {
+      "kind": "Text",
+      "value": "is",
+    },
   ],
 }
 `;
@@ -291,46 +291,46 @@ exports[`05: double-quoted strings 4`] = `
 Object {
   "input": "no C-style escapes: \\"[b]t[b]r[b]n\\"",
   "tokens": Array [
-    Array [
-      "Text",
-      "no",
-    ],
-    Array [
-      "Spaces",
-      " ",
-    ],
-    Array [
-      "Text",
-      "C",
-    ],
-    Array [
-      "Other",
-      "-",
-    ],
-    Array [
-      "Text",
-      "style",
-    ],
-    Array [
-      "Spaces",
-      " ",
-    ],
-    Array [
-      "Text",
-      "escapes",
-    ],
-    Array [
-      "Other",
-      ":",
-    ],
-    Array [
-      "Spaces",
-      " ",
-    ],
-    Array [
-      "DoubleQuotedText",
-      "trn",
-    ],
+    Object {
+      "kind": "Text",
+      "value": "no",
+    },
+    Object {
+      "kind": "Spaces",
+      "value": " ",
+    },
+    Object {
+      "kind": "Text",
+      "value": "C",
+    },
+    Object {
+      "kind": "Other",
+      "value": "-",
+    },
+    Object {
+      "kind": "Text",
+      "value": "style",
+    },
+    Object {
+      "kind": "Spaces",
+      "value": " ",
+    },
+    Object {
+      "kind": "Text",
+      "value": "escapes",
+    },
+    Object {
+      "kind": "Other",
+      "value": ":",
+    },
+    Object {
+      "kind": "Spaces",
+      "value": " ",
+    },
+    Object {
+      "kind": "DoubleQuotedText",
+      "value": "trn",
+    },
   ],
 }
 `;

--- a/libraries/rushell/src/test/__snapshots__/Tokenizer.test.ts.snap
+++ b/libraries/rushell/src/test/__snapshots__/Tokenizer.test.ts.snap
@@ -1,13 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`empty inputs 1`] = `
+exports[`00: empty inputs 1`] = `
 Object {
   "input": "",
   "tokens": Array [],
 }
 `;
 
-exports[`empty inputs 2`] = `
+exports[`00: empty inputs 2`] = `
 Object {
   "input": "[r][n]",
   "tokens": Array [
@@ -19,7 +19,7 @@ Object {
 }
 `;
 
-exports[`white space tokens 1`] = `
+exports[`01: white space tokens 1`] = `
 Object {
   "input": " [t] abc   [r][n]def  [n]  ghi[n][r]  ",
   "tokens": Array [
@@ -70,6 +70,46 @@ Object {
     Array [
       "Spaces",
       "  ",
+    ],
+  ],
+}
+`;
+
+exports[`02: text with escapes 1`] = `
+Object {
+  "input": " ab+56[b]>qrst$(abc[b]))",
+  "tokens": Array [
+    Array [
+      "Spaces",
+      " ",
+    ],
+    Array [
+      "Text",
+      "ab",
+    ],
+    Array [
+      "Other",
+      "+",
+    ],
+    Array [
+      "Text",
+      "56>qrst",
+    ],
+    Array [
+      "Other",
+      "$",
+    ],
+    Array [
+      "Other",
+      "(",
+    ],
+    Array [
+      "Text",
+      "abc)",
+    ],
+    Array [
+      "Other",
+      ")",
     ],
   ],
 }


### PR DESCRIPTION
This is an initial sketch of a lexical analyzer for POSIX shell commands. It supports these tokens:

- whitespace
- newlines
- plain text words with escapes
- the "&&" operator
- double-quoted strings with escapes
- dollar variables (e.g. "`$PATH`")
