### PR TITLE
[rush] Make rush purge also call rush unlink.

### DIFF
--- a/apps/rush-lib/src/cli/actions/PurgeAction.ts
+++ b/apps/rush-lib/src/cli/actions/PurgeAction.ts
@@ -10,6 +10,7 @@ import { BaseRushAction } from './BaseRushAction';
 import { RushCommandLineParser } from '../RushCommandLineParser';
 import { Stopwatch } from '../../utilities/Stopwatch';
 import { PurgeManager } from '../../logic/PurgeManager';
+import { UnlinkManager } from '../../logic/UnlinkManager';
 
 export class PurgeAction extends BaseRushAction {
   private _unsafeParameter: CommandLineFlagParameter;
@@ -37,7 +38,10 @@ export class PurgeAction extends BaseRushAction {
     return Promise.resolve().then(() => {
       const stopwatch: Stopwatch = Stopwatch.start();
 
+      const unlinkManager: UnlinkManager = new UnlinkManager(this.rushConfiguration);
       const purgeManager: PurgeManager = new PurgeManager(this.rushConfiguration);
+
+      unlinkManager.unlink();
 
       if (this._unsafeParameter.value!) {
         purgeManager.purgeUnsafe();

--- a/apps/rush-lib/src/cli/actions/UnlinkAction.ts
+++ b/apps/rush-lib/src/cli/actions/UnlinkAction.ts
@@ -1,13 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import * as os from 'os';
-import * as path from 'path';
-
-import { Utilities } from '../../utilities/Utilities';
 import { RushCommandLineParser } from '../RushCommandLineParser';
 import { BaseRushAction } from './BaseRushAction';
-import { FileSystem } from '@microsoft/node-core-library';
+import { UnlinkManager } from '../../logic/UnlinkManager';
 
 export class UnlinkAction extends BaseRushAction {
   constructor(parser: RushCommandLineParser) {
@@ -15,9 +11,9 @@ export class UnlinkAction extends BaseRushAction {
       actionName: 'unlink',
       summary: 'Delete node_modules symlinks for all projects in the repo',
       documentation: 'This removes the symlinks created by the "rush link" command. This is useful for'
-       + ' cleaning a repo using "git clean" without accidentally deleting source files, or for using standard NPM'
-       + ' commands on a project.',
-       parser
+        + ' cleaning a repo using "git clean" without accidentally deleting source files, or for using standard NPM'
+        + ' commands on a project.',
+      parser
     });
   }
 
@@ -26,24 +22,9 @@ export class UnlinkAction extends BaseRushAction {
   }
 
   protected run(): Promise<void> {
-    // Delete the flag file if it exists; this will ensure that
-    // a full "rush link" is required next time
-    Utilities.deleteFile(this.rushConfiguration.rushLinkJsonFilename);
-
-    let didAnything: boolean = false;
-    for (const rushProject of this.rushConfiguration.projects) {
-      const localModuleFolder: string = path.join(rushProject.projectFolder, 'node_modules');
-      if (FileSystem.exists(localModuleFolder)) {
-        console.log('Purging ' + localModuleFolder);
-        Utilities.dangerouslyDeletePath(localModuleFolder);
-        didAnything = true;
-      }
-    }
-    if (!didAnything) {
-      console.log('Nothing to do.');
-    } else {
-      console.log(os.EOL + 'Done.');
-    }
-    return Promise.resolve();
+    return Promise.resolve().then(() => {
+      const unlinkManager: UnlinkManager = new UnlinkManager(this.rushConfiguration);
+      unlinkManager.unlink();
+    });
   }
 }

--- a/apps/rush-lib/src/logic/UnlinkManager.ts
+++ b/apps/rush-lib/src/logic/UnlinkManager.ts
@@ -1,0 +1,60 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import * as os from 'os';
+import * as path from 'path';
+
+import { RushConfiguration } from '../api/RushConfiguration';
+import { Utilities } from '../utilities/Utilities';
+import { FileSystem } from '@microsoft/node-core-library';
+
+/**
+ * This class implements the logic for "rush unlink"
+ */
+export class UnlinkManager {
+  private _rushConfiguration: RushConfiguration;
+
+  public constructor(rushConfiguration: RushConfiguration) {
+    this._rushConfiguration = rushConfiguration;
+  }
+
+  /**
+   * Delete flag file and all the existing node_modules
+   * symlinks
+   */
+  public unlink(): void {
+    this._deleteFlagFile();
+    this._deleteSymlinks();
+  }
+
+  /**
+   * Delete all the node_modules symlinks of configured Rush
+   * projects
+   * */
+  private _deleteSymlinks(): void {
+    let didAnything: boolean = false;
+
+    for (const rushProject of this._rushConfiguration.projects) {
+      const localModuleFolder: string = path.join(rushProject.projectFolder, 'node_modules');
+      if (FileSystem.exists(localModuleFolder)) {
+        console.log('Purging ' + localModuleFolder);
+        Utilities.dangerouslyDeletePath(localModuleFolder);
+        didAnything = true;
+      }
+    }
+
+    if (!didAnything) {
+      console.log('Nothing to do.');
+    } else {
+      console.log(os.EOL + 'Done.');
+    }
+  }
+
+  /**
+   * Delete the flag file if it exists; this will ensure that
+   * a full "rush link" is required next time
+   */
+  private _deleteFlagFile(): void {
+    Utilities.deleteFile(this._rushConfiguration.rushLinkJsonFilename);
+  }
+}


### PR DESCRIPTION
Closes https://github.com/Microsoft/web-build-tools/issues/873

Extracts `UnlinkAction` logic into `UnlinkManager` so that it can be re-used by different actions. Replaces the logic in `UnlinkAction` by the newly created `UnlinkManager` and adds `rush unlink` logic to be executed also on `rush purge`.