### PR TITLE
[rush] Fix "rush link" regression when using NPM/Yarn package managers

### DIFF
--- a/apps/rush-lib/src/logic/base/BaseLinkManager.ts
+++ b/apps/rush-lib/src/logic/base/BaseLinkManager.ts
@@ -43,8 +43,10 @@ export abstract class BaseLinkManager {
       } else {
         // For files, we use a Windows "hard link", because creating a symbolic link requires
         // administrator permission.
+
+        // NOTE: We cannot use the relative path for hard links
         FileSystem.createHardLink({
-          linkTargetPath: targetRelativePath,
+          linkTargetPath: options.linkTargetPath,
           newLinkPath: options.newLinkPath
         });
       }

--- a/common/changes/@microsoft/rush/pgonzal-fix-symlink-regression_2018-10-08-23-06.json
+++ b/common/changes/@microsoft/rush/pgonzal-fix-symlink-regression_2018-10-08-23-06.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Fix a recent regression where \"rush link\" was failing for NPM/Yarn because hard links don't support relative paths",
+      "packageName": "@microsoft/rush",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "pgonzal@users.noreply.github.com"
+}


### PR DESCRIPTION
https://github.com/Microsoft/web-build-tools/pull/805 introduced a regression for NPM/Yarn package managers, which rely on hard links