### PR TITLE
API Documenter (Office Extension) - Unencoding code, bold, and italic markdown

### DIFF
--- a/apps/api-documenter/src/yaml/OfficeYamlDocumenter.ts
+++ b/apps/api-documenter/src/yaml/OfficeYamlDocumenter.ts
@@ -10,6 +10,7 @@ import { DocItemSet } from '../utils/DocItemSet';
 import { IYamlTocItem } from './IYamlTocFile';
 import { IYamlItem } from './IYamlApiFile';
 import { YamlDocumenter } from './YamlDocumenter';
+import { Text } from '@microsoft/node-core-library';
 
 interface ISnippetsFile {
   /**
@@ -128,18 +129,10 @@ export class OfficeYamlDocumenter extends YamlDocumenter {
   }
 
   private _fixBoldAndItalics(text: string): string {
-    while (text.indexOf('\\*') >= 0) {
-      text = text.replace('\\*', '*');
-    }
-
-    return text;
+    return Text.replaceAll(text, '\\*', '*');
   }
 
   private _fixCodeTicks(text: string): string {
-    while (text.indexOf('\\`') >= 0) {
-      text = text.replace('\\`', '`');
-    }
-
-    return text;
+    return Text.replaceAll(text, '\\`', '`');
   }
 }

--- a/apps/api-documenter/src/yaml/OfficeYamlDocumenter.ts
+++ b/apps/api-documenter/src/yaml/OfficeYamlDocumenter.ts
@@ -88,9 +88,21 @@ export class OfficeYamlDocumenter extends YamlDocumenter {
 
     if (yamlItem.summary) {
       yamlItem.summary = this._fixupApiSet(yamlItem.summary, yamlItem.uid);
+      yamlItem.summary = this._fixBoldAndItalics(yamlItem.summary);
+      yamlItem.summary = this._fixCodeTicks(yamlItem.summary);
     }
     if (yamlItem.remarks) {
       yamlItem.remarks = this._fixupApiSet(yamlItem.remarks, yamlItem.uid);
+      yamlItem.remarks = this._fixBoldAndItalics(yamlItem.remarks);
+      yamlItem.remarks = this._fixCodeTicks(yamlItem.remarks);
+    }
+    if (yamlItem.syntax && yamlItem.syntax.parameters) {
+      yamlItem.syntax.parameters.forEach(part => {
+          if (part.description) {
+            part.description = this._fixCodeTicks(part.description);
+            part.description = this._fixBoldAndItalics(part.description);
+          }
+      });
     }
   }
 
@@ -115,4 +127,19 @@ export class OfficeYamlDocumenter extends YamlDocumenter {
     return this._apiSetUrlDefault; // match not found.
   }
 
+  private _fixBoldAndItalics(text: string): string {
+    while (text.indexOf('\\*') >= 0) {
+      text = text.replace('\\*', '*');
+    }
+
+    return text;
+  }
+
+  private _fixCodeTicks(text: string): string {
+    while (text.indexOf('\\`') >= 0) {
+      text = text.replace('\\`', '`');
+    }
+
+    return text;
+  }
 }

--- a/common/changes/@microsoft/api-documenter/AlexJ-OfficeMarkdown_2018-06-22-19-16.json
+++ b/common/changes/@microsoft/api-documenter/AlexJ-OfficeMarkdown_2018-06-22-19-16.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-documenter",
+      "comment": "Fix a issue where Office Documentation had markdown characters escaped",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/api-documenter",
+  "email": "aljerabe@microsoft.com"
+}


### PR DESCRIPTION
This is a short-term fix to have the listed markdown functionality passed through the AD to OPS.