### PR TITLE
Downgrading the version of node-library-build in load-themed-styles to fix the lib-amd issue.

### DIFF
--- a/common/changes/@microsoft/load-themed-styles/ianc-fixing-lts_2018-08-29-20-18.json
+++ b/common/changes/@microsoft/load-themed-styles/ianc-fixing-lts_2018-08-29-20-18.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/load-themed-styles",
+      "comment": "Fix an issue where the lib-amd folder was missing.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/load-themed-styles",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/common/config/rush/common-versions.json
+++ b/common/config/rush/common-versions.json
@@ -5,5 +5,8 @@
   },
 
   "allowedAlternativeVersions": {
+    "@microsoft/node-library-build": [
+      "4.4.11" // Temporary, until we're able to fix the task to work for load-themed-styles
+    ]
   }
 }

--- a/libraries/load-themed-styles/package.json
+++ b/libraries/load-themed-styles/package.json
@@ -21,6 +21,6 @@
     "@types/webpack-env": "1.13.0",
     "chai": "~3.5.0",
     "gulp": "~3.9.1",
-    "@microsoft/node-library-build": "5.0.0"
+    "@microsoft/node-library-build": "4.4.11"
   }
 }

--- a/libraries/load-themed-styles/tsconfig.json
+++ b/libraries/load-themed-styles/tsconfig.json
@@ -1,6 +1,25 @@
 {
-  "extends": "./node_modules/@microsoft/rush-stack/includes/tsconfig-web.json",
+  // Put this back when the lib-amd issue is fixed
+  // "extends": "./node_modules/@microsoft/rush-stack/includes/tsconfig-web.json",
+  // "compilerOptions": {
+  //   "module": "commonjs"
+  // }
+
   "compilerOptions": {
-    "module": "commonjs"
+    "target": "es5",
+    "forceConsistentCasingInFileNames": true,
+    "module": "commonjs",
+    "jsx": "react",
+    "declaration": true,
+    "sourceMap": true,
+    "experimentalDecorators": true,
+    "types": [
+      "webpack-env"
+    ],
+    "lib": [
+      "es5",
+      "dom"
+    ],
+    "strictNullChecks": true
   }
 }


### PR DESCRIPTION
This is a temporary fix for issue https://github.com/Microsoft/web-build-tools/issues/796

Due to a tooling change, the legacy "lib-amd/" folder was no longer getting built.