### PR TITLE
Add an api on CommonVersionsConfiguration to get the filepath

### DIFF
--- a/apps/rush-lib/src/api/CommonVersionsConfiguration.ts
+++ b/apps/rush-lib/src/api/CommonVersionsConfiguration.ts
@@ -96,8 +96,11 @@ export class CommonVersionsConfiguration {
   /**
    * Writes the "common-versions.json" file to disk, using the filename that was passed to loadFromFile().
    */
-  public save(): void {
+  public save(): { filePath: string } {
     JsonFile.save(this._serialize(), this._filename);
+    return {
+      filePath: this._filename
+    }
   }
 
   /**

--- a/apps/rush-lib/src/api/CommonVersionsConfiguration.ts
+++ b/apps/rush-lib/src/api/CommonVersionsConfiguration.ts
@@ -94,13 +94,17 @@ export class CommonVersionsConfiguration {
   }
 
   /**
+   * Get the absolute file path of the common-versions.json file.
+   */
+  public get filepath(): string {
+    return this._filename;
+  }
+
+  /**
    * Writes the "common-versions.json" file to disk, using the filename that was passed to loadFromFile().
    */
-  public save(): { filePath: string } {
+  public save(): void {
     JsonFile.save(this._serialize(), this._filename);
-    return {
-      filePath: this._filename
-    }
   }
 
   /**

--- a/common/changes/@microsoft/rush/nickpape-add-missing-api_2018-08-21-22-25.json
+++ b/common/changes/@microsoft/rush/nickpape-add-missing-api_2018-08-21-22-25.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "git st",
+      "packageName": "@microsoft/rush",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": ""
+}

--- a/common/reviews/api/rush-lib.api.ts
+++ b/common/reviews/api/rush-lib.api.ts
@@ -64,6 +64,7 @@ class ChangeManager {
 // @public
 class CommonVersionsConfiguration {
   readonly allowedAlternativeVersions: Map<string, ReadonlyArray<string>>;
+  readonly filepath: string;
   getAllPreferredVersions(): Map<string, string>;
   static loadFromFile(jsonFilename: string): CommonVersionsConfiguration;
   readonly preferredVersions: Map<string, string>;


### PR DESCRIPTION
This is needed for some internal tooling which commits this file to Git, and therefore needs to know the filepath.