### PR TITLE
[node-core-library] Improve FileSystem API to eliminate confusion about "source" and "target" parameters

### DIFF
--- a/apps/rush-lib/src/cli/actions/PublishAction.ts
+++ b/apps/rush-lib/src/cli/actions/PublishAction.ts
@@ -388,7 +388,11 @@ export class PublishAction extends BaseRushAction {
       const destFolder: string = this._releaseFolder.value ?
        this._releaseFolder.value : path.join(this.rushConfiguration.commonTempFolder, 'artifacts', 'packages');
 
-      FileSystem.move(tarballPath, path.join(destFolder, tarballName), { overwrite: true });
+      FileSystem.move({
+        sourcePath: tarballPath,
+        destinationPath: path.join(destFolder, tarballName),
+        overwrite: true
+      });
     }
   }
 
@@ -417,7 +421,10 @@ export class PublishAction extends BaseRushAction {
           const toApiFolderPath: string = path.join(project.projectFolder, toApiFolder);
           if (FileSystem.exists(fromApiFolderPath) && FileSystem.exists(toApiFolderPath)) {
             FileSystem.readFolder(fromApiFolderPath).forEach(fileName => {
-              FileSystem.copyFile(path.join(fromApiFolderPath, fileName), path.join(toApiFolderPath, fileName));
+              FileSystem.copyFile({
+                sourcePath: path.join(fromApiFolderPath, fileName),
+                destinationPath: path.join(toApiFolderPath, fileName)
+              });
               console.log(`Copied file ${fileName} from ${fromApiFolderPath} to ${toApiFolderPath}`);
             });
           }

--- a/apps/rush-lib/src/logic/InstallManager.ts
+++ b/apps/rush-lib/src/logic/InstallManager.ts
@@ -334,8 +334,8 @@ export class InstallManager {
       }
 
       FileSystem.createSymbolicLinkJunction({
-        newLinkPath: localPackageManagerToolFolder,
-        linkTargetPath: packageManagerToolFolder
+        linkTargetPath: packageManagerToolFolder,
+        newLinkPath: localPackageManagerToolFolder
       });
 
       lock.release();

--- a/apps/rush-lib/src/logic/InstallManager.ts
+++ b/apps/rush-lib/src/logic/InstallManager.ts
@@ -334,7 +334,7 @@ export class InstallManager {
       }
 
       FileSystem.createSymbolicLinkJunction({
-        linkPath: localPackageManagerToolFolder,
+        newLinkPath: localPackageManagerToolFolder,
         linkTargetPath: packageManagerToolFolder
       });
 

--- a/apps/rush-lib/src/logic/InstallManager.ts
+++ b/apps/rush-lib/src/logic/InstallManager.ts
@@ -333,7 +333,10 @@ export class InstallManager {
         }
       }
 
-      FileSystem.createSymbolicLinkJunction(packageManagerToolFolder, localPackageManagerToolFolder);
+      FileSystem.createSymbolicLinkJunction({
+        linkPath: localPackageManagerToolFolder,
+        linkTargetPath: packageManagerToolFolder
+      });
 
       lock.release();
     });
@@ -976,17 +979,17 @@ export class InstallManager {
   }
 
   /**
-   * Copies the file "sourcePath" to "targetPath", overwriting the target file location.
+   * Copies the file "sourcePath" to "destinationPath", overwriting the target file location.
    * If the source file does not exist, then the target file is deleted.
    */
-  private _syncFile(sourcePath: string, targetPath: string): void {
+  private _syncFile(sourcePath: string, destinationPath: string): void {
     if (FileSystem.exists(sourcePath)) {
-      console.log('Updating ' + targetPath);
-      FileSystem.copyFile(sourcePath, targetPath);
+      console.log('Updating ' + destinationPath);
+      FileSystem.copyFile({sourcePath, destinationPath});
     } else {
-      if (FileSystem.exists(targetPath)) {
-        console.log('Deleting ' + targetPath);
-        FileSystem.deleteFile(targetPath);
+      if (FileSystem.exists(destinationPath)) {
+        console.log('Deleting ' + destinationPath);
+        FileSystem.deleteFile(destinationPath);
       }
     }
   }

--- a/apps/rush-lib/src/logic/StandardScriptUpdater.ts
+++ b/apps/rush-lib/src/logic/StandardScriptUpdater.ts
@@ -74,7 +74,10 @@ export class StandardScriptUpdater {
           + ' for this Rush version.  Please run "rush update" and commit the changes.');
       } else {
         console.log(`Script is out of date; updating "${targetFilePath}"`);
-        FileSystem.copyFile(sourceFilePath, targetFilePath);
+        FileSystem.copyFile({
+          sourcePath: sourceFilePath,
+          destinationPath: targetFilePath
+        });
       }
     }
 

--- a/apps/rush-lib/src/logic/base/BaseLinkManager.ts
+++ b/apps/rush-lib/src/logic/base/BaseLinkManager.ts
@@ -26,13 +26,13 @@ export abstract class BaseLinkManager {
   protected _rushConfiguration: RushConfiguration;
 
   protected static _createSymlink(options: IBaseLinkManagerCreateSymlinkOptions): void {
-    FileSystem.ensureFolder(path.dirname(options.linkPath));
+    FileSystem.ensureFolder(path.dirname(options.newLinkPath));
 
     if (options.symlinkKind === SymlinkKind.Directory) {
       // For directories, we use a Windows "junction".  On Unix, this produces a regular symlink.
       FileSystem.createSymbolicLinkJunction({
         linkTargetPath: options.linkTargetPath,
-        linkPath: options.linkPath
+        newLinkPath: options.newLinkPath
     });
     } else {
       if (process.platform === 'win32') {
@@ -40,14 +40,14 @@ export abstract class BaseLinkManager {
         // administrator permission.
         FileSystem.createHardLink({
           linkTargetPath: options.linkTargetPath,
-          linkPath: options.linkPath
+          newLinkPath: options.newLinkPath
         });
       } else {
         // However hard links seem to cause build failures on Mac, so for all other operating systems
         // we use symbolic links for this case.
         FileSystem.createSymbolicLinkFile({
           linkTargetPath: options.linkTargetPath,
-          linkPath: options.linkPath
+          newLinkPath: options.newLinkPath
         });
       }
     }
@@ -106,7 +106,7 @@ export abstract class BaseLinkManager {
       // If there are no children, then we can symlink the entire folder
       BaseLinkManager._createSymlink({
         linkTargetPath: localPackage.symlinkTargetFolderPath,
-        linkPath: localPackage.folderPath,
+        newLinkPath: localPackage.folderPath,
         symlinkKind: SymlinkKind.Directory
       });
     } else {
@@ -142,7 +142,7 @@ export abstract class BaseLinkManager {
 
           BaseLinkManager._createSymlink({
             linkTargetPath: linkTarget,
-            linkPath: linkSource,
+            newLinkPath: linkSource,
             symlinkKind
           });
         }

--- a/apps/rush-lib/src/logic/base/BaseLinkManager.ts
+++ b/apps/rush-lib/src/logic/base/BaseLinkManager.ts
@@ -31,24 +31,24 @@ export abstract class BaseLinkManager {
     if (options.symlinkKind === SymlinkKind.Directory) {
       // For directories, we use a Windows "junction".  On Unix, this produces a regular symlink.
       FileSystem.createSymbolicLinkJunction({
-        linkPath: options.linkPath,
-        linkTargetPath: options.linkTargetPath
-      });
+        linkTargetPath: options.linkTargetPath,
+        linkPath: options.linkPath
+    });
     } else {
       if (process.platform === 'win32') {
         // For files, we use a Windows "hard link", because creating a symbolic link requires
         // administrator permission.
         FileSystem.createHardLink({
-          linkPath: options.linkPath,
-          linkTargetPath: options.linkTargetPath
-          });
+          linkTargetPath: options.linkTargetPath,
+          linkPath: options.linkPath
+        });
       } else {
         // However hard links seem to cause build failures on Mac, so for all other operating systems
         // we use symbolic links for this case.
         FileSystem.createSymbolicLinkFile({
-          linkPath: options.linkPath,
-          linkTargetPath: options.linkTargetPath
-          });
+          linkTargetPath: options.linkTargetPath,
+          linkPath: options.linkPath
+        });
       }
     }
   }
@@ -105,8 +105,8 @@ export abstract class BaseLinkManager {
     if (localPackage.children.length === 0) {
       // If there are no children, then we can symlink the entire folder
       BaseLinkManager._createSymlink({
-        linkPath: localPackage.symlinkTargetFolderPath,
-        linkTargetPath: localPackage.folderPath,
+        linkTargetPath: localPackage.symlinkTargetFolderPath,
+        linkPath: localPackage.folderPath,
         symlinkKind: SymlinkKind.Directory
       });
     } else {
@@ -141,8 +141,8 @@ export abstract class BaseLinkManager {
           }
 
           BaseLinkManager._createSymlink({
-            linkPath: linkSource,
             linkTargetPath: linkTarget,
+            linkPath: linkSource,
             symlinkKind
           });
         }

--- a/apps/rush-lib/src/logic/npm/NpmLinkManager.ts
+++ b/apps/rush-lib/src/logic/npm/NpmLinkManager.ts
@@ -325,7 +325,7 @@ export class NpmLinkManager extends BaseLinkManager {
 
       if (FileSystem.exists(commonBinFolder)) {
         NpmLinkManager._createSymlink({
-          linkPath: projectBinFolder,
+          newLinkPath: projectBinFolder,
           linkTargetPath: commonBinFolder,
           symlinkKind: SymlinkKind.Directory
         });

--- a/apps/rush-lib/src/logic/npm/NpmLinkManager.ts
+++ b/apps/rush-lib/src/logic/npm/NpmLinkManager.ts
@@ -325,8 +325,8 @@ export class NpmLinkManager extends BaseLinkManager {
 
       if (FileSystem.exists(commonBinFolder)) {
         NpmLinkManager._createSymlink({
-          newLinkPath: projectBinFolder,
           linkTargetPath: commonBinFolder,
+          newLinkPath: projectBinFolder,
           symlinkKind: SymlinkKind.Directory
         });
       }

--- a/apps/rush-lib/src/logic/npm/NpmLinkManager.ts
+++ b/apps/rush-lib/src/logic/npm/NpmLinkManager.ts
@@ -324,7 +324,11 @@ export class NpmLinkManager extends BaseLinkManager {
       const projectBinFolder: string = path.join(localProjectPackage.folderPath, 'node_modules', '.bin');
 
       if (FileSystem.exists(commonBinFolder)) {
-        NpmLinkManager._createSymlink(commonBinFolder, projectBinFolder, SymlinkKind.Directory);
+        NpmLinkManager._createSymlink({
+          linkPath: projectBinFolder,
+          linkTargetPath: commonBinFolder,
+          symlinkKind: SymlinkKind.Directory
+        });
       }
     }
   }

--- a/apps/rush-lib/src/utilities/AsyncRecycler.ts
+++ b/apps/rush-lib/src/utilities/AsyncRecycler.ts
@@ -74,7 +74,7 @@ export class AsyncRecycler {
     }
 
     Utilities.retryUntilTimeout(
-      () => FileSystem.move(folderPath, newFolderPath),
+      () => FileSystem.move({ sourcePath: folderPath, destinationPath: newFolderPath }),
       maxWaitTimeMs,
       (e) => new Error(`Error: ${e}${os.EOL}Often this is caused by a file lock ` +
                       'from a process like the virus scanner.'),

--- a/common/changes/@microsoft/gulp-core-build/pgonzal-symlink-regression_2018-08-29-03-52.json
+++ b/common/changes/@microsoft/gulp-core-build/pgonzal-symlink-regression_2018-08-29-03-52.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/gulp-core-build",
+      "comment": "Update to use new node-core-library API",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/gulp-core-build",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/node-core-library/pgonzal-symlink-regression_2018-08-29-03-52.json
+++ b/common/changes/@microsoft/node-core-library/pgonzal-symlink-regression_2018-08-29-03-52.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/node-core-library",
+      "comment": "(Breaking API change) The FileSystem move/copy/createLink operations now require the source/target parameters to be explicitly specified, to avoid confusion",
+      "type": "major"
+    }
+  ],
+  "packageName": "@microsoft/node-core-library",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush/pgonzal-symlink-regression_2018-08-29-03-52.json
+++ b/common/changes/@microsoft/rush/pgonzal-symlink-regression_2018-08-29-03-52.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Fix regression causing \"ERROR: EEXIST: file already exists\"",
+      "packageName": "@microsoft/rush",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/reviews/api/node-core-library.api.ts
+++ b/common/reviews/api/node-core-library.api.ts
@@ -19,11 +19,11 @@ class FileDiffTest {
 // @public
 class FileSystem {
   static changePosixModeBits(path: string, mode: PosixModeBits): void;
-  static copyFile(sourcePath: string, destinationPath: string): void;
-  static createHardLink(linkTarget: string, linkSource: string): void;
-  static createSymbolicLinkFile(linkTarget: string, linkSource: string): void;
-  static createSymbolicLinkFolder(linkTarget: string, linkSource: string): void;
-  static createSymbolicLinkJunction(linkTarget: string, linkSource: string): void;
+  static copyFile(options: IFileSystemCopyFileOptions): void;
+  static createHardLink(options: IFileSystemCreateLinkOptions): void;
+  static createSymbolicLinkFile(options: IFileSystemCreateLinkOptions): void;
+  static createSymbolicLinkFolder(options: IFileSystemCreateLinkOptions): void;
+  static createSymbolicLinkJunction(options: IFileSystemCreateLinkOptions): void;
   static deleteFile(filePath: string, options?: IDeleteFileOptions): void;
   static deleteFolder(folderPath: string): void;
   static ensureEmptyFolder(folderPath: string): void;
@@ -34,7 +34,7 @@ class FileSystem {
   static getPosixModeBits(path: string): PosixModeBits;
   static getRealPath(linkPath: string): string;
   static getStatistics(path: string): fs.Stats;
-  static move(sourcePath: string, targetPath: string, options?: IFileSystemMoveOptions): void;
+  static move(options: IFileSystemMoveOptions): void;
   static readFile(filePath: string, options?: IReadFileOptions): string;
   static readFileToBuffer(filePath: string): Buffer;
   static readFolder(folderPath: string, options?: IReadFolderOptions): Array<string>;
@@ -75,9 +75,23 @@ interface IExecutableSpawnSyncOptions extends IExecutableResolveOptions {
 }
 
 // @public
+interface IFileSystemCopyFileOptions {
+  destinationPath: string;
+  sourcePath: string;
+}
+
+// @public
+interface IFileSystemCreateLinkOptions {
+  linkPath: string;
+  linkTargetPath: string;
+}
+
+// @public
 interface IFileSystemMoveOptions {
+  destinationPath: string;
   ensureFolderExists?: boolean;
   overwrite?: boolean;
+  sourcePath: string;
 }
 
 // @public

--- a/common/reviews/api/node-core-library.api.ts
+++ b/common/reviews/api/node-core-library.api.ts
@@ -77,8 +77,8 @@ interface IFileSystemCopyFileOptions {
 
 // @public
 interface IFileSystemCreateLinkOptions {
-  linkPath: string;
   linkTargetPath: string;
+  newLinkPath: string;
 }
 
 // @public

--- a/common/reviews/api/node-core-library.api.ts
+++ b/common/reviews/api/node-core-library.api.ts
@@ -24,7 +24,7 @@ class FileSystem {
   static createSymbolicLinkFile(options: IFileSystemCreateLinkOptions): void;
   static createSymbolicLinkFolder(options: IFileSystemCreateLinkOptions): void;
   static createSymbolicLinkJunction(options: IFileSystemCreateLinkOptions): void;
-  static deleteFile(filePath: string, options?: IDeleteFileOptions): void;
+  static deleteFile(filePath: string, options?: IFileSystemDeleteFileOptions): void;
   static deleteFolder(folderPath: string): void;
   static ensureEmptyFolder(folderPath: string): void;
   static ensureFolder(folderPath: string): void;
@@ -35,11 +35,11 @@ class FileSystem {
   static getRealPath(linkPath: string): string;
   static getStatistics(path: string): fs.Stats;
   static move(options: IFileSystemMoveOptions): void;
-  static readFile(filePath: string, options?: IReadFileOptions): string;
+  static readFile(filePath: string, options?: IFileSystemReadFileOptions): string;
   static readFileToBuffer(filePath: string): Buffer;
-  static readFolder(folderPath: string, options?: IReadFolderOptions): Array<string>;
-  static updateTimes(path: string, times: IUpdateTimeParameters): void;
-  static writeFile(filePath: string, contents: string | Buffer, options?: IWriteFileOptions): void;
+  static readFolder(folderPath: string, options?: IFileSystemReadFolderOptions): Array<string>;
+  static updateTimes(path: string, times: IFileSystemUpdateTimeParameters): void;
+  static writeFile(filePath: string, contents: string | Buffer, options?: IFileSystemWriteFileOptions): void;
 }
 
 // @public
@@ -53,11 +53,6 @@ class FileWriter {
 enum FolderConstants {
   Git = ".git",
   NodeModules = "node_modules"
-}
-
-// @public
-interface IDeleteFileOptions {
-  throwIfNotExists?: boolean;
 }
 
 // @beta
@@ -87,11 +82,40 @@ interface IFileSystemCreateLinkOptions {
 }
 
 // @public
+interface IFileSystemDeleteFileOptions {
+  throwIfNotExists?: boolean;
+}
+
+// @public
 interface IFileSystemMoveOptions {
   destinationPath: string;
   ensureFolderExists?: boolean;
   overwrite?: boolean;
   sourcePath: string;
+}
+
+// @public
+interface IFileSystemReadFileOptions {
+  convertLineEndings?: NewlineKind;
+  encoding?: Encoding;
+}
+
+// @public
+interface IFileSystemReadFolderOptions {
+  absolutePaths?: boolean;
+}
+
+// @public
+interface IFileSystemUpdateTimeParameters {
+  accessedTime: number | Date;
+  modifiedTime: number | Date;
+}
+
+// @public
+interface IFileSystemWriteFileOptions {
+  convertLineEndings?: NewlineKind;
+  encoding?: Encoding;
+  ensureFolderExists?: boolean;
 }
 
 // @public
@@ -185,30 +209,6 @@ interface IProtectableMapParameters<K, V> {
   onClear?: (source: ProtectableMap<K, V>) => void;
   onDelete?: (source: ProtectableMap<K, V>, key: K) => void;
   onSet?: (source: ProtectableMap<K, V>, key: K, value: V) => V;
-}
-
-// @public
-interface IReadFileOptions {
-  convertLineEndings?: NewlineKind;
-  encoding?: Encoding;
-}
-
-// @public
-interface IReadFolderOptions {
-  absolutePaths?: boolean;
-}
-
-// @public
-interface IUpdateTimeParameters {
-  accessedTime: number | Date;
-  modifiedTime: number | Date;
-}
-
-// @public
-interface IWriteFileOptions {
-  convertLineEndings?: NewlineKind;
-  encoding?: Encoding;
-  ensureFolderExists?: boolean;
 }
 
 // @public

--- a/core-build/gulp-core-build/src/tasks/GulpTask.ts
+++ b/core-build/gulp-core-build/src/tasks/GulpTask.ts
@@ -347,7 +347,10 @@ export abstract class GulpTask<TTaskConfig> implements IExecutable {
       this.buildConfig.rootPath,
       (localDestPath || path.basename(localSourcePath)));
 
-    FileSystem.copyFile(fullSourcePath, fullDestPath);
+    FileSystem.copyFile({
+      sourcePath: fullSourcePath,
+      destinationPath: fullDestPath
+    });
   }
 
   /**

--- a/core-build/gulp-core-build/src/tasks/JestTask.ts
+++ b/core-build/gulp-core-build/src/tasks/JestTask.ts
@@ -205,7 +205,10 @@ export class JestTask extends GulpTask<IJestConfig> {
     const testFileName: string = path.basename(snapDestFile, '.snap');
     const testFile: string = path.resolve(path.dirname(snapDestFile), '..', testFileName); // Up from `__snapshots__`.
     if (FileSystem.exists(testFile)) {
-      FileSystem.copyFile(snapSourceFile, snapDestFile);
+      FileSystem.copyFile({
+        sourcePath: snapSourceFile,
+        destinationPath: snapDestFile
+      });
       return true;
     } else {
       return false;

--- a/libraries/node-core-library/src/Executable.ts
+++ b/libraries/node-core-library/src/Executable.ts
@@ -5,7 +5,8 @@ import * as child_process from 'child_process';
 import * as os from 'os';
 import * as path from 'path';
 
-import { FileSystem, PosixModeBits } from './FileSystem';
+import { FileSystem } from './FileSystem';
+import { PosixModeBits } from './PosixModeBits';
 
 /**
  * Typings for one of the streams inside IExecutableSpawnSyncOptions.stdio.

--- a/libraries/node-core-library/src/FileDiffTest.ts
+++ b/libraries/node-core-library/src/FileDiffTest.ts
@@ -5,7 +5,8 @@ import * as path from 'path';
 
 import { PackageJsonLookup } from './PackageJsonLookup';
 import { Text } from './Text';
-import { FileSystem, PosixModeBits } from './FileSystem';
+import { FileSystem } from './FileSystem';
+import { PosixModeBits } from './PosixModeBits';
 
 /**
  * Implements a unit testing strategy that generates output files, and then

--- a/libraries/node-core-library/src/FileDiffTest.ts
+++ b/libraries/node-core-library/src/FileDiffTest.ts
@@ -77,7 +77,10 @@ export class FileDiffTest {
         throw new Error('The FileDiffTest failed, but the expected output cannot be copied because'
           + ' the file already exists:\n' + expectedCopyFilename);
       }
-      FileSystem.copyFile(expectedFilePath, expectedCopyFilename);
+      FileSystem.copyFile({
+        sourcePath: expectedFilePath,
+        destinationPath: expectedCopyFilename
+      });
 
       // Set to read-only so that developer doesn't accidentally modify the wrong file
       FileSystem.changePosixModeBits(expectedCopyFilename, PosixModeBits.AllRead);

--- a/libraries/node-core-library/src/FileSystem.ts
+++ b/libraries/node-core-library/src/FileSystem.ts
@@ -5,107 +5,11 @@ import * as pathUtilities from 'path';
 import * as fs from 'fs';
 import * as fsx from 'fs-extra';
 
-import { Text, NewlineKind } from './Text';
+import { Text, NewlineKind, Encoding } from './Text';
+import { PosixModeBits } from './PosixModeBits';
 
 // The PosixModeBits are intended to be used with bitwise operations.
 // tslint:disable:no-bitwise
-
-/**
- * The allowed types of encodings, as supported by Node.js
- * @public
- */
-export const enum Encoding {
-  Utf8 = 'utf8'
-}
-
-/**
- * An integer value used to specify file permissions for POSIX-like operating systems.
- *
- * @remarks
- *
- * This bitfield corresponds to the "mode_t" structure described in this document:
- * http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/sys_stat.h.html
- *
- * It is used with NodeJS APIs such as fs.Stat.mode and fs.chmodSync().  These values
- * represent a set of permissions and can be combined using bitwise arithmetic.
- *
- * POSIX is a registered trademark of the Institute of Electrical and Electronic Engineers, Inc.
- *
- * @public
- */
-export const enum PosixModeBits {
-  // The bits
-
-  /**
-   * Indicates that the item's owner can read the item.
-   */
-  UserRead = 1 << 8,
-
-  /**
-   * Indicates that the item's owner can modify the item.
-   */
-  UserWrite = 1 << 7,
-
-  /**
-   * Indicates that the item's owner can execute the item (if it is a file)
-   * or search the item (if it is a directory).
-   */
-  UserExecute = 1 << 6,
-
-  /**
-   * Indicates that users belonging to the item's group can read the item.
-   */
-  GroupRead = 1 << 5,
-
-  /**
-   * Indicates that users belonging to the item's group can modify the item.
-   */
-  GroupWrite = 1 << 4,
-
-  /**
-   * Indicates that users belonging to the item's group can execute the item (if it is a file)
-   * or search the item (if it is a directory).
-   */
-  GroupExecute = 1 << 3,
-
-  /**
-   * Indicates that other users (besides the item's owner user or group) can read the item.
-   */
-  OthersRead = 1 << 2,
-
-  /**
-   * Indicates that other users (besides the item's owner user or group) can modify the item.
-   */
-  OthersWrite = 1 << 1,
-
-  /**
-   * Indicates that other users (besides the item's owner user or group) can execute the item (if it is a file)
-   * or search the item (if it is a directory).
-   */
-  OthersExecute = 1 << 0,
-
-  // Helpful aliases
-
-  /**
-   * A zero value where no permissions bits are set.
-   */
-  None = 0,
-
-  /**
-   * An alias combining OthersRead, GroupRead, and UserRead permission bits.
-   */
-  AllRead = OthersRead | GroupRead | UserRead,
-
-  /**
-   * An alias combining OthersWrite, GroupWrite, and UserWrite permission bits.
-   */
-  AllWrite = OthersWrite | GroupWrite | UserWrite,
-
-  /**
-   * An alias combining OthersExecute, GroupExecute, and UserExecute permission bits.
-   */
-  AllExecute = OthersExecute | GroupExecute | UserExecute
-}
 
 /**
  * The options for FileSystem.readFolder()

--- a/libraries/node-core-library/src/FileSystem.ts
+++ b/libraries/node-core-library/src/FileSystem.ts
@@ -71,7 +71,7 @@ export interface IFileSystemReadFileOptions {
  */
 export interface IFileSystemMoveOptions {
   /**
-   * The path of the object to be moved.
+   * The path of the existing object to be moved.
    * The path may be absolute or relative.
    */
   sourcePath: string;
@@ -100,7 +100,7 @@ export interface IFileSystemMoveOptions {
  */
 export interface IFileSystemCopyFileOptions {
   /**
-   * The path of the object that will be copied.
+   * The path of the existing object to be copied.
    * The path may be absolute or relative.
    */
   sourcePath: string;
@@ -149,14 +149,14 @@ export interface IFileSystemUpdateTimeParameters {
  */
 export interface IFileSystemCreateLinkOptions {
   /**
-   * The path where the new symlink link will be created.
-   */
-  linkPath: string;
-
-  /**
-   * The newly created symbolic link will point to this target.
+   * The existing path that the symbolic link will point to.
    */
   linkTargetPath: string;
+
+  /**
+   * The new path for the new symlink link to be created.
+   */
+  linkPath: string;
 }
 
 /**
@@ -171,7 +171,7 @@ export interface IFileSystemCreateLinkOptions {
  * performance, versus improving it.
  *
  * Note that in the documentation, we refer to "filesystem objects", this can be a
- * file, folder, synbolic link, hard link, directory junction, etc.
+ * file, folder, symbolic link, hard link, directory junction, etc.
  *
  * @public
  */
@@ -448,8 +448,6 @@ export class FileSystem {
   /**
    * Creates a Windows "directory junction". Behaves like `createSymbolicLinkToFile()` on other platforms.
    * Behind the scenes it uses `fs.symlinkSync()`.
-   * @param linkSource - The absolute or relative path to the destination where the link should be created.
-   * @param linkTarget - The absolute or relative path to the target of the link.
    */
   public static createSymbolicLinkJunction(options: IFileSystemCreateLinkOptions): void {
     // For directories, we use a Windows "junction".  On POSIX operating systems, this produces a regular symlink.

--- a/libraries/node-core-library/src/FileSystem.ts
+++ b/libraries/node-core-library/src/FileSystem.ts
@@ -15,7 +15,7 @@ import { PosixModeBits } from './PosixModeBits';
  * The options for FileSystem.readFolder()
  * @public
  */
-export interface IReadFolderOptions {
+export interface IFileSystemReadFolderOptions {
   /**
    * If true, returns the absolute paths of the files in the folder.
    * Defaults to `false`.
@@ -27,7 +27,7 @@ export interface IReadFolderOptions {
  * The options for FileSystem.writeFile()
  * @public
  */
-export interface IWriteFileOptions {
+export interface IFileSystemWriteFileOptions {
   /**
    * If true, will ensure the folder is created before writing the file.
    * Defaults to `false`.
@@ -51,7 +51,7 @@ export interface IWriteFileOptions {
  * The options for FileSystem.readFile()
  * @public
  */
-export interface IReadFileOptions {
+export interface IFileSystemReadFileOptions {
   /**
    * If specified, will change the encoding of the file that will be written.
    * Defaults to `"utf8"`.
@@ -116,7 +116,7 @@ export interface IFileSystemCopyFileOptions {
  * The options for FileSystem.deleteFile()
  * @public
 */
-export interface IDeleteFileOptions {
+export interface IFileSystemDeleteFileOptions {
   /**
    * If true, will throw an exception if the file did not exist before `deleteFile()` was called.
    * Defaults to `false`.
@@ -129,7 +129,7 @@ export interface IDeleteFileOptions {
  * Both times must be specified.
  * @public
  */
-export interface IUpdateTimeParameters {
+export interface IFileSystemUpdateTimeParameters {
   /**
    * The POSIX epoch time or Date when this was last accessed.
    */
@@ -142,8 +142,8 @@ export interface IUpdateTimeParameters {
 }
 
 /**
- * The options for FileSystem.createSymbolicLinkJunction(), createSymbolicLinkFile(), createSymbolicLinkFolder(),
- * and createHardLink().
+ * The options for `FileSystem.createSymbolicLinkJunction()`, `createSymbolicLinkFile()`,
+ * `createSymbolicLinkFolder()`,  and `createHardLink()`.
  *
  * @public
  */
@@ -213,7 +213,7 @@ export class FileSystem {
    * @param path - The path of the file that should be modified.
    * @param times - The times that the object should be updated to reflect.
    */
-  public static updateTimes(path: string, times: IUpdateTimeParameters): void {
+  public static updateTimes(path: string, times: IFileSystemUpdateTimeParameters): void {
     // tslint:disable-next-line:no-any
     fsx.utimes(path, times.accessedTime as any, times.modifiedTime as any);
   }
@@ -301,7 +301,7 @@ export class FileSystem {
    * @param folderPath - The absolute or relative path to the folder which should be read.
    * @param options - Optional settings that can change the behavior. Type: `IReadFolderOptions`
    */
-  public static readFolder(folderPath: string, options?: IReadFolderOptions): Array<string> {
+  public static readFolder(folderPath: string, options?: IFileSystemReadFolderOptions): Array<string> {
     options = {
       absolutePaths: false,
       ...options
@@ -356,7 +356,7 @@ export class FileSystem {
    * @param contents - The text that should be written to the file.
    * @param options - Optional settings that can change the behavior. Type: `IWriteFileOptions`
    */
-  public static writeFile(filePath: string, contents: string | Buffer, options?: IWriteFileOptions): void {
+  public static writeFile(filePath: string, contents: string | Buffer, options?: IFileSystemWriteFileOptions): void {
     options = {
       ensureFolderExists: false,
       convertLineEndings: undefined,
@@ -380,7 +380,7 @@ export class FileSystem {
    * @param filePath - The relative or absolute path to the file whose contents should be read.
    * @param options - Optional settings that can change the behavior. Type: `IReadFileOptions`
    */
-  public static readFile(filePath: string, options?: IReadFileOptions): string {
+  public static readFile(filePath: string, options?: IFileSystemReadFileOptions): string {
     options = {
       encoding: Encoding.Utf8,
       convertLineEndings: undefined,
@@ -415,7 +415,7 @@ export class FileSystem {
    * @param filePath - The absolute or relative path to the file that should be deleted.
    * @param options - Optional settings that can change the behavior. Type: `IDeleteFileOptions`
    */
-  public static deleteFile(filePath: string, options?: IDeleteFileOptions): void {
+  public static deleteFile(filePath: string, options?: IFileSystemDeleteFileOptions): void {
     options = {
       throwIfNotExists: false,
       ...options

--- a/libraries/node-core-library/src/FileSystem.ts
+++ b/libraries/node-core-library/src/FileSystem.ts
@@ -156,7 +156,7 @@ export interface IFileSystemCreateLinkOptions {
   /**
    * The new path for the new symlink link to be created.
    */
-  linkPath: string;
+  newLinkPath: string;
 }
 
 /**
@@ -451,7 +451,7 @@ export class FileSystem {
    */
   public static createSymbolicLinkJunction(options: IFileSystemCreateLinkOptions): void {
     // For directories, we use a Windows "junction".  On POSIX operating systems, this produces a regular symlink.
-    fsx.symlinkSync(options.linkTargetPath, options.linkPath, 'junction');
+    fsx.symlinkSync(options.linkTargetPath, options.newLinkPath, 'junction');
   }
 
   /**
@@ -459,7 +459,7 @@ export class FileSystem {
    * Behind the scenes it uses `fs.symlinkSync()`.
    */
   public static createSymbolicLinkFile(options: IFileSystemCreateLinkOptions): void {
-    fsx.symlinkSync(options.linkTargetPath, options.linkPath, 'file');
+    fsx.symlinkSync(options.linkTargetPath, options.newLinkPath, 'file');
   }
 
   /**
@@ -467,7 +467,7 @@ export class FileSystem {
    * Behind the scenes it uses `fs.symlinkSync()`.
    */
   public static createSymbolicLinkFolder(options: IFileSystemCreateLinkOptions): void {
-    fsx.symlinkSync(options.linkTargetPath, options.linkPath, 'dir');
+    fsx.symlinkSync(options.linkTargetPath, options.newLinkPath, 'dir');
   }
 
   /**
@@ -475,7 +475,7 @@ export class FileSystem {
    * Behind the scenes it uses `fs.linkSync()`.
    */
   public static createHardLink(options: IFileSystemCreateLinkOptions): void {
-    fsx.linkSync(options.linkTargetPath, options.linkPath);
+    fsx.linkSync(options.linkTargetPath, options.newLinkPath);
   }
 
   /**

--- a/libraries/node-core-library/src/FileSystem.ts
+++ b/libraries/node-core-library/src/FileSystem.ts
@@ -71,6 +71,18 @@ export interface IReadFileOptions {
  */
 export interface IFileSystemMoveOptions {
   /**
+   * The path of the object to be moved.
+   * The path may be absolute or relative.
+   */
+  sourcePath: string;
+
+  /**
+   * The new path for the object.
+   * The path may be absolute or relative.
+   */
+  destinationPath: string;
+
+  /**
    * If true, will overwrite the file if it already exists. Defaults to true.
    */
   overwrite?: boolean;
@@ -80,6 +92,24 @@ export interface IFileSystemMoveOptions {
    * Defaults to `false`.
    */
   ensureFolderExists?: boolean;
+}
+
+/**
+ * The options for FileSystem.copyFile()
+ * @public
+ */
+export interface IFileSystemCopyFileOptions {
+  /**
+   * The path of the object that will be copied.
+   * The path may be absolute or relative.
+   */
+  sourcePath: string;
+
+  /**
+   * The path that the object will be copied to.
+   * The path may be absolute or relative.
+   */
+  destinationPath: string;
 }
 
 /**
@@ -109,6 +139,24 @@ export interface IUpdateTimeParameters {
    * The POSIX epoch time or Date when this was last modified
    */
   modifiedTime: number | Date;
+}
+
+/**
+ * The options for FileSystem.createSymbolicLinkJunction(), createSymbolicLinkFile(), createSymbolicLinkFolder(),
+ * and createHardLink().
+ *
+ * @public
+ */
+export interface IFileSystemCreateLinkOptions {
+  /**
+   * The path where the new symlink link will be created.
+   */
+  linkPath: string;
+
+  /**
+   * The newly created symbolic link will point to this target.
+   */
+  linkTargetPath: string;
 }
 
 /**
@@ -217,11 +265,8 @@ export class FileSystem {
   /**
    * Moves a file. The folder must exist, unless the `ensureFolderExists` option is provided.
    * Behind the scenes it uses `fs-extra.moveSync()`
-   * @param sourcePath - The absolute or relative path to the source file.
-   * @param targetPath - The absolute or relative path where the file should be moved to.
-   * @param options - Optional settings that can change the behavior. Type: `IFileSystemMoveOptions`
    */
-  public static move(sourcePath: string, targetPath: string, options?: IFileSystemMoveOptions): void {
+  public static move(options: IFileSystemMoveOptions): void {
     options = {
       overwrite: true,
       ensureFolderExists: false,
@@ -229,10 +274,10 @@ export class FileSystem {
     };
 
     if (options.ensureFolderExists) {
-      FileSystem.ensureFolder(pathUtilities.basename(sourcePath));
+      FileSystem.ensureFolder(pathUtilities.basename(options.sourcePath));
     }
 
-    fsx.moveSync(sourcePath, targetPath, { overwrite: options.overwrite });
+    fsx.moveSync(options.sourcePath, options.destinationPath, { overwrite: options.overwrite });
   }
 
   // ===============
@@ -359,11 +404,9 @@ export class FileSystem {
    * Copies a file from one location to another.
    * By default, destinationPath is overwritten if it already exists.
    * Behind the scenes it uses `fs.copyFileSync()`.
-   * @param sourcePath - The absolute or relative path to the source file to be copied.
-   * @param destinationPath - The absolute or relative path to the new copy that will be created.
    */
-  public static copyFile(sourcePath: string, destinationPath: string): void {
-    fsx.copySync(sourcePath, destinationPath);
+  public static copyFile(options: IFileSystemCopyFileOptions): void {
+    fsx.copySync(options.sourcePath, options.destinationPath);
   }
 
   /**
@@ -408,39 +451,33 @@ export class FileSystem {
    * @param linkSource - The absolute or relative path to the destination where the link should be created.
    * @param linkTarget - The absolute or relative path to the target of the link.
    */
-  public static createSymbolicLinkJunction(linkTarget: string, linkSource: string): void {
+  public static createSymbolicLinkJunction(options: IFileSystemCreateLinkOptions): void {
     // For directories, we use a Windows "junction".  On POSIX operating systems, this produces a regular symlink.
-    fsx.symlinkSync(linkTarget, linkSource, 'junction');
+    fsx.symlinkSync(options.linkTargetPath, options.linkPath, 'junction');
   }
 
   /**
    * Creates a symbolic link to a file (on Windows this requires elevated permissionsBits).
    * Behind the scenes it uses `fs.symlinkSync()`.
-   * @param linkSource - The absolute or relative path to the destination where the link should be created.
-   * @param linkTarget - The absolute or relative path to the target of the link.
    */
-  public static createSymbolicLinkFile(linkTarget: string, linkSource: string): void {
-    fsx.symlinkSync(linkSource, linkTarget, 'file');
+  public static createSymbolicLinkFile(options: IFileSystemCreateLinkOptions): void {
+    fsx.symlinkSync(options.linkTargetPath, options.linkPath, 'file');
   }
 
   /**
    * Creates a symbolic link to a folder (on Windows this requires elevated permissionsBits).
    * Behind the scenes it uses `fs.symlinkSync()`.
-   * @param linkSource - The absolute or relative path to the destination where the link should be created.
-   * @param linkTarget - The absolute or relative path to the target of the link.
    */
-  public static createSymbolicLinkFolder(linkTarget: string, linkSource: string): void {
-    fsx.symlinkSync(linkSource, linkTarget, 'dir');
+  public static createSymbolicLinkFolder(options: IFileSystemCreateLinkOptions): void {
+    fsx.symlinkSync(options.linkTargetPath, options.linkPath, 'dir');
   }
 
   /**
    * Creates a hard link.
    * Behind the scenes it uses `fs.linkSync()`.
-   * @param linkSource - The absolute or relative path to the destination where the link should be created.
-   * @param linkTarget - The absolute or relative path to the target of the link.
    */
-  public static createHardLink(linkTarget: string, linkSource: string): void {
-    fsx.linkSync(linkSource, linkTarget);
+  public static createHardLink(options: IFileSystemCreateLinkOptions): void {
+    fsx.linkSync(options.linkTargetPath, options.linkPath);
   }
 
   /**

--- a/libraries/node-core-library/src/PosixModeBits.ts
+++ b/libraries/node-core-library/src/PosixModeBits.ts
@@ -1,0 +1,94 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+// The PosixModeBits are intended to be used with bitwise operations.
+// tslint:disable:no-bitwise
+
+/**
+ * An integer value used to specify file permissions for POSIX-like operating systems.
+ *
+ * @remarks
+ *
+ * This bitfield corresponds to the "mode_t" structure described in this document:
+ * http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/sys_stat.h.html
+ *
+ * It is used with NodeJS APIs such as fs.Stat.mode and fs.chmodSync().  These values
+ * represent a set of permissions and can be combined using bitwise arithmetic.
+ *
+ * POSIX is a registered trademark of the Institute of Electrical and Electronic Engineers, Inc.
+ *
+ * @public
+ */
+export const enum PosixModeBits {
+  // The bits
+
+  /**
+   * Indicates that the item's owner can read the item.
+   */
+  UserRead = 1 << 8,
+
+  /**
+   * Indicates that the item's owner can modify the item.
+   */
+  UserWrite = 1 << 7,
+
+  /**
+   * Indicates that the item's owner can execute the item (if it is a file)
+   * or search the item (if it is a directory).
+   */
+  UserExecute = 1 << 6,
+
+  /**
+   * Indicates that users belonging to the item's group can read the item.
+   */
+  GroupRead = 1 << 5,
+
+  /**
+   * Indicates that users belonging to the item's group can modify the item.
+   */
+  GroupWrite = 1 << 4,
+
+  /**
+   * Indicates that users belonging to the item's group can execute the item (if it is a file)
+   * or search the item (if it is a directory).
+   */
+  GroupExecute = 1 << 3,
+
+  /**
+   * Indicates that other users (besides the item's owner user or group) can read the item.
+   */
+  OthersRead = 1 << 2,
+
+  /**
+   * Indicates that other users (besides the item's owner user or group) can modify the item.
+   */
+  OthersWrite = 1 << 1,
+
+  /**
+   * Indicates that other users (besides the item's owner user or group) can execute the item (if it is a file)
+   * or search the item (if it is a directory).
+   */
+  OthersExecute = 1 << 0,
+
+  // Helpful aliases
+
+  /**
+   * A zero value where no permissions bits are set.
+   */
+  None = 0,
+
+  /**
+   * An alias combining OthersRead, GroupRead, and UserRead permission bits.
+   */
+  AllRead = OthersRead | GroupRead | UserRead,
+
+  /**
+   * An alias combining OthersWrite, GroupWrite, and UserWrite permission bits.
+   */
+  AllWrite = OthersWrite | GroupWrite | UserWrite,
+
+  /**
+   * An alias combining OthersExecute, GroupExecute, and UserExecute permission bits.
+   */
+  AllExecute = OthersExecute | GroupExecute | UserExecute
+}

--- a/libraries/node-core-library/src/Text.ts
+++ b/libraries/node-core-library/src/Text.ts
@@ -2,6 +2,14 @@
 // See LICENSE in the project root for license information.
 
 /**
+ * The allowed types of encodings, as supported by Node.js
+ * @public
+ */
+export const enum Encoding {
+  Utf8 = 'utf8'
+}
+
+/**
  * Enumeration controlling conversion of newline characters.
  * @public
  */

--- a/libraries/node-core-library/src/index.ts
+++ b/libraries/node-core-library/src/index.ts
@@ -56,13 +56,13 @@ export { Path } from './Path';
 export { Text, NewlineKind } from './Text';
 export {
   FileSystem,
-  IReadFolderOptions,
-  IWriteFileOptions,
-  IReadFileOptions,
+  IFileSystemReadFolderOptions,
+  IFileSystemWriteFileOptions,
+  IFileSystemReadFileOptions,
   IFileSystemMoveOptions,
   IFileSystemCopyFileOptions,
-  IDeleteFileOptions,
-  IUpdateTimeParameters,
+  IFileSystemDeleteFileOptions,
+  IFileSystemUpdateTimeParameters,
   IFileSystemCreateLinkOptions
 } from './FileSystem';
 export {

--- a/libraries/node-core-library/src/index.ts
+++ b/libraries/node-core-library/src/index.ts
@@ -60,8 +60,10 @@ export {
   IWriteFileOptions,
   IReadFileOptions,
   IFileSystemMoveOptions,
+  IFileSystemCopyFileOptions,
   IDeleteFileOptions,
-  IUpdateTimeParameters
+  IUpdateTimeParameters,
+  IFileSystemCreateLinkOptions
 } from './FileSystem';
 export {
   FileWriter,

--- a/libraries/node-core-library/src/index.ts
+++ b/libraries/node-core-library/src/index.ts
@@ -42,6 +42,7 @@ export {
 export {
   MapExtensions
 } from './MapExtensions';
+export { PosixModeBits } from './PosixModeBits';
 export {
   ProtectableMap,
   IProtectableMapParameters
@@ -60,7 +61,6 @@ export {
   IReadFileOptions,
   IFileSystemMoveOptions,
   IDeleteFileOptions,
-  PosixModeBits,
   IUpdateTimeParameters
 } from './FileSystem';
 export {

--- a/libraries/node-core-library/src/test/Executable.test.ts
+++ b/libraries/node-core-library/src/test/Executable.test.ts
@@ -6,7 +6,8 @@ import * as path from 'path';
 import * as child_process from 'child_process';
 
 import { Executable, IExecutableSpawnSyncOptions } from '../Executable';
-import { FileSystem, PosixModeBits } from '../FileSystem';
+import { FileSystem } from '../FileSystem';
+import { PosixModeBits } from '../PosixModeBits';
 import { Text } from '../Text';
 
 // The PosixModeBits are intended to be used with bitwise operations.

--- a/libraries/node-core-library/src/test/FileSystem.test.ts
+++ b/libraries/node-core-library/src/test/FileSystem.test.ts
@@ -1,7 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import { FileSystem, PosixModeBits } from '../FileSystem';
+import { FileSystem } from '../FileSystem';
+import { PosixModeBits } from '../PosixModeBits';
 
 // The PosixModeBits are intended to be used with bitwise operations.
 // tslint:disable:no-bitwise


### PR DESCRIPTION
This includes the fix for issue https://github.com/Microsoft/web-build-tools/issues/788, which was a Rush regression where the source/target parameters were reversed for `fsx.symlinkSync(linkSource, linkTarget, 'file');`.

**The breaking change:** For all APIs with two path parameters, require explicit naming of the source/target (via an `options` object).

This is particularly tricky when creating a symlink, since the thing we're creating was called the "source" (and the "target" is what the link points to).  We clarified that as follows:

```ts
/**
 * The options for FileSystem.createSymbolicLinkJunction(), createSymbolicLinkFile(), createSymbolicLinkFolder(),
 * and createHardLink().
 *
 * @public
 */
export interface IFileSystemCreateLinkOptions {
  /**
   * The path where the new symlink link will be created.
   */
  linkPath: string;

  /**
   * The newly created symbolic link will point to this target.
   */
  linkTargetPath: string;
}
```