### PR TITLE
Fix immediate issue where Rush is calling a function that is not poly…

### DIFF
--- a/apps/rush-lib/src/logic/StandardScriptUpdater.ts
+++ b/apps/rush-lib/src/logic/StandardScriptUpdater.ts
@@ -75,7 +75,7 @@ export class StandardScriptUpdater {
           + ' for this Rush version.  Please run "rush update" and commit the changes.');
       } else {
         console.log(`Script is out of date; updating "${targetFilePath}"`);
-        fsx.copyFileSync(sourceFilePath, targetFilePath);
+        fsx.copySync(sourceFilePath, targetFilePath);
       }
     }
 

--- a/common/changes/@microsoft/rush/nickpape-fix-node-6-incompatibility_2018-06-25-22-10.json
+++ b/common/changes/@microsoft/rush/nickpape-fix-node-6-incompatibility_2018-06-25-22-10.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@microsoft/rush",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "nickpape-msft@users.noreply.github.com"
+}


### PR DESCRIPTION
…filled by fs-extra on Node 6..

Will follow up with another work item to downgrade Node 6 typings and also to remove all direct calls to fsx/fs in favor of a new API in node-core-library.