### PR TITLE
[rush] Add a --network-concurrency option for troubleshooting network issues

### DIFF
--- a/apps/rush-lib/src/cli/actions/BaseInstallAction.ts
+++ b/apps/rush-lib/src/cli/actions/BaseInstallAction.ts
@@ -4,7 +4,7 @@
 import * as colors from 'colors';
 import * as os from 'os';
 
-import { CommandLineFlagParameter } from '@microsoft/ts-command-line';
+import { CommandLineFlagParameter, CommandLineIntegerParameter } from '@microsoft/ts-command-line';
 
 import { BaseRushAction } from './BaseRushAction';
 import { Event } from '../../api/EventHooks';
@@ -21,6 +21,7 @@ export abstract class BaseInstallAction extends BaseRushAction {
   protected _purgeParameter: CommandLineFlagParameter;
   protected _bypassPolicyParameter: CommandLineFlagParameter;
   protected _noLinkParameter: CommandLineFlagParameter;
+  protected _networkConcurrencyParameter: CommandLineIntegerParameter;
   protected _debugPackageManagerParameter: CommandLineFlagParameter;
 
   protected onDefineParameters(): void {
@@ -39,6 +40,12 @@ export abstract class BaseInstallAction extends BaseRushAction {
         + ' after the installation completes.  You will need to run "rush link" manually.'
         + ' This flag is useful for automated builds that want to report stages individually'
         + ' or perform extra operations in between the two stages.'
+    });
+    this._networkConcurrencyParameter = this.defineIntegerParameter({
+      parameterLongName: '--network-concurrency',
+      argumentName: 'COUNT',
+      description: 'If specified, limits the maximum number of concurrent network requests.'
+        + '  This is useful when troubleshooting network failures.'
     });
     this._debugPackageManagerParameter = this.defineFlagParameter({
       parameterLongName: '--debug-package-manager',
@@ -69,6 +76,13 @@ export abstract class BaseInstallAction extends BaseRushAction {
       console.log('The --purge flag was specified, so performing "rush purge"');
       purgeManager.purgeNormal();
       console.log('');
+    }
+
+    if (this._networkConcurrencyParameter.value) {
+      if (this.rushConfiguration.packageManager !== 'pnpm') {
+        throw new Error(`The ${this._networkConcurrencyParameter.longName} parameter is currently`
+          + ` only supported when using the PNPM package manager.`);
+      }
     }
 
     const installManagerOptions: IInstallManagerOptions = this.buildInstallOptions();

--- a/apps/rush-lib/src/cli/actions/BaseInstallAction.ts
+++ b/apps/rush-lib/src/cli/actions/BaseInstallAction.ts
@@ -80,7 +80,7 @@ export abstract class BaseInstallAction extends BaseRushAction {
 
     if (this._networkConcurrencyParameter.value) {
       if (this.rushConfiguration.packageManager !== 'pnpm') {
-        throw new Error(`The ${this._networkConcurrencyParameter.longName} parameter is currently`
+        throw new Error(`The "${this._networkConcurrencyParameter.longName}" parameter is`
           + ` only supported when using the PNPM package manager.`);
       }
     }

--- a/apps/rush-lib/src/cli/actions/InstallAction.ts
+++ b/apps/rush-lib/src/cli/actions/InstallAction.ts
@@ -32,6 +32,7 @@ export class InstallAction extends BaseInstallAction {
       noLink: this._noLinkParameter.value!,
       fullUpgrade: false,
       recheckShrinkwrap: false,
+      networkConcurrency: this._networkConcurrencyParameter.value,
       collectLogFile: this._debugPackageManagerParameter.value!
     };
   }

--- a/apps/rush-lib/src/cli/actions/UpdateAction.ts
+++ b/apps/rush-lib/src/cli/actions/UpdateAction.ts
@@ -59,6 +59,7 @@ export class UpdateAction extends BaseInstallAction {
       noLink: this._noLinkParameter.value!,
       fullUpgrade: this._fullParameter.value!,
       recheckShrinkwrap: this._recheckParameter.value!,
+      networkConcurrency: this._networkConcurrencyParameter.value,
       collectLogFile: this._debugPackageManagerParameter.value!
     };
   }

--- a/apps/rush-lib/src/cli/test/__snapshots__/CommandLineHelp.test.ts.snap
+++ b/apps/rush-lib/src/cli/test/__snapshots__/CommandLineHelp.test.ts.snap
@@ -188,7 +188,7 @@ Optional arguments:
 
 exports[`CommandLineHelp prints the help for "rush install" 1`] = `
 "usage: rush install [-h] [-p] [--bypass-policy] [--no-link]
-                    [--debug-package-manager]
+                    [--network-concurrency COUNT] [--debug-package-manager]
                     
 
 The \\"rush install\\" command installs package dependencies for all your 
@@ -214,6 +214,10 @@ Optional arguments:
                         is useful for automated builds that want to report 
                         stages individually or perform extra operations in 
                         between the two stages.
+  --network-concurrency COUNT
+                        If specified, limits the maximum number of concurrent 
+                        network requests. This is useful when troubleshooting 
+                        network failures.
   --debug-package-manager
                         Activates verbose logging for the package manager. 
                         You will probably want to pipe the output of Rush to 
@@ -396,7 +400,8 @@ Optional arguments:
 
 exports[`CommandLineHelp prints the help for "rush update" 1`] = `
 "usage: rush update [-h] [-p] [--bypass-policy] [--no-link]
-                   [--debug-package-manager] [--full] [--recheck]
+                   [--network-concurrency COUNT] [--debug-package-manager]
+                   [--full] [--recheck]
                    
 
 The \\"rush update\\" command installs the dependencies described in your package.
@@ -421,6 +426,10 @@ Optional arguments:
                         is useful for automated builds that want to report 
                         stages individually or perform extra operations in 
                         between the two stages.
+  --network-concurrency COUNT
+                        If specified, limits the maximum number of concurrent 
+                        network requests. This is useful when troubleshooting 
+                        network failures.
   --debug-package-manager
                         Activates verbose logging for the package manager. 
                         You will probably want to pipe the output of Rush to 

--- a/apps/rush-lib/src/logic/InstallManager.ts
+++ b/apps/rush-lib/src/logic/InstallManager.ts
@@ -83,6 +83,8 @@ export interface IInstallManagerOptions {
   /**
    * The value of the "--network-concurrency" command-line parameter, which
    * is a diagnostic option used to troubleshoot network failures.
+   *
+   * Currently only supported for PNPM.
    */
   networkConcurrency: number | undefined;
 
@@ -778,6 +780,12 @@ export class InstallManager {
 
           console.log(os.EOL + colors.bold(`Running "${this._rushConfiguration.packageManager} install" in`
             + ` ${this._rushConfiguration.commonTempFolder}`) + os.EOL);
+
+          if (options.collectLogFile || options.networkConcurrency) {
+            // Show the full command-line when diagnostic options are specified
+            console.log(os.EOL + colors.green('Invoking package manager: ')
+              + FileSystem.getRealPath(packageManagerFilename) + ' ' + installArgs.join(' ') + os.EOL);
+          }
 
           Utilities.executeCommandWithRetry(MAX_INSTALL_ATTEMPTS, packageManagerFilename,
             installArgs,

--- a/apps/rush-lib/src/logic/InstallManager.ts
+++ b/apps/rush-lib/src/logic/InstallManager.ts
@@ -79,6 +79,13 @@ export interface IInstallManagerOptions {
    * (pnpmfile.js script logic, registry changes, etc).
    */
   recheckShrinkwrap: boolean;
+
+  /**
+   * The value of the "--network-concurrency" command-line parameter, which
+   * is a diagnostic option used to troubleshoot network failures.
+   */
+  networkConcurrency: number | undefined;
+
   /**
    * Whether or not to collect verbose logs from the package manager.
    * If specified when using PNPM, the logs will be in /common/temp/pnpm.log
@@ -239,8 +246,7 @@ export class InstallManager {
             }
           }
 
-          return this._installCommonModules(shrinkwrapIsUpToDate,
-            options.allowShrinkwrapUpdates, options.collectLogFile)
+          return this._installCommonModules(shrinkwrapIsUpToDate, options)
             .then(() => {
               if (!options.noLink) {
                 const linkManager: BaseLinkManager = LinkManagerFactory.getLinkManager(this._rushConfiguration);
@@ -616,10 +622,7 @@ export class InstallManager {
   /**
    * Runs "npm install" in the common folder.
    */
-  private _installCommonModules(
-    shrinkwrapIsUpToDate: boolean,
-    allowShrinkwrapUpdates: boolean,
-    collectLogFile: boolean): Promise<void> {
+  private _installCommonModules(shrinkwrapIsUpToDate: boolean, options: IInstallManagerOptions): Promise<void> {
     return Promise.resolve().then(() => {
       console.log(os.EOL + colors.bold('Checking node_modules in ' + this._rushConfiguration.commonTempFolder)
         + os.EOL);
@@ -726,7 +729,7 @@ export class InstallManager {
                 console.log(`Running "${this._rushConfiguration.packageManager} prune"`
                   + ` in ${this._rushConfiguration.commonTempFolder}`);
                 const args: string[] = ['prune'];
-                this._pushConfigurationArgs(args, collectLogFile);
+                this._pushConfigurationArgs(args, options);
 
                 Utilities.executeCommandWithRetry(MAX_INSTALL_ATTEMPTS, packageManagerFilename, args,
                   this._rushConfiguration.commonTempFolder);
@@ -771,7 +774,7 @@ export class InstallManager {
           // people would have different node_modules based on their system.
 
           const installArgs: string[] = ['install', '--no-optional'];
-          this._pushConfigurationArgs(installArgs, collectLogFile);
+          this._pushConfigurationArgs(installArgs, options);
 
           console.log(os.EOL + colors.bold(`Running "${this._rushConfiguration.packageManager} install" in`
             + ` ${this._rushConfiguration.commonTempFolder}`) + os.EOL);
@@ -799,7 +802,7 @@ export class InstallManager {
 
             console.log(os.EOL + colors.bold('Running "npm shrinkwrap"...'));
             const npmArgs: string[] = ['shrinkwrap'];
-            this._pushConfigurationArgs(npmArgs, collectLogFile);
+            this._pushConfigurationArgs(npmArgs, options);
             Utilities.executeCommand(this._rushConfiguration.packageManagerToolFilename,
               npmArgs, this._rushConfiguration.commonTempFolder);
             console.log('"npm shrinkwrap" completed' + os.EOL);
@@ -807,7 +810,7 @@ export class InstallManager {
             this._fixupNpm5Regression();
           }
 
-          if (allowShrinkwrapUpdates && !shrinkwrapIsUpToDate) {
+          if (options.allowShrinkwrapUpdates && !shrinkwrapIsUpToDate) {
             // Copy (or delete) common\temp\shrinkwrap.yaml --> common\config\rush\shrinkwrap.yaml
             this._syncFile(this._rushConfiguration.tempShrinkwrapFilename,
               this._rushConfiguration.committedShrinkwrapFilename);
@@ -939,12 +942,12 @@ export class InstallManager {
    * Used when invoking the NPM tool.  Appends the common configuration options
    * to the command-line.
    */
-  private _pushConfigurationArgs(args: string[], collectLogFile: boolean): void {
+  private _pushConfigurationArgs(args: string[], options: IInstallManagerOptions): void {
     if (this._rushConfiguration.packageManager === 'npm') {
       args.push('--cache', this._rushConfiguration.npmCacheFolder);
       args.push('--tmp', this._rushConfiguration.npmTmpFolder);
 
-      if (collectLogFile) {
+      if (options.collectLogFile) {
         args.push('--verbose');
       }
     } else if (this._rushConfiguration.packageManager === 'pnpm') {
@@ -957,8 +960,12 @@ export class InstallManager {
       // last install flag, which encapsulates the entire installation
       args.push('--no-lock');
 
-      if (collectLogFile) {
+      if (options.collectLogFile) {
         args.push('--reporter', 'ndjson');
+      }
+
+      if (options.networkConcurrency) {
+        args.push('--network-concurrency', options.networkConcurrency.toString());
       }
     }
   }

--- a/common/changes/@microsoft/rush/pgonzal-rush-network-concurrency_2018-08-10-18-17.json
+++ b/common/changes/@microsoft/rush/pgonzal-rush-network-concurrency_2018-08-10-18-17.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Add a \"--network-concurrency\" command-line option to help troubleshoot the ECONNRESET error that people occasionally have reported ( https://github.com/pnpm/pnpm/issues/1230 )",
+      "packageName": "@microsoft/rush",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "pgonzal@users.noreply.github.com"
+}


### PR DESCRIPTION
People have occasionally been reporting "integrity checksum failed" errors during PNPM install, which result from an ECONNRESET error that seems to be related to an issue with the network connection pool.  (See https://github.com/pnpm/pnpm/issues/1230 for details.)

We found that specifying PNPM's `--network-concurrency 1` option eliminates the error (but increases install times).  This PR exposes this switch to `rush install` so we can use it as a workaround.  We will experiment with different values and perhaps propose applying a default maximum for the PNPM tool.