### PR TITLE
[api-extractor] Upgrade to Typescript 2.9

### DIFF
--- a/apps/api-extractor/package.json
+++ b/apps/api-extractor/package.json
@@ -38,7 +38,7 @@
     "colors": "~1.2.1",
     "jju": "~1.3.0",
     "lodash": "~4.15.0",
-    "typescript": "~2.4.1",
+    "typescript": "~2.9.2",
     "z-schema": "~3.18.3"
   },
   "devDependencies": {

--- a/apps/api-extractor/src/ExtractorContext.ts
+++ b/apps/api-extractor/src/ExtractorContext.ts
@@ -107,7 +107,7 @@ export class ExtractorContext {
 
     this.typeChecker = options.program.getTypeChecker();
 
-    const rootFile: ts.SourceFile = options.program.getSourceFile(options.entryPointFile);
+    const rootFile: ts.SourceFile | undefined = options.program.getSourceFile(options.entryPointFile);
     if (!rootFile) {
       throw new Error('Unable to load file: ' + options.entryPointFile);
     }

--- a/build-tests/api-extractor-test-01/package.json
+++ b/build-tests/api-extractor-test-01/package.json
@@ -16,6 +16,6 @@
     "@types/jest": "21.1.10",
     "@types/node": "8.5.8",
     "fs-extra": "~5.0.0",
-    "typescript": "~2.4.1"
+    "typescript": "~2.9.2"
   }
 }

--- a/build-tests/api-extractor-test-02/package.json
+++ b/build-tests/api-extractor-test-02/package.json
@@ -18,6 +18,6 @@
     "api-extractor-test-01": "1.0.0",
     "semver": "~5.3.0",
     "fs-extra": "~5.0.0",
-    "typescript": "~2.4.1"
+    "typescript": "~2.9.2"
   }
 }

--- a/build-tests/api-extractor-test-03/package.json
+++ b/build-tests/api-extractor-test-03/package.json
@@ -11,6 +11,6 @@
     "@types/node": "8.5.8",
     "api-extractor-test-02": "1.0.0",
     "fs-extra": "~5.0.0",
-    "typescript": "~2.4.1"
+    "typescript": "~2.9.2"
   }
 }

--- a/build-tests/api-extractor-test-04/package.json
+++ b/build-tests/api-extractor-test-04/package.json
@@ -14,6 +14,6 @@
   "dependencies": {
     "@microsoft/api-extractor": "5.10.0",
     "fs-extra": "~5.0.0",
-    "typescript": "~2.4.1"
+    "typescript": "~2.9.2"
   }
 }

--- a/build-tests/api-extractor-test-05/package.json
+++ b/build-tests/api-extractor-test-05/package.json
@@ -17,6 +17,6 @@
     "@types/jest": "21.1.10",
     "@types/node": "8.5.8",
     "fs-extra": "~5.0.0",
-    "typescript": "~2.4.1"
+    "typescript": "~2.9.2"
   }
 }

--- a/common/changes/@microsoft/api-extractor/ts-29_2018-07-18-23-17.json
+++ b/common/changes/@microsoft/api-extractor/ts-29_2018-07-18-23-17.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@microsoft/api-extractor",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor",
+  "email": "hans@hansl.ca"
+}

--- a/common/changes/@microsoft/api-extractor/ts-29_2018-07-19-18-50.json
+++ b/common/changes/@microsoft/api-extractor/ts-29_2018-07-19-18-50.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@microsoft/api-extractor",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor",
+  "email": "hans@hansl.ca"
+}

--- a/common/changes/@microsoft/gulp-core-build-typescript/ts-29_2018-07-19-18-50.json
+++ b/common/changes/@microsoft/gulp-core-build-typescript/ts-29_2018-07-19-18-50.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/gulp-core-build-typescript",
+      "comment": "Upgrade TypeScript dependency to 2.9.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/gulp-core-build-typescript",
+  "email": "hans@hansl.ca"
+}

--- a/common/config/rush/shrinkwrap.yaml
+++ b/common/config/rush/shrinkwrap.yaml
@@ -160,7 +160,7 @@ dependencies:
   ts-jest: 22.4.6
   tslint: 5.9.1
   tslint-microsoft-contrib: 5.0.3
-  typescript: 2.4.2
+  typescript: 2.9.2
   uglify-js: 3.0.28
   webpack: 3.11.0
   wordwrap: 1.0.0
@@ -4096,6 +4096,19 @@ packages:
       source-map: 0.5.7
       through2: 2.0.3
       typescript: 2.4.2
+      vinyl-fs: 2.4.4
+    dev: false
+    id: registry.npmjs.org/gulp-typescript/3.1.7
+    peerDependencies:
+      typescript: ~2.0.3 || >=2.0.0-dev || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev
+    resolution:
+      integrity: sha1-2IYAqRQVPxHAnJpcqMJWHsdaSXg=
+  /gulp-typescript/3.1.7/typescript@2.9.2:
+    dependencies:
+      gulp-util: 3.0.8
+      source-map: 0.5.7
+      through2: 2.0.3
+      typescript: 2.9.2
       vinyl-fs: 2.4.4
     dev: false
     id: registry.npmjs.org/gulp-typescript/3.1.7
@@ -9333,6 +9346,18 @@ packages:
       typescript: ^2.1.0
     resolution:
       integrity: sha512-5AnfTGlfpUzpRHLmoojPBKFTTmbjnwgdaTHMdllausa4GBPya5u36i9ddrTX4PhetGZvd4JUYIpAmgHqVnsctg==
+  /tslint-microsoft-contrib/5.0.3/tslint@5.9.1+typescript@2.9.2:
+    dependencies:
+      tslint: /tslint/5.9.1/typescript@2.9.2
+      tsutils: /tsutils/2.27.1/typescript@2.9.2
+      typescript: 2.9.2
+    dev: false
+    id: registry.npmjs.org/tslint-microsoft-contrib/5.0.3
+    peerDependencies:
+      tslint: ^5.1.0
+      typescript: ^2.1.0
+    resolution:
+      integrity: sha512-5AnfTGlfpUzpRHLmoojPBKFTTmbjnwgdaTHMdllausa4GBPya5u36i9ddrTX4PhetGZvd4JUYIpAmgHqVnsctg==
   /tslint/5.9.1:
     dependencies:
       babel-code-frame: 6.26.0
@@ -9377,6 +9402,29 @@ packages:
       typescript: '>=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev'
     resolution:
       integrity: sha1-ElX4ej/1frCw4fDmEKi0dIBGya4=
+  /tslint/5.9.1/typescript@2.9.2:
+    dependencies:
+      babel-code-frame: 6.26.0
+      builtin-modules: 1.1.1
+      chalk: 2.4.1
+      commander: 2.15.1
+      diff: 3.5.0
+      glob: 7.1.2
+      js-yaml: 3.9.1
+      minimatch: 3.0.4
+      resolve: 1.7.1
+      semver: 5.3.0
+      tslib: 1.9.2
+      tsutils: /tsutils/2.27.1/typescript@2.9.2
+      typescript: 2.9.2
+    dev: false
+    engines:
+      node: '>=4.8.0'
+    id: registry.npmjs.org/tslint/5.9.1
+    peerDependencies:
+      typescript: '>=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev'
+    resolution:
+      integrity: sha1-ElX4ej/1frCw4fDmEKi0dIBGya4=
   /tsutils/2.27.1:
     dependencies:
       tslib: 1.9.2
@@ -9389,6 +9437,16 @@ packages:
     dependencies:
       tslib: 1.9.2
       typescript: 2.4.2
+    dev: false
+    id: registry.npmjs.org/tsutils/2.27.1
+    peerDependencies:
+      typescript: '>=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >= 3.0.0-dev'
+    resolution:
+      integrity: sha512-AE/7uzp32MmaHvNNFES85hhUDHFdFZp6OAiZcd6y4ZKKIg6orJTm8keYWBhIhrJQH3a4LzNKat7ZPXZt5aTf6w==
+  /tsutils/2.27.1/typescript@2.9.2:
+    dependencies:
+      tslib: 1.9.2
+      typescript: 2.9.2
     dev: false
     id: registry.npmjs.org/tsutils/2.27.1
     peerDependencies:
@@ -9449,6 +9507,12 @@ packages:
       node: '>=4.2.0'
     resolution:
       integrity: sha1-+DlfhdRZJ2BnyYiqQYN6j4KHCEQ=
+  /typescript/2.9.2:
+    dev: false
+    engines:
+      node: '>=4.2.0'
+    resolution:
+      integrity: sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==
   /uglify-js/2.8.29:
     dependencies:
       source-map: 0.5.7
@@ -10191,7 +10255,7 @@ packages:
     dev: false
     name: '@rush-temp/api-documenter'
     resolution:
-      integrity: sha512-mX9wyIqOspRpHlVyH9+Rq5fOrmMtPQG4J7NbsbUu5c6t7Qelq2ItSvR6ecZBtQerRjjiJIGat2ffwFCX1sVlSQ==
+      integrity: sha512-2aUG7f3NaUPSx5zDaIKTP+LXSRM1CScYRKf2S4vLUFYvOvPDdKCJnSbfcBCa7MoUdrf5LqyGFW9byGikcMXcIg==
       tarball: 'file:projects/api-documenter.tgz'
     version: 0.0.0
   'file:projects/api-extractor-test-01.tgz':
@@ -10199,11 +10263,11 @@ packages:
       '@types/jest': 21.1.10
       '@types/node': 8.5.8
       fs-extra: 5.0.0
-      typescript: 2.4.2
+      typescript: 2.9.2
     dev: false
     name: '@rush-temp/api-extractor-test-01'
     resolution:
-      integrity: sha512-ocgCMGScGAInr8hD6BfmVSGeK3WibnSqSueM8B4FDaSoyLWPOqhIjP0QoxyGF7tnkK6dVHU9A58vreJKvzeaiA==
+      integrity: sha512-124Z8ueGaXiKhngLsVLL8cYdSzdX3lTD8WxN2CX4Z62MlBxhX5Nqlc1tEqiZSJmmqAKX3/223XDVpbGTTuvBZA==
       tarball: 'file:projects/api-extractor-test-01.tgz'
     version: 0.0.0
   'file:projects/api-extractor-test-02.tgz':
@@ -10212,11 +10276,11 @@ packages:
       '@types/semver': 5.3.33
       fs-extra: 5.0.0
       semver: 5.3.0
-      typescript: 2.4.2
+      typescript: 2.9.2
     dev: false
     name: '@rush-temp/api-extractor-test-02'
     resolution:
-      integrity: sha512-drCO2FKVl/LM476v2qDjrAc2rlyVVujt3Xezm6kEpJHs3tetpvOr/C4xMXVrAlZueXq67s9DyNuGIwO2avGKWw==
+      integrity: sha512-pM9NMzNSPZEdTGfopzAYrXI6+elOo05xCzSswYN67lNSKUpRFte3O/jmXm8txrnbFXmm5Q6Cbi/2y9Ob60w4sg==
       tarball: 'file:projects/api-extractor-test-02.tgz'
     version: 0.0.0
   'file:projects/api-extractor-test-03.tgz':
@@ -10224,21 +10288,21 @@ packages:
       '@types/jest': 21.1.10
       '@types/node': 8.5.8
       fs-extra: 5.0.0
-      typescript: 2.4.2
+      typescript: 2.9.2
     dev: false
     name: '@rush-temp/api-extractor-test-03'
     resolution:
-      integrity: sha512-xTb9agHV/3tmoLxI3dDoCJkJrWT7BoDiVzTPkB6OcQoPGEe84aBvYnaAzLCqTNXxvj+8GYhJvaAwXvixN5gVMQ==
+      integrity: sha512-Ze4Ebg9uZ/CIIfvevt4MxgNls4hmlvOrtxS7aIgWgnYx4pwy1Wi8fh1p6V0SZvHpCMJT2VYKqAJNlswob5QW6Q==
       tarball: 'file:projects/api-extractor-test-03.tgz'
     version: 0.0.0
   'file:projects/api-extractor-test-04.tgz':
     dependencies:
       fs-extra: 5.0.0
-      typescript: 2.4.2
+      typescript: 2.9.2
     dev: false
     name: '@rush-temp/api-extractor-test-04'
     resolution:
-      integrity: sha512-ZIomMFVJNtdC4DchHI905z4z/RHMJ99fGHagF85l9flQpBaIojPT0RvIPfubjQ/W5QoDG5o6CEldGTwUEgEwrA==
+      integrity: sha512-6i9YOh694OCeUsVYq4gytza8HGNXOcOMBdy6NuecJMK6qHbiXt8wz1GYSr+h4OZJUXINjlYLcOiNkZzJ0D1MXA==
       tarball: 'file:projects/api-extractor-test-04.tgz'
     version: 0.0.0
   'file:projects/api-extractor-test-05.tgz':
@@ -10246,11 +10310,11 @@ packages:
       '@types/jest': 21.1.10
       '@types/node': 8.5.8
       fs-extra: 5.0.0
-      typescript: 2.4.2
+      typescript: 2.9.2
     dev: false
     name: '@rush-temp/api-extractor-test-05'
     resolution:
-      integrity: sha512-IZrSMawWpQgj+9JjR/ch/4FDKj60sTZDHvpo2YW7/Q2udBM60MyJWM+58UKXavB0mLwn8ojEcQlLrtDpWxfiIA==
+      integrity: sha512-2Ym30gL2FmRqdwDCBPAMgGtQIg+aBasSvn0v9VG0oD04VUYLf0h5Tm6uH/WcYdC7376YUfqi0d8w67Usz5lpaw==
       tarball: 'file:projects/api-extractor-test-05.tgz'
     version: 0.0.0
   'file:projects/api-extractor.tgz':
@@ -10266,12 +10330,12 @@ packages:
       gulp: 3.9.1
       jju: 1.3.0
       lodash: 4.15.0
-      typescript: 2.4.2
+      typescript: 2.9.2
       z-schema: 3.18.4
     dev: false
     name: '@rush-temp/api-extractor'
     resolution:
-      integrity: sha512-az8VjG6LnfFdPHJd1ebPYzLkrLnwhRJeUiLAhU6Jbo2BMijC3FacowYVvBgiDi8dILqwicK9Vejvh+z4vPcQrA==
+      integrity: sha512-DN1+jMQLRFoqBiz/Ro74GJI0qkgOo4Zl8wOV/peENssAn0dqBoLWqn1SSyyPwfyQbiGWBOpeey4rISKyaUrLeg==
       tarball: 'file:projects/api-extractor.tgz'
     version: 0.0.0
   'file:projects/gulp-core-build-karma.tgz':
@@ -10303,7 +10367,7 @@ packages:
     dev: false
     name: '@rush-temp/gulp-core-build-karma'
     resolution:
-      integrity: sha512-+SZo1eQLLUzovQn5STe3yRA13nwXIqIHHlLY2g5JXxSdJoXFy7a/WStoUIoK0g1fqMTnzprciQ5zAIUucpY8HQ==
+      integrity: sha512-E7VpzKVd/0owfWhGz7N4HID0i9/pdaIAoPMPI7JdM51BhzDpr8hiG17V2mHTS+WajAZJjLFVz1Zyx6ajnJ/pYQ==
       tarball: 'file:projects/gulp-core-build-karma.tgz'
     version: 0.0.0
   'file:projects/gulp-core-build-mocha.tgz':
@@ -10322,7 +10386,7 @@ packages:
     dev: false
     name: '@rush-temp/gulp-core-build-mocha'
     resolution:
-      integrity: sha512-i80CBqbKItTNrmdcvLrFi30uicZnu5RCKVJl+oG5UO3SSKrrmu/QLTu4d0cx5VDdM/pU7Naxj5MY84EGRChPVQ==
+      integrity: sha512-g264f9sIWHYn/VzpDU1iMxGfeZWS6xxOiAsSBYXHnI+18gW0D05ZT+fGXIdsZnnwhHC/7C5eBY0hQIqdFA25bQ==
       tarball: 'file:projects/gulp-core-build-mocha.tgz'
     version: 0.0.0
   'file:projects/gulp-core-build-sass.tgz':
@@ -10351,7 +10415,7 @@ packages:
     dev: false
     name: '@rush-temp/gulp-core-build-sass'
     resolution:
-      integrity: sha512-rCXNaO8QutO3qJKY00ujRTCHsMX8UTN+AhgENuRI6VEVfKfAu5GZyuCme3UKmAhhvSyWbztnwPqjo/L/nHOq6g==
+      integrity: sha512-S3x0HNVxiy3PC8gaJo1q2QXfLoS2i/aN5ygGisxcyR1wCMyIKKFQO/DY2ggYl5tqTSzalUS2hyzF+VQcLJvUOA==
       tarball: 'file:projects/gulp-core-build-sass.tgz'
     version: 0.0.0
   'file:projects/gulp-core-build-serve.tgz':
@@ -10381,13 +10445,14 @@ packages:
     dev: false
     name: '@rush-temp/gulp-core-build-serve'
     resolution:
-      integrity: sha512-MvZ02fGqujOJvAwwOiBiXp+HwetrQIyt8GJ7IfGLjDTLC4FYcEqsF90Bb2xHAjqgzWxsT/FMAQwqseWYkbPolA==
+      integrity: sha512-OeJo5pMerEmHE9TknTJyZUlQWal4VR94lDjyy/KiywD9fx8uoj213ustYhWR9aJHSKBQB6lLaDCEnfY6+dn4Dg==
       tarball: 'file:projects/gulp-core-build-serve.tgz'
     version: 0.0.0
   'file:projects/gulp-core-build-typescript.tgz':
     dependencies:
       '@microsoft/node-library-build': 4.3.41
       '@types/fs-extra': 5.0.1
+      '@types/glob': 5.0.30
       '@types/gulp': 3.8.32
       '@types/gulp-util': 3.0.30
       '@types/node': 8.5.8
@@ -10396,6 +10461,7 @@ packages:
       '@types/through2': 2.0.32
       '@types/vinyl': 1.2.30
       fs-extra: 5.0.0
+      glob: 7.0.6
       gulp: 3.9.1
       gulp-cache: 0.4.6
       gulp-changed: 1.3.2
@@ -10403,20 +10469,20 @@ packages:
       gulp-plumber: 1.1.0
       gulp-sourcemaps: 2.6.4
       gulp-texttojs: 1.0.3
-      gulp-typescript: /gulp-typescript/3.1.7/typescript@2.4.2
+      gulp-typescript: /gulp-typescript/3.1.7/typescript@2.9.2
       gulp-util: 3.0.8
       lodash: 4.15.0
       md5: 2.2.1
       merge2: 1.0.3
       object-assign: 4.1.1
       through2: 2.0.3
-      tslint: /tslint/5.9.1/typescript@2.4.2
-      tslint-microsoft-contrib: /tslint-microsoft-contrib/5.0.3/tslint@5.9.1+typescript@2.4.2
-      typescript: 2.4.2
+      tslint: /tslint/5.9.1/typescript@2.9.2
+      tslint-microsoft-contrib: /tslint-microsoft-contrib/5.0.3/tslint@5.9.1+typescript@2.9.2
+      typescript: 2.9.2
     dev: false
     name: '@rush-temp/gulp-core-build-typescript'
     resolution:
-      integrity: sha512-9Nieijl+p4Z3eZa4FZgfYdjPObyEBtH04eueSRvgHTZV8mbH0B+W5mYWNdTYyLmSBKaTh5PUlv7+3evTpVdl0Q==
+      integrity: sha512-opRl3bDSA3z/pwCPhXwFT1MDMHGsZcQABA/ePYYXezfVn7uZQfr18FofVhKpfCaTh2QOyD+IC5TKvk3qPZN5iA==
       tarball: 'file:projects/gulp-core-build-typescript.tgz'
     version: 0.0.0
   'file:projects/gulp-core-build-webpack.tgz':
@@ -10436,7 +10502,7 @@ packages:
     dev: false
     name: '@rush-temp/gulp-core-build-webpack'
     resolution:
-      integrity: sha512-4wCB8CCCLe5Kutcvxsm1SXbQORps4/RG1hzlNSwkRsIOxIv+0DW61+lHJ27WoQqVtIqRciFwD3y9SRfEgANmhQ==
+      integrity: sha512-E94HiIIdJToSB3ntP8+VlLv+a4zJaoA1J0x4RRAvUMvonW6uqmmEl4yKcinQ/MVlFmw+ACLcAW5Uzv5/PuCG3g==
       tarball: 'file:projects/gulp-core-build-webpack.tgz'
     version: 0.0.0
   'file:projects/gulp-core-build.tgz':
@@ -10488,7 +10554,7 @@ packages:
     dev: false
     name: '@rush-temp/gulp-core-build'
     resolution:
-      integrity: sha512-Ur2IUBZXdLXAZ6IxgoHw9JOGDL3TEmYp5RvwVAncou5Q547y1X2c+LiPQJofaQZd6+OfiYgMhaGfhnbZS6r5Xg==
+      integrity: sha512-RWfAD9NQWhgrxBvQ3eyhqlyDyhJIzoVIXhEqEyI6hkum8YMBmZmYAvMQCzBiwNHXNzXHFsktdt26uRM/BopYAw==
       tarball: 'file:projects/gulp-core-build.tgz'
     version: 0.0.0
   'file:projects/load-themed-styles.tgz':
@@ -10501,7 +10567,7 @@ packages:
     dev: false
     name: '@rush-temp/load-themed-styles'
     resolution:
-      integrity: sha512-qVTEvskrCERYw7rsBJsCpLLWx+H4qBOfQFRFFYQBJac2BtFSajJay71Z2rfMMph52vpqlhxN8P5pn41xVgxvgg==
+      integrity: sha512-Kwx2tRDLAnEClxxSCewyihsCVdvCPyKwySS5hpLuHmA1rl/13IlpUu1UExDSevkE+OWCDNHDNpgeQTZ9xYm2Ow==
       tarball: 'file:projects/load-themed-styles.tgz'
     version: 0.0.0
   'file:projects/loader-load-themed-styles.tgz':
@@ -10516,7 +10582,7 @@ packages:
     dev: false
     name: '@rush-temp/loader-load-themed-styles'
     resolution:
-      integrity: sha512-Z8QcAqBj7cvewlLA0VDOZDyymYdq5WJYH5TdHX9Llf+D7gZCIDlXmRr8EgQWBKm6D3dL4Vo5ou7j0TxGN17wbg==
+      integrity: sha512-KRU6CRoSrZ6yesU5Xdl7mP5dlfnbkJ3BMEreEW1JnrFHCtrvZJX3vKu7n2apRxPp045etimmzJmKQaleIw2e9g==
       tarball: 'file:projects/loader-load-themed-styles.tgz'
     version: 0.0.0
   'file:projects/loader-raw-script.tgz':
@@ -10530,7 +10596,7 @@ packages:
     dev: false
     name: '@rush-temp/loader-raw-script'
     resolution:
-      integrity: sha512-WIQmu/aBNtoetUottnLsHfHjdB+zBZuYlg8FwO79/049ct15leqow619rwSkgwmoaD1jS0O3hKRsa/IzAbpinw==
+      integrity: sha512-JwnxrH7TGO052NVSDrwik+wPQStcgTc1m94Y+mLwTovvM9B5CYoehpwiVddPK/Six2tnKQYYC58AB7ZJ8NWiHA==
       tarball: 'file:projects/loader-raw-script.tgz'
     version: 0.0.0
   'file:projects/loader-set-webpack-public-path.tgz':
@@ -10546,7 +10612,7 @@ packages:
     dev: false
     name: '@rush-temp/loader-set-webpack-public-path'
     resolution:
-      integrity: sha512-qIe29bMj/O9a14Rc+hvWANI/Rw0rDqUciQ680aXJvkc6YiiKdJvLJY+yZ5MKGZBCQm/X3KlY01hkq6PJPB2mfw==
+      integrity: sha512-dc5H1K035NOWrTevOT662UIB0dOpH0eyd8BcJP+jDWEdQzo2hZw4n52VGqpE0eBHvfUG1bS9xgG7HbALNh0NqA==
       tarball: 'file:projects/loader-set-webpack-public-path.tgz'
     version: 0.0.0
   'file:projects/node-core-library.tgz':
@@ -10554,6 +10620,7 @@ packages:
       '@microsoft/node-library-build': 4.3.41
       '@types/chai': 3.4.34
       '@types/fs-extra': 5.0.1
+      '@types/jest': 21.1.10
       '@types/mocha': 2.2.38
       '@types/node': 8.5.8
       '@types/z-schema': 3.16.31
@@ -10566,7 +10633,7 @@ packages:
     dev: false
     name: '@rush-temp/node-core-library'
     resolution:
-      integrity: sha512-A8SyLlO9498f3f9ze8CYwkO5/t+n8XBycHRpLtuMBKDVUpNDtEarpUme3KUkDIqkeZQcei/B5XV7xm0nvzJ6bQ==
+      integrity: sha512-qye/H942wISIS9blFXcm+rBT5NdLR3/RyFzTf+DQTkrsEIArsRit3pYPcDRHqOWNTRz/cQGG5SGOy81HUeWswQ==
       tarball: 'file:projects/node-core-library.tgz'
     version: 0.0.0
   'file:projects/node-library-build.tgz':
@@ -10577,7 +10644,7 @@ packages:
     dev: false
     name: '@rush-temp/node-library-build'
     resolution:
-      integrity: sha512-cpc2vtPi08fClez5L2L0jAzAhUXuQIGeoDzA2Iht/dr6SmxiiCt90Dxv+W1SZEm/rTqqhd8d/cMjENtayH75+g==
+      integrity: sha512-YVAovIqXu5i22W2RhDIL3um3QtVNS+JeApB8RkybOdazoVi8Uo58PI/GYAAbry8yRnDXdqI8c/bUCvfyXBJHNg==
       tarball: 'file:projects/node-library-build.tgz'
     version: 0.0.0
   'file:projects/package-deps-hash.tgz':
@@ -10590,7 +10657,7 @@ packages:
     dev: false
     name: '@rush-temp/package-deps-hash'
     resolution:
-      integrity: sha512-y1sB4fgfU8ugsnQxXNYjJMn40Uk5CYEpIVOh6uX876JfX66/kJMIFBj26G8qTS+zExmZPhyC4U7O0YkUhed7bA==
+      integrity: sha512-aYcqj7TJ4yYBqO+9g1I3AqkZFF8k8nRIF8cCkr8viIGkQ8Wf4Z0YRdWIldqyPyW/VYHaBIFCXi/NFnAJ3QAN2w==
       tarball: 'file:projects/package-deps-hash.tgz'
     version: 0.0.0
   'file:projects/resolve-chunk-plugin.tgz':
@@ -10603,7 +10670,7 @@ packages:
     dev: false
     name: '@rush-temp/resolve-chunk-plugin'
     resolution:
-      integrity: sha512-pqEwuaw6k4FoCVR+yhKJv9yArzNRNokMn3pRc8hgsBV2pL0ZJXHWes2GBF0VOfVOZEb+uIw3vGzMWbp+8qgi9w==
+      integrity: sha512-DUAj1Ir4npTZd7fbrgLVsvyMrKB9gkEO7/kQkY9RJjbyK7XZcr+sSLzMXv7sgHGB+V1qfJXIuTc/jPzM9cBTNw==
       tarball: 'file:projects/resolve-chunk-plugin.tgz'
     version: 0.0.0
   'file:projects/rush-lib.tgz':
@@ -10646,25 +10713,25 @@ packages:
     dev: false
     name: '@rush-temp/rush-lib'
     resolution:
-      integrity: sha512-1CjqT9sUJQycZouo7725rIRfO0XyS4+CuzYFsxms0eeNFa/9ot7WZZd17yHGlx8i0K/fmYKgNFaIzt8Wa63FZg==
+      integrity: sha512-XdrBako+0r9vdoDy0o6DApewCxDLPeGJO57cKI44syq9d2o/makqJ7DEbfV4jjfQ+bHIJ9UQ/mhtPqxrOlgvNA==
       tarball: 'file:projects/rush-lib.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler.tgz':
     dependencies:
-      tslint: /tslint/5.9.1/typescript@2.4.2
-      tslint-microsoft-contrib: /tslint-microsoft-contrib/5.0.3/tslint@5.9.1+typescript@2.4.2
-      typescript: 2.4.2
+      tslint: /tslint/5.9.1/typescript@2.9.2
+      tslint-microsoft-contrib: /tslint-microsoft-contrib/5.0.3/tslint@5.9.1+typescript@2.9.2
+      typescript: 2.9.2
     dev: false
     name: '@rush-temp/rush-stack-compiler'
     resolution:
-      integrity: sha512-2EaC65RtTAEh5fRG4dg8e0iW6IxLcBIrF/LpSox0eIHASIgD4LB+BKx2L/hdfRX8gvScY4aVJS9AYd0/GVj5Fg==
+      integrity: sha512-CZfIXYM7nFq54pSXPkMgwKCG0u32uMj9MISeTsRO0DFjoSvxfOhELIMqw2RVACamoOJsp1tlj/hfDXWbwZf2XQ==
       tarball: 'file:projects/rush-stack-compiler.tgz'
     version: 0.0.0
   'file:projects/rush-stack-library-test.tgz':
     dev: false
     name: '@rush-temp/rush-stack-library-test'
     resolution:
-      integrity: sha512-L56dsYfPz7QwJvGXWykJjhGqWk2CE4Ioy6fGRgzzDh13As2P56QgNb9OvTjH+aC4ZwAU3pLAB/KtytCjVuP8PQ==
+      integrity: sha512-gmHKAw3K2uDCpQ2zB6/eSuErnYwOXJ+Od7oUzcyRPjZLje/Minb1o6C5XO9a6H2U+2B7eXnL4CFmdoL4zRgOpA==
       tarball: 'file:projects/rush-stack-library-test.tgz'
     version: 0.0.0
   'file:projects/rush-stack.tgz':
@@ -10678,7 +10745,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack'
     resolution:
-      integrity: sha512-F/AUzCaAl1eeU2HarcuOCWkeQ5siyd8IaQ9MJFNB0w5By9+YdSmGFjg7QESG8cRLU/XsDDprzdDLcRlOOj+Fig==
+      integrity: sha512-0ug8dwJ4nJtxX/GCv7LK8aKnD/mY6RD6IVsH7WAZJovYNQ7OYd9AHuo3tNZXBr+aISMZa5P9wYwRyBOybxzcbw==
       tarball: 'file:projects/rush-stack.tgz'
     version: 0.0.0
   'file:projects/rush.tgz':
@@ -10698,7 +10765,7 @@ packages:
     dev: false
     name: '@rush-temp/rush'
     resolution:
-      integrity: sha512-+9xGN53lyYsvTHmhncdAZLKMd52QgM+ReXjdm+kh0SCb6Kg0hOK04ias6tsY3CFF/mdNUVMVeeuLQtui1rmHSw==
+      integrity: sha512-VCLBWQ3R+hGqrLPzT/bPA0HOK5DtAsoI+QShgdDuDWf85i3HJ2k+2h+J7Su+mAmT2EHWq8cdRfp6gwjMqiX3Ng==
       tarball: 'file:projects/rush.tgz'
     version: 0.0.0
   'file:projects/rushell.tgz':
@@ -10712,7 +10779,7 @@ packages:
     dev: false
     name: '@rush-temp/rushell'
     resolution:
-      integrity: sha512-P2lZCerVj9nwanjnQwPgBXJ1ahnO+irVT9kGZKxnJcXfPiWbt9qf+t2d0JtCdjtJ63imzizH/84J/t8RtVT0tw==
+      integrity: sha512-9HcaLPMz2Cy3TZzYfrFhRHmb0YYJBRx+8rj0QwfKZAf9GA5eYl9mqzWVTGhQU+V5b//zl3b040bfZVj3xnLOJA==
       tarball: 'file:projects/rushell.tgz'
     version: 0.0.0
   'file:projects/set-webpack-public-path-plugin.tgz':
@@ -10731,7 +10798,7 @@ packages:
     dev: false
     name: '@rush-temp/set-webpack-public-path-plugin'
     resolution:
-      integrity: sha512-hJxLw0hIeUhe0rB/C0sSNUOU2uVPHfKqkZbncrvtbFWIeM4cmz0DxE8vhLDkqUwUBDV9nmTKb+JhrtkYYjJCRQ==
+      integrity: sha512-xo03BcXC2vQYVXYKNKtS11K8KGCoZw8U/4QEdhOOEybmOLgka86KBXCHM0vNBuevgmaU8DBuNRYnbEMLllkniA==
       tarball: 'file:projects/set-webpack-public-path-plugin.tgz'
     version: 0.0.0
   'file:projects/stream-collator.tgz':
@@ -10746,7 +10813,7 @@ packages:
     dev: false
     name: '@rush-temp/stream-collator'
     resolution:
-      integrity: sha512-BWzRV7aL6zR1Ac71aeBy7/ccfGzgx8/m1w1sdBSrqfCxU9hBUkYXufpQz1MzsJvuxIpt9RMAuHX/bBKQLythoA==
+      integrity: sha512-/4CsQ40Pn9/7WXwWp/nu1n16036K4WUmOhjnH3DWGLPm3DXVhzKLmyjl2a2xX1QyWef8/j7eqdyn8832EgYkJQ==
       tarball: 'file:projects/stream-collator.tgz'
     version: 0.0.0
   'file:projects/ts-command-line.tgz':
@@ -10761,7 +10828,7 @@ packages:
     dev: false
     name: '@rush-temp/ts-command-line'
     resolution:
-      integrity: sha512-RkmrxJaSJrTF+0j4jyUGeq7JW0GtjbuurD5CArocWepHaS51qL9wqYY5zftHfiXQxuk3E3EqEJYS+G8zbBJpZQ==
+      integrity: sha512-7NBCycl/ev0w8S+Qye0ifW0NOnLI6JzmHmtHuUzXzSkxHwebusIyqB3JlMv0+ZdzvBxvBAZL3Wxgvf/+ooAZkg==
       tarball: 'file:projects/ts-command-line.tgz'
     version: 0.0.0
   'file:projects/web-library-build-test.tgz':
@@ -10774,7 +10841,7 @@ packages:
     dev: false
     name: '@rush-temp/web-library-build-test'
     resolution:
-      integrity: sha512-eF1tuYlDaRqp/u7vd2FWU0/0jlClad704TkAHwTihklvkxBuZDzFE2yyiOrSq8K1F9IR75fhgW8dB30vMZJLoA==
+      integrity: sha512-vD6GbPV8g4U2SjRqfhEaPdDjrPn/4kUyo5PVDqmBKCn1t5jNHb1SWvF+k5IrnT6LnIAO0Ezj/yztrZO1Nu72mg==
       tarball: 'file:projects/web-library-build-test.tgz'
     version: 0.0.0
   'file:projects/web-library-build.tgz':
@@ -10786,7 +10853,7 @@ packages:
     dev: false
     name: '@rush-temp/web-library-build'
     resolution:
-      integrity: sha512-22J+ovChTd3rRdNymTzbIYnHDgqNVL5WNQWo7ahqm5lQF+5clqs+getyy4xmt92xBq83sQ/6hVodszQLdFKQNw==
+      integrity: sha512-nDCL/V21hHi8Brzivhf5oakikcjNwl31IJB73u7Kv4IB1CtDSqTP6lquCm+HCLAFlMnTMnhZllgxRBQG5fhTxw==
       tarball: 'file:projects/web-library-build.tgz'
     version: 0.0.0
 registry: 'https://registry.npmjs.org/'
@@ -10954,7 +11021,7 @@ specifiers:
   ts-jest: ~22.4.6
   tslint: ~5.9.1
   tslint-microsoft-contrib: ~5.0.2
-  typescript: ~2.4.1
+  typescript: ~2.9.2
   uglify-js: ~3.0.28
   webpack: ~3.11.0
   wordwrap: ~1.0.0

--- a/core-build/gulp-core-build-typescript/package.json
+++ b/core-build/gulp-core-build-typescript/package.json
@@ -36,7 +36,7 @@
     "through2": "~2.0.1",
     "tslint": "~5.9.1",
     "tslint-microsoft-contrib": "~5.0.2",
-    "typescript": "~2.4.1"
+    "typescript": "~2.9.2"
   },
   "devDependencies": {
     "@microsoft/node-library-build": "4.3.41",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,3 @@
+{
+  "lockfileVersion": 1
+}

--- a/stack/rush-stack-compiler/package.json
+++ b/stack/rush-stack-compiler/package.json
@@ -15,6 +15,6 @@
     "@microsoft/api-extractor": "5.10.0",
     "tslint": "~5.9.1",
     "tslint-microsoft-contrib": "~5.0.2",
-    "typescript": "~2.4.1"
+    "typescript": "~2.9.2"
   }
 }


### PR DESCRIPTION
It was fully compatible, except for a typing error (which was checked for at runtime).

Fixes #702 