### PR TITLE
[rush] Add a --skip-install flag which only updates the shrinkwrap

### DIFF
--- a/apps/rush-lib/src/api/LastInstallFlag.ts
+++ b/apps/rush-lib/src/api/LastInstallFlag.ts
@@ -20,7 +20,7 @@ export class LastInstallFlag {
    * @param folderPath - the folder that this flag is managing
    * @param state - optional, the state that should be managed or compared
   */
-  constructor(folderPath: string, state: Object = {}) {
+  public constructor(folderPath: string, state: Object = {}) {
     this._path = path.join(folderPath, LAST_INSTALL_FLAG_FILE_NAME);
     this._state = state;
   }

--- a/apps/rush-lib/src/api/RushLastInstallFlag.ts
+++ b/apps/rush-lib/src/api/RushLastInstallFlag.ts
@@ -1,0 +1,12 @@
+import { LastInstallFlag } from './LastInstallFlag';
+import { RushConfiguration } from './RushConfiguration';
+
+export class RushLastInstallFlag extends LastInstallFlag {
+  constructor(rushConfiguration: RushConfiguration) {
+    super(rushConfiguration.commonTempFolder, {
+      node: process.versions.node,
+      packageManager: rushConfiguration.packageManager,
+      packageManagerVersion: rushConfiguration.packageManagerToolVersion
+    });
+  }
+}

--- a/apps/rush-lib/src/cli/actions/InstallAction.ts
+++ b/apps/rush-lib/src/cli/actions/InstallAction.ts
@@ -32,7 +32,8 @@ export class InstallAction extends BaseInstallAction {
       noLink: this._noLinkParameter.value!,
       fullUpgrade: false,
       recheckShrinkwrap: false,
-      collectLogFile: this._debugPackageManagerParameter.value!
+      collectLogFile: this._debugPackageManagerParameter.value!,
+      skipInstall: false
     };
   }
 }

--- a/apps/rush-lib/src/cli/actions/UpdateAction.ts
+++ b/apps/rush-lib/src/cli/actions/UpdateAction.ts
@@ -10,6 +10,7 @@ import { RushCommandLineParser } from '../RushCommandLineParser';
 export class UpdateAction extends BaseInstallAction {
   private _fullParameter: CommandLineFlagParameter;
   private _recheckParameter: CommandLineFlagParameter;
+  private _skipInstallParameter: CommandLineFlagParameter;
 
   constructor(parser: RushCommandLineParser) {
     super({
@@ -50,6 +51,22 @@ export class UpdateAction extends BaseInstallAction {
         + ' to process the shrinkwrap file.  This will also update your shrinkwrap file with Rush\'s fixups.'
         + ' (To minimize shrinkwrap churn, these fixups are normally performed only in the temporary folder.)'
     });
+
+    this._skipInstallParameter = this.defineFlagParameter({
+      parameterLongName: '--skip-install',
+      description: '(PNPM only) Updates the shrinkwrap file, but doesn\'t perform an installation.'
+        + ' Useful in certain cases where you only need changes to a shrinkwrap, but don\'t want to'
+        + ' tie up your disk or computer doing an install, e.g. if you are merging from master but'
+        + ' are not planning on doing a local installation.'
+    });
+  }
+
+  protected run(): Promise<void> {
+    if (this._skipInstallParameter.value && this.rushConfiguration.packageManager !== 'pnpm') {
+      return Promise.reject(`The --skip-install flag only works when using PNPM.`);
+    }
+
+    return super.run();
   }
 
   protected buildInstallOptions(): IInstallManagerOptions {
@@ -59,7 +76,8 @@ export class UpdateAction extends BaseInstallAction {
       noLink: this._noLinkParameter.value!,
       fullUpgrade: this._fullParameter.value!,
       recheckShrinkwrap: this._recheckParameter.value!,
-      collectLogFile: this._debugPackageManagerParameter.value!
+      collectLogFile: this._debugPackageManagerParameter.value!,
+      skipInstall: this._skipInstallParameter.value
     };
   }
 }

--- a/apps/rush-lib/src/cli/actions/UpdateAction.ts
+++ b/apps/rush-lib/src/cli/actions/UpdateAction.ts
@@ -73,7 +73,7 @@ export class UpdateAction extends BaseInstallAction {
     return {
       allowShrinkwrapUpdates: true,
       bypassPolicy: this._bypassPolicyParameter.value!,
-      noLink: this._noLinkParameter.value!,
+      noLink: this._noLinkParameter.value! || this._skipInstallParameter.value,
       fullUpgrade: this._fullParameter.value!,
       recheckShrinkwrap: this._recheckParameter.value!,
       collectLogFile: this._debugPackageManagerParameter.value!,

--- a/apps/rush-lib/src/cli/actions/UpdateAction.ts
+++ b/apps/rush-lib/src/cli/actions/UpdateAction.ts
@@ -54,19 +54,11 @@ export class UpdateAction extends BaseInstallAction {
 
     this._skipInstallParameter = this.defineFlagParameter({
       parameterLongName: '--skip-install',
-      description: '(PNPM only) Updates the shrinkwrap file, but doesn\'t perform an installation.'
+      description: 'Updates the shrinkwrap file, but doesn\'t perform an installation.'
         + ' Useful in certain cases where you only need changes to a shrinkwrap, but don\'t want to'
         + ' tie up your disk or computer doing an install, e.g. if you are merging from master but'
         + ' are not planning on doing a local installation.'
     });
-  }
-
-  protected run(): Promise<void> {
-    if (this._skipInstallParameter.value && this.rushConfiguration.packageManager !== 'pnpm') {
-      return Promise.reject(`The --skip-install flag only works when using PNPM.`);
-    }
-
-    return super.run();
   }
 
   protected buildInstallOptions(): IInstallManagerOptions {

--- a/apps/rush-lib/src/cli/test/__snapshots__/CommandLineHelp.test.ts.snap
+++ b/apps/rush-lib/src/cli/test/__snapshots__/CommandLineHelp.test.ts.snap
@@ -397,6 +397,7 @@ Optional arguments:
 exports[`CommandLineHelp prints the help for "rush update" 1`] = `
 "usage: rush update [-h] [-p] [--bypass-policy] [--no-link]
                    [--debug-package-manager] [--full] [--recheck]
+                   [--skip-install]
                    
 
 The \\"rush update\\" command installs the dependencies described in your package.
@@ -444,6 +445,12 @@ Optional arguments:
                         your shrinkwrap file with Rush's fixups. (To minimize 
                         shrinkwrap churn, these fixups are normally performed 
                         only in the temporary folder.)
+  --skip-install        (PNPM only) Updates the shrinkwrap file, but doesn't 
+                        perform an installation. Useful in certain cases 
+                        where you only need changes to a shrinkwrap, but 
+                        don't want to tie up your disk or computer doing an 
+                        install, e.g. if you are merging from master but are 
+                        not planning on doing a local installation.
 "
 `;
 

--- a/apps/rush-lib/src/logic/GitPolicy.ts
+++ b/apps/rush-lib/src/logic/GitPolicy.ts
@@ -57,10 +57,10 @@ If you didn't configure your e-mail yet, try something like this:`);
 
     for (const pattern of rushConfiguration.gitAllowedEmailRegExps) {
       const regex: RegExp = new RegExp('^' + pattern + '$', 'i');
-      if (!userEmail.match(regex)) {
+      if (userEmail.match(regex)) {
         // For debugging:
         // console.log(`${userEmail} did not match pattern: "${pattern}"`);
-        return false;
+        return true;
       }
     }
 

--- a/apps/rush-lib/src/logic/InstallManager.ts
+++ b/apps/rush-lib/src/logic/InstallManager.ts
@@ -87,7 +87,8 @@ export interface IInstallManagerOptions {
   collectLogFile: boolean;
   /**
    * If specified, the shrinkwrap file will be updated, but an actual installation will
-   * not be performed. Note this option only works if the package manager being used is PNPM.
+   * not be performed. Note that PNPM has to still download tarballs to the store:
+   *   https://github.com/pnpm/pnpm/pull/1177
    */
   skipInstall: boolean;
 }
@@ -959,6 +960,10 @@ export class InstallManager {
 
       if (options.collectLogFile) {
         args.push('--verbose');
+      }
+
+      if (options.skipInstall) {
+        args.push('--package-lock-only');
       }
     } else if (this._rushConfiguration.packageManager === 'pnpm') {
       args.push('--store', this._rushConfiguration.pnpmStoreFolder);

--- a/apps/rush-lib/src/start.ts
+++ b/apps/rush-lib/src/start.ts
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-console.log('Importing dependencies...');
-
 import { Rush } from './api/Rush';
 
 Rush.launch(Rush.version, false);

--- a/apps/rush-lib/src/start.ts
+++ b/apps/rush-lib/src/start.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
+console.log('Importing dependencies...');
+
 import { Rush } from './api/Rush';
 
 Rush.launch(Rush.version, false);

--- a/common/changes/@microsoft/rush/nickpape-rush-fast-install-flag_2018-08-08-01-03.json
+++ b/common/changes/@microsoft/rush/nickpape-rush-fast-install-flag_2018-08-08-01-03.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Add a --skip-install flag for the update command, which will update the shrinkwrap but not do an installation.",
+      "packageName": "@microsoft/rush",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "nickpape-msft@users.noreply.github.com"
+}


### PR DESCRIPTION
Sometimes there is a need to update a shrinkwrap file, but you aren't interested in doing a local install (as it may take a lot of time) [e.g. if you are merging from master into your branch.]