### PR TITLE
[rush] Fix capitalization of CommonVersionsConfiguration.filePath

### DIFF
--- a/apps/rush-lib/src/api/ChangeFile.ts
+++ b/apps/rush-lib/src/api/ChangeFile.ts
@@ -63,7 +63,7 @@ export class ChangeFile {
 
   /**
    * Writes the change file to disk in sync mode.
-   * Returns the filepath.
+   * Returns the file path.
    * @returns the path to the file that was written (based on generatePath())
    */
   public writeSync(): string {

--- a/apps/rush-lib/src/api/CommonVersionsConfiguration.ts
+++ b/apps/rush-lib/src/api/CommonVersionsConfiguration.ts
@@ -56,7 +56,7 @@ export class CommonVersionsConfiguration {
   private static _jsonSchema: JsonSchema = JsonSchema.fromFile(
     path.join(__dirname, '../schemas/common-versions.schema.json'));
 
-  private _filename: string;
+  private _filePath: string;
   private _preferredVersions: ProtectableMap<string, string>;
   private _xstitchPreferredVersions: ProtectableMap<string, string>;
   private _allowedAlternativeVersions: ProtectableMap<string, string[]>;
@@ -99,15 +99,15 @@ export class CommonVersionsConfiguration {
   /**
    * Get the absolute file path of the common-versions.json file.
    */
-  public get filepath(): string {
-    return this._filename;
+  public get filePath(): string {
+    return this._filePath;
   }
 
   /**
    * Writes the "common-versions.json" file to disk, using the filename that was passed to loadFromFile().
    */
   public save(): void {
-    JsonFile.save(this._serialize(), this._filename, { updateExistingFile: true });
+    JsonFile.save(this._serialize(), this._filePath, { updateExistingFile: true });
   }
 
   /**
@@ -173,7 +173,7 @@ export class CommonVersionsConfiguration {
     return allPreferredVersions;
   }
 
-  private constructor(commonVersionsJson: ICommonVersionsJson | undefined, filename: string) {
+  private constructor(commonVersionsJson: ICommonVersionsJson | undefined, filePath: string) {
     this._preferredVersions = new ProtectableMap<string, string>(
       { onSet: this._onSetPreferredVersions.bind(this) });
 
@@ -192,10 +192,10 @@ export class CommonVersionsConfiguration {
         CommonVersionsConfiguration._deserializeTable(this.allowedAlternativeVersions,
           commonVersionsJson.allowedAlternativeVersions);
       } catch (e) {
-        throw new Error(`Error loading "${path.basename(filename)}": ${e.message}`);
+        throw new Error(`Error loading "${path.basename(filePath)}": ${e.message}`);
       }
     }
-    this._filename = filename;
+    this._filePath = filePath;
   }
 
   private _onSetPreferredVersions(source: ProtectableMap<string, string>, key: string, value: string): string {

--- a/apps/rush-lib/src/api/RushConfiguration.ts
+++ b/apps/rush-lib/src/api/RushConfiguration.ts
@@ -28,7 +28,7 @@ const knownRushConfigFilenames: string[] = [
   RushConstants.commonVersionsFilename,
   RushConstants.browserApprovedPackagesFilename,
   RushConstants.nonbrowserApprovedPackagesFilename,
-  RushConstants.versionPoliciesFileName,
+  RushConstants.versionPoliciesFilename,
   RushConstants.commandLineFilename
 ];
 
@@ -772,7 +772,7 @@ export class RushConfiguration {
     }
 
     const versionPolicyConfigFile: string =
-      path.join(this._commonRushConfigFolder, RushConstants.versionPoliciesFileName);
+      path.join(this._commonRushConfigFolder, RushConstants.versionPoliciesFilename);
     this._versionPolicyConfiguration = new VersionPolicyConfiguration(versionPolicyConfigFile);
 
     this._projects = [];

--- a/apps/rush-lib/src/logic/PackageChangeAnalyzer.ts
+++ b/apps/rush-lib/src/logic/PackageChangeAnalyzer.ts
@@ -75,16 +75,16 @@ export class PackageChangeAnalyzer {
     }
 
     // Sort each project folder into its own package deps hash
-    Object.keys(repoDeps.files).forEach((filepath: string) => {
-      const fileHash: string = repoDeps.files[filepath];
+    Object.keys(repoDeps.files).forEach((filePath: string) => {
+      const fileHash: string = repoDeps.files[filePath];
 
-      const projectName: string | undefined = this._getProjectForFile(filepath);
+      const projectName: string | undefined = this._getProjectForFile(filePath);
 
       // If we found a project for the file, go ahead and store this file's hash
       if (projectName) {
-        projectHashDeps.get(projectName)!.files[filepath] = fileHash;
+        projectHashDeps.get(projectName)!.files[filePath] = fileHash;
       } else {
-        noProjectHashes[filepath] = fileHash;
+        noProjectHashes[filePath] = fileHash;
       }
     });
 
@@ -123,9 +123,9 @@ export class PackageChangeAnalyzer {
 
     // Add the "NO_PROJECT" files to every project's dependencies
     // for (const project of PackageChangeAnalyzer.rushConfig.projects) {
-    //  Object.keys(noProjectHashes).forEach((filepath: string) => {
-    //    const fileHash: string = noProjectHashes[filepath];
-    //    projectHashDeps.get(project.packageName).files[filepath] = fileHash;
+    //  Object.keys(noProjectHashes).forEach((filePath: string) => {
+    //    const fileHash: string = noProjectHashes[filePath];
+    //    projectHashDeps.get(project.packageName).files[filePath] = fileHash;
     //  });
     // }
 
@@ -145,9 +145,9 @@ export class PackageChangeAnalyzer {
     return projectHashDeps;
   }
 
-  private _getProjectForFile(filepath: string): string | undefined {
+  private _getProjectForFile(filePath: string): string | undefined {
     for (const project of this._rushConfiguration.projects) {
-      if (this._fileExistsInFolder(filepath, project.projectRelativeFolder)) {
+      if (this._fileExistsInFolder(filePath, project.projectRelativeFolder)) {
         return project.packageName;
       }
     }

--- a/apps/rush-lib/src/logic/RushConstants.ts
+++ b/apps/rush-lib/src/logic/RushConstants.ts
@@ -110,7 +110,7 @@ export namespace RushConstants {
   /**
    * @beta
    */
-  export const versionPoliciesFileName: string = 'version-policies.json';
+  export const versionPoliciesFilename: string = 'version-policies.json';
 
   /**
    * The URL ("http://rushjs.io") for the Rush web site.

--- a/common/changes/@microsoft/gulp-core-build-sass/pgonzal-filepath_2018-08-22-22-46.json
+++ b/common/changes/@microsoft/gulp-core-build-sass/pgonzal-filepath_2018-08-22-22-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@microsoft/gulp-core-build-sass",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/gulp-core-build-sass",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/gulp-core-build-typescript/pgonzal-filepath_2018-08-22-22-46.json
+++ b/common/changes/@microsoft/gulp-core-build-typescript/pgonzal-filepath_2018-08-22-22-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@microsoft/gulp-core-build-typescript",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/gulp-core-build-typescript",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/gulp-core-build/pgonzal-filepath_2018-08-22-22-46.json
+++ b/common/changes/@microsoft/gulp-core-build/pgonzal-filepath_2018-08-22-22-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@microsoft/gulp-core-build",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/gulp-core-build",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush/pgonzal-filepath_2018-08-22-22-46.json
+++ b/common/changes/@microsoft/rush/pgonzal-filepath_2018-08-22-22-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Fix capitalization of new \"filePath\" API property",
+      "packageName": "@microsoft/rush",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/reviews/api/rush-lib.api.ts
+++ b/common/reviews/api/rush-lib.api.ts
@@ -64,7 +64,7 @@ class ChangeManager {
 // @public
 class CommonVersionsConfiguration {
   readonly allowedAlternativeVersions: Map<string, ReadonlyArray<string>>;
-  readonly filepath: string;
+  readonly filePath: string;
   getAllPreferredVersions(): Map<string, string>;
   static loadFromFile(jsonFilename: string): CommonVersionsConfiguration;
   readonly preferredVersions: Map<string, string>;

--- a/core-build/gulp-core-build-sass/src/SassTask.ts
+++ b/core-build/gulp-core-build-sass/src/SassTask.ts
@@ -111,8 +111,8 @@ export class SassTask extends GulpTask<ISassTaskConfig> {
     const checkFilenameForCSSModule: (file: gulpUtil.File) => void = (file: gulpUtil.File) => {
       if (!path.basename(file.path).match(/module\.scss$/)) {
 
-        const filepath: string = path.relative(this.buildConfig.rootPath, file.path);
-        this.logWarning(`${filepath}: filename should end with module.scss`);
+        const filePath: string = path.relative(this.buildConfig.rootPath, file.path);
+        this.logWarning(`${filePath}: filename should end with module.scss`);
       }
     };
 

--- a/core-build/gulp-core-build-typescript/src/TSLintTask.ts
+++ b/core-build/gulp-core-build-typescript/src/TSLintTask.ts
@@ -139,7 +139,7 @@ export class TSLintTask extends GulpTask<ITSLintTaskConfig> {
 
     const lintRulesFile: ITSLintRulesFile = self._loadLintConfiguration();
 
-    JsonFile.save(lintRulesFile, this._getTsLintFilepath(), { ensureFolderExists: true });
+    JsonFile.save(lintRulesFile, this._getTsLintFilePath(), { ensureFolderExists: true });
 
     const cached = require('gulp-cache'); // tslint:disable-line
 
@@ -243,7 +243,7 @@ export class TSLintTask extends GulpTask<ITSLintTaskConfig> {
     }
   }
 
-  private _getTsLintFilepath(): string {
+  private _getTsLintFilePath(): string {
     return path.join(this.buildConfig.rootPath, this.buildConfig.tempFolder, 'tslint.json');
   }
 

--- a/core-build/gulp-core-build/src/utilities/FileDeletionUtility.ts
+++ b/core-build/gulp-core-build/src/utilities/FileDeletionUtility.ts
@@ -16,10 +16,10 @@ export class FileDeletionUtility {
   }
 
   public static deleteFiles(files: string[]) {
-    del.sync(this.escapeFilepaths(this.removeChildren(files)));
+    del.sync(this.escapeFilePaths(this.removeChildren(files)));
   }
 
-  public static escapeFilepaths(files: string[]): string[] {
+  public static escapeFilePaths(files: string[]): string[] {
     return files.map((file: string) => {
       return globEscape(file);
     });
@@ -56,13 +56,13 @@ export class FileDeletionUtility {
     return filesToDelete;
   }
 
-  public static isParentDirectory(directory: string | undefined, filepath: string | undefined): boolean {
-    if (!directory || !filepath) {
+  public static isParentDirectory(directory: string | undefined, filePath: string | undefined): boolean {
+    if (!directory || !filePath) {
       return false;
     }
 
     const directoryParts: string[] = path.resolve(directory).split(path.sep);
-    const fileParts: string[] = path.resolve(filepath).split(path.sep);
+    const fileParts: string[] = path.resolve(filePath).split(path.sep);
 
     if (directoryParts[directoryParts.length - 1] === '') {
       // this is to fix an issue with windows roots


### PR DESCRIPTION
"Filename" is a common English word that appears in dictionaries.  "Filepath" is not.

Thus `fileName` and `filename` are both acceptable casings, but a file path must always be capitalized as `filePath`.