### PR TITLE
[gulp-core-build-sass] Better support for indented syntax and, likewise, `.sass` extension

### DIFF
--- a/common/changes/@microsoft/gulp-core-build-sass/sass-extension-support_2018-09-29-03-21.json
+++ b/common/changes/@microsoft/gulp-core-build-sass/sass-extension-support_2018-09-29-03-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/gulp-core-build-sass",
+      "comment": "Better support for indented syntax and, likewise, `.sass` extension.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/gulp-core-build-sass",
+  "email": "jareha@gmail.com"
+}

--- a/core-build/gulp-core-build-sass/README.md
+++ b/core-build/gulp-core-build-sass/README.md
@@ -1,6 +1,6 @@
 # @microsoft/gulp-core-build-sass
 
-`gulp-core-build-sass` is a `gulp-core-build` subtask which processes scss files using SASS, runs them through postcss, and produces commonjs/amd modules which are injected using the `@microsoft/load-themed-styles` package.
+`gulp-core-build-sass` is a `gulp-core-build` subtask which processes sass and scss files using SASS, runs them through postcss, and produces commonjs/amd modules which are injected using the `@microsoft/load-themed-styles` package.
 
 [![npm version](https://badge.fury.io/js/%40microsoft%2Fgulp-core-build-sass.svg)](https://badge.fury.io/js/%40microsoft%2Fgulp-core-build-sass)
 [![Build Status](https://travis-ci.org/Microsoft/gulp-core-build-sass.svg?branch=master)](https://travis-ci.org/Microsoft/gulp-core-build-sass) [![Dependencies](https://david-dm.org/Microsoft/gulp-core-build-sass.svg)](https://david-dm.org/Microsoft/gulp-core-build-sass)
@@ -27,7 +27,7 @@ An array of glob patterns for locating SASS files.
 **Default:** `['src/**/*.scss']`
 
 ### useCSSModules
-If this option is specified, ALL files will be treated as a `module.scss` and will
+If this option is specified, ALL files will be treated as `module.sass` or `module.scss` and will
 automatically generate a corresponding TypeScript file. All classes will be
 appended with a hash to help ensure uniqueness on a page. This file can be
 imported directly, and will contain an object describing the mangled class names.
@@ -39,8 +39,13 @@ If this is false, then we do not create `.css` files in the `lib` directory.
 
 **Default:** `false`
 
+### sassSyntax
+An optional parameter for setting SASS syntax.
+
+**Default:** `scss`
+
 ### warnOnNonCSSModules
-If files are matched by sassMatch which do not end in .module.scss, log a warning.
+If files are matched by sassMatch which do not end in `.module.sass` or `.module.scss`, log a warning.
 
 **Default:** `false`
 

--- a/core-build/gulp-core-build-sass/src/SassTask.ts
+++ b/core-build/gulp-core-build-sass/src/SassTask.ts
@@ -68,7 +68,6 @@ export class SassTask extends GulpTask<ISassTaskConfig> {
         preamble: '/* tslint:disable */',
         postamble: '/* tslint:enable */',
         sassMatch: [
-          'src/**/*.sass',
           'src/**/*.scss'
         ],
         useCSSModules: false,

--- a/core-build/gulp-core-build-sass/src/SassTask.ts
+++ b/core-build/gulp-core-build-sass/src/SassTask.ts
@@ -125,7 +125,7 @@ export class SassTask extends GulpTask<ISassTaskConfig> {
     } else {
       const moduleSrcPattern: string[] = srcPattern.map((value: string) => {
         return value.replace(/(\.s(a|c)ss)/, '.module$1');
-      }
+      });
 
       moduleSrcPattern.forEach((value: string) => srcPattern.push(`!${value}`));
 

--- a/core-build/gulp-core-build-sass/src/SassTask.ts
+++ b/core-build/gulp-core-build-sass/src/SassTask.ts
@@ -124,9 +124,9 @@ export class SassTask extends GulpTask<ISassTaskConfig> {
       return this._processFiles(gulp, srcPattern, completeCallback, modulePostCssPlugins);
     } else {
       const moduleSrcPattern: string[] = srcPattern.map((value: string) => {
-        return value.replace('.sass', '.module.sass').replace('.scss', '.module.scss'));
+        return value.replace(/(\.s(a|c)ss)/, '.module$1');
       }
-      
+
       moduleSrcPattern.forEach((value: string) => srcPattern.push(`!${value}`));
 
       return merge(this._processFiles(gulp, srcPattern, completeCallback, postCSSPlugins,

--- a/core-build/gulp-core-build-sass/src/SassTask.ts
+++ b/core-build/gulp-core-build-sass/src/SassTask.ts
@@ -79,8 +79,6 @@ export class SassTask extends GulpTask<ISassTaskConfig> {
     );
   }
 
-  let sassTsExtName: string = `.${this.taskConfig.moduleExportName}.ts`;
-
   public loadSchema(): Object {
     return require('./sass.schema.json');
   }
@@ -198,7 +196,7 @@ export class SassTask extends GulpTask<ISassTaskConfig> {
 
     tasks.push(baseTask.pipe(clone())
       .pipe(texttojs({
-        ext: sassTsExtName,
+        ext: `.${this.taskConfig.sassSyntax}.ts`,
         isExtensionAppended: false,
         template: (file: gulpUtil.File): string => {
           const content: string = file.contents!.toString();
@@ -254,7 +252,7 @@ export class SassTask extends GulpTask<ISassTaskConfig> {
 
           if (this.taskConfig.dropCssFiles) {
             lines = lines.concat([
-              `require('./${path.basename(file.path, sassTsExtName)}.css');`,
+              `require('./${path.basename(file.path, `.${this.taskConfig.sassSyntax}.ts`)}.css');`,
               exportClassNames
             ]);
           } else if (!!content) {
@@ -283,7 +281,7 @@ export class SassTask extends GulpTask<ISassTaskConfig> {
   }
 
   private _generateModuleStub(cssFileName: string, json: Object): void {
-    cssFileName = cssFileName.replace('.css', sassTsExtName);
+    cssFileName = cssFileName.replace('.css', `.${this.taskConfig.sassSyntax}.ts`);
     _classMaps[cssFileName] = json;
   }
 

--- a/core-build/gulp-core-build-sass/src/SassTask.ts
+++ b/core-build/gulp-core-build-sass/src/SassTask.ts
@@ -123,7 +123,10 @@ export class SassTask extends GulpTask<ISassTaskConfig> {
       this.logVerbose('Generating CSS modules.');
       return this._processFiles(gulp, srcPattern, completeCallback, modulePostCssPlugins);
     } else {
-      const moduleSrcPattern: string[] = srcPattern.map((value: string) => value.replace('.sass', '.module.sass').replace('.scss', '.module.scss'));
+      const moduleSrcPattern: string[] = srcPattern.map((value: string) => {
+        return value.replace('.sass', '.module.sass').replace('.scss', '.module.scss'));
+      }
+      
       moduleSrcPattern.forEach((value: string) => srcPattern.push(`!${value}`));
 
       return merge(this._processFiles(gulp, srcPattern, completeCallback, postCSSPlugins,

--- a/core-build/gulp-core-build-sass/src/sass.schema.json
+++ b/core-build/gulp-core-build-sass/src/sass.schema.json
@@ -23,15 +23,21 @@
     },
 
     "sassMatch": {
-      "title": "Sass File Glob Pattern",
+      "title": "SASS File Glob Pattern",
       "description": "An array of glob patterns for locating SASS files.",
-      "type": "string"
+      "type": "array"
     },
 
     "useCSSModules": {
       "title": "Use CSS Modules",
-      "description": "If this option is specified, files ending with .module.scss extension will automatically generate a corresponding TypeScript file. All classes will be appended with a hash to help ensure uniqueness on a page. This file can be imported directly, and will contain an object describing the mangled class names.",
+      "description": "If this option is specified, files ending with .module.sass or .module.scss extension will automatically generate a corresponding TypeScript file. All classes will be appended with a hash to help ensure uniqueness on a page. This file can be imported directly, and will contain an object describing the mangled class names.",
       "type": "boolean"
+    },
+
+    "sassSyntax": {
+      "title": "SASS syntax",
+      "description": "An optional parameter for setting SASS syntax.",
+      "type": "string"
     },
 
     "warnOnCssInvalidPropertyName ": {


### PR DESCRIPTION
See https://github.com/SharePoint/sp-dev-docs/issues/2637.