### PR TITLE
Temporarily restore the old nodeSupportedVersionRange in rush.json

### DIFF
--- a/rush.json
+++ b/rush.json
@@ -57,7 +57,7 @@
    * Specify a SemVer range to ensure developers use a NodeJS version that is appropriate
    * for your repo.
    */
-  "nodeSupportedVersionRange": ">=8.9.4 <9.0.0",
+  "nodeSupportedVersionRange": ">=6.9.0 <7.0.0 || >=8.9.4 <9.0.0",
 
   /**
    * If you would like the version specifiers for your dependencies to be consistent, then


### PR DESCRIPTION
@nickpape-msft  FYI your PR https://github.com/Microsoft/web-build-tools/pull/854 changed the `nodeSupportedVersionRange` which was breaking our CI jobs.  I'm temporarily reverting that line.

Since Node 10 is LTS now, next week we'll follow up with a better fix.