### PR TITLE
[rush] Add support for the Yarn package manager

### DIFF
--- a/apps/rush-lib/package.json
+++ b/apps/rush-lib/package.json
@@ -27,6 +27,7 @@
     "@microsoft/ts-command-line": "4.2.2",
     "@pnpm/link-bins": "~1.0.1",
     "@pnpm/logger": "~1.0.1",
+    "@yarnpkg/lockfile": "~1.0.2",
     "builtins": "~1.0.3",
     "colors": "~1.2.1",
     "git-repo-info": "~1.1.4",

--- a/apps/rush-lib/src/api/RushConfiguration.ts
+++ b/apps/rush-lib/src/api/RushConfiguration.ts
@@ -311,11 +311,17 @@ export class RushConfiguration {
       }
 
       const knownSet: Set<string> = new Set<string>(knownRushConfigFilenames.map(x => x.toUpperCase()));
-      if (packageManager === 'npm') {
-        knownSet.add(RushConstants.npmShrinkwrapFilename.toUpperCase());
-      } else if (packageManager === 'pnpm') {
-        knownSet.add(RushConstants.pnpmShrinkwrapFilename.toUpperCase());
-        knownSet.add(RushConstants.pnpmFileFilename.toUpperCase());
+      switch (packageManager) {
+        case 'npm':
+          knownSet.add(RushConstants.npmShrinkwrapFilename.toUpperCase());
+          break;
+        case 'pnpm':
+          knownSet.add(RushConstants.pnpmShrinkwrapFilename.toUpperCase());
+          knownSet.add(RushConstants.pnpmFileFilename.toUpperCase());
+          break;
+        case 'yarn':
+          knownSet.add(RushConstants.yarnShrinkwrapFilename.toUpperCase());
+          break;
       }
 
       // Is the filename something we know?  If not, report an error.

--- a/apps/rush-lib/src/api/RushConfiguration.ts
+++ b/apps/rush-lib/src/api/RushConfiguration.ts
@@ -485,6 +485,21 @@ export class RushConfiguration {
   }
 
   /**
+   * Returns an English phrase such as "shrinkwrap file" that can be used in logging messages
+   * to refer to the shrinkwrap file using appropriate terminology for the currently selected
+   * package manager.
+   */
+  public get shrinkwrapFilePhrase(): string {
+    if (this._packageManager === 'yarn') {
+      // Eventually we'd like to be consistent with Yarn's terminology of calling this a "lock file",
+      // but a lot of Rush documentation uses "shrinkwrap" file and would all need to be updated.
+      return 'shrinkwrap file (yarn.lock)';
+    } else {
+      return 'shrinkwrap file';
+    }
+  }
+
+  /**
    * The absolute path to Rush's storage in the home directory for the current user.  On Windows,
    * it would be something like "C:\Users\YourName\.rush".
    */

--- a/apps/rush-lib/src/api/RushConfiguration.ts
+++ b/apps/rush-lib/src/api/RushConfiguration.ts
@@ -123,9 +123,10 @@ export class RushConfiguration {
   private _commonScriptsFolder: string;
   private _commonRushConfigFolder: string;
   private _packageManager: PackageManager;
-  private _pnpmStoreFolder: string;
   private _npmCacheFolder: string;
   private _npmTmpFolder: string;
+  private _pnpmStoreFolder: string;
+  private _yarnCacheFolder: string;
   private _committedShrinkwrapFilename: string;
   private _tempShrinkwrapFilename: string;
   private _tempShrinkwrapPreinstallFilename: string;
@@ -440,6 +441,15 @@ export class RushConfiguration {
   }
 
   /**
+   * The local folder that will store the Yarn package cache.
+   *
+   * Example: "C:\MyRepo\common\temp\yarn-cache"
+   */
+  public get yarnCacheFolder(): string {
+    return this._yarnCacheFolder;
+  }
+
+  /**
    * The full path of the shrinkwrap file that is tracked by Git.  (The "rush install"
    * command uses a temporary copy, whose path is tempShrinkwrapFilename.)
    * @remarks
@@ -696,6 +706,7 @@ export class RushConfiguration {
     this._npmCacheFolder = path.resolve(path.join(this._commonTempFolder, 'npm-cache'));
     this._npmTmpFolder = path.resolve(path.join(this._commonTempFolder, 'npm-tmp'));
     this._pnpmStoreFolder = path.resolve(path.join(this._commonTempFolder, 'pnpm-store'));
+    this._yarnCacheFolder = path.resolve(path.join(this._commonTempFolder, 'yarn-cache'));
 
     this._changesFolder = path.join(this._commonFolder, RushConstants.changeFilesFolderName);
     this._rushUserFolder = path.join(Utilities.getHomeDirectory(), '.rush');

--- a/apps/rush-lib/src/cli/actions/InstallAction.ts
+++ b/apps/rush-lib/src/cli/actions/InstallAction.ts
@@ -27,6 +27,7 @@ export class InstallAction extends BaseInstallAction {
 
   protected buildInstallOptions(): IInstallManagerOptions {
     return {
+      debug: this.parser.isDebug,
       allowShrinkwrapUpdates: false,
       bypassPolicy: this._bypassPolicyParameter.value!,
       noLink: this._noLinkParameter.value!,

--- a/apps/rush-lib/src/cli/actions/UpdateAction.ts
+++ b/apps/rush-lib/src/cli/actions/UpdateAction.ts
@@ -54,6 +54,7 @@ export class UpdateAction extends BaseInstallAction {
 
   protected buildInstallOptions(): IInstallManagerOptions {
     return {
+      debug: this.parser.isDebug,
       allowShrinkwrapUpdates: true,
       bypassPolicy: this._bypassPolicyParameter.value!,
       noLink: this._noLinkParameter.value!,

--- a/apps/rush-lib/src/logic/InstallManager.ts
+++ b/apps/rush-lib/src/logic/InstallManager.ts
@@ -764,8 +764,7 @@ export class InstallManager {
           if (this._rushConfiguration.packageManager === 'yarn') {
             // Yarn does not correctly detect changes to a tarball, so we need to forcibly clear its cache
             const yarnRushTempCacheFolder: string = path.join(
-              this._rushConfiguration.commonTempFolder,
-              'yarn-cache', 'v2', 'npm-@rush-temp'
+              this._rushConfiguration.yarnCacheFolder, 'v2', 'npm-@rush-temp'
             );
             if (FileSystem.exists(yarnRushTempCacheFolder)) {
               console.log('Deleting ' + yarnRushTempCacheFolder);
@@ -1000,8 +999,10 @@ export class InstallManager {
     } else if (this._rushConfiguration.packageManager === 'yarn') {
       args.push('--ignore-optional');
       args.push('--link-folder', 'yarn-link');
-      args.push('--cache-folder', 'yarn-cache');
+      args.push('--cache-folder', this._rushConfiguration.yarnCacheFolder);
 
+      // Without this option, Yarn will sometimes stop and ask for user input on STDIN
+      // (e.g. "Which command would you like to run?").
       args.push('--non-interactive');
 
       if (options.networkConcurrency) {

--- a/apps/rush-lib/src/logic/InstallManager.ts
+++ b/apps/rush-lib/src/logic/InstallManager.ts
@@ -761,6 +761,18 @@ export class InstallManager {
             }
           }
 
+          if (this._rushConfiguration.packageManager === 'yarn') {
+            // Yarn does not correctly detect changes to a tarball, so we need to forcibly clear its cache
+            const yarnRushTempCacheFolder: string = path.join(
+              this._rushConfiguration.commonTempFolder,
+              'yarn-cache', 'v2', 'npm-@rush-temp'
+            );
+            if (FileSystem.exists(yarnRushTempCacheFolder)) {
+              console.log('Deleting ' + yarnRushTempCacheFolder);
+              Utilities.dangerouslyDeletePath(yarnRushTempCacheFolder);
+            }
+          }
+
           // Run "npm install" in the common folder
 
           // NOTE:

--- a/apps/rush-lib/src/logic/InstallManager.ts
+++ b/apps/rush-lib/src/logic/InstallManager.ts
@@ -1077,7 +1077,7 @@ export class InstallManager {
     for (const tempProjectName of shrinkwrapFile.getTempProjectNames()) {
       if (!this._rushConfiguration.findProjectByTempName(tempProjectName)) {
         console.log(os.EOL + colors.yellow(Utilities.wrapWords(
-          `Your NPM shrinkwrap file references a project "${tempProjectName}" which no longer exists.`))
+          `Your shrinkwrap file references a project "${tempProjectName}" which no longer exists.`))
           + os.EOL);
         return true;  // found one
       }

--- a/apps/rush-lib/src/logic/InstallManager.ts
+++ b/apps/rush-lib/src/logic/InstallManager.ts
@@ -226,7 +226,7 @@ export class InstallManager {
                 this._rushConfiguration.committedShrinkwrapFilename);
             } catch (ex) {
               console.log();
-              console.log('Unable to load the shrinkwrap file: ' + ex.message);
+              console.log(`Unable to load the ${this._shrinkwrapFilePhrase}: ${ex.message}`);
 
               if (!options.allowShrinkwrapUpdates) {
                 console.log();
@@ -244,7 +244,8 @@ export class InstallManager {
           if (!shrinkwrapIsUpToDate) {
             if (!options.allowShrinkwrapUpdates) {
               console.log();
-              console.log(colors.red('The shrinkwrap file is out of date.  You need to run "rush update".'));
+              console.log(colors.red(`The ${this._shrinkwrapFilePhrase} is out of date.`
+                + `  You need to run "rush update".`));
               throw new AlreadyReportedError();
             }
           }
@@ -615,7 +616,9 @@ export class InstallManager {
 
     if (shrinkwrapWarnings.length > 0) {
       console.log();
-      console.log(colors.yellow(Utilities.wrapWords(`The shrinkwrap file is missing the following dependencies:`)));
+      console.log(colors.yellow(Utilities.wrapWords(
+        `The ${this._shrinkwrapFilePhrase} is missing the following dependencies:`)));
+
       for (const shrinkwrapWarning of shrinkwrapWarnings) {
         console.log(colors.yellow('  ' + shrinkwrapWarning));
       }
@@ -1090,12 +1093,16 @@ export class InstallManager {
     for (const tempProjectName of shrinkwrapFile.getTempProjectNames()) {
       if (!this._rushConfiguration.findProjectByTempName(tempProjectName)) {
         console.log(os.EOL + colors.yellow(Utilities.wrapWords(
-          `Your shrinkwrap file references a project "${tempProjectName}" which no longer exists.`))
+          `Your ${this._shrinkwrapFilePhrase} references a project "${tempProjectName}" which no longer exists.`))
           + os.EOL);
         return true;  // found one
       }
     }
 
     return false;  // none found
+  }
+
+  private get _shrinkwrapFilePhrase(): string {
+    return this._rushConfiguration.shrinkwrapFilePhrase;
   }
 }

--- a/apps/rush-lib/src/logic/LinkManagerFactory.ts
+++ b/apps/rush-lib/src/logic/LinkManagerFactory.ts
@@ -8,11 +8,17 @@ import { PnpmLinkManager } from './pnpm/PnpmLinkManager';
 
 export class LinkManagerFactory {
   public static getLinkManager(rushConfiguration: RushConfiguration): BaseLinkManager {
-    if (rushConfiguration.packageManager === 'npm') {
-      return new NpmLinkManager(rushConfiguration);
-    } else if (rushConfiguration.packageManager === 'pnpm') {
-      return new PnpmLinkManager(rushConfiguration);
+
+    switch (rushConfiguration.packageManager) {
+      case 'npm':
+        return new NpmLinkManager(rushConfiguration);
+      case 'pnpm':
+        return new PnpmLinkManager(rushConfiguration);
+      case 'yarn':
+        // Yarn uses the same node_modules structure as NPM
+        return new NpmLinkManager(rushConfiguration);
     }
-    throw new Error(`Invalid package manager: ${rushConfiguration.packageManager}`);
+
+    throw new Error(`Unsupported package manager: ${rushConfiguration.packageManager}`);
   }
 }

--- a/apps/rush-lib/src/logic/RushConstants.ts
+++ b/apps/rush-lib/src/logic/RushConstants.ts
@@ -73,6 +73,11 @@ export namespace RushConstants {
   export const pnpmFileFilename: string = 'pnpmfile.js';
 
   /**
+   * The filename ("shrinkwrap.yaml") used to store state for pnpm
+   */
+  export const yarnShrinkwrapFilename: string = 'yarn.lock';
+
+  /**
    * The folder name ("node_modules") where NPM installs its packages.
    */
   export const nodeModulesFolderName: string = 'node_modules';

--- a/apps/rush-lib/src/logic/ShrinkwrapFileFactory.ts
+++ b/apps/rush-lib/src/logic/ShrinkwrapFileFactory.ts
@@ -2,15 +2,19 @@ import { PackageManager } from '../api/RushConfiguration';
 import { BaseShrinkwrapFile } from './base/BaseShrinkwrapFile';
 import { NpmShrinkwrapFile } from './npm/NpmShrinkwrapFile';
 import { PnpmShrinkwrapFile } from './pnpm/PnpmShrinkwrapFile';
+import { YarnShrinkwrapFile } from './yarn/YarnShrinkwrapFile';
 
 export class ShrinkwrapFileFactory {
   public static getShrinkwrapFile(packageManager: PackageManager,
     shrinkwrapFilename: string): BaseShrinkwrapFile | undefined {
 
-    if (packageManager === 'npm') {
-      return NpmShrinkwrapFile.loadFromFile(shrinkwrapFilename);
-    } else if (packageManager === 'pnpm') {
-      return PnpmShrinkwrapFile.loadFromFile(shrinkwrapFilename);
+    switch (packageManager) {
+      case 'npm':
+        return NpmShrinkwrapFile.loadFromFile(shrinkwrapFilename);
+      case 'pnpm':
+        return PnpmShrinkwrapFile.loadFromFile(shrinkwrapFilename);
+      case 'yarn':
+        return YarnShrinkwrapFile.loadFromFile(shrinkwrapFilename);
     }
     throw new Error(`Invalid package manager: ${packageManager}`);
   }

--- a/apps/rush-lib/src/logic/base/BaseShrinkwrapFile.ts
+++ b/apps/rush-lib/src/logic/base/BaseShrinkwrapFile.ts
@@ -32,7 +32,6 @@ export abstract class BaseShrinkwrapFile {
    * Returns true if the shrinkwrap file includes a top-level package that would satisfy the specified
    * package name and SemVer version range
    */
-
   public hasCompatibleTopLevelDependency(dependencyName: string, versionRange: string): boolean {
     const dependencyVersion: string | undefined = this.getTopLevelDependencyVersion(dependencyName);
     if (!dependencyVersion) {

--- a/apps/rush-lib/src/logic/base/BaseShrinkwrapFile.ts
+++ b/apps/rush-lib/src/logic/base/BaseShrinkwrapFile.ts
@@ -31,6 +31,8 @@ export abstract class BaseShrinkwrapFile {
   /**
    * Returns true if the shrinkwrap file includes a top-level package that would satisfy the specified
    * package name and SemVer version range
+   *
+   * @virtual
    */
   public hasCompatibleTopLevelDependency(dependencyName: string, versionRange: string): boolean {
     const dependencyVersion: string | undefined = this.getTopLevelDependencyVersion(dependencyName);
@@ -57,6 +59,8 @@ export abstract class BaseShrinkwrapFile {
    *
    * In this example, hasCompatibleDependency("lib-b", ">= 1.1.0", "temp-project") would fail
    * because it finds lib-b@1.0.0 which does not satisfy the pattern ">= 1.1.0".
+   *
+   * @virtual
    */
   public tryEnsureCompatibleDependency(dependencyName: string, versionRange: string, tempProjectName: string): boolean {
     const dependencyVersion: string | undefined =

--- a/apps/rush-lib/src/logic/npm/NpmShrinkwrapFile.ts
+++ b/apps/rush-lib/src/logic/npm/NpmShrinkwrapFile.ts
@@ -9,21 +9,21 @@ import {
   BaseShrinkwrapFile
 } from '../base/BaseShrinkwrapFile';
 
-interface IShrinkwrapDependencyJson {
+interface INpmShrinkwrapDependencyJson {
   version: string;
   from: string;
   resolved: string;
-  dependencies: { [dependency: string]: IShrinkwrapDependencyJson };
+  dependencies: { [dependency: string]: INpmShrinkwrapDependencyJson };
 }
 
-interface IShrinkwrapJson {
+interface INpmShrinkwrapJson {
   name: string;
   version: string;
-  dependencies: { [dependency: string]: IShrinkwrapDependencyJson };
+  dependencies: { [dependency: string]: INpmShrinkwrapDependencyJson };
 }
 
 export class NpmShrinkwrapFile extends BaseShrinkwrapFile {
-  private _shrinkwrapJson: IShrinkwrapJson;
+  private _shrinkwrapJson: INpmShrinkwrapJson;
 
   public static loadFromFile(shrinkwrapJsonFilename: string): NpmShrinkwrapFile | undefined {
     let data: string | undefined = undefined;
@@ -55,7 +55,7 @@ export class NpmShrinkwrapFile extends BaseShrinkwrapFile {
 
   protected getTopLevelDependencyVersion(dependencyName: string): string | undefined {
      // First, check under tempProjectName, as this is the first place "rush link" looks.
-    const dependencyJson: IShrinkwrapDependencyJson | undefined =
+    const dependencyJson: INpmShrinkwrapDependencyJson | undefined =
       NpmShrinkwrapFile.tryGetValue(this._shrinkwrapJson.dependencies, dependencyName);
 
      if (!dependencyJson) {
@@ -75,9 +75,9 @@ export class NpmShrinkwrapFile extends BaseShrinkwrapFile {
     versionRange: string): string | undefined {
 
     // First, check under tempProjectName, as this is the first place "rush link" looks.
-    let dependencyJson: IShrinkwrapDependencyJson | undefined = undefined;
+    let dependencyJson: INpmShrinkwrapDependencyJson | undefined = undefined;
 
-    const tempDependency: IShrinkwrapDependencyJson | undefined = NpmShrinkwrapFile.tryGetValue(
+    const tempDependency: INpmShrinkwrapDependencyJson | undefined = NpmShrinkwrapFile.tryGetValue(
       this._shrinkwrapJson.dependencies, tempProjectName);
     if (tempDependency && tempDependency.dependencies) {
       dependencyJson = NpmShrinkwrapFile.tryGetValue(tempDependency.dependencies, dependencyName);
@@ -91,7 +91,7 @@ export class NpmShrinkwrapFile extends BaseShrinkwrapFile {
     return dependencyJson.version;
   }
 
-  private constructor(shrinkwrapJson: IShrinkwrapJson) {
+  private constructor(shrinkwrapJson: INpmShrinkwrapJson) {
     super();
     this._shrinkwrapJson = shrinkwrapJson;
 

--- a/apps/rush-lib/src/logic/pnpm/PnpmShrinkwrapFile.ts
+++ b/apps/rush-lib/src/logic/pnpm/PnpmShrinkwrapFile.ts
@@ -14,7 +14,7 @@ const SHRINKWRAP_YAML_FORMAT: yaml.DumpOptions = {
   sortKeys: true
 };
 
-interface IShrinkwrapDependencyJson {
+interface IPnpmShrinkwrapDependencyYaml {
   /** Information about the resolved package */
   resolution: {
     /** The hash of the tarball, to ensure archive integrity */
@@ -57,11 +57,11 @@ interface IShrinkwrapDependencyJson {
  *    }
  *  }
  */
-interface IShrinkwrapYaml {
+interface IPnpmShrinkwrapYaml {
   /** The list of resolved version numbers for direct dependencies */
   dependencies: { [dependency: string]: string };
   /** The description of the solved graph */
-  packages: { [dependencyVersion: string]: IShrinkwrapDependencyJson };
+  packages: { [dependencyVersion: string]: IPnpmShrinkwrapDependencyYaml };
   /** URL of the registry which was used */
   registry: string;
   /** The list of specifiers used to resolve direct dependency versions */
@@ -105,7 +105,7 @@ export function extractVersionFromPnpmVersionSpecifier(version: string): string 
 }
 
 export class PnpmShrinkwrapFile extends BaseShrinkwrapFile {
-  private _shrinkwrapJson: IShrinkwrapYaml;
+  private _shrinkwrapJson: IPnpmShrinkwrapYaml;
 
   public static loadFromFile(shrinkwrapYamlFilename: string): PnpmShrinkwrapFile | undefined {
     try {
@@ -115,7 +115,7 @@ export class PnpmShrinkwrapFile extends BaseShrinkwrapFile {
 
       // We don't use JsonFile/jju here because shrinkwrap.json is a special NPM file format
       // and typically very large, so we want to load it the same way that NPM does.
-      const parsedData: IShrinkwrapYaml = yaml.safeLoad(FileSystem.readFile(shrinkwrapYamlFilename).toString());
+      const parsedData: IPnpmShrinkwrapYaml = yaml.safeLoad(FileSystem.readFile(shrinkwrapYamlFilename).toString());
 
       return new PnpmShrinkwrapFile(parsedData);
     } catch (error) {
@@ -159,7 +159,7 @@ export class PnpmShrinkwrapFile extends BaseShrinkwrapFile {
     // linked to.
 
     const tempProjectDependencyKey: string = this._getTempProjectKey(tempProjectName);
-    const packageDescription: IShrinkwrapDependencyJson | undefined =
+    const packageDescription: IPnpmShrinkwrapDependencyYaml | undefined =
       this._getPackageDescription(tempProjectDependencyKey);
     if (!packageDescription) {
       return undefined;
@@ -203,7 +203,7 @@ export class PnpmShrinkwrapFile extends BaseShrinkwrapFile {
     return super.checkValidVersionRange(dependencyVersion.split('/').pop()!, versionRange);
   }
 
-  private constructor(shrinkwrapJson: IShrinkwrapYaml) {
+  private constructor(shrinkwrapJson: IPnpmShrinkwrapYaml) {
     super();
     this._shrinkwrapJson = shrinkwrapJson;
 
@@ -227,7 +227,7 @@ export class PnpmShrinkwrapFile extends BaseShrinkwrapFile {
    */
   private _getDependencyVersion(dependencyName: string, tempProjectName: string): string | undefined {
     const tempProjectDependencyKey: string = this._getTempProjectKey(tempProjectName);
-    const packageDescription: IShrinkwrapDependencyJson | undefined =
+    const packageDescription: IPnpmShrinkwrapDependencyYaml | undefined =
       this._getPackageDescription(tempProjectDependencyKey);
     if (!packageDescription) {
       return undefined;
@@ -243,8 +243,8 @@ export class PnpmShrinkwrapFile extends BaseShrinkwrapFile {
   /**
    * Gets the package description for a tempProject from the shrinkwrap file.
    */
-  private _getPackageDescription(tempProjectDependencyKey: string): IShrinkwrapDependencyJson | undefined {
-    const packageDescription: IShrinkwrapDependencyJson | undefined
+  private _getPackageDescription(tempProjectDependencyKey: string): IPnpmShrinkwrapDependencyYaml | undefined {
+    const packageDescription: IPnpmShrinkwrapDependencyYaml | undefined
       = BaseShrinkwrapFile.tryGetValue(this._shrinkwrapJson.packages, tempProjectDependencyKey);
 
     if (!packageDescription || !packageDescription.dependencies) {

--- a/apps/rush-lib/src/logic/yarn/YarnShrinkwrapFile.ts
+++ b/apps/rush-lib/src/logic/yarn/YarnShrinkwrapFile.ts
@@ -1,0 +1,33 @@
+import {
+  BaseShrinkwrapFile
+} from '../base/BaseShrinkwrapFile';
+
+export class YarnShrinkwrapFile extends BaseShrinkwrapFile {
+  public static loadFromFile(shrinkwrapJsonFilename: string): YarnShrinkwrapFile | undefined {
+    return undefined;
+  }
+
+  public getTempProjectNames(): ReadonlyArray<string> {
+    throw new Error('todo');
+  }
+
+  protected serialize(): string {
+    throw new Error('todo');
+  }
+
+  protected getTopLevelDependencyVersion(dependencyName: string): string | undefined {
+    throw new Error('todo');
+  }
+
+  /**
+   * @param dependencyName the name of the dependency to get a version for
+   * @param tempProjectName the name of the temp project to check for this dependency
+   * @param versionRange Not used, just exists to satisfy abstract API contract
+   */
+  protected tryEnsureDependencyVersion(dependencyName: string,
+    tempProjectName: string,
+    versionRange: string): string | undefined {
+
+    throw new Error('todo');
+  }
+}

--- a/apps/rush-lib/src/logic/yarn/YarnShrinkwrapFile.ts
+++ b/apps/rush-lib/src/logic/yarn/YarnShrinkwrapFile.ts
@@ -65,6 +65,14 @@ interface IYarnShrinkwrapJson {
 
 /**
  * Support for consuming the "yarn.lock" file.
+ *
+ * Yarn refers to its shrinkwrap file as a "lock file", even though it has nothing to do
+ * with file locking.  Apparently this was based on a convention of the Ruby bundler.
+ * Since Rush has to work interchangeably with 3 different package managers, here we refer
+ * generically to yarn.lock as a "shrinkwrap file".
+ *
+ * If Rush's Yarn support gains popularity, we will try to improve the wording of
+ * logging messages to use terminology more consistent with Yarn's own documentation.
  */
 export class YarnShrinkwrapFile extends BaseShrinkwrapFile {
   // Example inputs:
@@ -103,7 +111,7 @@ export class YarnShrinkwrapFile extends BaseShrinkwrapFile {
     const result: RegExpExecArray | null = YarnShrinkwrapFile.packageNameAndSemVerRegExp.exec(packageNameAndSemVer);
     if (!result) {
       // Sanity check -- this should never happen
-      throw new Error('Unable to parse package/semver expression in the Yarn shrinkwrap file: '
+      throw new Error('Unable to parse package/semver expression in the Yarn shrinkwrap file (yarn.lock): '
         + JSON.stringify(packageNameAndSemVer));
     }
 
@@ -111,7 +119,7 @@ export class YarnShrinkwrapFile extends BaseShrinkwrapFile {
     const parsedPackageName: IParsedPackageNameOrError = PackageName.tryParse(packageName);
     if (parsedPackageName.error) {
       // Sanity check -- this should never happen
-      throw new Error('Invalid package name the Yarn shrinkwrap file: '
+      throw new Error('Invalid package name the Yarn shrinkwrap file (yarn.lock): '
         + JSON.stringify(packageNameAndSemVer) + '\n' + parsedPackageName.error);
     }
 
@@ -186,13 +194,13 @@ export class YarnShrinkwrapFile extends BaseShrinkwrapFile {
         if (!/^file:/i.test(packageNameAndSemVer.semVerRange)) {
           // Sanity check to make sure this is a real package.
           // (Nobody should ever have an actual dependency on an "@rush-temp/" package.
-          throw new Error('Unexpected package/semver expression found in the Yarn shrinkwrap file: '
+          throw new Error('Unexpected package/semver expression found in the Yarn shrinkwrap file (yarn.lock): '
             + JSON.stringify(key));
         }
 
         if (!seenEntries.add(packageNameAndSemVer.packageName)) {
           // Sanity check -- this should never happen
-          throw new Error('Duplicate @rush-temp package found in the Yarn shrinkwrap file: '
+          throw new Error('Duplicate @rush-temp package found in the Yarn shrinkwrap file (yarn.lock): '
             + JSON.stringify(key));
         }
 

--- a/apps/rush-lib/src/logic/yarn/YarnShrinkwrapFile.ts
+++ b/apps/rush-lib/src/logic/yarn/YarnShrinkwrapFile.ts
@@ -1,14 +1,130 @@
+import * as os from 'os';
+import * as lockfile from '@yarnpkg/lockfile';
 import {
   BaseShrinkwrapFile
 } from '../base/BaseShrinkwrapFile';
+import { FileSystem, PackageName } from '@microsoft/node-core-library';
+import { RushConstants } from '../RushConstants';
 
+interface IPackageNameAndSemVer {
+  packageName: string;
+  semVerRange: string;
+}
+
+interface IYarnShrinkwrapSemVerResolution {
+  /**
+   * The specific version that was chosen for this entry (i.e. package name and SemVer range)/
+   *
+   */
+  version: string;
+
+  /**
+   * The source (e.g. registry tarball URL) of the package that was installed
+   * with the integrity hash as a suffix.
+   *
+   * Examples:
+   * https://registry.yarnpkg.com/@pnpm/types/-/types-1.7.0.tgz#9d66a8bed3fabcd80f288b3e7884b7418b05b5a9
+   * file:./projects/api-documenter.tgz#d95f9779aa45df3ef1bbd95dec324793540765ba
+   */
+  resolved: string;
+
+  /**
+   * Records the original (unsolved) "dependencies" from the package.json.
+   */
+  dependencies?: { [dependency: string]: string };
+
+  /**
+   * Records the original (unsolved) "optionalDependencies" from the package.json.
+   *
+   * NOTE: Interestingly "peerDependencies" are apparently not tracked by the shrinkwrap file.
+   * The "devDependencies" are not tracked either, because they are always indirect dependencies
+   * for the installation.
+   */
+  optionalDependencies?: { [dependency: string]: string };
+}
+
+interface IYarnShrinkwrapJson {
+  /**
+   * Example keys:
+   * `js-tokens@^3.0.0 || ^4.0.0`
+   * `@rush-temp/api-extractor-test-03@file:./projects/api-extractor-test-03.tgz`
+   *
+   * The value records how the SemVer range was solved.
+   */
+  [packageNameAndSemVer: string]: IYarnShrinkwrapSemVerResolution;
+}
+
+/**
+ * Support for consuming the "yarn.lock" file.  (The Yarn documentation refers to this
+ * as a "lock file", but we avoid that terminology because it is inconsistent with decades
+ * of industry convention.  Its function is identical to the NPM/PNPM shrinkwrap file.)
+ */
 export class YarnShrinkwrapFile extends BaseShrinkwrapFile {
-  public static loadFromFile(shrinkwrapJsonFilename: string): YarnShrinkwrapFile | undefined {
-    return undefined;
+  // Example inputs:
+  // "js-tokens@^3.0.0 || ^4.0.0"
+  // "@rush-temp/api-extractor-test-03@file:./projects/api-extractor-test-03.tgz"
+  private static packageNameAndSemVerRegExp: RegExp = /^(@?[^@\s]+)(?:@(.*))?$/;
+
+  private _shrinkwrapJson: IYarnShrinkwrapJson;
+
+  public static loadFromFile(shrinkwrapFilename: string): YarnShrinkwrapFile | undefined {
+    let shrinkwrapJson: lockfile.ParseResult;
+    try {
+      if (!FileSystem.exists(shrinkwrapFilename)) {
+        return undefined; // file does not exist
+      }
+
+      const fileContent: string = FileSystem.readFile(shrinkwrapFilename);
+      shrinkwrapJson = lockfile.parse(fileContent);
+    } catch (error) {
+      throw new Error(`Error reading "${shrinkwrapFilename}":` + os.EOL + `  ${error.message}`);
+    }
+
+    return new YarnShrinkwrapFile(shrinkwrapJson.object as IYarnShrinkwrapJson);
+  }
+
+  private static _parsePackageNameAndSemVer(packageNameAndSemVer: string): IPackageNameAndSemVer {
+    const result: RegExpExecArray | null = YarnShrinkwrapFile.packageNameAndSemVerRegExp.exec(packageNameAndSemVer);
+    if (!result) {
+      // Sanity check -- this should never happen
+      throw new Error('Unable to parse package/semver expression in the Yarn shrinkwrap file: '
+        + JSON.stringify(packageNameAndSemVer));
+    }
+    return {
+      packageName: result[1] || '',
+      semVerRange: result[2] || ''
+    };
   }
 
   public getTempProjectNames(): ReadonlyArray<string> {
-    throw new Error('todo');
+    const seenEntries: Set<string> = new Set();
+    const result: string[] = [];
+
+    for (const key of Object.keys(this._shrinkwrapJson)) {
+      // Example key:
+      const packageNameAndSemVer: IPackageNameAndSemVer = YarnShrinkwrapFile._parsePackageNameAndSemVer(key);
+
+      // If it starts with @rush-temp, then include it:
+      if (PackageName.getScope(packageNameAndSemVer.packageName) === RushConstants.rushTempNpmScope) {
+        if (!/^file:/i.test(packageNameAndSemVer.semVerRange)) {
+          // Sanity check to make sure this is a real package.
+          // (Nobody should ever have an actual dependency on an "@rush-temp/" package.
+          throw new Error('Unexpected package/semver expression found in the Yarn shrinkwrap file: '
+            + JSON.stringify(key));
+        }
+
+        if (!seenEntries.add(packageNameAndSemVer.packageName)) {
+          // Sanity check -- this should never happen
+          throw new Error('Duplicate @rush-temp package found in the Yarn shrinkwrap file: '
+            + JSON.stringify(key));
+        }
+
+        result.push(packageNameAndSemVer.packageName);
+      }
+    }
+
+    result.sort();  // make the result deterministic
+    return result;
   }
 
   protected serialize(): string {
@@ -29,5 +145,10 @@ export class YarnShrinkwrapFile extends BaseShrinkwrapFile {
     versionRange: string): string | undefined {
 
     throw new Error('todo');
+  }
+
+  private constructor(shrinkwrapJson: IYarnShrinkwrapJson) {
+    super();
+    this._shrinkwrapJson = shrinkwrapJson;
   }
 }

--- a/apps/rush-lib/src/logic/yarn/YarnShrinkwrapFile.ts
+++ b/apps/rush-lib/src/logic/yarn/YarnShrinkwrapFile.ts
@@ -3,7 +3,7 @@ import * as lockfile from '@yarnpkg/lockfile';
 import {
   BaseShrinkwrapFile
 } from '../base/BaseShrinkwrapFile';
-import { FileSystem, PackageName } from '@microsoft/node-core-library';
+import { FileSystem, PackageName, IParsedPackageNameOrError } from '@microsoft/node-core-library';
 import { RushConstants } from '../RushConstants';
 
 interface IPackageNameAndSemVer {
@@ -92,8 +92,17 @@ export class YarnShrinkwrapFile extends BaseShrinkwrapFile {
       throw new Error('Unable to parse package/semver expression in the Yarn shrinkwrap file: '
         + JSON.stringify(packageNameAndSemVer));
     }
+
+    const packageName: string = result[1] || '';
+    const parsedPackageName: IParsedPackageNameOrError = PackageName.tryParse(packageName);
+    if (parsedPackageName.error) {
+      // Sanity check -- this should never happen
+      throw new Error('Invalid package name the Yarn shrinkwrap file: '
+        + JSON.stringify(packageNameAndSemVer) + '\n' + parsedPackageName.error);
+    }
+
     return {
-      packageName: result[1] || '',
+      packageName,
       semVerRange: result[2] || ''
     };
   }

--- a/apps/rush-lib/src/schemas/rush.schema.json
+++ b/apps/rush-lib/src/schemas/rush.schema.json
@@ -2,46 +2,30 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "title": "Rush main config File",
   "description": "The main configuration file for the Rush multi-project build tool. See http://rushjs.io for details.",
-
   "type": "object",
-  "oneOf": [
-    {
-      "type": "object",
-      "required": ["npmVersion"],
-      "properties": {
-        "npmVersion": {
-          "description": "The version of the NPM tool to install.",
-          "type": "string",
-          "pattern": "^[0-9]+\\.[0-9]+\\.[0-9a-zA-Z.+\\-]+$"
-        }
-      }
-    },
-    {
-      "type": "object",
-      "required": ["pnpmVersion"],
-      "properties": {
-        "pnpmVersion": {
-          "description": "The version of the PNPM tool to install.",
-          "type": "string",
-          "pattern": "^[0-9]+\\.[0-9]+\\.[0-9a-zA-Z.+\\-]+$"
-        }
-      }
-    }
-  ],
 
   "properties": {
-
     "$schema": {
       "description": "Part of the JSON Schema standard, this optional keyword declares the URL of the schema that the file conforms to. Editors may download the schema and use it to perform syntax highlighting.",
       "type": "string"
     },
 
     "npmVersion": {
-      "type": "string"
+      "description": "If specified, selects NPM as the package manager and specifies the deterministic version to be installed by Rush.",
+      "type": "string",
+      "pattern": "^[0-9]+\\.[0-9]+\\.[0-9a-zA-Z.+\\-]+$"
     },
 
     "pnpmVersion": {
-      "type": "string"
+      "description": "If specified, selects PNPM as the package manager and specifies the deterministic version to be installed by Rush.",
+      "type": "string",
+      "pattern": "^[0-9]+\\.[0-9]+\\.[0-9a-zA-Z.+\\-]+$"
+    },
+
+    "yarnVersion": {
+      "description": "If specified, selects Yarn as the package manager and specifies the deterministic version to be installed by Rush.",
+      "type": "string",
+      "pattern": "^[0-9]+\\.[0-9]+\\.[0-9a-zA-Z.+\\-]+$"
     },
 
     "rushVersion": {

--- a/apps/rush-lib/typings/tsd.d.ts
+++ b/apps/rush-lib/typings/tsd.d.ts
@@ -11,3 +11,4 @@
 /// <reference path="read-package-tree/read-package-tree.d.ts" />
 /// <reference path="strict-uri-encode/strict-uri-encode.d.ts" />
 /// <reference path="wordwrap/wordwrap.d.ts" />
+/// <reference path="yarnpkg-lockfile/yarnpkg-lockfile.d.ts" />

--- a/apps/rush-lib/typings/yarnpkg-lockfile/yarnpkg-lockfile.d.ts
+++ b/apps/rush-lib/typings/yarnpkg-lockfile/yarnpkg-lockfile.d.ts
@@ -1,0 +1,18 @@
+// Type definitions for @yarnpkg/lockfile 1.0.2
+// Project: https://www.npmjs.com/package/@yarnpkg/lockfile
+// Definitions by: pgonzal
+
+// NOTE: The entry point is here:
+// https://github.com/yarnpkg/yarn/blob/master/src/lockfile/index.js
+
+declare module '@yarnpkg/lockfile' {
+  export type ParseResultType = 'merge' | 'success' | 'conflict';
+
+  export type ParseResult = {
+    type: ParseResultType,
+    object: Object,
+  };
+
+  export function parse(str: string, fileLoc?: string): ParseResult;
+  export function stringify(obj: Object, noHeader?: boolean, enableVersions?: boolean): string;
+}

--- a/common/changes/@microsoft/node-core-library/pgonzal-yarn-for-rush_2018-09-07-21-04.json
+++ b/common/changes/@microsoft/node-core-library/pgonzal-yarn-for-rush_2018-09-07-21-04.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@microsoft/node-core-library",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/node-core-library",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush/pgonzal-yarn-for-rush_2018-09-07-01-35.json
+++ b/common/changes/@microsoft/rush/pgonzal-yarn-for-rush_2018-09-07-01-35.json
@@ -1,7 +1,7 @@
 {
   "changes": [
     {
-      "comment": "Add support for the Yarn package manager",
+      "comment": "Add support for the Yarn package manager (this is a \"beta\" feature; please report any issues you encounter!)",
       "packageName": "@microsoft/rush",
       "type": "none"
     }

--- a/common/changes/@microsoft/rush/pgonzal-yarn-for-rush_2018-09-07-01-35.json
+++ b/common/changes/@microsoft/rush/pgonzal-yarn-for-rush_2018-09-07-01-35.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Add support for the Yarn package manager",
+      "packageName": "@microsoft/rush",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/config/rush/nonbrowser-approved-packages.json
+++ b/common/config/rush/nonbrowser-approved-packages.json
@@ -99,6 +99,10 @@
       "allowedCategories": [ "libraries" ]
     },
     {
+      "name": "@yarnpkg/lockfile",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
       "name": "api-extractor-test-01",
       "allowedCategories": [ "tests" ]
     },

--- a/common/config/rush/shrinkwrap.yaml
+++ b/common/config/rush/shrinkwrap.yaml
@@ -79,6 +79,7 @@ dependencies:
   '@types/webpack-env': 1.13.0
   '@types/yargs': 0.0.34
   '@types/z-schema': 3.16.31
+  '@yarnpkg/lockfile': 1.0.2
   argparse: 1.0.10
   autoprefixer: 9.1.5
   builtins: 1.0.3
@@ -757,6 +758,10 @@ packages:
     dev: false
     resolution:
       integrity: sha1-LrHQCl5Ow/pYx2r94S4YK2bcXBw=
+  /@yarnpkg/lockfile/1.0.2:
+    dev: false
+    resolution:
+      integrity: sha512-MqJ00WXw89ga0rK6GZkdmmgv3bAsxpJixyTthjcix73O44pBqotyU2BejBkLuIsaOBI6SEu77vAnSyLe5iIHkw==
   /@zkochan/cmd-shim/2.2.4:
     dependencies:
       is-windows: 1.0.2
@@ -10622,6 +10627,7 @@ packages:
       '@types/semver': 5.3.33
       '@types/tar': 4.0.0
       '@types/z-schema': 3.16.31
+      '@yarnpkg/lockfile': 1.0.2
       builtins: 1.0.3
       colors: 1.2.5
       git-repo-info: 1.1.4
@@ -10646,7 +10652,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-lib'
     resolution:
-      integrity: sha512-YPe3TrUuv+C/iwW0UndM1GlPoEo2v2y0Ulhr2xW/25QVLPBuQv0zaXIGg6EqNGnADiXFVuFK7V3HopdVmdx1eg==
+      integrity: sha512-rK6vQ5lcB+FX48o5kpkZKBXe8cjx5ze4KWyPJvzBope4oAP5aJpB22+lao1fa0jZ1FRHBezVlkHAKD3hvOpMlw==
       tarball: 'file:projects/rush-lib.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler.tgz':
@@ -10769,7 +10775,7 @@ packages:
     dev: false
     name: '@rush-temp/web-library-build-test'
     resolution:
-      integrity: sha512-iQaBADz5Yl1Mrzxn15UpYNxuF9blITyNsTlyvjtk43RlnBuUtiNXXsjyq9Je8MB2AQmoyK0/6T0mpF2vYYwW9w==
+      integrity: sha512-A6B5i5lyAI4+TFdeItv6SD9U7NG/4Z7KEN0n7OanKaVFvDWaYM4ywK9w9HTr6qSjAHEeooN4fGaM06tuk2n+Iw==
       tarball: 'file:projects/web-library-build-test.tgz'
     version: 0.0.0
   'file:projects/web-library-build.tgz':
@@ -10781,7 +10787,7 @@ packages:
     dev: false
     name: '@rush-temp/web-library-build'
     resolution:
-      integrity: sha512-lImcj4rOrmXvZxWHZk135boGjNiU3UWE1R5Fgm0eMB6MAtFyQfj9fEQ507NQTySf2kHZ1HHG2bUTAelTrRC5fQ==
+      integrity: sha512-KbZvE6BDht/HSNHqV/NEip71E3lnk7Hi77MwFWPHiocpY1lnoLDBwmZN0qoCj9WguFjzJN+jLs2LvADWBX7jhw==
       tarball: 'file:projects/web-library-build.tgz'
     version: 0.0.0
 registry: 'https://registry.npmjs.org/'
@@ -10868,6 +10874,7 @@ specifiers:
   '@types/webpack-env': 1.13.0
   '@types/yargs': 0.0.34
   '@types/z-schema': 3.16.31
+  '@yarnpkg/lockfile': ~1.0.2
   argparse: ~1.0.9
   autoprefixer: ~9.1.3
   builtins: ~1.0.3

--- a/common/reviews/api/rush-lib.api.ts
+++ b/common/reviews/api/rush-lib.api.ts
@@ -171,6 +171,7 @@ class RushConfiguration {
   readonly rushJsonFolder: string;
   readonly rushLinkJsonFilename: string;
   readonly rushUserFolder: string;
+  readonly shrinkwrapFilePhrase: string;
   // @beta
   readonly telemetryEnabled: boolean;
   readonly tempShrinkwrapFilename: string;

--- a/common/reviews/api/rush-lib.api.ts
+++ b/common/reviews/api/rush-lib.api.ts
@@ -178,6 +178,7 @@ class RushConfiguration {
   static tryFindRushJsonLocation(verbose?: boolean): string | undefined;
   // @beta (undocumented)
   readonly versionPolicyConfiguration: VersionPolicyConfiguration;
+  readonly yarnCacheFolder: string;
 }
 
 // @public

--- a/libraries/node-core-library/src/PackageName.ts
+++ b/libraries/node-core-library/src/PackageName.ts
@@ -48,6 +48,7 @@ export class PackageName {
 
   /**
    * This attempts to parse a package name that may include a scope component.
+   * The packageName must not be an empty string.
    * @remarks
    * This function will not throw an exception.
    *
@@ -135,7 +136,9 @@ export class PackageName {
 
   /**
    * Same as {@link PackageName.tryParse}, except this throws an exception if the input
-   * cannot be parsed
+   * cannot be parsed.
+   * @remarks
+   * The packageName must not be an empty string.
    */
   public static parse(packageName: string): IParsedPackageName {
     const result: IParsedPackageNameOrError = PackageName.tryParse(packageName);
@@ -171,6 +174,7 @@ export class PackageName {
 
   /**
    * Throws an exception if the specified name is not a valid package name.
+   * The packageName must not be an empty string.
    */
   public static validate(packageName: string): void {
     PackageName.parse(packageName);


### PR DESCRIPTION
This PR allows [Yarn](https://yarnpkg.com/) to be used in a Rush repo.  (Hurray!!!)

The symlinking model is the same as Rush's approach for NPM.