### PR TITLE
BaseCmdTask displaying wrong version of package when overridePackagePath is set

### DIFF
--- a/common/changes/@microsoft/gulp-core-build-typescript/master_2018-09-21-02-37.json
+++ b/common/changes/@microsoft/gulp-core-build-typescript/master_2018-09-21-02-37.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/gulp-core-build-typescript",
+      "comment": "Fixed overridePackagePath not loading correct version of package.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/gulp-core-build-typescript",
+  "email": "36238331+GolaWaya@users.noreply.github.com"
+}

--- a/core-build/gulp-core-build-typescript/src/BaseCmdTask.ts
+++ b/core-build/gulp-core-build-typescript/src/BaseCmdTask.ts
@@ -108,14 +108,6 @@ export abstract class BaseCmdTask<TTaskConfig extends IBaseCmdTaskConfig> extend
   }
 
   public executeTask(gulp: Object, completeCallback: (error?: string) => void): Promise<void> | undefined {
-    const packageJsonPath: string | undefined = BaseCmdTask._getPackageJsonPath(this._packageName);
-    if (!packageJsonPath) {
-      completeCallback(`Unable to find the package.json file for ${this._packageName}.`);
-      return;
-    }
-
-    let binaryPackagePath: string = path.dirname(packageJsonPath);
-
     if (this.taskConfig.overridePackagePath) {
       // The package version is being overridden
       if (!FileSystem.exists(this.taskConfig.overridePackagePath)) {
@@ -125,9 +117,16 @@ export abstract class BaseCmdTask<TTaskConfig extends IBaseCmdTaskConfig> extend
         );
         return;
       }
-
-      binaryPackagePath = this.taskConfig.overridePackagePath;
     }
+
+    const targetPackage: string = this.taskConfig.overridePackagePath ? path.resolve(this.taskConfig.overridePackagePath) : this._packageName;
+    const packageJsonPath: string | undefined = BaseCmdTask._getPackageJsonPath(targetPackage);
+    if (!packageJsonPath) {
+      completeCallback(`Unable to find the package.json file for ${this._packageName}.`);
+      return;
+    }
+
+    let binaryPackagePath: string = path.dirname(packageJsonPath);
 
     // Print the version
     const packageJson: IPackageJson = JsonFile.load(packageJsonPath);


### PR DESCRIPTION
The code uses require.resolve() to fetch a package by name.  The same method can also take an absolute path and fetch a package located there instead.  If an overridePackagePath is set, the task will now attempt to fetch the updated package.json (if it can't, it will still use the original).

#835 