### PR TITLE
Ensure cyclic dependencies are consistent as well

### DIFF
--- a/apps/rush-lib/src/api/VersionMismatchFinder.ts
+++ b/apps/rush-lib/src/api/VersionMismatchFinder.ts
@@ -149,20 +149,22 @@ export class VersionMismatchFinder {
         ];
 
         dependencies.forEach((dependency: PackageJsonDependency) => {
-          if (dependency.dependencyType !== DependencyType.Peer
-            && !project.cyclicDependencyProjects.has(dependency.name)) {
-
+          if (dependency.dependencyType !== DependencyType.Peer) {
             const version: string = dependency.version!;
+
+            const isCyclic: boolean = project.cyclicDependencyProjects.has(dependency.name);
 
             if (this._isVersionAllowedAlternative(dependency.name, version)) {
               return;
             }
 
-            if (!this._mismatches.has(dependency.name)) {
-              this._mismatches.set(dependency.name, new Map<string, string[]>());
+            const name: string = dependency.name + (isCyclic ? ' (cyclic)' : '');
+
+            if (!this._mismatches.has(name)) {
+              this._mismatches.set(name, new Map<string, string[]>());
             }
 
-            const dependencyVersions: Map<string, string[]> = this._mismatches.get(dependency.name)!;
+            const dependencyVersions: Map<string, string[]> = this._mismatches.get(name)!;
 
             if (!dependencyVersions.has(version)) {
               dependencyVersions.set(version, []);

--- a/common/changes/@microsoft/rush/nickpape-check-cyclic_2018-10-05-00-48.json
+++ b/common/changes/@microsoft/rush/nickpape-check-cyclic_2018-10-05-00-48.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Change \"rush check\" so that it considers \"cyclicDependencyProjects\" and ensures they are consistent or listed in \"allowedAlternateVersions\"",
+      "packageName": "@microsoft/rush",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "nickpape-msft@users.noreply.github.com"
+}


### PR DESCRIPTION
Right now we ignore cyclic dependencies, but this can be bad.

We want to make sure they are consistent.