### PR TITLE
[api-extractor] Fixing incorrect TypeScript error message printing.

### DIFF
--- a/apps/api-extractor/src/ExtractorContext.ts
+++ b/apps/api-extractor/src/ExtractorContext.ts
@@ -15,6 +15,7 @@ import { AstPackage } from './ast/AstPackage';
 import { DocItemLoader } from './DocItemLoader';
 import { ILogger } from './extractor/ILogger';
 import { IExtractorPoliciesConfig, IExtractorValidationRulesConfig } from './extractor/IExtractorConfig';
+import { TypeScriptMessageSerializer } from './utils/TypeScriptMessageSerializer';
 
 /**
  * Options for ExtractorContext constructor.
@@ -102,7 +103,8 @@ export class ExtractorContext {
     // with semantic information (i.e. symbols).  The "diagnostics" are a subset of the everyday
     // compile errors that would result from a full compilation.
     for (const diagnostic of options.program.getSemanticDiagnostics()) {
-      this.reportError('TypeScript: ' + diagnostic.messageText, diagnostic.file, diagnostic.start);
+      const errorText: string = TypeScriptMessageSerializer.serialize(diagnostic.messageText);
+      this.reportError(`TypeScript: ${errorText}`, diagnostic.file, diagnostic.start);
     }
 
     this.typeChecker = options.program.getTypeChecker();

--- a/apps/api-extractor/src/ExtractorContext.ts
+++ b/apps/api-extractor/src/ExtractorContext.ts
@@ -15,7 +15,7 @@ import { AstPackage } from './ast/AstPackage';
 import { DocItemLoader } from './DocItemLoader';
 import { ILogger } from './extractor/ILogger';
 import { IExtractorPoliciesConfig, IExtractorValidationRulesConfig } from './extractor/IExtractorConfig';
-import { TypeScriptMessageSerializer } from './utils/TypeScriptMessageSerializer';
+import { TypeScriptMessageFormatter } from './utils/TypeScriptMessageFormatter';
 
 /**
  * Options for ExtractorContext constructor.
@@ -103,7 +103,7 @@ export class ExtractorContext {
     // with semantic information (i.e. symbols).  The "diagnostics" are a subset of the everyday
     // compile errors that would result from a full compilation.
     for (const diagnostic of options.program.getSemanticDiagnostics()) {
-      const errorText: string = TypeScriptMessageSerializer.serialize(diagnostic.messageText);
+      const errorText: string = TypeScriptMessageFormatter.format(diagnostic.messageText);
       this.reportError(`TypeScript: ${errorText}`, diagnostic.file, diagnostic.start);
     }
 

--- a/apps/api-extractor/src/extractor/Extractor.ts
+++ b/apps/api-extractor/src/extractor/Extractor.ts
@@ -24,7 +24,7 @@ import { ApiJsonGenerator } from '../generators/ApiJsonGenerator';
 import { ApiFileGenerator } from '../generators/ApiFileGenerator';
 import { DtsRollupGenerator, DtsRollupKind } from '../generators/dtsRollup/DtsRollupGenerator';
 import { MonitoredLogger } from './MonitoredLogger';
-import { TypeScriptMessageSerializer } from '../utils/TypeScriptMessageSerializer';
+import { TypeScriptMessageFormatter } from '../utils/TypeScriptMessageFormatter';
 
 /**
  * Options for {@link Extractor.processProject}.
@@ -206,7 +206,7 @@ export class Extractor {
         this._program = ts.createProgram(analysisFilePaths, commandLine.options);
 
         if (commandLine.errors.length > 0) {
-          const errorText: string = TypeScriptMessageSerializer.serialize(commandLine.errors[0].messageText);
+          const errorText: string = TypeScriptMessageFormatter.format(commandLine.errors[0].messageText);
           throw new Error(`Error parsing tsconfig.json content: ${errorText}`);
         }
 

--- a/apps/api-extractor/src/extractor/Extractor.ts
+++ b/apps/api-extractor/src/extractor/Extractor.ts
@@ -24,6 +24,7 @@ import { ApiJsonGenerator } from '../generators/ApiJsonGenerator';
 import { ApiFileGenerator } from '../generators/ApiFileGenerator';
 import { DtsRollupGenerator, DtsRollupKind } from '../generators/dtsRollup/DtsRollupGenerator';
 import { MonitoredLogger } from './MonitoredLogger';
+import { TypeScriptMessageSerializer } from '../utils/TypeScriptMessageSerializer';
 
 /**
  * Options for {@link Extractor.processProject}.
@@ -205,7 +206,8 @@ export class Extractor {
         this._program = ts.createProgram(analysisFilePaths, commandLine.options);
 
         if (commandLine.errors.length > 0) {
-          throw new Error('Error parsing tsconfig.json content: ' + commandLine.errors[0].messageText);
+          const errorText: string = TypeScriptMessageSerializer.serialize(commandLine.errors[0].messageText);
+          throw new Error(`Error parsing tsconfig.json content: ${errorText}`);
         }
 
         break;

--- a/apps/api-extractor/src/utils/TypeScriptMessageFormatter.ts
+++ b/apps/api-extractor/src/utils/TypeScriptMessageFormatter.ts
@@ -3,11 +3,11 @@
 
 import * as ts from 'typescript';
 
-export class TypeScriptMessageSerializer {
+export class TypeScriptMessageFormatter {
   /**
    * Serialize a TypeScript diagnostic message or message chain.
    */
-  public static serialize(messageText: string | ts.DiagnosticMessageChain): string {
+  public static format(messageText: string | ts.DiagnosticMessageChain): string {
     const serializedErrors: string[] = [];
     for (
       let wrappedMessageText: string | ts.DiagnosticMessageChain | undefined = messageText;

--- a/apps/api-extractor/src/utils/TypeScriptMessageFormatter.ts
+++ b/apps/api-extractor/src/utils/TypeScriptMessageFormatter.ts
@@ -5,22 +5,22 @@ import * as ts from 'typescript';
 
 export class TypeScriptMessageFormatter {
   /**
-   * Serialize a TypeScript diagnostic message or message chain.
+   * Format a TypeScript diagnostic message or message chain.
    */
   public static format(messageText: string | ts.DiagnosticMessageChain): string {
-    const serializedErrors: string[] = [];
+    const formattedErrors: string[] = [];
     for (
       let wrappedMessageText: string | ts.DiagnosticMessageChain | undefined = messageText;
       wrappedMessageText !== undefined;
       wrappedMessageText = (wrappedMessageText as ts.DiagnosticMessageChain).next
     ) {
       if (typeof wrappedMessageText === 'string') {
-        serializedErrors.push(wrappedMessageText);
+        formattedErrors.push(wrappedMessageText);
       } else {
-        serializedErrors.push(wrappedMessageText.messageText);
+        formattedErrors.push(wrappedMessageText.messageText);
       }
     }
 
-    return serializedErrors.join('; ');
+    return formattedErrors.join('; ');
   }
 }

--- a/apps/api-extractor/src/utils/TypeScriptMessageSerializer.ts
+++ b/apps/api-extractor/src/utils/TypeScriptMessageSerializer.ts
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import * as ts from 'typescript';
+
+export class TypeScriptMessageSerializer {
+  /**
+   * Serialize a TypeScript diagnostic message or message chain.
+   */
+  public static serialize(messageText: string | ts.DiagnosticMessageChain): string {
+    const serializedErrors: string[] = [];
+    for (
+      let wrappedMessageText: string | ts.DiagnosticMessageChain | undefined = messageText;
+      wrappedMessageText !== undefined;
+      wrappedMessageText = (wrappedMessageText as ts.DiagnosticMessageChain).next
+    ) {
+      if (typeof wrappedMessageText === 'string') {
+        serializedErrors.push(wrappedMessageText);
+      } else {
+        serializedErrors.push(wrappedMessageText.messageText);
+      }
+    }
+
+    return serializedErrors.join('; ');
+  }
+}

--- a/common/changes/@microsoft/api-extractor/ianc-fixing-api-extractor-error-messages_2018-09-21-00-31.json
+++ b/common/changes/@microsoft/api-extractor/ianc-fixing-api-extractor-error-messages_2018-09-21-00-31.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor",
+      "comment": "Fix an issue where TypeScript errors are often logged as \"[Object object]\" instead of the actual error message.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor",
+  "email": "iclanton@users.noreply.github.com"
+}


### PR DESCRIPTION
This PR fixes an issue where TypeScript errors are often logged as "[Object object]" instead of the actual error message.