### PR TITLE
[api-documenter] Add limited support for type reference hyperlinks

### DIFF
--- a/apps/api-documenter/src/cli/BaseAction.ts
+++ b/apps/api-documenter/src/cli/BaseAction.ts
@@ -56,8 +56,6 @@ export abstract class BaseAction extends CommandLineAction {
       }
     }
 
-    docItemSet.calculateReferences();
-
     return docItemSet;
   }
 }

--- a/apps/api-documenter/src/utils/DocItemSet.ts
+++ b/apps/api-documenter/src/utils/DocItemSet.ts
@@ -186,27 +186,13 @@ export interface IDocItemSetResolveResult {
 export class DocItemSet {
   public readonly docPackagesByName: Map<string, DocItem> = new Map<string, DocItem>();
   public readonly docPackages: DocItem[] = [];
-  private _calculated: boolean = false;
 
   public loadApiJsonFile(apiJsonFilename: string): void {
-    if (this._calculated) {
-      throw new Error('calculateReferences() was already called');
-    }
-
     const apiPackage: IApiPackage = ApiJsonFile.loadFromFile(apiJsonFilename);
 
     const docItem: DocItem = new DocItem(apiPackage, apiPackage.name, this, undefined);
     this.docPackagesByName.set(apiPackage.name, docItem);
     this.docPackages.push(docItem);
-  }
-
-  public calculateReferences(): void {
-    if (this._calculated) {
-      return;
-    }
-    for (const docPackage of this.docPackages) {
-      this._calculateReferences(docPackage);
-    }
   }
 
   /**
@@ -247,13 +233,5 @@ export class DocItemSet {
 
     result.docItem = result.closestMatch;
     return result;
-  }
-
-  private _calculateReferences(docItem: DocItem): void {
-    // (Calculate base classes and child classes)
-
-    for (const child of docItem.children) {
-      this._calculateReferences(child);
-    }
   }
 }

--- a/apps/api-documenter/src/utils/DocItemSet.ts
+++ b/apps/api-documenter/src/utils/DocItemSet.ts
@@ -157,6 +157,16 @@ export class DocItem {
     }
     return undefined;
   }
+
+  /**
+   * Visits this DocItem and every child DocItem in a preorder traversal.
+   */
+  public forEach(callback: (docItem: DocItem) => void): void {
+    callback(this);
+    for (const child of this.children) {
+      child.forEach(callback);
+    }
+  }
 }
 
 /**
@@ -233,5 +243,14 @@ export class DocItemSet {
 
     result.docItem = result.closestMatch;
     return result;
+  }
+
+  /**
+   * Visits every DocItem in the tree.
+   */
+  public forEach(callback: (docItem: DocItem) => void): void {
+    for (const docPackage of this.docPackages) {
+      docPackage.forEach(callback);
+    }
   }
 }

--- a/common/changes/@microsoft/api-documenter/pgonzal-api-documenter-links_2018-06-25-22-47.json
+++ b/common/changes/@microsoft/api-documenter/pgonzal-api-documenter-links_2018-06-25-22-47.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-documenter",
+      "comment": "The YAML target now automatically hyperlinks type references, but only if the type name is simple and not ambiguous",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@microsoft/api-documenter",
+  "email": "pgonzal@users.noreply.github.com"
+}


### PR DESCRIPTION
Ideally we'd like every type reference (e.g. parameter type, return type, property type) to automatically hyperlink to the corresponding documentation item.  However, today the DocFX YAML schema only supports hyperlinks for simple types (e.g. `MyClass` but not `Promise<MyClass>` or `MyClass | undefined`).

This PR enables support for this limited form of hyperlinking.  When the schema is improved in the future, we will replace this workaround with a full implementation.