### PR TITLE
[rush] Relax the email policy checking

### DIFF
--- a/apps/rush-lib/src/api/ChangeManagement.ts
+++ b/apps/rush-lib/src/api/ChangeManagement.ts
@@ -47,7 +47,7 @@ export interface IChangeInfo {
   comment?: string;
 
   /**
-   * The email of the user who provided the comment. Pulled from the git log.
+   * The email of the user who provided the comment. Pulled from the Git log.
    */
   author?: string;
 

--- a/apps/rush-lib/src/cli/actions/PublishAction.ts
+++ b/apps/rush-lib/src/cli/actions/PublishAction.ts
@@ -257,7 +257,7 @@ export class PublishAction extends BaseRushAction {
           }
         }
 
-        // Create and push appropriate git tags.
+        // Create and push appropriate Git tags.
         this._gitAddTags(git, orderedChanges);
         git.push(tempBranch);
 

--- a/apps/rush-lib/src/logic/Git.ts
+++ b/apps/rush-lib/src/logic/Git.ts
@@ -55,10 +55,27 @@ export class Git {
     }
   }
 
+  /**
+   * If a Git email address is configured and is nonempty, this returns it.
+   * Otherwise, undefined is returned.
+   */
+  public static tryGetGitEmail(rushConfiguration: RushConfiguration): string | undefined {
+    const emailResult: IResultOrError<string> = Git._tryGetGitEmail();
+    if (emailResult.result !== undefined && emailResult.result.length > 0) {
+      return emailResult.result;
+    }
+    return undefined;
+  }
+
+  /**
+   * If a Git email address is configured and is nonempty, this returns it.
+   * Otherwise, configuration instructions are printed to the console,
+   * and AlreadyReportedError is thrown.
+   */
   public static getGitEmail(rushConfiguration: RushConfiguration): string {
     // Determine the user's account
     // Ex: "bob@example.com"
-    const emailResult: IResultOrError<string> = Git.tryGetGitEmail();
+    const emailResult: IResultOrError<string> = Git._tryGetGitEmail();
     if (emailResult.error) {
       console.log(
         [
@@ -72,7 +89,7 @@ export class Git {
       throw new AlreadyReportedError();
     }
 
-    if (!emailResult.result) {
+    if (emailResult.result === undefined || emailResult.result.length === 0) {
       console.log([
         'This operation requires that a git email be specified.',
         '',
@@ -87,7 +104,7 @@ export class Git {
     return emailResult.result;
   }
 
-  private static tryGetGitEmail(): IResultOrError<string> {
+  private static _tryGetGitEmail(): IResultOrError<string> {
     const gitPath: string | undefined = Git.getGitPath();
     if (!gitPath) {
       return {

--- a/apps/rush-lib/src/logic/Git.ts
+++ b/apps/rush-lib/src/logic/Git.ts
@@ -2,8 +2,8 @@
 // See LICENSE in the project root for license information.
 
 import gitInfo = require('git-repo-info');
-import * as child_process from 'child_process';
 import * as os from 'os';
+import { Executable } from '@microsoft/node-core-library';
 
 import { Utilities } from '../utilities/Utilities';
 import { AlreadyReportedError } from '../utilities/AlreadyReportedError';
@@ -16,32 +16,32 @@ interface IResultOrError<TResult> {
 }
 
 export class Git {
-  private static _hasGit: boolean | undefined = undefined;
+  private static _checkedGitPath: boolean = false;
   private static _gitPath: string | undefined;
 
+  private static _gitEmailResult: IResultOrError<string> | undefined = undefined;
+
   /**
-   * Returns the path to the git binary if git is found. If git can't be found, return undefined.
+   * Returns the path to the Git binary if git is found. If git can't be found, return undefined.
    */
   public static getGitPath(): string | undefined {
-    if (Git._hasGit === undefined) {
-      const command: string = process.platform === 'win32' ? 'where' : 'which';
-      const result: child_process.SpawnSyncReturns<string> = child_process.spawnSync(command, ['git']);
-
-      if (result.status === 0) {
-        Git._gitPath = result.stdout;
-        Git._hasGit = !!result.stdout;
-      }
+    if (!Git._checkedGitPath) {
+      Git._gitPath = Executable.tryResolve('git');
+      Git._checkedGitPath = true;
     }
 
     return Git._gitPath;
   }
 
+  /**
+   * Returns true if the Git binary can be found.
+   */
   public static isGitPresent(): boolean {
     return !!Git.getGitPath();
   }
 
   /**
-   * Checks if git is supported and if the current path is under a git working tree.
+   * Returns true if the Git binary was found and the current path is under a Git working tree.
    */
   public static isPathUnderGitWorkingTree(): boolean {
     if (Git.isGitPresent()) { // Do we even have a git binary?
@@ -105,25 +105,28 @@ export class Git {
   }
 
   private static _tryGetGitEmail(): IResultOrError<string> {
-    const gitPath: string | undefined = Git.getGitPath();
-    if (!gitPath) {
-      return {
-        error: new Error('Git isn\'t present on the path')
-      };
+    if (Git._gitEmailResult === undefined) {
+      if (!Git.isGitPresent()) {
+        Git._gitEmailResult = {
+          error: new Error('Git isn\'t present on the path')
+        };
+      } else {
+        try {
+          Git._gitEmailResult = {
+            result: Utilities.executeCommandAndCaptureOutput(
+              'git',
+              ['config', 'user.email'],
+              '.'
+            ).trim()
+          };
+        } catch (e) {
+          Git._gitEmailResult = {
+            error: e
+          };
+        }
+      }
     }
 
-    try {
-      return {
-        result: Utilities.executeCommandAndCaptureOutput(
-          'git',
-          ['config', 'user.email'],
-          '.'
-        ).trim()
-      };
-    } catch (e) {
-      return {
-        error: e
-      };
-    }
+    return Git._gitEmailResult;
   }
 }

--- a/apps/rush-lib/src/logic/Git.ts
+++ b/apps/rush-lib/src/logic/Git.ts
@@ -22,7 +22,7 @@ export class Git {
   private static _gitEmailResult: IResultOrError<string> | undefined = undefined;
 
   /**
-   * Returns the path to the Git binary if git is found. If git can't be found, return undefined.
+   * Returns the path to the Git binary if found. Otherwise, return undefined.
    */
   public static getGitPath(): string | undefined {
     if (!Git._checkedGitPath) {
@@ -44,7 +44,7 @@ export class Git {
    * Returns true if the Git binary was found and the current path is under a Git working tree.
    */
   public static isPathUnderGitWorkingTree(): boolean {
-    if (Git.isGitPresent()) { // Do we even have a git binary?
+    if (Git.isGitPresent()) { // Do we even have a Git binary?
       try {
         return !!gitInfo().sha;
       } catch (e) {
@@ -91,7 +91,7 @@ export class Git {
 
     if (emailResult.result === undefined || emailResult.result.length === 0) {
       console.log([
-        'This operation requires that a git email be specified.',
+        'This operation requires that a Git email be specified.',
         '',
         `If you didn't configure your email yet, try something like this:`,
         '',

--- a/apps/rush-lib/src/logic/PackageChangeAnalyzer.ts
+++ b/apps/rush-lib/src/logic/PackageChangeAnalyzer.ts
@@ -66,7 +66,7 @@ export class PackageChangeAnalyzer {
       }
     } catch (e) {
       // If getPackageDeps fails, don't fail the whole build. Treat this case as if we don't know anything about
-      // the state of the files in the repo. This can happen if the environment doesn't have git.
+      // the state of the files in the repo. This can happen if the environment doesn't have Git.
       console.log(colors.yellow(
         `Error calculating the state of the repo. (inner error: ${e}). Continuing without diffing files.`
       ));

--- a/apps/rush-lib/src/logic/policy/GitEmailPolicy.ts
+++ b/apps/rush-lib/src/logic/policy/GitEmailPolicy.ts
@@ -11,18 +11,25 @@ import { Git } from '../Git';
 
 export class GitEmailPolicy {
   public static validate(rushConfiguration: RushConfiguration): void {
+    if (!Git.isGitPresent()) {
+      // If Git isn't installed, or this Rush project is not under a Git working folder,
+      // then we don't care about the Git email
+      console.log(colors.cyan(
+        'Ignoring Git validation because the Git binary was not found in the shell path.') + os.EOL);
+      return;
+    }
+
     if (!Git.isPathUnderGitWorkingTree()) {
       // If Git isn't installed, or this Rush project is not under a Git working folder,
       // then we don't care about the Git email
-      console.log('Ignoring Git validation because this is not a Git working folder.' + os.EOL);
+      console.log(colors.cyan(
+        'Ignoring Git validation because this is not a Git working folder.' + os.EOL));
       return;
     }
 
     // If there isn't a Git policy, then we don't care whether the person configured
     // a Git email address at all.  This helps people who don't
-    if (rushConfiguration.gitAllowedEmailRegExps.length === 0
-      && rushConfiguration.gitSampleEmail === '') {
-
+    if (rushConfiguration.gitAllowedEmailRegExps.length === 0) {
       if (Git.tryGetGitEmail(rushConfiguration) === undefined) {
         return;
       }
@@ -34,6 +41,20 @@ export class GitEmailPolicy {
     let userEmail: string;
     try {
       userEmail = Git.getGitEmail(rushConfiguration);
+
+      // sanity check; a valid email should not contain any whitespace
+      // if this fails, then we have another issue to report
+      if (!userEmail.match(/^\S+$/g)) {
+        console.log([
+          colors.red('Your Git email address is invalid: ' + JSON.stringify(userEmail)),
+          '',
+          `To configure your Git email address, try something like this:`,
+          '',
+          ...GitEmailPolicy.getEmailExampleLines(rushConfiguration),
+          ''
+        ].join(os.EOL));
+        throw new AlreadyReportedError();
+      }
     } catch (e) {
       if (e instanceof AlreadyReportedError) {
         console.log(colors.red('Aborting, so you can go fix your settings.  (Or use --bypass-policy to skip.)'));
@@ -43,16 +64,18 @@ export class GitEmailPolicy {
       }
     }
 
+    if (rushConfiguration.gitAllowedEmailRegExps.length === 0) {
+      // If there is no policy, then we're good
+      return;
+    }
+
     console.log('Checking Git policy for this repository.' + os.EOL);
 
-    // sanity check; a valid email should not contain any whitespace
-    // if this fails, then we have another issue to report
-    if (userEmail.match(/^\S+$/g)) {
-      for (const pattern of rushConfiguration.gitAllowedEmailRegExps) {
-        const regex: RegExp = new RegExp('^' + pattern + '$', 'i');
-        if (userEmail.match(regex)) {
-          return;
-        }
+    // If there is a policy, at least one of the RegExp's must match
+    for (const pattern of rushConfiguration.gitAllowedEmailRegExps) {
+      const regex: RegExp = new RegExp('^' + pattern + '$', 'i');
+      if (userEmail.match(regex)) {
+        return;
       }
     }
 

--- a/common/changes/@microsoft/node-core-library/pgonzal-relax-rush-email-policy_2018-08-31-22-35.json
+++ b/common/changes/@microsoft/node-core-library/pgonzal-relax-rush-email-policy_2018-08-31-22-35.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@microsoft/node-core-library",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/node-core-library",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush/pgonzal-relax-rush-email-policy_2018-08-31-22-35.json
+++ b/common/changes/@microsoft/rush/pgonzal-relax-rush-email-policy_2018-08-31-22-35.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Skip validation of the Git email address if Git is not installed, or if rush.json isn't in a Git working directory, or if no policy was defined",
+      "packageName": "@microsoft/rush",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/libraries/node-core-library/src/Executable.ts
+++ b/libraries/node-core-library/src/Executable.ts
@@ -247,7 +247,6 @@ export class Executable {
    * @param filename - The name of the executable file.  This string must not contain any
    * command-line arguments.  If the name contains any path delimiters, then the shell's
    * default PATH will not be searched.
-   * @param filename - the name of the executable, which may be missing the path or file extension
    * @param options - optional other parameters
    * @returns the absolute path of the executable, or undefined if it was not found
    */


### PR DESCRIPTION
To simplify onboarding for new developers in a repo, Rush performs various checks to ensure that the Git email address is configured.  However @jbcpollak recently reported that his CI build was failing, because it does not have a Git email configured.  (Presumably the build definition does not need a command such as `rush publish` that would perform Git operations.)

We are relaxing the check as follows:

Require an email and validate it **IF**:
- Git is installed, **AND**
- rush.json is under a Git working folder, **AND**
- At least one email policy regex is defined in rush.json

Or, merely require a correctly formatted email address **IF**:
- Git is installed, **AND**
- rush.json is under a Git working folder, **AND**
- A nonempty value has been configured for the Git email address

Otherwise, the Git email address isn't checked at all.