### PR TITLE
Rush: fix an issue where after running "rush add", "rush update" was not detecting changes

### DIFF
--- a/apps/rush-lib/src/api/PackageJsonEditor.ts
+++ b/apps/rush-lib/src/api/PackageJsonEditor.ts
@@ -93,11 +93,11 @@ export class PackageJsonEditor {
     return this._filePath;
   }
 
-  public get dependencyList(): Array<PackageJsonDependency> {
+  public get dependencyList(): ReadonlyArray<PackageJsonDependency> {
     return [...this._dependencies.values()];
   }
 
-  public get devDependencyList(): Array<PackageJsonDependency> {
+  public get devDependencyList(): ReadonlyArray<PackageJsonDependency> {
     return [...this._devDependencies.values()];
   }
 

--- a/apps/rush-lib/src/logic/npm/NpmLinkManager.ts
+++ b/apps/rush-lib/src/logic/npm/NpmLinkManager.ts
@@ -137,7 +137,7 @@ export class NpmLinkManager extends BaseLinkManager {
 
     // TODO: Validate that the project's package.json still matches the common folder
     const localProjectPackage: NpmPackage = NpmPackage.createLinkedNpmPackage(
-      project.packageJson.name,
+      project.packageJsonEditor.name,
       commonProjectPackage.version,
       commonProjectPackage.dependencies,
       project.projectFolder
@@ -180,7 +180,7 @@ export class NpmLinkManager extends BaseLinkManager {
           this._rushConfiguration.getProjectByName(dependency.name);
 
         if (matchedRushPackage) {
-          const matchedVersion: string = matchedRushPackage.packageJson.version;
+          const matchedVersion: string = matchedRushPackage.packageJsonEditor.version;
 
           // The dependency name matches an Rush project, but are there any other reasons not
           // to create a local link?

--- a/apps/rush-lib/src/logic/pnpm/PnpmLinkManager.ts
+++ b/apps/rush-lib/src/logic/pnpm/PnpmLinkManager.ts
@@ -78,7 +78,7 @@ export class PnpmLinkManager extends BaseLinkManager {
     const commonPackage: BasePackage = BasePackage.createVirtualTempPackage(packageJsonFilename, installFolderName);
 
     const localPackage: BasePackage = BasePackage.createLinkedPackage(
-      project.packageJson.name,
+      project.packageJsonEditor.name,
       commonPackage.version,
       project.projectFolder
     );
@@ -94,7 +94,7 @@ export class PnpmLinkManager extends BaseLinkManager {
       if (matchedRushPackage) {
         // We found a suitable match, so place a new local package that
         // symlinks to the Rush project
-        const matchedVersion: string = matchedRushPackage.packageJson.version;
+        const matchedVersion: string = matchedRushPackage.packageJsonEditor.version;
 
         let localLinks: string[] = rushLinkJson.localLinks[localPackage.name];
         if (!localLinks) {

--- a/common/changes/@microsoft/rush/nickpape-fix-rush-update-bug_2018-10-02-23-05.json
+++ b/common/changes/@microsoft/rush/nickpape-fix-rush-update-bug_2018-10-02-23-05.json
@@ -1,7 +1,7 @@
 {
   "changes": [
     {
-      "comment": "Fix an issue where after running \"rush add\", \"rush update\" was not detecting any changes.",
+      "comment": "Fix an issue where after running \"rush add\" (after successfully running \"rush install\"), the new package was not being installed or linked.",
       "packageName": "@microsoft/rush",
       "type": "none"
     }

--- a/common/changes/@microsoft/rush/nickpape-fix-rush-update-bug_2018-10-02-23-05.json
+++ b/common/changes/@microsoft/rush/nickpape-fix-rush-update-bug_2018-10-02-23-05.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Fix an issue where after running \"rush add\", \"rush update\" was not detecting any changes.",
+      "packageName": "@microsoft/rush",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "nickpape-msft@users.noreply.github.com"
+}

--- a/common/config/rush/version-policies.json
+++ b/common/config/rush/version-policies.json
@@ -3,7 +3,7 @@
     "policyName": "rush",
     "definitionName": "lockStepVersion",
     "version": "5.3.0",
-    "nextBump": "minor",
+    "nextBump": "patch",
     "mainProject": "@microsoft/rush"
   }
 ]

--- a/common/reviews/api/rush-lib.api.ts
+++ b/common/reviews/api/rush-lib.api.ts
@@ -155,9 +155,9 @@ class PackageJsonEditor {
   // (undocumented)
   addOrUpdateDependency(packageName: string, newVersion: string, dependencyType: DependencyType): void;
   // (undocumented)
-  readonly dependencyList: Array<PackageJsonDependency>;
+  readonly dependencyList: ReadonlyArray<PackageJsonDependency>;
   // (undocumented)
-  readonly devDependencyList: Array<PackageJsonDependency>;
+  readonly devDependencyList: ReadonlyArray<PackageJsonDependency>;
   // (undocumented)
   readonly filePath: string;
   // (undocumented)


### PR DESCRIPTION
`rush add` modifies the new `PackageJsonEditor` API, whereas `rush update` was using the deprecated `packageJson` API. So, `rush update` was running using a package.json that wasn't modified, therefore it didn't do anything.