### PR TITLE
Republish packages to resolve GitHub issue #782

### DIFF
--- a/common/changes/@microsoft/api-documenter/pgonzal-republish-bad-packages_2018-08-23-18-07.json
+++ b/common/changes/@microsoft/api-documenter/pgonzal-republish-bad-packages_2018-08-23-18-07.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-documenter",
+      "comment": "Republish all packages in web-build-tools to resolve GitHub issue #782",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/api-documenter",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/api-extractor/pgonzal-republish-bad-packages_2018-08-23-18-07.json
+++ b/common/changes/@microsoft/api-extractor/pgonzal-republish-bad-packages_2018-08-23-18-07.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor",
+      "comment": "Republish all packages in web-build-tools to resolve GitHub issue #782",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/gulp-core-build-karma/pgonzal-republish-bad-packages_2018-08-23-18-07.json
+++ b/common/changes/@microsoft/gulp-core-build-karma/pgonzal-republish-bad-packages_2018-08-23-18-07.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/gulp-core-build-karma",
+      "comment": "Republish all packages in web-build-tools to resolve GitHub issue #782",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/gulp-core-build-karma",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/gulp-core-build-mocha/pgonzal-republish-bad-packages_2018-08-23-18-07.json
+++ b/common/changes/@microsoft/gulp-core-build-mocha/pgonzal-republish-bad-packages_2018-08-23-18-07.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/gulp-core-build-mocha",
+      "comment": "Republish all packages in web-build-tools to resolve GitHub issue #782",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/gulp-core-build-mocha",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/gulp-core-build-sass/pgonzal-republish-bad-packages_2018-08-23-18-07.json
+++ b/common/changes/@microsoft/gulp-core-build-sass/pgonzal-republish-bad-packages_2018-08-23-18-07.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/gulp-core-build-sass",
+      "comment": "Republish all packages in web-build-tools to resolve GitHub issue #782",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/gulp-core-build-sass",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/gulp-core-build-serve/pgonzal-republish-bad-packages_2018-08-23-18-07.json
+++ b/common/changes/@microsoft/gulp-core-build-serve/pgonzal-republish-bad-packages_2018-08-23-18-07.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/gulp-core-build-serve",
+      "comment": "Republish all packages in web-build-tools to resolve GitHub issue #782",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/gulp-core-build-serve",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/gulp-core-build-typescript/pgonzal-republish-bad-packages_2018-08-23-18-07.json
+++ b/common/changes/@microsoft/gulp-core-build-typescript/pgonzal-republish-bad-packages_2018-08-23-18-07.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/gulp-core-build-typescript",
+      "comment": "Republish all packages in web-build-tools to resolve GitHub issue #782",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/gulp-core-build-typescript",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/gulp-core-build-webpack/pgonzal-republish-bad-packages_2018-08-23-18-07.json
+++ b/common/changes/@microsoft/gulp-core-build-webpack/pgonzal-republish-bad-packages_2018-08-23-18-07.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/gulp-core-build-webpack",
+      "comment": "Republish all packages in web-build-tools to resolve GitHub issue #782",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/gulp-core-build-webpack",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/gulp-core-build/pgonzal-republish-bad-packages_2018-08-23-18-07.json
+++ b/common/changes/@microsoft/gulp-core-build/pgonzal-republish-bad-packages_2018-08-23-18-07.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/gulp-core-build",
+      "comment": "Republish all packages in web-build-tools to resolve GitHub issue #782",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/gulp-core-build",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/load-themed-styles/pgonzal-republish-bad-packages_2018-08-23-18-07.json
+++ b/common/changes/@microsoft/load-themed-styles/pgonzal-republish-bad-packages_2018-08-23-18-07.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/load-themed-styles",
+      "comment": "Republish all packages in web-build-tools to resolve GitHub issue #782",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/load-themed-styles",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/loader-load-themed-styles/pgonzal-republish-bad-packages_2018-08-23-18-07.json
+++ b/common/changes/@microsoft/loader-load-themed-styles/pgonzal-republish-bad-packages_2018-08-23-18-07.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/loader-load-themed-styles",
+      "comment": "Republish all packages in web-build-tools to resolve GitHub issue #782",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/loader-load-themed-styles",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/loader-raw-script/pgonzal-republish-bad-packages_2018-08-23-18-07.json
+++ b/common/changes/@microsoft/loader-raw-script/pgonzal-republish-bad-packages_2018-08-23-18-07.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/loader-raw-script",
+      "comment": "Republish all packages in web-build-tools to resolve GitHub issue #782",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/loader-raw-script",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/loader-set-webpack-public-path/pgonzal-republish-bad-packages_2018-08-23-18-07.json
+++ b/common/changes/@microsoft/loader-set-webpack-public-path/pgonzal-republish-bad-packages_2018-08-23-18-07.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/loader-set-webpack-public-path",
+      "comment": "Republish all packages in web-build-tools to resolve GitHub issue #782",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/loader-set-webpack-public-path",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/node-core-library/pgonzal-republish-bad-packages_2018-08-23-18-07.json
+++ b/common/changes/@microsoft/node-core-library/pgonzal-republish-bad-packages_2018-08-23-18-07.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/node-core-library",
+      "comment": "Republish all packages in web-build-tools to resolve GitHub issue #782",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/node-core-library",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/node-library-build/pgonzal-republish-bad-packages_2018-08-23-18-07.json
+++ b/common/changes/@microsoft/node-library-build/pgonzal-republish-bad-packages_2018-08-23-18-07.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/node-library-build",
+      "comment": "Republish all packages in web-build-tools to resolve GitHub issue #782",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/node-library-build",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/package-deps-hash/pgonzal-republish-bad-packages_2018-08-23-18-07.json
+++ b/common/changes/@microsoft/package-deps-hash/pgonzal-republish-bad-packages_2018-08-23-18-07.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/package-deps-hash",
+      "comment": "Republish all packages in web-build-tools to resolve GitHub issue #782",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/package-deps-hash",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/resolve-chunk-plugin/pgonzal-republish-bad-packages_2018-08-23-18-07.json
+++ b/common/changes/@microsoft/resolve-chunk-plugin/pgonzal-republish-bad-packages_2018-08-23-18-07.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/resolve-chunk-plugin",
+      "comment": "Republish all packages in web-build-tools to resolve GitHub issue #782",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/resolve-chunk-plugin",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush/pgonzal-republish-bad-packages_2018-08-23-18-07.json
+++ b/common/changes/@microsoft/rush/pgonzal-republish-bad-packages_2018-08-23-18-07.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@microsoft/rush",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/set-webpack-public-path-plugin/pgonzal-republish-bad-packages_2018-08-23-18-07.json
+++ b/common/changes/@microsoft/set-webpack-public-path-plugin/pgonzal-republish-bad-packages_2018-08-23-18-07.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/set-webpack-public-path-plugin",
+      "comment": "Republish all packages in web-build-tools to resolve GitHub issue #782",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/set-webpack-public-path-plugin",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/stream-collator/pgonzal-republish-bad-packages_2018-08-23-18-07.json
+++ b/common/changes/@microsoft/stream-collator/pgonzal-republish-bad-packages_2018-08-23-18-07.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/stream-collator",
+      "comment": "Republish all packages in web-build-tools to resolve GitHub issue #782",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/stream-collator",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/ts-command-line/pgonzal-republish-bad-packages_2018-08-23-18-07.json
+++ b/common/changes/@microsoft/ts-command-line/pgonzal-republish-bad-packages_2018-08-23-18-07.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/ts-command-line",
+      "comment": "Republish all packages in web-build-tools to resolve GitHub issue #782",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/ts-command-line",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/web-library-build/pgonzal-republish-bad-packages_2018-08-23-18-07.json
+++ b/common/changes/@microsoft/web-library-build/pgonzal-republish-bad-packages_2018-08-23-18-07.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/web-library-build",
+      "comment": "Republish all packages in web-build-tools to resolve GitHub issue #782",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/web-library-build",
+  "email": "pgonzal@users.noreply.github.com"
+}


### PR DESCRIPTION
Due to a misconfigured CI build definition, we accidentally published empty NPM packages for some projects in this repo.

See https://github.com/Microsoft/web-build-tools/issues/782 for details.

@qz2017 