### PR TITLE
[API Documenter] - OfficeYamlDocumenter: Replacing =&lt; with => in remarks sections 

### DIFF
--- a/apps/api-documenter/src/yaml/OfficeYamlDocumenter.ts
+++ b/apps/api-documenter/src/yaml/OfficeYamlDocumenter.ts
@@ -96,6 +96,7 @@ export class OfficeYamlDocumenter extends YamlDocumenter {
       yamlItem.remarks = this._fixupApiSet(yamlItem.remarks, yamlItem.uid);
       yamlItem.remarks = this._fixBoldAndItalics(yamlItem.remarks);
       yamlItem.remarks = this._fixCodeTicks(yamlItem.remarks);
+      yamlItem.remarks = this._fixCodeArrows(yamlItem.remarks);
     }
     if (yamlItem.syntax && yamlItem.syntax.parameters) {
       yamlItem.syntax.parameters.forEach(part => {
@@ -134,5 +135,9 @@ export class OfficeYamlDocumenter extends YamlDocumenter {
 
   private _fixCodeTicks(text: string): string {
     return Text.replaceAll(text, '\\`', '`');
+  }
+
+  private _fixCodeArrows(text: string): string {
+    return Text.replaceAll(text, '=&gt;', '=>');
   }
 }

--- a/common/changes/@microsoft/api-documenter/AlexJ-AllowFunctionArrow_2018-06-25-23-28.json
+++ b/common/changes/@microsoft/api-documenter/AlexJ-AllowFunctionArrow_2018-06-25-23-28.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-documenter",
+      "comment": "Improve OfficeYamlDocumenter to replace escaped function arrows in code lines with =>",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/api-documenter",
+  "email": "AlexJerabek@users.noreply.github.com"
+}


### PR DESCRIPTION
In code sections, function arrows are displayed like this:
`getCallbackTokenAsync(callback: (result: AsyncResult) =&gt; void): void;`