### PR TITLE
[api-extractor] Introducing --skip-lib-check option to api-extractor.

### DIFF
--- a/apps/api-extractor/src/cli/RunAction.ts
+++ b/apps/api-extractor/src/cli/RunAction.ts
@@ -68,10 +68,10 @@ export class RunAction extends CommandLineAction {
     this._skipLibCheck = this.defineFlagParameter({
       parameterLongName: '--skip-lib-check',
       description: 'This flag causes the typechecker to be invoked with the --skipLibCheck option. This option is not'
-        + ' recommended and may cause api-extractor to produce incomplete or incorrect declarations, but it '
-        + ' may be required when dependencies contain declarations that are incompatible with newer versions'
-        + ' of TypeScript. If this option is used, it is strongly recommended that broken dependencies be'
-        + ' fixed or upgraded.'
+        + ' recommended and may cause API Extractor to produce incomplete or incorrect declarations, but it '
+        + ' may be required when dependencies contain declarations that are incompatible with the TypeScript engine'
+        + ' that API Extractor uses for its analysis. If this option is used, it is strongly recommended that broken'
+        + ' dependencies be fixed or upgraded.'
     });
   }
 

--- a/apps/api-extractor/src/cli/RunAction.ts
+++ b/apps/api-extractor/src/cli/RunAction.ts
@@ -29,6 +29,7 @@ export class RunAction extends CommandLineAction {
   private _configFileParameter: CommandLineStringParameter;
   private _localParameter: CommandLineFlagParameter;
   private _typescriptCompilerFolder: CommandLineStringParameter;
+  private _skipLibCheck: CommandLineFlagParameter;
 
   constructor(parser: ApiExtractorCommandLine) {
     super({
@@ -62,6 +63,15 @@ export class RunAction extends CommandLineAction {
       description: 'By default API Extractor uses its own TypeScript compiler version to analyze your project.'
         + ' This can often cause compiler errors due to incompatibilities between different TS versions.'
         + ' Use "--typescript-compiler-folder" to specify the folder path for your compiler version.'
+    });
+
+    this._skipLibCheck = this.defineFlagParameter({
+      parameterLongName: '--skip-lib-check',
+      description: 'This flag causes the typechecker to be invoked with the --skipLibCheck option. This option is not'
+        + ' recommended and may cause api-extractor to produce incomplete or incorrect declarations, but it '
+        + ' may be required when dependencies contain declarations that are incompatible with newer versions'
+        + ' of TypeScript. If this option is used, it is strongly recommended that broken dependencies be'
+        + ' fixed or upgraded.'
     });
   }
 
@@ -124,7 +134,8 @@ export class RunAction extends CommandLineAction {
       config,
       {
         localBuild: this._localParameter.value,
-        typescriptCompilerFolder: typescriptCompilerFolder
+        typescriptCompilerFolder: typescriptCompilerFolder,
+        skipLibCheck: this._skipLibCheck.value
       }
     );
 

--- a/apps/api-extractor/src/extractor/Extractor.ts
+++ b/apps/api-extractor/src/extractor/Extractor.ts
@@ -79,15 +79,13 @@ export interface IExtractorOptions {
 
   /**
    * This option causes the typechecker to be invoked with the --skipLibCheck option. This option is not
-   * recommended and may cause api-extractor to produce incomplete or incorrect declarations, but it
-   * may be required when dependencies contain declarations that are incompatible with newer versions
-   * of TypeScript. If this option is used, it is strongly recommended that broken dependencies be
-   * fixed or upgraded.
+   * recommended and may cause API Extractor to produce incomplete or incorrect declarations, but it
+   * may be required when dependencies contain declarations that are incompatible with the TypeScript engine
+   * that API Extractor uses for its analysis. If this option is used, it is strongly recommended that broken
+   * dependencies be fixed or upgraded.
    *
    * @remarks
    * This option only applies when compiler.config.configType is set to "tsconfig"
-   *
-   * @beta
    */
   skipLibCheck?: boolean;
 }

--- a/apps/api-extractor/src/extractor/Extractor.ts
+++ b/apps/api-extractor/src/extractor/Extractor.ts
@@ -206,6 +206,10 @@ export class Extractor {
 
         if (!commandLine.options.skipLibCheck && options.skipLibCheck) {
           commandLine.options.skipLibCheck = true;
+          console.log(colors.cyan(
+            'API Extractor was invoked with skipLibCheck. This is not recommended and may cause ' +
+            'incorrect type analysis.'
+          ));
         }
 
         this._updateCommandLineForTypescriptPackage(commandLine, options);

--- a/apps/api-extractor/src/extractor/Extractor.ts
+++ b/apps/api-extractor/src/extractor/Extractor.ts
@@ -76,6 +76,20 @@ export interface IExtractorOptions {
    * @beta
    */
   typescriptCompilerFolder?: string;
+
+  /**
+   * This option causes the typechecker to be invoked with the --skipLibCheck option. This option is not
+   * recommended and may cause api-extractor to produce incomplete or incorrect declarations, but it
+   * may be required when dependencies contain declarations that are incompatible with newer versions
+   * of TypeScript. If this option is used, it is strongly recommended that broken dependencies be
+   * fixed or upgraded.
+   *
+   * @remarks
+   * This option only applies when compiler.config.configType is set to "tsconfig"
+   *
+   * @beta
+   */
+  skipLibCheck?: boolean;
 }
 
 /**
@@ -191,6 +205,10 @@ export class Extractor {
           ts.sys,
           this._absoluteRootFolder
         );
+
+        if (!commandLine.options.skipLibCheck && options.skipLibCheck) {
+          commandLine.options.skipLibCheck = true;
+        }
 
         this._updateCommandLineForTypescriptPackage(commandLine, options);
 

--- a/common/changes/@microsoft/api-extractor/ianc-adding-skip-lib-check_2018-09-26-08-18.json
+++ b/common/changes/@microsoft/api-extractor/ianc-adding-skip-lib-check_2018-09-26-08-18.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/api-extractor",
-      "comment": "Create a new experimental option that causes the typechecker to be invoked with --skipLibCheck.",
+      "comment": "Add new command line option --skip-lib-check",
       "type": "minor"
     }
   ],

--- a/common/changes/@microsoft/api-extractor/ianc-adding-skip-lib-check_2018-09-26-08-18.json
+++ b/common/changes/@microsoft/api-extractor/ianc-adding-skip-lib-check_2018-09-26-08-18.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor",
+      "comment": "Create a new experimental option that causes the typechecker to be invoked with --skipLibCheck.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/gulp-core-build-typescript/ianc-adding-skip-lib-check_2018-09-26-08-18.json
+++ b/common/changes/@microsoft/gulp-core-build-typescript/ianc-adding-skip-lib-check_2018-09-26-08-18.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/gulp-core-build-typescript",
+      "comment": "Expose new api-extractor skipLibCheck option.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@microsoft/gulp-core-build-typescript",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/common/reviews/api/api-extractor.api.ts
+++ b/common/reviews/api/api-extractor.api.ts
@@ -214,7 +214,6 @@ interface IExtractorOptions {
   compilerProgram?: ts.Program;
   customLogger?: Partial<ILogger>;
   localBuild?: boolean;
-  // @beta
   skipLibCheck?: boolean;
   // @beta
   typescriptCompilerFolder?: string;

--- a/common/reviews/api/api-extractor.api.ts
+++ b/common/reviews/api/api-extractor.api.ts
@@ -215,6 +215,8 @@ interface IExtractorOptions {
   customLogger?: Partial<ILogger>;
   localBuild?: boolean;
   // @beta
+  skipLibCheck?: boolean;
+  // @beta
   typescriptCompilerFolder?: string;
 }
 

--- a/core-build/gulp-core-build-typescript/src/ApiExtractorTask.ts
+++ b/core-build/gulp-core-build-typescript/src/ApiExtractorTask.ts
@@ -112,12 +112,10 @@ export interface IApiExtractorTaskConfig {
 
   /**
    * This option causes the typechecker to be invoked with the --skipLibCheck option. This option is not
-   * recommended and may cause api-extractor to produce incomplete or incorrect declarations, but it
-   * may be required when dependencies contain declarations that are incompatible with newer versions
-   * of TypeScript. If this option is used, it is strongly recommended that broken dependencies be
-   * fixed or upgraded.
-   *
-   * @beta
+   * recommended and may cause API Extractor to produce incomplete or incorrect declarations, but it
+   * may be required when dependencies contain declarations that are incompatible with the TypeScript engine
+   * that API Extractor uses for its analysis. If this option is used, it is strongly recommended that broken
+   * dependencies be fixed or upgraded.
    */
   skipLibCheck?: boolean;
 }
@@ -194,9 +192,8 @@ export class ApiExtractorTask extends GulpTask<IApiExtractorTaskConfig>  {
         apiJsonFile: {
           enabled: true,
           outputFolder: this.taskConfig.apiJsonFolder
-        },
-        skipLibCheck: this.taskConfig.skipLibCheck
-      } as IExtractorConfig;
+        }
+      };
 
       if (this.taskConfig.generateDtsRollup) {
         extractorConfig.dtsRollup = {
@@ -216,7 +213,8 @@ export class ApiExtractorTask extends GulpTask<IApiExtractorTaskConfig>  {
           logWarning: (message: string) => this.logWarning(message),
           logError: (message: string) => this.logError(message)
         },
-        typescriptCompilerFolder: this.taskConfig.typescriptCompilerFolder
+        typescriptCompilerFolder: this.taskConfig.typescriptCompilerFolder,
+        skipLibCheck: this.taskConfig.skipLibCheck
       };
 
       const extractor: Extractor = new Extractor(extractorConfig, extractorOptions);

--- a/core-build/gulp-core-build-typescript/src/ApiExtractorTask.ts
+++ b/core-build/gulp-core-build-typescript/src/ApiExtractorTask.ts
@@ -109,6 +109,17 @@ export interface IApiExtractorTaskConfig {
    * @beta
    */
   typescriptCompilerFolder?: string;
+
+  /**
+   * This option causes the typechecker to be invoked with the --skipLibCheck option. This option is not
+   * recommended and may cause api-extractor to produce incomplete or incorrect declarations, but it
+   * may be required when dependencies contain declarations that are incompatible with newer versions
+   * of TypeScript. If this option is used, it is strongly recommended that broken dependencies be
+   * fixed or upgraded.
+   *
+   * @beta
+   */
+  skipLibCheck?: boolean;
 }
 
 /**
@@ -183,7 +194,8 @@ export class ApiExtractorTask extends GulpTask<IApiExtractorTaskConfig>  {
         apiJsonFile: {
           enabled: true,
           outputFolder: this.taskConfig.apiJsonFolder
-        }
+        },
+        skipLibCheck: this.taskConfig.skipLibCheck
       } as IExtractorConfig;
 
       if (this.taskConfig.generateDtsRollup) {

--- a/core-build/gulp-core-build-typescript/src/schemas/api-extractor.schema.json
+++ b/core-build/gulp-core-build-typescript/src/schemas/api-extractor.schema.json
@@ -46,6 +46,10 @@
     "publishFolderForPublic": {
       "description": "This setting is only used if \"dtsRollupTrimming\" is true. It indicates the folder where \"npm publish\" will be run for a public release. The default value is \"./dist/public\". A public release will contain all definitions that are reachable from the entry point, except definitions marked as @beta, @alpha, or @internal.",
       "type": "string"
+    },
+    "skipLibCheck": {
+      "description": "This option causes the typechecker to be invoked with the --skipLibCheck option. This option is not recommended and may cause API Extractor to produce incomplete or incorrect declarations, but it may be required when dependencies contain declarations that are incompatible with the TypeScript engine that API Extractor uses for its analysis. If this option is used, it is strongly recommended that broken dependencies be fixed or upgraded.",
+      "type": "boolean"
     }
   },
   "required": [ "enabled" ],


### PR DESCRIPTION
This option causes the typechecker to be invoked with the --skipLibCheck option. This option is not recommended and may cause api-extractor to produce incomplete or incorrect declarations, but may be required when dependencies contain declarations that are incompatible with newer versions of TypeScript. If this option is used, it is strongly recommended that broken dependencies be fixed or upgraded.