### PR TITLE
Add missing patterns to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,8 +57,11 @@ jspm_packages/
 
 # Common toolchain intermediate files
 lib
+lib-amd
+lib-es6
 dist
 temp
+*.scss.ts
 
 # Rush files
 common/temp/**


### PR DESCRIPTION
When we cleaned up .gitignore we were a little overzealous