### PR TITLE
[gulp-core-build] Eliminate packages with security warnings

### DIFF
--- a/build-tests/web-library-build-test/config/serve.json
+++ b/build-tests/web-library-build-test/config/serve.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/spfx-build/spfx-serve.schema.json",
   "port": 4321,
-  "initialPage": "https://localhost:5432/workbench",
+  "initialPage": "https://localhost:4321/",
   "https": true,
   "tryCreateDevCertificate": true
 }

--- a/common/changes/@microsoft/gulp-core-build-serve/pgonzal-upgrade-insecure-packages_2018-08-07-20-56.json
+++ b/common/changes/@microsoft/gulp-core-build-serve/pgonzal-upgrade-insecure-packages_2018-08-07-20-56.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/gulp-core-build-serve",
+      "comment": "Upgrade gulp-open to elimiante security warning",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/gulp-core-build-serve",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/gulp-core-build-webpack/pgonzal-upgrade-insecure-packages_2018-08-07-20-56.json
+++ b/common/changes/@microsoft/gulp-core-build-webpack/pgonzal-upgrade-insecure-packages_2018-08-07-20-56.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/gulp-core-build-webpack",
+      "comment": "Update typings",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/gulp-core-build-webpack",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/gulp-core-build/pgonzal-upgrade-insecure-packages_2018-08-07-20-56.json
+++ b/common/changes/@microsoft/gulp-core-build/pgonzal-upgrade-insecure-packages_2018-08-07-20-56.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/gulp-core-build",
+      "comment": "Add explicit dependency on jsdom to workaround Jest regression #6766",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/gulp-core-build",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/config/rush/common-versions.json
+++ b/common/config/rush/common-versions.json
@@ -1,13 +1,6 @@
 {
   "preferredVersions": {
-    "ajv": "5.2.2"
   },
   "allowedAlternativeVersions": {
-    "jest-environment-jsdom": [
-      "~21.2.1"
-    ],
-    "@types/webpack": [
-      "4.4.0"
-    ]
   }
 }

--- a/common/config/rush/nonbrowser-approved-packages.json
+++ b/common/config/rush/nonbrowser-approved-packages.json
@@ -298,6 +298,10 @@
       "allowedCategories": [ "libraries" ]
     },
     {
+      "name": "jsdom",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
       "name": "karma",
       "allowedCategories": [ "libraries" ]
     },

--- a/common/config/rush/shrinkwrap.yaml
+++ b/common/config/rush/shrinkwrap.yaml
@@ -74,10 +74,10 @@ dependencies:
   '@types/through2': 2.0.32
   '@types/uglify-js': 2.6.29
   '@types/vinyl': 1.2.30
+  '@types/webpack': 4.4.0
   '@types/webpack-env': 1.13.0
   '@types/yargs': 0.0.34
   '@types/z-schema': 3.16.31
-  ajv: 5.2.2
   argparse: 1.0.10
   autoprefixer: 6.3.7
   builtins: 1.0.3
@@ -106,7 +106,7 @@ dependencies:
   gulp-istanbul: 0.10.4
   gulp-karma: 0.0.5
   gulp-mocha: 6.0.0
-  gulp-open: 2.0.0
+  gulp-open: 3.0.1
   gulp-plumber: 1.1.0
   gulp-postcss: 6.3.0
   gulp-replace: 0.5.4
@@ -124,6 +124,7 @@ dependencies:
   jest-resolve: 22.4.3
   jju: 1.3.0
   js-yaml: 3.9.1
+  jsdom: 11.11.0
   karma: 0.13.22
   karma-coverage: 0.5.5
   karma-mocha: 1.3.0
@@ -156,7 +157,7 @@ dependencies:
   sinon-chai: 2.8.0
   strict-uri-encode: 2.0.0
   sudo: 1.0.3
-  tar: 4.4.4
+  tar: 4.4.6
   through2: 2.0.3
   ts-jest: 22.4.6
   tslint: 5.9.1
@@ -168,32 +169,32 @@ dependencies:
   yargs: 4.6.0
   z-schema: 3.18.4
 packages:
-  /@babel/code-frame/7.0.0-beta.51:
+  /@babel/code-frame/7.0.0-beta.56:
     dependencies:
-      '@babel/highlight': 7.0.0-beta.51
+      '@babel/highlight': 7.0.0-beta.56
     dev: false
     resolution:
-      integrity: sha1-vXHZsZKvl435FYKdOdQJRFZDmgw=
-  /@babel/highlight/7.0.0-beta.51:
+      integrity: sha512-OBeGs8UXWpKl0oK2T5nUXNl2yu8RKxqL/7aUnMtKDXCU6VUrNP3npdrPivBA11HPB15TVI49nWf2lntTzoUuAg==
+  /@babel/highlight/7.0.0-beta.56:
     dependencies:
       chalk: 2.4.1
       esutils: 2.0.2
       js-tokens: 3.0.2
     dev: false
     resolution:
-      integrity: sha1-6IRK4loVlcz9QriWI7Q3bKBtIl0=
-  /@gulp-sourcemaps/identity-map/1.0.1:
+      integrity: sha512-q4TfI+jJISul6vVpZJktzH4tupwRiVk6KXRhB8PHqJ7erl966I6ePDXl9mAbE8jMM7YswhnnB0j1SYP7LBVyhg==
+  /@gulp-sourcemaps/identity-map/1.0.2:
     dependencies:
-      acorn: 5.6.2
+      acorn: 5.7.1
       css: 2.2.3
       normalize-path: 2.1.1
-      source-map: 0.5.7
+      source-map: 0.6.1
       through2: 2.0.3
     dev: false
     engines:
       node: '>= 0.10'
     resolution:
-      integrity: sha1-z6I7xYQPkQTOMqZedNt+epdLvuE=
+      integrity: sha512-ciiioYMLdo16ShmfHBXJBOFm3xPC4AuwO4xeRpFeHz7WK9PYsWCmigagG2XyzZpubK4a3qNKoUBDhbzHfa50LQ==
   /@gulp-sourcemaps/map-sources/1.0.0:
     dependencies:
       normalize-path: 2.1.1
@@ -217,32 +218,6 @@ packages:
     dev: false
     resolution:
       integrity: sha1-x2ad5EBSupoyPSFVMiUtiBAEfCA=
-  /@microsoft/api-extractor/5.7.2:
-    dependencies:
-      '@microsoft/node-core-library': 1.3.2
-      '@microsoft/ts-command-line': 4.1.0
-      '@types/fs-extra': 5.0.1
-      '@types/node': 8.5.8
-      '@types/z-schema': 3.16.31
-      colors: 1.2.5
-      fs-extra: 5.0.0
-      jju: 1.3.0
-      lodash: 4.15.0
-      typescript: 2.4.2
-      z-schema: 3.18.4
-    dev: false
-    resolution:
-      integrity: sha1-zLaQ9YoYXC7cqapSQtMp53qawbg=
-  /@microsoft/gulp-core-build-mocha/3.3.28:
-    dependencies:
-      '@microsoft/gulp-core-build': 3.8.2
-      '@types/node': 8.5.8
-      gulp: 3.9.1
-      gulp-istanbul: 0.10.4
-      gulp-mocha: 2.2.0
-    dev: false
-    resolution:
-      integrity: sha1-pdU0/ahKE+VtIuZm63sl0oKglLA=
   /@microsoft/gulp-core-build-mocha/3.4.0:
     dependencies:
       '@microsoft/gulp-core-build': 3.8.5
@@ -282,83 +257,6 @@ packages:
     dev: false
     resolution:
       integrity: sha1-WE4OhFR1mJJlPf2fVnSlNEwr7/w=
-  /@microsoft/gulp-core-build-typescript/4.9.14:
-    dependencies:
-      '@microsoft/api-extractor': 5.7.2
-      '@microsoft/gulp-core-build': 3.8.2
-      '@microsoft/node-core-library': 1.3.2
-      '@types/fs-extra': 5.0.1
-      '@types/gulp': 3.8.32
-      '@types/node': 8.5.8
-      '@types/vinyl': 1.2.30
-      fs-extra: 5.0.0
-      gulp: 3.9.1
-      gulp-cache: 0.4.6
-      gulp-changed: 1.3.2
-      gulp-decomment: 0.1.3
-      gulp-plumber: 1.1.0
-      gulp-sourcemaps: 2.6.4
-      gulp-texttojs: 1.0.3
-      gulp-typescript: /gulp-typescript/3.1.7/typescript@2.4.2
-      gulp-util: 3.0.8
-      lodash: 4.15.0
-      md5: 2.2.1
-      merge2: 1.0.3
-      object-assign: 4.1.1
-      through2: 2.0.3
-      tslint: /tslint/5.9.1/typescript@2.4.2
-      tslint-microsoft-contrib: /tslint-microsoft-contrib/5.0.3/tslint@5.9.1+typescript@2.4.2
-      typescript: 2.4.2
-    dev: false
-    resolution:
-      integrity: sha1-5Y21x8jhSznX0idODnliSa8ox/I=
-  /@microsoft/gulp-core-build/3.8.2:
-    dependencies:
-      '@microsoft/node-core-library': 1.3.2
-      '@types/assertion-error': 1.0.30
-      '@types/chai': 3.4.34
-      '@types/chalk': 0.4.31
-      '@types/gulp': 3.8.32
-      '@types/gulp-util': 3.0.30
-      '@types/mocha': 2.2.38
-      '@types/node': 8.5.8
-      '@types/node-notifier': 0.0.28
-      '@types/orchestrator': 0.0.30
-      '@types/q': 0.0.32
-      '@types/rimraf': 0.0.28
-      '@types/semver': 5.3.33
-      '@types/through2': 2.0.32
-      '@types/vinyl': 1.2.30
-      '@types/yargs': 0.0.34
-      colors: 1.2.5
-      del: 2.2.2
-      end-of-stream: 1.1.0
-      fs-extra: 5.0.0
-      glob-escape: 0.0.2
-      globby: 5.0.0
-      gulp: 3.9.1
-      gulp-flatten: 0.2.0
-      gulp-if: 2.0.2
-      gulp-util: 3.0.8
-      jest: 22.4.4
-      jest-cli: 22.4.4
-      jest-environment-jsdom: 22.4.3
-      jest-resolve: 22.4.3
-      jju: 1.3.0
-      lodash.merge: 4.3.5
-      merge2: 1.0.3
-      node-notifier: 5.0.2
-      object-assign: 4.1.1
-      orchestrator: 0.3.8
-      pretty-hrtime: 1.0.3
-      rimraf: 2.5.4
-      semver: 5.3.0
-      through2: 2.0.3
-      yargs: 4.6.0
-      z-schema: 3.18.4
-    dev: false
-    resolution:
-      integrity: sha1-YMNfLlsUfHVhMeTlD7le8kvNRWI=
   /@microsoft/gulp-core-build/3.8.5:
     dependencies:
       '@microsoft/node-core-library': 1.5.0
@@ -405,17 +303,6 @@ packages:
     dev: false
     resolution:
       integrity: sha1-yc/3lb47EVRMb5GrX5FgB5IKA7Q=
-  /@microsoft/node-core-library/1.3.2:
-    dependencies:
-      '@types/fs-extra': 5.0.1
-      '@types/node': 8.5.8
-      '@types/z-schema': 3.16.31
-      fs-extra: 5.0.0
-      jju: 1.3.0
-      z-schema: 3.18.4
-    dev: false
-    resolution:
-      integrity: sha1-tBvy/mtgGtjEZarRj06MhtPbUHc=
   /@microsoft/node-core-library/1.5.0:
     dependencies:
       '@types/fs-extra': 5.0.1
@@ -427,17 +314,6 @@ packages:
     dev: false
     resolution:
       integrity: sha1-6NhOdq+N0ivvcRSyz76iW2AXWdQ=
-  /@microsoft/node-library-build/4.3.41:
-    dependencies:
-      '@microsoft/gulp-core-build': 3.8.2
-      '@microsoft/gulp-core-build-mocha': 3.3.28
-      '@microsoft/gulp-core-build-typescript': 4.9.14
-      '@types/gulp': 3.8.32
-      '@types/node': 8.5.8
-      gulp: 3.9.1
-    dev: false
-    resolution:
-      integrity: sha1-TkNG4RWsVkmliSf5PMLi09edRRk=
   /@microsoft/node-library-build/4.4.0:
     dependencies:
       '@microsoft/gulp-core-build': 3.8.5
@@ -449,15 +325,6 @@ packages:
     dev: false
     resolution:
       integrity: sha1-vBgXfcdJ6pritLx2UJJCU3LCzNs=
-  /@microsoft/ts-command-line/4.1.0:
-    dependencies:
-      '@types/argparse': 1.0.33
-      '@types/node': 8.5.8
-      argparse: 1.0.10
-      colors: 1.2.5
-    dev: false
-    resolution:
-      integrity: sha1-zyVX06aLE8igUtILviMQtf6mlUk=
   /@microsoft/ts-command-line/4.2.0:
     dependencies:
       '@types/argparse': 1.0.33
@@ -472,8 +339,8 @@ packages:
       '@pnpm/package-bins': 1.0.0
       '@pnpm/types': 1.7.0
       '@types/mz': 0.0.32
-      '@types/node': 10.3.2
-      '@types/ramda': 0.25.32
+      '@types/node': 10.5.7
+      '@types/ramda': 0.25.36
       '@zkochan/cmd-shim': 2.2.4
       arr-flatten: 1.1.0
       is-windows: 1.0.2
@@ -496,8 +363,8 @@ packages:
       '@pnpm/package-bins': 1.0.0
       '@pnpm/types': 1.7.0
       '@types/mz': 0.0.32
-      '@types/node': 10.3.2
-      '@types/ramda': 0.25.32
+      '@types/node': 10.5.7
+      '@types/ramda': 0.25.36
       '@zkochan/cmd-shim': 2.2.4
       arr-flatten: 1.1.0
       is-windows: 1.0.2
@@ -517,7 +384,7 @@ packages:
       integrity: sha512-thVgwrQ5rMcPYI6a0IPOt2pnlF1n5zX7BN4CrFeBp0/JCGsZAht/VOPv9bD3cZ+j0vDemEwE23BfhOWxmxq2yQ==
   /@pnpm/logger/1.0.2:
     dependencies:
-      '@types/node': 10.3.2
+      '@types/node': 10.5.7
       bole: 3.0.2
       ndjson: 1.5.0
     dev: false
@@ -707,10 +574,10 @@ packages:
     dev: false
     resolution:
       integrity: sha1-hro9OqjZGDUswxkdiN4yiyDck8E=
-  /@types/node/10.3.2:
+  /@types/node/10.5.7:
     dev: false
     resolution:
-      integrity: sha512-9NfEUDp3tgRhmoxzTpTo+lq+KIVFxZahuRX0LHF/9IzKHaWuoWsIrrJ61zw5cnnlGINX8lqJzXYfQTOICS5Q+A==
+      integrity: sha512-VkKcfuitP+Nc/TaTFH0B8qNmn+6NbI6crLkQonbedViVz7O2w8QV/GERPlkJ4bg42VGHiEWa31CoTOPs1q6z1w==
   /@types/node/8.5.8:
     dev: false
     resolution:
@@ -725,10 +592,10 @@ packages:
     dev: false
     resolution:
       integrity: sha1-vShOV8hPEyXacCur/IKlMoGQwMU=
-  /@types/ramda/0.25.32:
+  /@types/ramda/0.25.36:
     dev: false
     resolution:
-      integrity: sha512-KvkOhOprW8ln1XtlBoUPxrObnrZ1SQZezF9UlkWMYF0ZKpzlbwZDEcMZo6XcMsg/9M9Vl1lstCnCE8J7qxFAvQ==
+      integrity: sha512-LAeBECPU9IG+K0pRdGl2L9lxanb0CKgue0IGpdn9nmpmKefDrCglrYwkxFYoQxCtY0w/mTxpJaQ4VAChcSIN+A==
   /@types/rimraf/0.0.28:
     dev: false
     resolution:
@@ -752,10 +619,6 @@ packages:
     dev: false
     resolution:
       integrity: sha1-3TS72OMv5OdPLj2KwH+KpbRaR6w=
-  /@types/tapable/0.2.5:
-    dev: false
-    resolution:
-      integrity: sha512-dEoVvo/I9QFomyhY+4Q6Qk+I+dhG59TYceZgC6Q0mCifVPErx6Y83PNTKGDS5e9h9Eti6q0S2mm16BU6iQK+3w==
   /@types/tapable/1.0.2:
     dev: false
     resolution:
@@ -788,15 +651,6 @@ packages:
     dev: false
     resolution:
       integrity: sha1-MEQ4FkfhHulzxa8uklMjkw9pHYA=
-  /@types/webpack/3.8.11:
-    dependencies:
-      '@types/node': 8.5.8
-      '@types/tapable': 0.2.5
-      '@types/uglify-js': 2.6.29
-      source-map: 0.6.1
-    dev: false
-    resolution:
-      integrity: sha512-6a+XQjFMAJekCE7IxkDavoX8cGCEmTE+MrKeUK4CL0Q7SL9w4c5TdrYrUEzcJx3GX3I0fTIC79x0C07Pi5VmlA==
   /@types/webpack/4.4.0:
     dependencies:
       '@types/node': 8.5.8
@@ -838,7 +692,7 @@ packages:
       integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
   /accepts/1.3.3:
     dependencies:
-      mime-types: 2.1.18
+      mime-types: 2.1.19
       negotiator: 0.6.1
     dev: false
     engines:
@@ -847,7 +701,7 @@ packages:
       integrity: sha1-w8p0NJOGSMPg2cHjKN1otiLChMo=
   /accepts/1.3.5:
     dependencies:
-      mime-types: 2.1.18
+      mime-types: 2.1.19
       negotiator: 0.6.1
     dev: false
     engines:
@@ -862,7 +716,7 @@ packages:
       integrity: sha1-x1K9IQvvZ5UBtsbLf8hPj0cVjMQ=
   /acorn-globals/4.1.0:
     dependencies:
-      acorn: 5.6.2
+      acorn: 5.7.1
     dev: false
     resolution:
       integrity: sha512-KjZwU26uG3u6eZcfGbTULzFcsoz6pegNKtHPksZPOUsiKo5bUmiBPa38FuHZ/Eun+XYh/JCCkS9AS3Lu4McQOQ==
@@ -872,27 +726,27 @@ packages:
       node: '>=0.4.0'
     resolution:
       integrity: sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c=
-  /acorn/5.6.2:
+  /acorn/5.7.1:
     dev: false
     engines:
       node: '>=0.4.0'
     resolution:
-      integrity: sha512-zUzo1E5dI2Ey8+82egfnttyMlMZ2y0D8xOCO3PNPPlYXpl8NZvF6Qk9L9BEtJs+43FqEmfBViDqc5d1ckRDguw==
+      integrity: sha512-d+nbxBUGKg7Arpsvbnlq61mc12ek3EY8EQldM3GPAhWJ1UVxC6TDGbIvUMNU6obBX3i1+ptCIzV4vq0gFPEGVQ==
   /after/0.8.2:
     dev: false
     resolution:
       integrity: sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8=
-  /agent-base/4.2.0:
+  /agent-base/4.2.1:
     dependencies:
       es6-promisify: 5.0.0
     dev: false
     engines:
       node: '>= 4.0.0'
     resolution:
-      integrity: sha512-c+R/U5X+2zz2+UCrCFv6odQzJdoqI+YecuhnAJLa1zYaMc13zPfwMwZrr91Pd1DYNo/yPRbiM4WVf9whgwFsIg==
-  /ajv-keywords/3.2.0/ajv@6.5.1:
+      integrity: sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==
+  /ajv-keywords/3.2.0/ajv@6.5.2:
     dependencies:
-      ajv: 6.5.1
+      ajv: 6.5.2
     dev: false
     id: registry.npmjs.org/ajv-keywords/3.2.0
     peerDependencies:
@@ -906,16 +760,16 @@ packages:
     dev: false
     resolution:
       integrity: sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=
-  /ajv/5.2.2:
+  /ajv/5.5.2:
     dependencies:
       co: 4.6.0
       fast-deep-equal: 1.1.0
+      fast-json-stable-stringify: 2.0.0
       json-schema-traverse: 0.3.1
-      json-stable-stringify: 1.0.1
     dev: false
     resolution:
-      integrity: sha1-R8aNaehvXZUxA7AHSpQw3GPaXjk=
-  /ajv/6.5.1:
+      integrity: sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=
+  /ajv/6.5.2:
     dependencies:
       fast-deep-equal: 2.0.1
       fast-json-stable-stringify: 2.0.0
@@ -923,7 +777,7 @@ packages:
       uri-js: 4.2.2
     dev: false
     resolution:
-      integrity: sha512-pgZos1vgOHDiC7gKNbZW8eKvCnNXARv2oqrGQT7Hzbq5Azp7aZG6DJzADnkuSq7RH6qkXp4J/m68yPX/2uBHyQ==
+      integrity: sha512-hOs7GfvI6tUI1LfZddH82ky6mOMyTuY0mk7kE2pWpmhhUSkumzaTO5vbVwij39MdwPQWCV4Zv57Eo06NtL/GVA==
   /align-text/0.1.4:
     dependencies:
       kind-of: 3.2.2
@@ -1183,10 +1037,12 @@ packages:
     dev: false
     resolution:
       integrity: sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==
-  /asn1/0.2.3:
+  /asn1/0.2.4:
+    dependencies:
+      safer-buffer: 2.1.2
     dev: false
     resolution:
-      integrity: sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=
+      integrity: sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==
   /assert-plus/0.2.0:
     dev: false
     engines:
@@ -1260,7 +1116,7 @@ packages:
   /autoprefixer/6.3.7:
     dependencies:
       browserslist: 1.3.6
-      caniuse-db: 1.0.30000853
+      caniuse-db: 1.0.30000875
       normalize-range: 0.1.2
       num2fraction: 1.2.2
       postcss: 5.2.18
@@ -1276,10 +1132,10 @@ packages:
     dev: false
     resolution:
       integrity: sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=
-  /aws4/1.7.0:
+  /aws4/1.8.0:
     dev: false
     resolution:
-      integrity: sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w==
+      integrity: sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
   /babel-code-frame/6.26.0:
     dependencies:
       chalk: 1.1.3
@@ -1491,13 +1347,13 @@ packages:
     dev: false
     resolution:
       integrity: sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY=
-  /bcrypt-pbkdf/1.0.1:
+  /bcrypt-pbkdf/1.0.2:
     dependencies:
       tweetnacl: 0.14.5
     dev: false
     optional: true
     resolution:
-      integrity: sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=
+      integrity: sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=
   /beeper/1.1.1:
     dev: false
     engines:
@@ -1668,12 +1524,12 @@ packages:
     dev: false
     resolution:
       integrity: sha1-Ql1opY00R/AqBKqJQYf86K+Le44=
-  /browser-resolve/1.11.2:
+  /browser-resolve/1.11.3:
     dependencies:
       resolve: 1.1.7
     dev: false
     resolution:
-      integrity: sha1-j/CbCixCFxihBRwmCzLkj0QpOM4=
+      integrity: sha512-exDi1BYWB/6raKHmDTCicQfTkqwN5fioMFV4j8BsfMU4R2DK/QfZfK7kOVkmWCNANf0snkBzqGqAJBao9gZMdQ==
   /browser-stdout/1.3.1:
     dev: false
     resolution:
@@ -1692,19 +1548,20 @@ packages:
   /browserify-cipher/1.0.1:
     dependencies:
       browserify-aes: 1.2.0
-      browserify-des: 1.0.1
+      browserify-des: 1.0.2
       evp_bytestokey: 1.0.3
     dev: false
     resolution:
       integrity: sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==
-  /browserify-des/1.0.1:
+  /browserify-des/1.0.2:
     dependencies:
       cipher-base: 1.0.4
       des.js: 1.0.0
       inherits: 2.0.3
+      safe-buffer: 5.1.2
     dev: false
     resolution:
-      integrity: sha512-zy0Cobe3hhgpiOM32Tj7KQ3Vl91m0njwsjzZQK1L+JDf11dzP9qIvjreVinsvXrgfjhStXwUWAEpB9D7Gwmayw==
+      integrity: sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==
   /browserify-rsa/4.0.1:
     dependencies:
       bn.js: 4.11.8
@@ -1732,7 +1589,8 @@ packages:
       integrity: sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==
   /browserslist/1.3.6:
     dependencies:
-      caniuse-db: 1.0.30000853
+      caniuse-db: 1.0.30000875
+    deprecated: Browserslist 2 could fail on reading Browserslist >3.0 config used in other tools.
     dev: false
     resolution:
       integrity: sha1-lS/0jVZGPTtTj4XvL46t39KEsTM=
@@ -1742,10 +1600,25 @@ packages:
     dev: false
     resolution:
       integrity: sha1-mseNPtXZFYBP2HrLFYvHlxR6Fxk=
-  /buffer-from/1.1.0:
+  /buffer-alloc-unsafe/1.1.0:
     dev: false
     resolution:
-      integrity: sha512-c5mRlguI/Pe2dSZmpER62rSCu0ryKmWddzRYsuXc50U2/g8jMOulc31VZMa4mYx31U5xsmSOpDCgH88Vl9cDGQ==
+      integrity: sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==
+  /buffer-alloc/1.2.0:
+    dependencies:
+      buffer-alloc-unsafe: 1.1.0
+      buffer-fill: 1.0.0
+    dev: false
+    resolution:
+      integrity: sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==
+  /buffer-fill/1.0.0:
+    dev: false
+    resolution:
+      integrity: sha1-+PeLdniYiO858gXNY39o5wISKyw=
+  /buffer-from/1.1.1:
+    dev: false
+    resolution:
+      integrity: sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
   /buffer-xor/1.0.3:
     dev: false
     resolution:
@@ -1854,20 +1727,16 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=
-  /caniuse-db/1.0.30000853:
+  /caniuse-db/1.0.30000875:
     dev: false
     resolution:
-      integrity: sha1-MpAafWuTqH1Z8Iqu5H6o/27JD98=
+      integrity: sha512-L1YQcIv8YPymJpbQyO8uM2KEkEVsuFcQRO2vNp0n4GNGAmq0f8GWQKUCTqZHvsyX2EeOO4aLWgc3qCH6zMWFag==
   /capture-exit/1.2.0:
     dependencies:
       rsvp: 3.6.2
     dev: false
     resolution:
       integrity: sha1-HF/MSJ/QqwDU8ax64QcuMXP7q28=
-  /caseless/0.11.0:
-    dev: false
-    resolution:
-      integrity: sha1-cVuW6phBWTzDMGeSP17GDr2k99c=
   /caseless/0.12.0:
     dev: false
     resolution:
@@ -1944,7 +1813,7 @@ packages:
       fsevents: 1.2.4
     resolution:
       integrity: sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=
-  /chokidar/2.0.3:
+  /chokidar/2.0.4:
     dependencies:
       anymatch: 2.0.0
       async-each: 1.0.1
@@ -1953,6 +1822,7 @@ packages:
       inherits: 2.0.3
       is-binary-path: 1.0.1
       is-glob: 4.0.0
+      lodash.debounce: 4.0.8
       normalize-path: 2.1.1
       path-is-absolute: 1.0.1
       readdirp: 2.1.0
@@ -1961,7 +1831,7 @@ packages:
     optionalDependencies:
       fsevents: 1.2.4
     resolution:
-      integrity: sha512-zW8iXYZtXMx4kux/nuZVXjkLP+CyIK5Al5FHnj1OgTKGZfp4Oy6/ymtMSKFv3GD8DviEmUPmJg9eFdJ/JzudMg==
+      integrity: sha512-z9n7yt9rOvIJrMhvDtDictKrkFHeihkNl6uWMmZlmL6tJtX9Cs+87oK+teBx+JIgzvbX3yZHT3eF8vpbDxHJXQ==
   /chownr/1.0.1:
     dev: false
     resolution:
@@ -1988,14 +1858,14 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==
-  /clean-css/4.1.11:
+  /clean-css/4.2.1:
     dependencies:
-      source-map: 0.5.7
+      source-map: 0.6.1
     dev: false
     engines:
       node: '>= 4.0'
     resolution:
-      integrity: sha1-Ls3xRaujj1R0DybO/Q/z4D4SXWo=
+      integrity: sha512-4ZxI6dy4lrY6FHzfiy1aEOXgu4LIsW2MhwG0VBKdcoGoH/XLFgaHSdLTGr4O8Be6A8r3MOphEiI8Gc1n0ecf3g==
   /cli-cursor/1.0.2:
     dependencies:
       restore-cursor: 1.0.1
@@ -2096,12 +1966,6 @@ packages:
       node: '>= 0.8'
     resolution:
       integrity: sha1-cj599ugBrFYTETp+RFqbactjKBg=
-  /commander/0.6.1:
-    dev: false
-    engines:
-      node: '>= 0.4.x'
-    resolution:
-      integrity: sha1-+mihT2qUXVTbvlDYzbMyDp47GgY=
   /commander/2.11.0:
     dev: false
     resolution:
@@ -2110,12 +1974,10 @@ packages:
     dev: false
     resolution:
       integrity: sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==
-  /commander/2.3.0:
+  /commander/2.17.1:
     dev: false
-    engines:
-      node: '>= 0.6.x'
     resolution:
-      integrity: sha1-/UMOiJgy7DU7ms0d4hfBHLPu+HM=
+      integrity: sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==
   /compare-versions/3.3.0:
     dev: false
     resolution:
@@ -2142,7 +2004,7 @@ packages:
       integrity: sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
   /concat-stream/1.6.2:
     dependencies:
-      buffer-from: 1.1.0
+      buffer-from: 1.1.1
       inherits: 2.0.3
       readable-stream: 2.3.6
       typedarray: 0.0.6
@@ -2365,13 +2227,13 @@ packages:
     dev: false
     resolution:
       integrity: sha1-yBSQPkViM3GgR3tAEJqq++6t27Q=
-  /cssom/0.3.2:
+  /cssom/0.3.4:
     dev: false
     resolution:
-      integrity: sha1-uANhcMefB6kP8vFuIihAJ6JDhIs=
+      integrity: sha512-+7prCSORpXNeR4/fUP3rL+TzqtiFfhMvTd7uEqMdgPvLPt4+uzFUeufx5RHjGTACCargg/DiEt/moMQmvnfkog==
   /cssstyle/0.3.1:
     dependencies:
-      cssom: 0.3.2
+      cssom: 0.3.4
     dev: false
     resolution:
       integrity: sha512-tNvaxM5blOnxanyxI6panOsnfiyLRj3HV4qjqqS45WPNS1usdYWRUQjqTEEELK73lpeP/1KoIGYUwrBn/VcECA==
@@ -2443,7 +2305,7 @@ packages:
   /debug-fabulous/1.1.0:
     dependencies:
       debug: 3.1.0
-      memoizee: 0.4.12
+      memoizee: 0.4.13
       object-assign: 4.1.1
     dev: false
     resolution:
@@ -2490,7 +2352,7 @@ packages:
       integrity: sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=
   /decomment/0.8.8:
     dependencies:
-      esprima: 4.0.0
+      esprima: 4.0.1
     dev: false
     engines:
       node: '>=0.10'
@@ -2533,7 +2395,7 @@ packages:
   /define-properties/1.1.2:
     dependencies:
       foreach: 2.0.5
-      object-keys: 1.0.11
+      object-keys: 1.0.12
     dev: false
     engines:
       node: '>= 0.4'
@@ -2648,12 +2510,6 @@ packages:
     dev: false
     resolution:
       integrity: sha1-gGZJMmzqp8qjMG112YXqJ0i6kTw=
-  /diff/1.4.0:
-    dev: false
-    engines:
-      node: '>=0.3.1'
-    resolution:
-      integrity: sha1-fyjS657nsVqX79ic5j3P2qPMur8=
   /diff/3.5.0:
     dev: false
     engines:
@@ -2672,7 +2528,7 @@ packages:
     dependencies:
       custom-event: 1.0.1
       ent: 2.2.0
-      extend: 3.0.1
+      extend: 3.0.2
       void-elements: 2.0.1
     dev: false
     resolution:
@@ -2709,13 +2565,14 @@ packages:
     dev: false
     resolution:
       integrity: sha512-fO3Di4tBKJpYTFHAxTU00BcfWMY9w24r/x21a6rZRbsD/ToUgGxsMbiGRmB7uVAXeGKXD9MwiLZa5E97EVgIRQ==
-  /ecc-jsbn/0.1.1:
+  /ecc-jsbn/0.1.2:
     dependencies:
       jsbn: 0.1.1
+      safer-buffer: 2.1.2
     dev: false
     optional: true
     resolution:
-      integrity: sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=
+      integrity: sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=
   /ee-first/1.1.1:
     dev: false
     resolution:
@@ -2724,7 +2581,7 @@ packages:
     dependencies:
       bn.js: 4.11.8
       brorand: 1.1.0
-      hash.js: 1.1.4
+      hash.js: 1.1.5
       hmac-drbg: 1.0.1
       inherits: 2.0.3
       minimalistic-assert: 1.0.1
@@ -2816,18 +2673,18 @@ packages:
     dev: false
     resolution:
       integrity: sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==
-  /error-ex/1.3.1:
+  /error-ex/1.3.2:
     dependencies:
       is-arrayish: 0.2.1
     dev: false
     resolution:
-      integrity: sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=
+      integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==
   /es-abstract/1.12.0:
     dependencies:
       es-to-primitive: 1.1.1
       function-bind: 1.1.1
       has: 1.0.3
-      is-callable: 1.1.3
+      is-callable: 1.1.4
       is-regex: 1.0.4
     dev: false
     engines:
@@ -2836,7 +2693,7 @@ packages:
       integrity: sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==
   /es-to-primitive/1.1.1:
     dependencies:
-      is-callable: 1.1.3
+      is-callable: 1.1.4
       is-date-object: 1.0.1
       is-symbol: 1.0.1
     dev: false
@@ -2911,19 +2768,13 @@ packages:
     dev: false
     resolution:
       integrity: sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=
-  /escape-string-regexp/1.0.2:
-    dev: false
-    engines:
-      node: '>=0.8.0'
-    resolution:
-      integrity: sha1-Tbwv5nTnGUnK8/smlc5/LcHZqNE=
   /escape-string-regexp/1.0.5:
     dev: false
     engines:
       node: '>=0.8.0'
     resolution:
       integrity: sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
-  /escodegen/1.10.0:
+  /escodegen/1.11.0:
     dependencies:
       esprima: 3.1.3
       estraverse: 4.2.0
@@ -2935,7 +2786,7 @@ packages:
     optionalDependencies:
       source-map: 0.6.1
     resolution:
-      integrity: sha512-fjUOf8johsv23WuIKdNQU4P9t9jhQ4Qzx6pC2uW890OloK3Zs1ZAoCNpg/2larNF501jLl3UNy0kIRcF6VI22g==
+      integrity: sha512-IeMV45ReixHS53K/OmfKAIztN/igDHzTJUhZM3k1jMhIZWjk45SMwAtBsEXiJp3vSPmTcu6CXn7mDvFHRN66fw==
   /escodegen/1.7.1:
     dependencies:
       esprima: 1.2.5
@@ -2997,12 +2848,6 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=
-  /esprima/4.0.0:
-    dev: false
-    engines:
-      node: '>=4'
-    resolution:
-      integrity: sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==
   /esprima/4.0.1:
     dev: false
     engines:
@@ -3097,12 +2942,12 @@ packages:
     dev: false
     resolution:
       integrity: sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==
-  /exec-sh/0.2.1:
+  /exec-sh/0.2.2:
     dependencies:
       merge: 1.2.0
     dev: false
     resolution:
-      integrity: sha512-aLt95pexaugVtQerpmE51+4QfWrNc304uez7jvj6fWnN8GeEHpttB8F36n8N7uVhUMbH/1enbxQ9HImZ4w/9qg==
+      integrity: sha512-FIUCJz1RbuS0FKTdaAafAByGS0CPvU3R0MeHxgtl+djzCc//F8HakL8GzmVNZanasTbTAY/3DRFA0KpVqj/eAw==
   /execa/0.10.0:
     dependencies:
       cross-spawn: 6.0.5
@@ -3232,7 +3077,7 @@ packages:
       on-finished: 2.3.0
       parseurl: 1.3.2
       path-to-regexp: 0.1.7
-      proxy-addr: 2.0.3
+      proxy-addr: 2.0.4
       qs: 6.5.1
       range-parser: 1.2.0
       safe-buffer: 5.1.1
@@ -3265,13 +3110,13 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=
-  /extend/3.0.1:
+  /extend/3.0.2:
     dev: false
     resolution:
-      integrity: sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=
+      integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
   /external-editor/1.1.1:
     dependencies:
-      extend: 3.0.1
+      extend: 3.0.2
       spawn-sync: 1.0.15
       tmp: 0.0.29
     dev: false
@@ -3515,14 +3360,14 @@ packages:
       node: '>= 0.8.0'
     resolution:
       integrity: sha1-Tnmumy6zi/hrO7Vr8+ClaqX8q9c=
-  /follow-redirects/1.5.0:
+  /follow-redirects/1.5.2:
     dependencies:
       debug: 3.1.0
     dev: false
     engines:
       node: '>=4.0'
     resolution:
-      integrity: sha512-fdrt472/9qQ6Kgjvb935ig6vJCuofpBUD14f9Vb+SLlm7xIe4Qva5gey8EKtv8lp7ahE1wilg3xL1znpVGtZIA==
+      integrity: sha512-kssLorP/9acIdpQ2udQVTiCS5LQmdEz9mvdIfDcl1gYX2tPKFADHSyFdvJS040XdFsPzemWtgI3q8mFVCxtX8A==
   /for-in/1.0.2:
     dev: false
     engines:
@@ -3561,7 +3406,7 @@ packages:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.6
-      mime-types: 2.1.18
+      mime-types: 2.1.19
     dev: false
     engines:
       node: '>= 0.12'
@@ -3571,7 +3416,7 @@ packages:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.6
-      mime-types: 2.1.18
+      mime-types: 2.1.19
     dev: false
     engines:
       node: '>= 0.12'
@@ -3626,7 +3471,7 @@ packages:
     dependencies:
       graceful-fs: 4.1.11
       jsonfile: 4.0.0
-      universalify: 0.1.1
+      universalify: 0.1.2
     dev: false
     resolution:
       integrity: sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==
@@ -3704,26 +3549,16 @@ packages:
       node: '>= 4.0.0'
     resolution:
       integrity: sha512-BRdNm8hbWzFzWHERTrejLqwHDfS4GibPoq5wjTPIoJHoBtKGPg3xAFfxmM+9ztbXelxcf2hwQcaz1PtmFeue8g==
-  /generate-function/2.0.0:
-    dev: false
-    resolution:
-      integrity: sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=
-  /generate-object-property/1.2.0:
-    dependencies:
-      is-property: 1.0.2
-    dev: false
-    resolution:
-      integrity: sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=
   /generic-names/1.0.3:
     dependencies:
       loader-utils: 0.2.17
     dev: false
     resolution:
       integrity: sha1-LXhqEhruUIh2eWk56OO/+DbCCRc=
-  /get-caller-file/1.0.2:
+  /get-caller-file/1.0.3:
     dev: false
     resolution:
-      integrity: sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=
+      integrity: sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==
   /get-stdin/4.0.1:
     dev: false
     engines:
@@ -3795,7 +3630,7 @@ packages:
       integrity: sha1-kXCl8St5Awb9/lmPMT+PeVT9FDs=
   /glob-stream/5.3.5:
     dependencies:
-      extend: 3.0.1
+      extend: 3.0.2
       glob: 5.0.15
       glob-parent: 3.1.0
       micromatch: 2.3.11
@@ -3824,13 +3659,6 @@ packages:
     dev: false
     resolution:
       integrity: sha1-0p4KBV3qUTj00H7UDomC6DwgZs0=
-  /glob/3.2.11:
-    dependencies:
-      inherits: 2.0.3
-      minimatch: 0.3.0
-    dev: false
-    resolution:
-      integrity: sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=
   /glob/4.5.3:
     dependencies:
       inflight: 1.0.6
@@ -3987,10 +3815,6 @@ packages:
       node: '>=4.x'
     resolution:
       integrity: sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==
-  /growl/1.9.2:
-    dev: false
-    resolution:
-      integrity: sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=
   /growly/1.3.0:
     dev: false
     resolution:
@@ -4020,7 +3844,7 @@ packages:
       integrity: sha1-nvyNMl+YBcx2aP3059YNSxQQ8s8=
   /gulp-clean-css/3.0.4:
     dependencies:
-      clean-css: 4.1.11
+      clean-css: 4.2.1
       gulp-util: 3.0.8
       through2: 2.0.3
       vinyl-sourcemaps-apply: 0.2.1
@@ -4142,19 +3966,6 @@ packages:
       node: '>= 0.10.0'
     resolution:
       integrity: sha1-kcfA1/Kb7NZgbVfYCn+Hdqh6uo4=
-  /gulp-mocha/2.2.0:
-    dependencies:
-      gulp-util: 3.0.8
-      mocha: 2.5.3
-      plur: 2.1.2
-      resolve-from: 1.0.1
-      temp: 0.8.3
-      through: 2.3.8
-    dev: false
-    engines:
-      node: '>=0.10.0'
-    resolution:
-      integrity: sha1-HOXrpLlLQMdDav7DxJgsjuqJQZI=
   /gulp-mocha/6.0.0:
     dependencies:
       dargs: 5.1.0
@@ -4169,17 +3980,17 @@ packages:
       node: '>=6'
     resolution:
       integrity: sha512-FfBldW5ttnDpKf4Sg6/BLOOKCCbr5mbixDGK1t02/8oSrTCwNhgN/mdszG3cuQuYNzuouUdw4EH/mlYtgUscPg==
-  /gulp-open/2.0.0:
+  /gulp-open/3.0.1:
     dependencies:
       colors: 1.2.5
-      gulp-util: 3.0.8
-      open: 0.0.5
+      opn: 5.2.0
+      plugin-log: 0.1.0
       through2: 2.0.3
     dev: false
     engines:
-      node: '>= 0.9.0'
+      node: '>=4'
     resolution:
-      integrity: sha1-oW9n6VzqiyBhtjo7jDibxVm44c4=
+      integrity: sha512-dohokw+npnt48AsD0hhvCLEHLnDMqM35F+amvIfJlX1H2nNHYUClR0Oy1rI0TvbL1/pHiHGNLmohhk+kvwIKjA==
   /gulp-plumber/1.1.0:
     dependencies:
       gulp-util: 3.0.8
@@ -4213,7 +4024,7 @@ packages:
     dependencies:
       gulp-util: 3.0.8
       lodash.clonedeep: 4.5.0
-      node-sass: 4.9.0
+      node-sass: 4.9.2
       through2: 2.0.3
       vinyl-sourcemaps-apply: 0.2.1
     dev: false
@@ -4231,9 +4042,9 @@ packages:
       integrity: sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=
   /gulp-sourcemaps/2.6.4:
     dependencies:
-      '@gulp-sourcemaps/identity-map': 1.0.1
+      '@gulp-sourcemaps/identity-map': 1.0.2
       '@gulp-sourcemaps/map-sources': 1.0.0
-      acorn: 5.6.2
+      acorn: 5.7.1
       convert-source-map: 1.5.1
       css: 2.2.3
       debug-fabulous: 1.1.0
@@ -4375,17 +4186,6 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=
-  /har-validator/2.0.6:
-    dependencies:
-      chalk: 1.1.3
-      commander: 2.15.1
-      is-my-json-valid: 2.17.2
-      pinkie-promise: 2.0.1
-    dev: false
-    engines:
-      node: '>=0.10'
-    resolution:
-      integrity: sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=
   /har-validator/4.2.1:
     dependencies:
       ajv: 4.11.8
@@ -4397,7 +4197,7 @@ packages:
       integrity: sha1-M0gdDxu/9gDdID11gSpqX7oALio=
   /har-validator/5.0.3:
     dependencies:
-      ajv: 5.2.2
+      ajv: 5.5.2
       har-schema: 2.0.0
     dev: false
     engines:
@@ -4512,13 +4312,13 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=
-  /hash.js/1.1.4:
+  /hash.js/1.1.5:
     dependencies:
       inherits: 2.0.3
       minimalistic-assert: 1.0.1
     dev: false
     resolution:
-      integrity: sha512-A6RlQvvZEtFS5fLU43IDu0QUmBy+fDO9VMdTXvufKwIkt/rFfvICAViCax5fbDO4zdNzaC3/27ZhKUok5bAJyw==
+      integrity: sha512-eWI5HG9Np+eHV1KQhisXWwM+4EPPYe5dFX1UZZH7k/E3JzDEazVH+VGlZi6R94ZqImq+A3D1mCEtrFIfg/E7sA==
   /hasha/2.2.0:
     dependencies:
       is-stream: 1.1.0
@@ -4545,7 +4345,7 @@ packages:
       integrity: sha1-k0EP0hsAlzUVH4howvJx80J+I/0=
   /hmac-drbg/1.0.1:
     dependencies:
-      hash.js: 1.1.4
+      hash.js: 1.1.5
       minimalistic-assert: 1.0.1
       minimalistic-crypto-utils: 1.0.1
     dev: false
@@ -4574,12 +4374,10 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-TCu8inWJmP7r9e1oWA921GdotLw=
-  /hosted-git-info/2.6.0:
+  /hosted-git-info/2.7.1:
     dev: false
-    engines:
-      node: '>=4'
     resolution:
-      integrity: sha512-lIbgIIQA3lz5XaB6vxakj6sDHADJiZadYEJB+FgA+C4nubM1NwcuvUr9EJPmnH1skZqpqUzWborWo8EIUi0Sdw==
+      integrity: sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==
   /html-encoding-sniffer/1.0.2:
     dependencies:
       whatwg-encoding: 1.0.3
@@ -4624,7 +4422,7 @@ packages:
   /http-proxy/1.17.0:
     dependencies:
       eventemitter3: 3.1.0
-      follow-redirects: 1.5.0
+      follow-redirects: 1.5.2
       requires-port: 1.0.0
     dev: false
     engines:
@@ -4659,7 +4457,7 @@ packages:
       integrity: sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=
   /https-proxy-agent/2.2.1:
     dependencies:
-      agent-base: 4.2.0
+      agent-base: 4.2.1
       debug: 3.1.0
     dev: false
     engines:
@@ -4781,7 +4579,7 @@ packages:
       integrity: sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ=
   /invariant/2.2.4:
     dependencies:
-      loose-envify: 1.3.1
+      loose-envify: 1.4.0
     dev: false
     resolution:
       integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==
@@ -4791,18 +4589,12 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-EEqOSqym09jNFXqO+L+rLXo//bY=
-  /ipaddr.js/1.6.0:
+  /ipaddr.js/1.8.0:
     dev: false
     engines:
       node: '>= 0.10'
     resolution:
-      integrity: sha1-4/o1e3c9phnybpXwSdBVxyeW+Gs=
-  /irregular-plurals/1.4.0:
-    dev: false
-    engines:
-      node: '>=0.10.0'
-    resolution:
-      integrity: sha1-LKmwM2UREYVUEvFr5dd8YqRYp2Y=
+      integrity: sha1-6qM9bd16zo9/b+DJygRA5wZzix4=
   /is-absolute/1.0.0:
     dependencies:
       is-relative: 1.0.0
@@ -4852,12 +4644,12 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-VAVy0096wxGfj3bDDLwbHgN6/74=
-  /is-callable/1.1.3:
+  /is-callable/1.1.4:
     dev: false
     engines:
       node: '>= 0.4'
     resolution:
-      integrity: sha1-hut1OSgF3cM69xySoO7fdO52BLI=
+      integrity: sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==
   /is-ci/1.1.0:
     dependencies:
       ci-info: 1.1.3
@@ -5004,20 +4796,6 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=
-  /is-my-ip-valid/1.0.0:
-    dev: false
-    resolution:
-      integrity: sha512-gmh/eWXROncUzRnIa1Ubrt5b8ep/MGSnfAUI3aRp+sqTCs1tv1Isl8d8F6JmkN3dXKc3ehZMrtiPN9eL03NuaQ==
-  /is-my-json-valid/2.17.2:
-    dependencies:
-      generate-function: 2.0.0
-      generate-object-property: 1.2.0
-      is-my-ip-valid: 1.0.0
-      jsonpointer: 4.0.1
-      xtend: 4.0.1
-    dev: false
-    resolution:
-      integrity: sha512-IBhBslgngMQN8DDSppmgDv7RNrlFotuuDsKcrCP3+HbFaVivIBU7u9oiiErw8sH4ynx3+gOGQ3q2otkgiSi6kg==
   /is-number/0.1.1:
     dev: false
     engines:
@@ -5046,14 +4824,6 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==
-  /is-odd/2.0.0:
-    dependencies:
-      is-number: 4.0.0
-    dev: false
-    engines:
-      node: '>=0.10.0'
-    resolution:
-      integrity: sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==
   /is-path-cwd/1.0.0:
     dev: false
     engines:
@@ -5100,10 +4870,6 @@ packages:
     dev: false
     resolution:
       integrity: sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=
-  /is-property/1.0.2:
-    dev: false
-    resolution:
-      integrity: sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=
   /is-regex/1.0.4:
     dependencies:
       has: 1.0.3
@@ -5160,6 +4926,12 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==
+  /is-wsl/1.1.0:
+    dev: false
+    engines:
+      node: '>=4'
+    resolution:
+      integrity: sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=
   /is/3.2.1:
     dev: false
     resolution:
@@ -5172,12 +4944,14 @@ packages:
     dev: false
     resolution:
       integrity: sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=
-  /isbinaryfile/3.0.2:
+  /isbinaryfile/3.0.3:
+    dependencies:
+      buffer-alloc: 1.2.0
     dev: false
     engines:
       node: '>=0.6.0'
     resolution:
-      integrity: sha1-Sj6XTsDLqQBNP8bN5yCeppNopiE=
+      integrity: sha512-8cJBL5tTd2OS0dM4jz07wQd5g0dCCqIhUxPIGtZfa5L6hWlvV5MHTITy/DBAsF+Oe2LS1X3krBUhNwaGUWpWxw==
   /isexe/2.0.0:
     dev: false
     resolution:
@@ -5272,7 +5046,7 @@ packages:
     dependencies:
       istanbul-lib-coverage: 1.2.0
       mkdirp: 0.5.1
-      path-parse: 1.0.5
+      path-parse: 1.0.6
       supports-color: 3.2.3
     dev: false
     resolution:
@@ -5357,14 +5131,6 @@ packages:
       node: '>=0.4'
     resolution:
       integrity: sha1-rOGTVNGpoBc+/rEITOD4ewrX3s8=
-  /jade/0.26.3:
-    dependencies:
-      commander: 0.6.1
-      mkdirp: 0.3.0
-    deprecated: 'Jade has been renamed to pug, please install the latest version of pug instead of jade'
-    dev: false
-    resolution:
-      integrity: sha1-jxDXl32NefL2/4YqgbBRPMslaGw=
   /jest-changed-files/22.4.3:
     dependencies:
       throat: 4.1.0
@@ -5400,7 +5166,7 @@ packages:
       jest-worker: 22.4.3
       micromatch: 2.3.11
       node-notifier: 5.2.1
-      realpath-native: 1.0.0
+      realpath-native: 1.0.1
       rimraf: 2.5.4
       slash: 1.0.0
       string-length: 2.0.0
@@ -5506,7 +5272,7 @@ packages:
       integrity: sha512-lsEHVaTnKzdAPR5t4B6OcxXo9Vy4K+kRRbG5gtddY8lBEC+Mlpvm1CJcsMESRjzUhzkz568exMV1hTB76nAKbA==
   /jest-message-util/22.4.3:
     dependencies:
-      '@babel/code-frame': 7.0.0-beta.51
+      '@babel/code-frame': 7.0.0-beta.56
       chalk: 2.4.1
       micromatch: 2.3.11
       slash: 1.0.0
@@ -5530,7 +5296,7 @@ packages:
       integrity: sha512-06czCMVToSN8F2U4EvgSB1Bv/56gc7MpCftZ9z9fBgUQM7dzHGCMBsyfVA6dZTx8v0FDcnALf7hupeQxaBCvpA==
   /jest-resolve/22.4.3:
     dependencies:
-      browser-resolve: 1.11.2
+      browser-resolve: 1.11.3
       chalk: 2.4.1
     dev: false
     resolution:
@@ -5568,7 +5334,7 @@ packages:
       jest-validate: 22.4.4
       json-stable-stringify: 1.0.1
       micromatch: 2.3.11
-      realpath-native: 1.0.0
+      realpath-native: 1.0.1
       slash: 1.0.0
       strip-bom: 3.0.0
       write-file-atomic: 2.3.0
@@ -5632,18 +5398,22 @@ packages:
     dev: false
     resolution:
       integrity: sha1-2t2e8BkkvHKLA/L3l5vb1i96Kqo=
-  /js-base64/2.4.5:
+  /js-base64/2.4.8:
     dev: false
     resolution:
-      integrity: sha512-aUnNwqMOXw3yvErjMPSQu6qIIzUmT1e5KcU1OZxRDU1g/am6mzBvcrmLAYwzmB59BHPrh5/tKaiF4OPhqRWESQ==
+      integrity: sha512-hm2nYpDrwoO/OzBhdcqs/XGT6XjSuSSCVEpia+Kl2J6x4CYt5hISlVL/AYU1khoDXv0AQVgxtdJySb9gjAn56Q==
   /js-tokens/3.0.2:
     dev: false
     resolution:
       integrity: sha1-mGbfOVECEw449/mWvOtlRDIJwls=
+  /js-tokens/4.0.0:
+    dev: false
+    resolution:
+      integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
   /js-yaml/3.9.1:
     dependencies:
       argparse: 1.0.10
-      esprima: 4.0.0
+      esprima: 4.0.1
     dev: false
     resolution:
       integrity: sha512-CbcG379L1e+mWBnLvHWWeLs8GyV/EMw862uLI3c+GxVyDHWZcjZinwuBd3iW2pgxgIlksW/1vNJa4to+RvDOww==
@@ -5655,24 +5425,24 @@ packages:
   /jsdom/11.11.0:
     dependencies:
       abab: 1.0.4
-      acorn: 5.6.2
+      acorn: 5.7.1
       acorn-globals: 4.1.0
       array-equal: 1.0.0
-      cssom: 0.3.2
+      cssom: 0.3.4
       cssstyle: 0.3.1
       data-urls: 1.0.0
       domexception: 1.0.1
-      escodegen: 1.10.0
+      escodegen: 1.11.0
       html-encoding-sniffer: 1.0.2
       left-pad: 1.3.0
-      nwsapi: 2.0.3
+      nwsapi: 2.0.8
       parse5: 4.0.0
       pn: 1.1.0
       request: 2.87.0
       request-promise-native: /request-promise-native/1.0.5/request@2.87.0
       sax: 1.2.4
       symbol-tree: 3.2.2
-      tough-cookie: 2.4.2
+      tough-cookie: 2.4.3
       w3c-hr-time: 1.0.1
       webidl-conversions: 4.0.2
       whatwg-encoding: 1.0.3
@@ -5745,12 +5515,6 @@ packages:
     dev: false
     resolution:
       integrity: sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=
-  /jsonpointer/4.0.1:
-    dev: false
-    engines:
-      node: '>=0.10.0'
-    resolution:
-      integrity: sha1-T9kss04OnbPInIYi7PUfm5eMbLk=
   /jsprim/1.4.1:
     dependencies:
       assert-plus: 1.0.0
@@ -5871,7 +5635,7 @@ packages:
       glob: 7.0.6
       graceful-fs: 4.1.11
       http-proxy: 1.17.0
-      isbinaryfile: 3.0.2
+      isbinaryfile: 3.0.3
       lodash: 3.10.1
       log4js: 0.6.38
       mime: 1.6.0
@@ -5976,14 +5740,14 @@ packages:
       integrity: sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=
   /liftoff/2.5.0:
     dependencies:
-      extend: 3.0.1
+      extend: 3.0.2
       findup-sync: 2.0.0
       fined: 1.1.0
       flagged-respawn: 1.0.0
       is-plain-object: 2.0.4
       object.map: 1.0.1
       rechoir: 0.6.2
-      resolve: 1.7.1
+      resolve: 1.8.1
     dev: false
     engines:
       node: '>= 0.8'
@@ -6141,6 +5905,10 @@ packages:
     dev: false
     resolution:
       integrity: sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=
+  /lodash.debounce/4.0.8:
+    dev: false
+    resolution:
+      integrity: sha1-gteb/zCmfEAF/9XiUVMArZyk168=
   /lodash.defaults/2.4.1:
     dependencies:
       lodash._objecttypes: 2.4.1
@@ -6345,12 +6113,12 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=
-  /loose-envify/1.3.1:
+  /loose-envify/1.4.0:
     dependencies:
-      js-tokens: 3.0.2
+      js-tokens: 4.0.0
     dev: false
     resolution:
-      integrity: sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=
+      integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
   /loud-rejection/1.6.0:
     dependencies:
       currently-unhandled: 0.4.1
@@ -6452,7 +6220,7 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=
-  /memoizee/0.4.12:
+  /memoizee/0.4.13:
     dependencies:
       d: 1.0.0
       es5-ext: 0.10.45
@@ -6464,7 +6232,7 @@ packages:
       timers-ext: 0.1.5
     dev: false
     resolution:
-      integrity: sha512-sprBu6nwxBWBvBOh5v2jcsGqiGLlL2xr2dLub3vR8dnE8YB17omwtm/0NSHl8jjNbcsJd5GMWJAnTSVe/O0Wfg==
+      integrity: sha512-OVDg4OBcDOaNnTKbVYZPf+N6ON4oon2V0fBVJ1QkIGnfjdusLoUISUptQTY5kP5+zmnAr6k5V/zLc8nKNmVrcg==
   /memory-fs/0.4.1:
     dependencies:
       errno: 0.1.7
@@ -6545,7 +6313,7 @@ packages:
       extglob: 2.0.4
       fragment-cache: 0.2.1
       kind-of: 6.0.2
-      nanomatch: 1.2.9
+      nanomatch: 1.2.13
       object.pick: 1.3.0
       regex-not: 1.0.2
       snapdragon: 0.8.2
@@ -6562,20 +6330,20 @@ packages:
     dev: false
     resolution:
       integrity: sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==
-  /mime-db/1.33.0:
+  /mime-db/1.35.0:
     dev: false
     engines:
       node: '>= 0.6'
     resolution:
-      integrity: sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==
-  /mime-types/2.1.18:
+      integrity: sha512-JWT/IcCTsB0Io3AhWUMjRqucrHSPsSf2xKLaRldJVULioggvkJvggZ3VXNNSRkCddE6D+BUI4HEIZIA2OjwIvg==
+  /mime-types/2.1.19:
     dependencies:
-      mime-db: 1.33.0
+      mime-db: 1.35.0
     dev: false
     engines:
       node: '>= 0.6'
     resolution:
-      integrity: sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==
+      integrity: sha512-P1tKYHVSZ6uFo26mtnve4HQFE3koh1UWVkp8YUC+ESBHe945xWSoXuHHiGarDqcEZ+whpCDnlNw5LON0kLo+sw==
   /mime/1.3.4:
     dev: false
     resolution:
@@ -6612,14 +6380,6 @@ packages:
     dev: false
     resolution:
       integrity: sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=
-  /minimatch/0.3.0:
-    dependencies:
-      lru-cache: 2.7.3
-      sigmund: 1.0.1
-    deprecated: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
-    dev: false
-    resolution:
-      integrity: sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=
   /minimatch/2.0.10:
     dependencies:
       brace-expansion: 1.1.11
@@ -6679,10 +6439,6 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha1-6bj2jlUsaKnBcTuEiD96HdA5uKE=
-  /mkdirp/0.3.0:
-    dev: false
-    resolution:
-      integrity: sha1-G79asbqCevI1dRQ0kEJkVfSB/h4=
   /mkdirp/0.5.1:
     dependencies:
       minimist: 0.0.8
@@ -6693,23 +6449,6 @@ packages:
     dev: false
     resolution:
       integrity: sha1-CbaYXDIYFhQDIeED593ktIdgkhw=
-  /mocha/2.5.3:
-    dependencies:
-      commander: 2.3.0
-      debug: 2.2.0
-      diff: 1.4.0
-      escape-string-regexp: 1.0.2
-      glob: 3.2.11
-      growl: 1.9.2
-      jade: 0.26.3
-      mkdirp: 0.5.1
-      supports-color: 1.2.0
-      to-iso-string: 0.0.2
-    dev: false
-    engines:
-      node: '>= 0.8.x'
-    resolution:
-      integrity: sha1-FhvlvetJZ3HrmzV0UFC2IrWu/Fg=
   /mocha/5.2.0:
     dependencies:
       browser-stdout: 1.3.1
@@ -6766,14 +6505,13 @@ packages:
     dev: false
     resolution:
       integrity: sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==
-  /nanomatch/1.2.9:
+  /nanomatch/1.2.13:
     dependencies:
       arr-diff: 4.0.0
       array-unique: 0.3.2
       define-property: 2.0.2
       extend-shallow: 3.0.2
       fragment-cache: 0.2.1
-      is-odd: 2.0.0
       is-windows: 1.0.2
       kind-of: 6.0.2
       object.pick: 1.3.0
@@ -6784,7 +6522,7 @@ packages:
     engines:
       node: '>=0.10.0'
     resolution:
-      integrity: sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==
+      integrity: sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==
   /natives/1.1.4:
     dev: false
     resolution:
@@ -6899,7 +6637,7 @@ packages:
     dev: false
     resolution:
       integrity: sha512-MIBs+AAd6dJ2SklbbE8RUDRlIVhU8MaNLh1A9SUZDUHPiZkWLFde6UNwG41yQHZEToHgJMXqyVZ9UcS/ReOVTg==
-  /node-sass/4.9.0:
+  /node-sass/4.9.2:
     dependencies:
       async-foreach: 0.1.3
       chalk: 1.1.3
@@ -6916,7 +6654,7 @@ packages:
       nan: 2.10.0
       node-gyp: 3.7.0
       npmlog: 4.1.2
-      request: 2.79.0
+      request: 2.87.0
       sass-graph: 2.2.4
       stdout-stream: 1.4.0
       true-case-path: 1.0.2
@@ -6925,7 +6663,7 @@ packages:
       node: '>=0.10.0'
     requiresBuild: true
     resolution:
-      integrity: sha512-QFHfrZl6lqRU3csypwviz2XLgGNOoWQbo2GOvtsfQqOfL4cy1BtWnhx/XUeAO9LT3ahBzSRXcEO6DdvAH9DzSg==
+      integrity: sha512-LdxoJLZutx0aQXHtWIYwJKMj+9pTjneTcLWJgzf2XbGu0q5pRNqW5QvFCEdm3mc5rJOdru/mzln5d0EZLacf6g==
   /node.extend/1.1.6:
     dependencies:
       is: 3.2.1
@@ -6942,10 +6680,10 @@ packages:
       integrity: sha1-xkZdvwirzU2zWTF/eaxopkayj/k=
   /normalize-package-data/2.4.0:
     dependencies:
-      hosted-git-info: 2.6.0
+      hosted-git-info: 2.7.1
       is-builtin-module: 1.0.0
       semver: 5.3.0
-      validate-npm-package-license: 3.0.3
+      validate-npm-package-license: 3.0.4
     dev: false
     resolution:
       integrity: sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==
@@ -6971,7 +6709,7 @@ packages:
       integrity: sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=
   /npm-package-arg/5.1.2:
     dependencies:
-      hosted-git-info: 2.6.0
+      hosted-git-info: 2.7.1
       osenv: 0.1.5
       semver: 5.3.0
       validate-npm-package-name: 3.0.0
@@ -7005,10 +6743,10 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=
-  /nwsapi/2.0.3:
+  /nwsapi/2.0.8:
     dev: false
     resolution:
-      integrity: sha512-zFJF9lOpg2+uicP0BQKOAfIOqeTp/p8PC669mewxgRkR1hGjne8BMUHk4wpRS9o5Z0icA5Nv04HmGkW31KfMKw==
+      integrity: sha512-7RZ+qbFGiVc6v14Y8DSZjPN1wZPOaMbiiP4tzf5eNuyOITAeOIA3cMhjuKUypVIqBgCSg1KaSyAv8Ocq/0ZJ1A==
   /oauth-sign/0.8.2:
     dev: false
     resolution:
@@ -7049,12 +6787,12 @@ packages:
     dev: false
     resolution:
       integrity: sha1-KKaq50KN0sOpLz2V8hM13SBOAzY=
-  /object-keys/1.0.11:
+  /object-keys/1.0.12:
     dev: false
     engines:
       node: '>= 0.4'
     resolution:
-      integrity: sha1-xUYBd4rVYPEULODgG8yotW0TQm0=
+      integrity: sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag==
   /object-visit/1.0.1:
     dependencies:
       isobject: 3.0.1
@@ -7136,12 +6874,14 @@ packages:
     resolution:
       integrity: sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=
       tarball: 'http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz'
-  /open/0.0.5:
+  /opn/5.2.0:
+    dependencies:
+      is-wsl: 1.1.0
     dev: false
     engines:
-      node: '>= 0.6.0'
+      node: '>=4'
     resolution:
-      integrity: sha1-QsPhjslUZra/DcQvOilFw/DK2Pw=
+      integrity: sha512-Jd/GpzPyHF4P2/aNOVmS3lfMSWV9J7cOhCG1s08XCEAsPkB7lp6ddiU0J7XzyQRDUh8BqJ7PchfINjR8jyofRQ==
   /optimist/0.6.1:
     dependencies:
       minimist: 0.0.10
@@ -7326,7 +7066,7 @@ packages:
       integrity: sha1-ssN2z7EfNVE7rdFz7wu246OIORw=
   /parse-json/2.2.0:
     dependencies:
-      error-ex: 1.3.1
+      error-ex: 1.3.2
     dev: false
     engines:
       node: '>=0.10.0'
@@ -7410,10 +7150,10 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=
-  /path-parse/1.0.5:
+  /path-parse/1.0.6:
     dev: false
     resolution:
-      integrity: sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=
+      integrity: sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==
   /path-root-regex/0.1.2:
     dev: false
     engines:
@@ -7553,14 +7293,15 @@ packages:
       node: '>= 0.10'
     resolution:
       integrity: sha512-L1zP0dk7vGweZME2i+EeakvUNqSrdiI3F91TwEoYiGrAfUXmVv6fJIq4g82PAXxNsWOp0J7ZqQy/3Szz0ajTxA==
-  /plur/2.1.2:
+  /plugin-log/0.1.0:
     dependencies:
-      irregular-plurals: 1.4.0
+      chalk: 1.1.3
+      dateformat: 1.0.12
     dev: false
     engines:
-      node: '>=0.10.0'
+      node: '>= 0.9.0'
     resolution:
-      integrity: sha1-dIJFLBoPUI4+NE6uwxLJHCncZVo=
+      integrity: sha1-hgSc9qsQgzOYqTHzaJy67nteEzM=
   /pn/1.1.0:
     dev: false
     resolution:
@@ -7602,28 +7343,28 @@ packages:
       integrity: sha1-dFdoEWWZrKLwCfrUJrABdQSdjZI=
   /postcss-modules-extract-imports/1.1.0:
     dependencies:
-      postcss: 6.0.22
+      postcss: 6.0.23
     dev: false
     resolution:
       integrity: sha1-thTJcgvmgW6u41+zpfqh26agXds=
   /postcss-modules-local-by-default/1.2.0:
     dependencies:
       css-selector-tokenizer: 0.7.0
-      postcss: 6.0.22
+      postcss: 6.0.23
     dev: false
     resolution:
       integrity: sha1-99gMOYxaOT+nlkRmvRlQCn1hwGk=
   /postcss-modules-scope/1.1.0:
     dependencies:
       css-selector-tokenizer: 0.7.0
-      postcss: 6.0.22
+      postcss: 6.0.23
     dev: false
     resolution:
       integrity: sha1-1upkmUx5+XtipytCb75gVqGUu5A=
   /postcss-modules-values/1.3.0:
     dependencies:
       icss-replace-symbols: 1.1.0
-      postcss: 6.0.22
+      postcss: 6.0.23
     dev: false
     resolution:
       integrity: sha1-7P+p1+GSUYOJ9CrQ6D9yrsRW6iA=
@@ -7643,7 +7384,7 @@ packages:
   /postcss/5.2.18:
     dependencies:
       chalk: 1.1.3
-      js-base64: 2.4.5
+      js-base64: 2.4.8
       source-map: 0.5.7
       supports-color: 3.2.3
     dev: false
@@ -7661,7 +7402,7 @@ packages:
       node: '>=4.0.0'
     resolution:
       integrity: sha1-AA29H47vIXqjaLmiEsX8QLKo8/I=
-  /postcss/6.0.22:
+  /postcss/6.0.23:
     dependencies:
       chalk: 2.4.1
       source-map: 0.6.1
@@ -7670,7 +7411,7 @@ packages:
     engines:
       node: '>=4.0.0'
     resolution:
-      integrity: sha512-Toc9lLoUASwGqxBSJGTVcOQiDqjK+Z2XlWBg+IgYwQMY9vA2f7iMpXVc1GpPcfTSyM5lkxNo0oDwDRO+wm7XHA==
+      integrity: sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==
   /prelude-ls/1.1.2:
     dev: false
     engines:
@@ -7718,15 +7459,15 @@ packages:
       node: '>=0.4.0'
     resolution:
       integrity: sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=
-  /proxy-addr/2.0.3:
+  /proxy-addr/2.0.4:
     dependencies:
       forwarded: 0.1.2
-      ipaddr.js: 1.6.0
+      ipaddr.js: 1.8.0
     dev: false
     engines:
       node: '>= 0.10'
     resolution:
-      integrity: sha512-jQTChiCJteusULxjBp8+jftSQE5Obdl3k4cnmLA6WXtK6XFuWRnvVL7aCiBqaLPM8c4ph0S4tKna8XvmIwEnXQ==
+      integrity: sha512-5erio2h9jp5CHGwcybmxmVqHmnCBZeewlfJ0pex+UW7Qny7OOZXTtH56TGNyBizkgiOwhJtMKrVzDTeKcySZwA==
   /prr/1.0.1:
     dev: false
     resolution:
@@ -7735,10 +7476,10 @@ packages:
     dev: false
     resolution:
       integrity: sha1-8FKijacOYYkX7wqKw0wa5aaChrM=
-  /psl/1.1.28:
+  /psl/1.1.29:
     dev: false
     resolution:
-      integrity: sha512-+AqO1Ae+N/4r7Rvchrdm432afjT9hqJRyBN3DQv9At0tPz4hIFSGKbq64fN9dVoCow4oggIIax5/iONx0r9hZw==
+      integrity: sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ==
   /public-encrypt/4.0.2:
     dependencies:
       bn.js: 4.11.8
@@ -7771,12 +7512,6 @@ packages:
     dev: false
     resolution:
       integrity: sha1-qfMRQq9GjLcrJbMBNrokVoNJFr4=
-  /qs/6.3.2:
-    dev: false
-    engines:
-      node: '>=0.6'
-    resolution:
-      integrity: sha1-51vV9uJoEioqDgvaYwslUMFmUCw=
   /qs/6.4.0:
     dev: false
     engines:
@@ -7995,17 +7730,17 @@ packages:
       node: '>=0.6'
     resolution:
       integrity: sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=
-  /realpath-native/1.0.0:
+  /realpath-native/1.0.1:
     dependencies:
       util.promisify: 1.0.0
     dev: false
     engines:
       node: '>=4'
     resolution:
-      integrity: sha512-XJtlRJ9jf0E1H1SLeJyQ9PGzQD7S65h1pRXEcAeK48doKOnKxcgPeNohJvD5u/2sI9J1oke6E8bZHS/fmW1UiQ==
+      integrity: sha512-W14EcXuqUvKP8dkWkD7B95iMy77lpMnlFXbbk409bQtNCbeu0kvRE5reo+yIZ3JXxg6frbGsz2DLQ39lrCB40g==
   /rechoir/0.6.2:
     dependencies:
-      resolve: 1.7.1
+      resolve: 1.8.1
     dev: false
     engines:
       node: '>= 0.10'
@@ -8130,7 +7865,7 @@ packages:
       request: 2.87.0
       request-promise-core: /request-promise-core/1.1.1/request@2.87.0
       stealthy-require: 1.1.1
-      tough-cookie: 2.4.2
+      tough-cookie: 2.4.3
     dev: false
     engines:
       node: '>=0.12.0'
@@ -8139,40 +7874,13 @@ packages:
       request: ^2.34
     resolution:
       integrity: sha1-UoF3D2jgyXGeUWP9P6tIIhX0/aU=
-  /request/2.79.0:
-    dependencies:
-      aws-sign2: 0.6.0
-      aws4: 1.7.0
-      caseless: 0.11.0
-      combined-stream: 1.0.6
-      extend: 3.0.1
-      forever-agent: 0.6.1
-      form-data: 2.1.4
-      har-validator: 2.0.6
-      hawk: 3.1.3
-      http-signature: 1.1.1
-      is-typedarray: 1.0.0
-      isstream: 0.1.2
-      json-stringify-safe: 5.0.1
-      mime-types: 2.1.18
-      oauth-sign: 0.8.2
-      qs: 6.3.2
-      stringstream: 0.0.6
-      tough-cookie: 2.3.4
-      tunnel-agent: 0.4.3
-      uuid: 3.2.1
-    dev: false
-    engines:
-      node: '>= 4'
-    resolution:
-      integrity: sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=
   /request/2.81.0:
     dependencies:
       aws-sign2: 0.6.0
-      aws4: 1.7.0
+      aws4: 1.8.0
       caseless: 0.12.0
       combined-stream: 1.0.6
-      extend: 3.0.1
+      extend: 3.0.2
       forever-agent: 0.6.1
       form-data: 2.1.4
       har-validator: 4.2.1
@@ -8181,7 +7889,7 @@ packages:
       is-typedarray: 1.0.0
       isstream: 0.1.2
       json-stringify-safe: 5.0.1
-      mime-types: 2.1.18
+      mime-types: 2.1.19
       oauth-sign: 0.8.2
       performance-now: 0.2.0
       qs: 6.4.0
@@ -8189,7 +7897,7 @@ packages:
       stringstream: 0.0.6
       tough-cookie: 2.3.4
       tunnel-agent: 0.6.0
-      uuid: 3.2.1
+      uuid: 3.3.2
     dev: false
     engines:
       node: '>= 4'
@@ -8198,10 +7906,10 @@ packages:
   /request/2.87.0:
     dependencies:
       aws-sign2: 0.7.0
-      aws4: 1.7.0
+      aws4: 1.8.0
       caseless: 0.12.0
       combined-stream: 1.0.6
-      extend: 3.0.1
+      extend: 3.0.2
       forever-agent: 0.6.1
       form-data: 2.3.2
       har-validator: 5.0.3
@@ -8209,14 +7917,14 @@ packages:
       is-typedarray: 1.0.0
       isstream: 0.1.2
       json-stringify-safe: 5.0.1
-      mime-types: 2.1.18
+      mime-types: 2.1.19
       oauth-sign: 0.8.2
       performance-now: 2.1.0
       qs: 6.5.2
       safe-buffer: 5.1.2
       tough-cookie: 2.3.4
       tunnel-agent: 0.6.0
-      uuid: 3.2.1
+      uuid: 3.3.2
     dev: false
     engines:
       node: '>= 4'
@@ -8259,12 +7967,6 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=
-  /resolve-from/1.0.1:
-    dev: false
-    engines:
-      node: '>=0.10.0'
-    resolution:
-      integrity: sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=
   /resolve-from/3.0.0:
     dev: false
     engines:
@@ -8279,15 +7981,9 @@ packages:
     dev: false
     resolution:
       integrity: sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=
-  /resolve/1.7.1:
-    dependencies:
-      path-parse: 1.0.5
-    dev: false
-    resolution:
-      integrity: sha512-c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw==
   /resolve/1.8.1:
     dependencies:
-      path-parse: 1.0.5
+      path-parse: 1.0.6
     dev: false
     resolution:
       integrity: sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==
@@ -8314,10 +8010,6 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-YTObci/mo1FWiSENJOFMlhSGE+8=
-  /rimraf/2.2.8:
-    dev: false
-    resolution:
-      integrity: sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=
   /rimraf/2.5.4:
     dependencies:
       glob: 7.0.6
@@ -8385,7 +8077,7 @@ packages:
     dependencies:
       anymatch: 2.0.0
       capture-exit: 1.2.0
-      exec-sh: 0.2.1
+      exec-sh: 0.2.2
       fb-watchman: 2.0.0
       micromatch: 3.1.10
       minimist: 1.2.0
@@ -8413,7 +8105,7 @@ packages:
       integrity: sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
   /schema-utils/0.3.0:
     dependencies:
-      ajv: 5.2.2
+      ajv: 5.5.2
     dev: false
     engines:
       node: '>= 4.3 < 5.0.0 || >= 5.10'
@@ -8421,7 +8113,7 @@ packages:
       integrity: sha1-9YdyIs4+kx7a4DnxfrNxbnE3+M8=
   /scss-tokenizer/0.2.3:
     dependencies:
-      js-base64: 2.4.5
+      js-base64: 2.4.8
       source-map: 0.4.4
     dev: false
     resolution:
@@ -8490,7 +8182,7 @@ packages:
       debug: 2.6.9
       escape-html: 1.0.3
       http-errors: 1.6.3
-      mime-types: 2.1.18
+      mime-types: 2.1.19
       parseurl: 1.3.2
     dev: false
     engines:
@@ -8656,7 +8348,7 @@ packages:
       map-cache: 0.2.2
       source-map: 0.5.7
       source-map-resolve: 0.5.2
-      use: 3.1.0
+      use: 3.1.1
     dev: false
     engines:
       node: '>=0.10.0'
@@ -8736,7 +8428,7 @@ packages:
       integrity: sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==
   /source-map-support/0.5.6:
     dependencies:
-      buffer-from: 1.1.0
+      buffer-from: 1.1.1
       source-map: 0.6.1
     dev: false
     resolution:
@@ -8850,7 +8542,7 @@ packages:
       integrity: sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
   /sshpk/1.14.2:
     dependencies:
-      asn1: 0.2.3
+      asn1: 0.2.4
       assert-plus: 1.0.0
       dashdash: 1.14.1
       getpass: 0.1.7
@@ -8859,8 +8551,8 @@ packages:
     engines:
       node: '>=0.10.0'
     optionalDependencies:
-      bcrypt-pbkdf: 1.0.1
-      ecc-jsbn: 0.1.1
+      bcrypt-pbkdf: 1.0.2
+      ecc-jsbn: 0.1.2
       jsbn: 0.1.1
       tweetnacl: 0.14.5
     resolution:
@@ -9095,12 +8787,6 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-2S3iaU6z9nMjlz1649i1W0wiGQo=
-  /supports-color/1.2.0:
-    dev: false
-    engines:
-      node: '>=0.10.0'
-    resolution:
-      integrity: sha1-/x7R5hFp0Gs88tWI4YixjYhH4X4=
   /supports-color/2.0.0:
     dev: false
     engines:
@@ -9153,7 +8839,7 @@ packages:
     dev: false
     resolution:
       integrity: sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=
-  /tar/4.4.4:
+  /tar/4.4.6:
     dependencies:
       chownr: 1.0.1
       fs-minipass: 1.2.5
@@ -9166,16 +8852,7 @@ packages:
     engines:
       node: '>=4.5'
     resolution:
-      integrity: sha512-mq9ixIYfNF9SK0IS/h2HKMu8Q2iaCuhDDsZhdEag/FHv8fOaYld4vN7ouMgcSSt5WKZzPs8atclTcJm36OTh4w==
-  /temp/0.8.3:
-    dependencies:
-      os-tmpdir: 1.0.2
-      rimraf: 2.2.8
-    dev: false
-    engines:
-      '0': node >=0.8.0
-    resolution:
-      integrity: sha1-4Ma8TSa5AxJEEOT+2BEDAU38H1k=
+      integrity: sha512-tMkTnh9EdzxyfW+6GK6fCahagXsnYk6kE6S9Gr9pjVdys769+laCTbodXDhPAjzVtEBazRgP0gYqOjnk9dQzLg==
   /ternary-stream/2.0.1:
     dependencies:
       duplexify: 3.6.0
@@ -9276,12 +8953,12 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-dkpaEa9QVhkhsTPztE5hhofg9cM=
-  /time-stamp/2.0.0:
+  /time-stamp/2.0.1:
     dev: false
     engines:
       node: '>=0.10.0'
     resolution:
-      integrity: sha1-lcakRTDhW6jW9KPsuMOj+sRto1c=
+      integrity: sha512-KUnkvOWC3C+pEbwE/0u3CcmNpGCDqkYGYZOphe1QFxApYQkJ5g195TDBjgZch/zG6chU1NcabLwnM7BCpWAzTQ==
   /timers-browserify/2.0.10:
     dependencies:
       setimmediate: 1.0.5
@@ -9350,11 +9027,6 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=
-  /to-iso-string/0.0.2:
-    deprecated: 'to-iso-string has been deprecated, use @segment/to-iso-string instead.'
-    dev: false
-    resolution:
-      integrity: sha1-TcGeZk38y+Jb2NtQiwDG2hWCVdE=
   /to-object-path/0.3.0:
     dependencies:
       kind-of: 3.2.2
@@ -9391,15 +9063,15 @@ packages:
       node: '>=0.8'
     resolution:
       integrity: sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==
-  /tough-cookie/2.4.2:
+  /tough-cookie/2.4.3:
     dependencies:
-      psl: 1.1.28
+      psl: 1.1.29
       punycode: 1.4.1
     dev: false
     engines:
       node: '>=0.8'
     resolution:
-      integrity: sha512-vahm+X8lSV/KjXziec8x5Vp0OTC9mq8EVCOApIsRAooeuMPSO8aT7PFACYkaL0yZ/3hVqw+8DzhCJwl8H2Ad6w==
+      integrity: sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==
   /tr46/1.0.1:
     dependencies:
       punycode: 2.1.1
@@ -9440,7 +9112,7 @@ packages:
       lodash: 4.17.10
       pkg-dir: 2.0.0
       source-map-support: 0.5.6
-      yargs: 11.0.0
+      yargs: 11.1.0
     dev: false
     peerDependencies:
       jest: ^22.4.0 || ^22.5.0-alpha.1 || ^23.0.0-alpha.1
@@ -9460,7 +9132,7 @@ packages:
       lodash: 4.17.10
       pkg-dir: 2.0.0
       source-map-support: 0.5.6
-      yargs: 11.0.0
+      yargs: 11.1.0
     dev: false
     id: registry.npmjs.org/ts-jest/22.4.6
     peerDependencies:
@@ -9468,13 +9140,13 @@ packages:
       typescript: 2.x
     resolution:
       integrity: sha512-kYQ6g1G1AU+bOO9rv+SSQXg4WTcni6Wx3AM48iHni0nP1vIuhdNRjKTE9Cxx36Ix/IOV7L85iKu07dgXJzH2pQ==
-  /tslib/1.9.2:
+  /tslib/1.9.3:
     dev: false
     resolution:
-      integrity: sha512-AVP5Xol3WivEr7hnssHDsaM+lVrVXWUvd1cfXTRkTj80b//6g2wIFEH6hZG0muGZRnHGrfttpdzRk3YlBkWjKw==
+      integrity: sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==
   /tslint-microsoft-contrib/5.0.3:
     dependencies:
-      tsutils: 2.27.1
+      tsutils: 2.29.0
     dev: false
     peerDependencies:
       tslint: ^5.1.0
@@ -9484,7 +9156,7 @@ packages:
   /tslint-microsoft-contrib/5.0.3/tslint@5.9.1+typescript@2.4.2:
     dependencies:
       tslint: /tslint/5.9.1/typescript@2.4.2
-      tsutils: /tsutils/2.27.1/typescript@2.4.2
+      tsutils: /tsutils/2.29.0/typescript@2.4.2
       typescript: 2.4.2
     dev: false
     id: registry.npmjs.org/tslint-microsoft-contrib/5.0.3
@@ -9498,15 +9170,15 @@ packages:
       babel-code-frame: 6.26.0
       builtin-modules: 1.1.1
       chalk: 2.4.1
-      commander: 2.15.1
+      commander: 2.17.1
       diff: 3.5.0
       glob: 7.1.2
       js-yaml: 3.9.1
       minimatch: 3.0.4
-      resolve: 1.7.1
+      resolve: 1.8.1
       semver: 5.3.0
-      tslib: 1.9.2
-      tsutils: 2.27.1
+      tslib: 1.9.3
+      tsutils: 2.29.0
     dev: false
     engines:
       node: '>=4.8.0'
@@ -9519,15 +9191,15 @@ packages:
       babel-code-frame: 6.26.0
       builtin-modules: 1.1.1
       chalk: 2.4.1
-      commander: 2.15.1
+      commander: 2.17.1
       diff: 3.5.0
       glob: 7.1.2
       js-yaml: 3.9.1
       minimatch: 3.0.4
-      resolve: 1.7.1
+      resolve: 1.8.1
       semver: 5.3.0
-      tslib: 1.9.2
-      tsutils: /tsutils/2.27.1/typescript@2.4.2
+      tslib: 1.9.3
+      tsutils: /tsutils/2.29.0/typescript@2.4.2
       typescript: 2.4.2
     dev: false
     engines:
@@ -9537,32 +9209,28 @@ packages:
       typescript: '>=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev'
     resolution:
       integrity: sha1-ElX4ej/1frCw4fDmEKi0dIBGya4=
-  /tsutils/2.27.1:
+  /tsutils/2.29.0:
     dependencies:
-      tslib: 1.9.2
+      tslib: 1.9.3
     dev: false
     peerDependencies:
-      typescript: '>=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >= 3.0.0-dev'
+      typescript: '>=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >= 3.0.0-dev || >= 3.1.0-dev'
     resolution:
-      integrity: sha512-AE/7uzp32MmaHvNNFES85hhUDHFdFZp6OAiZcd6y4ZKKIg6orJTm8keYWBhIhrJQH3a4LzNKat7ZPXZt5aTf6w==
-  /tsutils/2.27.1/typescript@2.4.2:
+      integrity: sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==
+  /tsutils/2.29.0/typescript@2.4.2:
     dependencies:
-      tslib: 1.9.2
+      tslib: 1.9.3
       typescript: 2.4.2
     dev: false
-    id: registry.npmjs.org/tsutils/2.27.1
+    id: registry.npmjs.org/tsutils/2.29.0
     peerDependencies:
-      typescript: '>=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >= 3.0.0-dev'
+      typescript: '>=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >= 3.0.0-dev || >= 3.1.0-dev'
     resolution:
-      integrity: sha512-AE/7uzp32MmaHvNNFES85hhUDHFdFZp6OAiZcd6y4ZKKIg6orJTm8keYWBhIhrJQH3a4LzNKat7ZPXZt5aTf6w==
+      integrity: sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==
   /tty-browserify/0.0.0:
     dev: false
     resolution:
       integrity: sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=
-  /tunnel-agent/0.4.3:
-    dev: false
-    resolution:
-      integrity: sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=
   /tunnel-agent/0.6.0:
     dependencies:
       safe-buffer: 5.1.2
@@ -9593,7 +9261,7 @@ packages:
   /type-is/1.6.16:
     dependencies:
       media-typer: 0.3.0
-      mime-types: 2.1.18
+      mime-types: 2.1.19
     dev: false
     engines:
       node: '>= 0.6'
@@ -9679,10 +9347,6 @@ packages:
     dev: false
     resolution:
       integrity: sha1-WqADz76Uxf+GbE59ZouxxNuts2k=
-  /universalify/0.1.1:
-    dev: false
-    resolution:
-      integrity: sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc=
   /universalify/0.1.2:
     dev: false
     engines:
@@ -9727,14 +9391,12 @@ packages:
     dev: false
     resolution:
       integrity: sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=
-  /use/3.1.0:
-    dependencies:
-      kind-of: 6.0.2
+  /use/3.1.1:
     dev: false
     engines:
       node: '>=0.10.0'
     resolution:
-      integrity: sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==
+      integrity: sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==
   /user-home/1.1.1:
     dev: false
     engines:
@@ -9783,10 +9445,10 @@ packages:
       node: '>= 0.4.0'
     resolution:
       integrity: sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=
-  /uuid/3.2.1:
+  /uuid/3.3.2:
     dev: false
     resolution:
-      integrity: sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA==
+      integrity: sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
   /v8flags/2.1.1:
     dependencies:
       user-home: 1.1.1
@@ -9801,13 +9463,13 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-G5BKWWCfsyjvB4E4Qgk09rhnCaY=
-  /validate-npm-package-license/3.0.3:
+  /validate-npm-package-license/3.0.4:
     dependencies:
       spdx-correct: 3.0.0
       spdx-expression-parse: 3.0.0
     dev: false
     resolution:
-      integrity: sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==
+      integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==
   /validate-npm-package-name/3.0.0:
     dependencies:
       builtins: 1.0.3
@@ -9944,7 +9606,7 @@ packages:
       integrity: sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=
   /watch/0.18.0:
     dependencies:
-      exec-sh: 0.2.1
+      exec-sh: 0.2.2
       minimist: 1.2.0
     dev: false
     engines:
@@ -9953,7 +9615,7 @@ packages:
       integrity: sha1-KAlUdsbffJDJYxOJkMClQj60uYY=
   /watchpack/1.6.0:
     dependencies:
-      chokidar: 2.0.3
+      chokidar: 2.0.4
       graceful-fs: 4.1.11
       neo-async: 2.5.1
     dev: false
@@ -9969,7 +9631,7 @@ packages:
       mime: 1.6.0
       path-is-absolute: 1.0.1
       range-parser: 1.2.0
-      time-stamp: 2.0.0
+      time-stamp: 2.0.1
     dev: false
     engines:
       node: '>=0.6'
@@ -9983,7 +9645,7 @@ packages:
       mime: 1.6.0
       path-is-absolute: 1.0.1
       range-parser: 1.2.0
-      time-stamp: 2.0.0
+      time-stamp: 2.0.1
       webpack: 3.11.0
     dev: false
     engines:
@@ -10002,10 +9664,10 @@ packages:
       integrity: sha512-aqYp18kPphgoO5c/+NaUvEeACtZjMESmDChuD3NBciVpah3XpMEU9VAAtIaB1BsfJWWTSdv8Vv1m3T0aRk2dUw==
   /webpack/3.11.0:
     dependencies:
-      acorn: 5.6.2
+      acorn: 5.7.1
       acorn-dynamic-import: 2.0.2
-      ajv: 6.5.1
-      ajv-keywords: /ajv-keywords/3.2.0/ajv@6.5.1
+      ajv: 6.5.2
+      ajv-keywords: /ajv-keywords/3.2.0/ajv@6.5.2
       async: 2.6.1
       enhanced-resolve: 3.4.1
       escope: 3.6.0
@@ -10227,7 +9889,7 @@ packages:
       cliui: 4.1.0
       decamelize: 1.2.0
       find-up: 2.1.0
-      get-caller-file: 1.0.2
+      get-caller-file: 1.0.3
       os-locale: 2.1.0
       require-directory: 2.1.1
       require-main-filename: 1.0.1
@@ -10239,12 +9901,12 @@ packages:
     dev: false
     resolution:
       integrity: sha512-ivSoxqBGYOqQVruxD35+EyCFDYNEFL/Uo6FcOnz+9xZdZzK0Zzw4r4KhbrME1Oo2gOggwJod2MnsdamSG7H9ig==
-  /yargs/11.0.0:
+  /yargs/11.1.0:
     dependencies:
       cliui: 4.1.0
       decamelize: 1.2.0
       find-up: 2.1.0
-      get-caller-file: 1.0.2
+      get-caller-file: 1.0.3
       os-locale: 2.1.0
       require-directory: 2.1.1
       require-main-filename: 1.0.1
@@ -10255,7 +9917,7 @@ packages:
       yargs-parser: 9.0.2
     dev: false
     resolution:
-      integrity: sha512-Rjp+lMYQOWtgqojx1dEWorjCofi1YN7AoFvYV7b1gx/7dAAeuI4kN5SZiEvr0ZmsZTOpDRcCqrpI10L31tFkBw==
+      integrity: sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==
   /yargs/3.10.0:
     dependencies:
       camelcase: 1.2.1
@@ -10287,7 +9949,7 @@ packages:
       camelcase: 3.0.0
       cliui: 3.2.0
       decamelize: 1.2.0
-      get-caller-file: 1.0.2
+      get-caller-file: 1.0.3
       os-locale: 1.4.0
       read-pkg-up: 1.0.1
       require-directory: 2.1.1
@@ -10305,7 +9967,7 @@ packages:
       camelcase: 4.1.0
       cliui: 3.2.0
       decamelize: 1.2.0
-      get-caller-file: 1.0.2
+      get-caller-file: 1.0.3
       os-locale: 2.1.0
       read-pkg-up: 2.0.0
       require-directory: 2.1.1
@@ -10335,23 +9997,21 @@ packages:
       validator: 8.2.0
     dev: false
     optionalDependencies:
-      commander: 2.15.1
+      commander: 2.17.1
     resolution:
       integrity: sha512-DUOKC/IhbkdLKKiV89gw9DUauTV8U/8yJl1sjf6MtDmzevLKOF2duNJ495S3MFVjqZarr+qNGCPbkg4mu4PpLw==
   'file:projects/api-documenter.tgz':
     dependencies:
-      '@types/fs-extra': 5.0.1
       '@types/jest': 21.1.10
       '@types/js-yaml': 3.9.1
       '@types/node': 8.5.8
       colors: 1.2.5
-      fs-extra: 5.0.0
       gulp: 3.9.1
       js-yaml: 3.9.1
     dev: false
     name: '@rush-temp/api-documenter'
     resolution:
-      integrity: sha512-wqKPn5yFNu9EYNbMAn6BdXRATND7aKsrM5Ic+m8Mo06oyVD+tCfkMO4GNpynbrlMbN3jYar1chXj2P6LBzZYgQ==
+      integrity: sha512-dbJVoOM68An0tAV593KKY27zUlgZkUBQ4e0UxsdPXYBATdl+NX0dAYXGtZoLJxyHSUcR5Z8UiI57NhzEchTHwQ==
       tarball: 'file:projects/api-documenter.tgz'
     version: 0.0.0
   'file:projects/api-extractor-test-01.tgz':
@@ -10410,19 +10070,17 @@ packages:
     dev: false
     name: '@rush-temp/api-extractor-test-05'
     resolution:
-      integrity: sha512-HWd+e1bD1CR0R1wreKdYy6kZ2iDobLIRM0j/Sre2vBvbLfL7u+WJkA3E3q1jqiQTHN/DatHC7Y7BDIC8h5b+eg==
+      integrity: sha512-YCGYKdYyR/EOJM7n/kNrs1TpaF3YIv/niZkZMXJxUl3BVcW8ZnhUJEbb8fuGHi2QKZDyrKykQL3UjkSyee6ifg==
       tarball: 'file:projects/api-extractor-test-05.tgz'
     version: 0.0.0
   'file:projects/api-extractor.tgz':
     dependencies:
       '@microsoft/node-library-build': 4.4.0
-      '@types/fs-extra': 5.0.1
       '@types/jest': 21.1.10
       '@types/lodash': 4.14.74
       '@types/node': 8.5.8
       '@types/z-schema': 3.16.31
       colors: 1.2.5
-      fs-extra: 5.0.0
       gulp: 3.9.1
       jju: 1.3.0
       lodash: 4.15.0
@@ -10511,7 +10169,7 @@ packages:
     dev: false
     name: '@rush-temp/gulp-core-build-sass'
     resolution:
-      integrity: sha512-j9Is58dTKv0JEyzhtCVjPU9P2GvaYnFzPgtjkwlVVeSuJVAkn4HKhFlqRbsgrQat+DiJfYLXZ1hepItnRZwweA==
+      integrity: sha512-s68lAmMtwKkELfrz4HM/jfFVKnysanYsVU7J3ypTfMc5D7ZYdX0O1n8wxHZgcDz2QxIrw23orFX/XFYqAAjreA==
       tarball: 'file:projects/gulp-core-build-sass.tgz'
     version: 0.0.0
   'file:projects/gulp-core-build-serve.tgz':
@@ -10534,20 +10192,19 @@ packages:
       express: 4.16.3
       gulp: 3.9.1
       gulp-connect: 5.5.0
-      gulp-open: 2.0.0
+      gulp-open: 3.0.1
       gulp-util: 3.0.8
       node-forge: 0.7.5
       sudo: 1.0.3
     dev: false
     name: '@rush-temp/gulp-core-build-serve'
     resolution:
-      integrity: sha512-EBzj9JG21RRJZKRrCjslO61a0P361sPfcol6cePw4K3yOkJxl5cfKN+kzzXo6dhaESY/xw3uq5lduWxFyQf0wg==
+      integrity: sha512-1/QGgbFubGWHP6F5Ih6Ps2WzRgz7gz8MWQ9QpMTjFlWT49x14kYe9ufy3DRVXgD4dSPKcvR9inqohGK/Pg9pCg==
       tarball: 'file:projects/gulp-core-build-serve.tgz'
     version: 0.0.0
   'file:projects/gulp-core-build-typescript.tgz':
     dependencies:
       '@microsoft/node-library-build': 4.4.0
-      '@types/fs-extra': 5.0.1
       '@types/glob': 5.0.30
       '@types/gulp': 3.8.32
       '@types/gulp-util': 3.0.30
@@ -10557,7 +10214,6 @@ packages:
       '@types/through2': 2.0.32
       '@types/vinyl': 1.2.30
       decomment: 0.9.1
-      fs-extra: 5.0.0
       glob: 7.0.6
       glob-escape: 0.0.2
       gulp: 3.9.1
@@ -10592,7 +10248,7 @@ packages:
       '@types/q': 0.0.32
       '@types/source-map': 0.5.0
       '@types/uglify-js': 2.6.29
-      '@types/webpack': 3.8.11
+      '@types/webpack': 4.4.0
       colors: 1.2.5
       gulp: 3.9.1
       gulp-util: 3.0.8
@@ -10600,7 +10256,7 @@ packages:
     dev: false
     name: '@rush-temp/gulp-core-build-webpack'
     resolution:
-      integrity: sha512-SpBa0OMEnWvk3gGLBFIzexzCLvj42CoF5qJF9csUmGfa7BBXmNbLKfb5MFLmoHCp16pXgWOk2iztw2US+5LRng==
+      integrity: sha512-trQ6tS/KZqOE/p49Pl5n0G9lB1S+mY71M23OORKBpuITuFVKND/Plw2ar4H+WbgO2qrAc6AIISG31ES4tCoIxw==
       tarball: 'file:projects/gulp-core-build-webpack.tgz'
     version: 0.0.0
   'file:projects/gulp-core-build.tgz':
@@ -10626,7 +10282,6 @@ packages:
       colors: 1.2.5
       del: 2.2.2
       end-of-stream: 1.1.0
-      fs-extra: 5.0.0
       glob-escape: 0.0.2
       globby: 5.0.0
       gulp: 3.9.1
@@ -10638,6 +10293,7 @@ packages:
       jest-environment-jsdom: 22.4.3
       jest-resolve: 22.4.3
       jju: 1.3.0
+      jsdom: 11.11.0
       lodash.merge: 4.3.5
       merge2: 1.0.3
       node-notifier: 5.0.2
@@ -10652,7 +10308,7 @@ packages:
     dev: false
     name: '@rush-temp/gulp-core-build'
     resolution:
-      integrity: sha512-bFawjgwY/dAhn1bgwZ7dsZS6i8dHCV7wgX9c1Ts6W2vzNBHS4XF7NDtKOT4kEqzEY2uHwbMjFT69KHxD2sWRmA==
+      integrity: sha512-CHEQ+mp531cvGFB3kY1AzAT4CaSa/x2qSi4/WWJ67LCLvFwjZmL2mO1XgjrVEqj9Dlz8pm0BYdUe7HkeXmB52Q==
       tarball: 'file:projects/gulp-core-build.tgz'
     version: 0.0.0
   'file:projects/load-themed-styles.tgz':
@@ -10665,7 +10321,7 @@ packages:
     dev: false
     name: '@rush-temp/load-themed-styles'
     resolution:
-      integrity: sha512-8WrmhY+kd3sIA6fJmx3yQByH9BeavLcznpcc6cjFKnrVR+pqxv7NWmKPqLTH1ukpkJOEN771mkt4/Kh3SkweSg==
+      integrity: sha512-dVCbv/7Mdsno5SuXl78C8r7jiZAJs5naHMIChAsHvGWP0fXZkGOgFobjOfmGQCC60HngllZKEMz+PawK9DHX4Q==
       tarball: 'file:projects/load-themed-styles.tgz'
     version: 0.0.0
   'file:projects/loader-load-themed-styles.tgz':
@@ -10680,7 +10336,7 @@ packages:
     dev: false
     name: '@rush-temp/loader-load-themed-styles'
     resolution:
-      integrity: sha512-oVUBOevjacGFX0OM5PYgK7k4pObaMsMo8ZNVebohvE6JlfDaTK2BJXJR8nPI5OgQfYvsN6vhLUOTduuHqzbazQ==
+      integrity: sha512-9K3KHBhp042CiQBRMk4+i0TFUMiZey48Cci/Am7MCizf/MhXCQGKs2rhptc8vwMc7eBPA7PhEU0pkZv0aUYzbw==
       tarball: 'file:projects/loader-load-themed-styles.tgz'
     version: 0.0.0
   'file:projects/loader-raw-script.tgz':
@@ -10694,7 +10350,7 @@ packages:
     dev: false
     name: '@rush-temp/loader-raw-script'
     resolution:
-      integrity: sha512-nDSwUAMvj6vHpe1US8RExDW6DfRJ6iQsJncU8m8f5GvyHSkjAfA6N+Ls7KUprzKnxoAUA1P+J2URRPOTqPZEXA==
+      integrity: sha512-I0VEnKzwzAlEBCxc9FLlVIvg7KdNCxcaptn/1Ctg2sAQx09SeCxJOc1QFNstBHb63Nkckmbh3BcJThZOy+Q7WQ==
       tarball: 'file:projects/loader-raw-script.tgz'
     version: 0.0.0
   'file:projects/loader-set-webpack-public-path.tgz':
@@ -10710,23 +10366,19 @@ packages:
     dev: false
     name: '@rush-temp/loader-set-webpack-public-path'
     resolution:
-      integrity: sha512-0xHTKoPdkq+yYLf43+0d7q+Tl1XxGHxDobhybswllEsX/NUxRt5zMQg3nVPwdmiiXBAgmgA2gQHOzEQPN2ZIvg==
+      integrity: sha512-SoCo7XKDp2Ww4I9U9mEGZWYuUVGM+bFtjOPNNFgUx3FkrZRovlk1Jj6aPgdAJbajmL0apcZscOn00j4CW3l1yQ==
       tarball: 'file:projects/loader-set-webpack-public-path.tgz'
     version: 0.0.0
   'file:projects/node-core-library.tgz':
     dependencies:
       '@microsoft/node-library-build': 4.4.0
-      '@types/chai': 3.4.34
       '@types/fs-extra': 5.0.1
       '@types/jest': 21.1.10
-      '@types/mocha': 2.2.38
       '@types/node': 8.5.8
       '@types/z-schema': 3.16.31
-      chai: 3.5.0
       fs-extra: 5.0.0
       gulp: 3.9.1
       jju: 1.3.0
-      mocha: 5.2.0
       z-schema: 3.18.4
     dev: false
     name: '@rush-temp/node-core-library'
@@ -10742,7 +10394,7 @@ packages:
     dev: false
     name: '@rush-temp/node-library-build'
     resolution:
-      integrity: sha512-REL1KYZ2rHaiPDBIXQ5SNC2R39lrl5e62JzinKouo0Xy9gWagBFn6E2D/t9jgCHF1YkOtSoaUPzZs1W98qaf8w==
+      integrity: sha512-CVTH6SNUrpji8FccHcIX8E2G3fc/grVXirZuDa5Alq7UIelsUtIBGOPqGsUDY5nEePa/vm3JL6OFDYrinXtTrA==
       tarball: 'file:projects/node-library-build.tgz'
     version: 0.0.0
   'file:projects/package-deps-hash.tgz':
@@ -10755,7 +10407,7 @@ packages:
     dev: false
     name: '@rush-temp/package-deps-hash'
     resolution:
-      integrity: sha512-z0J1m7MLGNpew5k1qUjnzF+8qkesY1Ipocp7+iVs19ifVsGWFJ8aNoaNvH9cLQjZ8kybC/UXeWtBW/+0WiI2bw==
+      integrity: sha512-MG5TE5gSUXpNEoak5oNwcBkAg7r/KxezvoHwsuSxVpZz1BM+FIK0Lo89kqEyMllKHLxFn4E1z/nfzkwRUpHayQ==
       tarball: 'file:projects/package-deps-hash.tgz'
     version: 0.0.0
   'file:projects/resolve-chunk-plugin.tgz':
@@ -10768,14 +10420,13 @@ packages:
     dev: false
     name: '@rush-temp/resolve-chunk-plugin'
     resolution:
-      integrity: sha512-V/BqHoxIJ8f6f2w/zzbiwZm7eoOc8eg44c9ckdQeHypu6D0jowhkRs09p0B+a4INHjjbEuc9NZZemE7YzpwhfQ==
+      integrity: sha512-PQt5bvE5NybxI0G+z9NMr2r27u426pPWKh9AsMFwVcLCLjq+DzXvdUBHQ67rwHCS5sKAqHJJq0QHfPYypIvvBg==
       tarball: 'file:projects/resolve-chunk-plugin.tgz'
     version: 0.0.0
   'file:projects/rush-lib.tgz':
     dependencies:
       '@pnpm/link-bins': /@pnpm/link-bins/1.0.3/@pnpm!logger@1.0.2
       '@pnpm/logger': 1.0.2
-      '@types/fs-extra': 5.0.1
       '@types/glob': 5.0.30
       '@types/jest': 21.1.10
       '@types/js-yaml': 3.9.1
@@ -10788,7 +10439,6 @@ packages:
       '@types/z-schema': 3.16.31
       builtins: 1.0.3
       colors: 1.2.5
-      fs-extra: 5.0.0
       git-repo-info: 1.1.4
       glob: 7.0.6
       glob-escape: 0.0.2
@@ -10805,13 +10455,13 @@ packages:
       rimraf: 2.5.4
       semver: 5.3.0
       strict-uri-encode: 2.0.0
-      tar: 4.4.4
+      tar: 4.4.6
       wordwrap: 1.0.0
       z-schema: 3.18.4
     dev: false
     name: '@rush-temp/rush-lib'
     resolution:
-      integrity: sha512-wiYy3KA7Ui6VB05AAEUPGk9+tSL8jW4BiPmSR2mM0DGWawuFbdkewfjlaeETXUjjRDqo+S4AJnCXVnclUQQ9vg==
+      integrity: sha512-iY/cZcKSGRFJWRZ1tY9HdQwVDs47C0d+ofR/iSwbMeoc3c8o+Aw9pKmCtmlng4EWj8ZLuBn1SaF52AJeZYhYYA==
       tarball: 'file:projects/rush-lib.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler.tgz':
@@ -10835,40 +10485,35 @@ packages:
   'file:projects/rush-stack.tgz':
     dependencies:
       '@types/colors': 1.2.1
-      '@types/fs-extra': 5.0.1
       '@types/node': 8.5.8
       colors: 1.2.5
-      fs-extra: 5.0.0
       gulp: 3.9.1
     dev: false
     name: '@rush-temp/rush-stack'
     resolution:
-      integrity: sha512-3NoFxFlBqLp5bpBOTJ/6E9crpEHjLuYx70DIib1liIn2FJm5/2Dt6IgNAM4Bf5Cz0/XsA4yUsorufyYwYfc39g==
+      integrity: sha512-i+2yqR0F2z0wN59C3SzPAN5OFPlvThBhlPhgDVn7pkLTHTm1z1qvu24PNzVCA1BFShW2sQQzbGp7AHRSSj6M6A==
       tarball: 'file:projects/rush-stack.tgz'
     version: 0.0.0
   'file:projects/rush.tgz':
     dependencies:
       '@types/chai': 3.4.34
-      '@types/fs-extra': 5.0.1
       '@types/mocha': 5.2.5
       '@types/node': 8.5.8
       '@types/semver': 5.3.33
       '@types/sinon': 1.16.34
       chai: 3.5.0
       colors: 1.2.5
-      fs-extra: 5.0.0
       gulp: 3.9.1
       semver: 5.3.0
       sinon: 1.17.7
     dev: false
     name: '@rush-temp/rush'
     resolution:
-      integrity: sha512-9BAS2tl9IDNYZKPhJg0YqZIOCLc+xb/HxsuxViRx3oDFNCKIGXPvXZK46rddITPIn8w0HI/3TGCbcd34u7fwuw==
+      integrity: sha512-0+cRsQzruLfhsWQdIwZd78L2wOEZxQ/Y8eAZ5/Hf/243jW/hMLBNulY+DRrK7lDAH0JuykKe5/p45UtwMjRxSQ==
       tarball: 'file:projects/rush.tgz'
     version: 0.0.0
   'file:projects/rushell.tgz':
     dependencies:
-      '@microsoft/node-library-build': 4.3.41
       '@types/jest': 21.1.10
       '@types/node': 8.5.8
       gulp: 3.9.1
@@ -10877,7 +10522,7 @@ packages:
     dev: false
     name: '@rush-temp/rushell'
     resolution:
-      integrity: sha512-rjqCEuibdYCTH5AzIjx3z+qyTma0/PHjcF/fQ3r5kJc9TkkOBsvZHexrHZeYtJlcOQmczPvtNtqE8J0GVRoOsg==
+      integrity: sha512-jC6lhOgDax8YbTZzxsxbTwM2njgQX9bKO/Zm07FaRPOrOs+h0cMooaCXjgDp2S1u5cuWdLZYGB6KyZ5jUhvljw==
       tarball: 'file:projects/rushell.tgz'
     version: 0.0.0
   'file:projects/set-webpack-public-path-plugin.tgz':
@@ -10896,7 +10541,7 @@ packages:
     dev: false
     name: '@rush-temp/set-webpack-public-path-plugin'
     resolution:
-      integrity: sha512-5HbLkXPW5WASImd4AzIAGqnksP6G0Soc2TcoQAf4/PcjLAqEygthZDF7JO6v5PkuIar2xxHvFGCtoDmZBxKpFw==
+      integrity: sha512-3fDJzsc4mSw04g7FyEVVYUpKbt/QSG1Puovu9nLgx7auEPaI2b9XC06cdwvbhtqY29JV+2PwS0Opys9K4fxZRw==
       tarball: 'file:projects/set-webpack-public-path-plugin.tgz'
     version: 0.0.0
   'file:projects/stream-collator.tgz':
@@ -10911,7 +10556,7 @@ packages:
     dev: false
     name: '@rush-temp/stream-collator'
     resolution:
-      integrity: sha512-UXMxvV1hNjznT5wggdz48oasAAcbxXSa0TgVbZ8mMD10FOgtYw30uZbGXlYRCxXFkwLMxMZmMsCslih2Dp8++w==
+      integrity: sha512-fEHCm2HGJf9qoH+fu5nW1D/nhvacoGG6R/LzDM7e3cxsLW7r9/ZSeFypjYsgomf2l64ezrqwi9Wbbg4NozPv+g==
       tarball: 'file:projects/stream-collator.tgz'
     version: 0.0.0
   'file:projects/ts-command-line.tgz':
@@ -10939,7 +10584,7 @@ packages:
     dev: false
     name: '@rush-temp/web-library-build-test'
     resolution:
-      integrity: sha512-2y6CixGqxHmtbkyDWiLhmaggPdd2YeepIyjVkB1EyDy4ijLUo8nK2FO+bFm+XJf1xjgfPhvuyqLk0XUuwQAyGQ==
+      integrity: sha512-bnRIBkjC8NEFspjgka2PfOYGSGUP5HfZfKVHlaQiVLoeD90sda3NigG5TiWmB7VDqLuhSSegRMtv1c250IaPlQ==
       tarball: 'file:projects/web-library-build-test.tgz'
     version: 0.0.0
   'file:projects/web-library-build.tgz':
@@ -10951,7 +10596,7 @@ packages:
     dev: false
     name: '@rush-temp/web-library-build'
     resolution:
-      integrity: sha512-mpdlUVtTfl8B5Ps1StwdqtZoQWZ7g/1DmZ6d1TYqRMfXPQ9/JIs/4bhf5d75UzIV9zKFXUaQXIbTlm+DGjn3Ow==
+      integrity: sha512-yYJUVGIt88J6ZcLgvmVQ4nZhnOV5U7qNX1mc48iRXkq78LJCzrltIDyT+CcI41Fyxi3Rx4arTYnNifTHamDFLQ==
       tarball: 'file:projects/web-library-build.tgz'
     version: 0.0.0
 registry: 'https://registry.npmjs.org/'
@@ -11033,10 +10678,10 @@ specifiers:
   '@types/through2': 2.0.32
   '@types/uglify-js': 2.6.29
   '@types/vinyl': 1.2.30
+  '@types/webpack': 4.4.0
   '@types/webpack-env': 1.13.0
   '@types/yargs': 0.0.34
   '@types/z-schema': 3.16.31
-  ajv: 5.2.2
   argparse: ~1.0.9
   autoprefixer: 6.3.7
   builtins: ~1.0.3
@@ -11065,7 +10710,7 @@ specifiers:
   gulp-istanbul: ~0.10.3
   gulp-karma: ~0.0.5
   gulp-mocha: ~6.0.0
-  gulp-open: ~2.0.0
+  gulp-open: ~3.0.1
   gulp-plumber: ~1.1.0
   gulp-postcss: ~6.3.0
   gulp-replace: ^0.5.4
@@ -11083,6 +10728,7 @@ specifiers:
   jest-resolve: ~22.4.3
   jju: ~1.3.0
   js-yaml: ~3.9.1
+  jsdom: ~11.11.0
   karma: ~0.13.9
   karma-coverage: ~0.5.5
   karma-mocha: ~1.3.0

--- a/core-build/gulp-core-build-serve/package.json
+++ b/core-build/gulp-core-build-serve/package.json
@@ -21,7 +21,7 @@
     "express": "~4.16.2",
     "gulp": "~3.9.1",
     "gulp-connect": "~5.5.0",
-    "gulp-open": "~2.0.0",
+    "gulp-open": "~3.0.1",
     "gulp-util": "~3.0.7",
     "node-forge": "~0.7.1",
     "sudo": "~1.0.3"

--- a/core-build/gulp-core-build-webpack/package.json
+++ b/core-build/gulp-core-build-webpack/package.json
@@ -27,6 +27,6 @@
     "@types/q": "0.0.32",
     "@types/source-map": "0.5.0",
     "@types/uglify-js": "2.6.29",
-    "@types/webpack": "3.8.11"
+    "@types/webpack": "4.4.0"
   }
 }

--- a/core-build/gulp-core-build/package.json
+++ b/core-build/gulp-core-build/package.json
@@ -53,7 +53,8 @@
     "jest-cli": "~22.4.3",
     "jest-environment-jsdom": "~22.4.3",
     "jest-resolve": "~22.4.3",
-    "jest": "~22.4.3"
+    "jest": "~22.4.3",
+    "jsdom": "~11.11.0"
   },
   "devDependencies": {
     "@types/z-schema": "3.16.31",


### PR DESCRIPTION
This PR removes these package versions from our shrinkwrap.yaml file:
- growl 1.9.2
- open 0.0.5