### PR TITLE
Fixes an issue where "rush version" would fail with a bad message if Git user email not specified

### DIFF
--- a/common/changes/@microsoft/rush/nickpape-fix-issue-with-user-email-rush-version_2018-07-10-01-36.json
+++ b/common/changes/@microsoft/rush/nickpape-fix-issue-with-user-email-rush-version_2018-07-10-01-36.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Fix an issue where \"rush version\" would fail with a useless error message if the Git user email is not specified.",
+      "packageName": "@microsoft/rush",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "nickpape-msft@users.noreply.github.com"
+}


### PR DESCRIPTION
Resolves #738 738