### PR TITLE
[api-extractor] Introduce --typescript-lib-package option.

### DIFF
--- a/common/changes/@microsoft/api-extractor/ianc-api-extractor-swap-ts-libs_2018-09-20-23-42.json
+++ b/common/changes/@microsoft/api-extractor/ianc-api-extractor-swap-ts-libs_2018-09-20-23-42.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor",
+      "comment": "Add new feature: Support using a different version of the TypeScript compiler.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/gulp-core-build-typescript/ianc-api-extractor-swap-ts-libs_2018-09-20-23-42.json
+++ b/common/changes/@microsoft/gulp-core-build-typescript/ianc-api-extractor-swap-ts-libs_2018-09-20-23-42.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/gulp-core-build-typescript",
+      "comment": "Include support for the typescriptCompilerFolder api-extractor option.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/gulp-core-build-typescript",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/common/reviews/api/api-extractor.api.ts
+++ b/common/reviews/api/api-extractor.api.ts
@@ -214,8 +214,8 @@ interface IExtractorOptions {
   compilerProgram?: ts.Program;
   customLogger?: Partial<ILogger>;
   localBuild?: boolean;
-  // @alpha
-  typescriptLibPackagePath?: string;
+  // @beta
+  typescriptCompilerFolder?: string;
 }
 
 // @public

--- a/common/reviews/api/api-extractor.api.ts
+++ b/common/reviews/api/api-extractor.api.ts
@@ -214,6 +214,8 @@ interface IExtractorOptions {
   compilerProgram?: ts.Program;
   customLogger?: Partial<ILogger>;
   localBuild?: boolean;
+  // @alpha
+  typescriptLibPackagePath?: string;
 }
 
 // @public

--- a/core-build/gulp-core-build-typescript/src/ApiExtractorTask.ts
+++ b/core-build/gulp-core-build-typescript/src/ApiExtractorTask.ts
@@ -14,6 +14,8 @@ import {
   IExtractorConfig
 } from '@microsoft/api-extractor';
 
+import { BaseCmdTask } from './BaseCmdTask';
+
 /** @public */
 export interface IApiExtractorTaskConfig {
   /**
@@ -100,6 +102,14 @@ export interface IApiExtractorTaskConfig {
    * except definitions marked as \@beta, \@alpha, or \@internal.
    */
   publishFolderForPublic?: string;
+
+  /**
+   * If specified, use typings specified in the project's compilerOptions -> lib option
+   * from this TypeScript compiler package.
+   *
+   * @alpha
+   */
+  typescriptLibPackagePath?: string;
 }
 
 /**
@@ -116,7 +126,8 @@ export class ApiExtractorTask extends GulpTask<IApiExtractorTaskConfig>  {
         enabled: false,
         entry: undefined,
         apiReviewFolder: undefined,
-        apiJsonFolder: undefined
+        apiJsonFolder: undefined,
+        typescriptLibPackagePath: BaseCmdTask.getPackagePath('typescript')
       }
     );
   }
@@ -193,7 +204,8 @@ export class ApiExtractorTask extends GulpTask<IApiExtractorTaskConfig>  {
           logInfo: (message: string) => this.log(message),
           logWarning: (message: string) => this.logWarning(message),
           logError: (message: string) => this.logError(message)
-        }
+        },
+        typescriptLibPackagePath: this.taskConfig.typescriptLibPackagePath
       };
 
       const extractor: Extractor = new Extractor(extractorConfig, extractorOptions);

--- a/core-build/gulp-core-build-typescript/src/ApiExtractorTask.ts
+++ b/core-build/gulp-core-build-typescript/src/ApiExtractorTask.ts
@@ -104,12 +104,11 @@ export interface IApiExtractorTaskConfig {
   publishFolderForPublic?: string;
 
   /**
-   * If specified, use typings specified in the project's compilerOptions -> lib option
-   * from this TypeScript compiler package.
+   * Use this option to override the version of the TypeScript compiler API extractor should use.
    *
-   * @alpha
+   * @beta
    */
-  typescriptLibPackagePath?: string;
+  typescriptCompilerFolder?: string;
 }
 
 /**
@@ -127,7 +126,7 @@ export class ApiExtractorTask extends GulpTask<IApiExtractorTaskConfig>  {
         entry: undefined,
         apiReviewFolder: undefined,
         apiJsonFolder: undefined,
-        typescriptLibPackagePath: BaseCmdTask.getPackagePath('typescript')
+        typescriptCompilerFolder: BaseCmdTask.getPackagePath('typescript')
       }
     );
   }
@@ -205,7 +204,7 @@ export class ApiExtractorTask extends GulpTask<IApiExtractorTaskConfig>  {
           logWarning: (message: string) => this.logWarning(message),
           logError: (message: string) => this.logError(message)
         },
-        typescriptLibPackagePath: this.taskConfig.typescriptLibPackagePath
+        typescriptCompilerFolder: this.taskConfig.typescriptCompilerFolder
       };
 
       const extractor: Extractor = new Extractor(extractorConfig, extractorOptions);

--- a/core-build/gulp-core-build-typescript/src/BaseCmdTask.ts
+++ b/core-build/gulp-core-build-typescript/src/BaseCmdTask.ts
@@ -9,7 +9,7 @@ import {
   JsonFile,
   IPackageJson,
   FileSystem,
-  FileConstants
+  PackageJsonLookup
 } from '@microsoft/node-core-library';
 import { GulpTask } from '@microsoft/gulp-core-build';
 
@@ -89,6 +89,17 @@ export abstract class BaseCmdTask<TTaskConfig extends IBaseCmdTaskConfig> extend
   protected _packageBinPath: string;
   protected _errorHasBeenLogged: boolean;
 
+  public static getPackagePath(packageName: string): string | undefined {
+    const packageJsonPath: string | undefined = BaseCmdTask._getPackageJsonPath(packageName);
+    return packageJsonPath ? path.dirname(packageJsonPath) : undefined;
+  }
+
+  private static _getPackageJsonPath(packageName: string): string | undefined {
+    const lookup: PackageJsonLookup = new PackageJsonLookup();
+    const mainEntryPath: string = require.resolve(packageName);
+    return lookup.tryGetPackageJsonFilePathFor(mainEntryPath);
+  }
+
   constructor(name: string, options: IBaseTaskOptions<TTaskConfig>) {
     super(name, options.initialTaskConfig);
 
@@ -97,18 +108,13 @@ export abstract class BaseCmdTask<TTaskConfig extends IBaseCmdTaskConfig> extend
   }
 
   public executeTask(gulp: Object, completeCallback: (error?: string) => void): Promise<void> | undefined {
-    let binaryPackagePath: string = require.resolve(this._packageName);
-    let packageJsonPath: string;
-    while (!FileSystem.exists(packageJsonPath = path.join(binaryPackagePath, FileConstants.PackageJson))) {
-      const tempBinaryPackagePath: string = path.dirname(binaryPackagePath);
-      if (binaryPackagePath === tempBinaryPackagePath) {
-        // We've hit the disk root
-        completeCallback(`Unable to find the package.json file for ${this._packageName}.`);
-        return;
-      }
-
-      binaryPackagePath = tempBinaryPackagePath;
+    const packageJsonPath: string | undefined = BaseCmdTask._getPackageJsonPath(this._packageName);
+    if (!packageJsonPath) {
+      completeCallback(`Unable to find the package.json file for ${this._packageName}.`);
+      return;
     }
+
+    let binaryPackagePath: string = path.dirname(packageJsonPath);
 
     if (this.taskConfig.overridePackagePath) {
       // The package version is being overridden


### PR DESCRIPTION
This PR introduces an option to api-extractor to specify a different version of the TypeScript compiler to get lib typings from.