### PR TITLE
[rush] Add workaround for issue where shrinkwrap.yaml was sometimes out of sync

### DIFF
--- a/apps/rush-lib/src/logic/InstallManager.ts
+++ b/apps/rush-lib/src/logic/InstallManager.ts
@@ -968,6 +968,10 @@ export class InstallManager {
       // last install flag, which encapsulates the entire installation
       args.push('--no-lock');
 
+      // Ensure that Rush's tarball dependencies get synchronized properly with the shrinkwrap.yaml file.
+      // See this GitHub issue: https://github.com/pnpm/pnpm/issues/1342
+      args.push('--prefer-frozen-shrinkwrap', 'false');
+
       if (options.collectLogFile) {
         args.push('--reporter', 'ndjson');
       }

--- a/common/changes/@microsoft/rush/pgonzal-prefer-frozen-shrinkwrap_2018-08-31-20-00.json
+++ b/common/changes/@microsoft/rush/pgonzal-prefer-frozen-shrinkwrap_2018-08-31-20-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Add \"--prefer-frozen-shrinkwrap false\" to the \"pnpm install\" command line as a workaround for https://github.com/pnpm/pnpm/issues/1342",
+      "packageName": "@microsoft/rush",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "pgonzal@users.noreply.github.com"
+}


### PR DESCRIPTION
Based on the discussion in https://github.com/pnpm/pnpm/issues/1342 , we are adding `--prefer-frozen-shrinkwrap false` to the command line for `pnpm install`.
