### PR TITLE
[rush] Fix an issue where "rush publish" didn't work with Yarn

### DIFF
--- a/apps/rush-lib/src/cli/actions/PublishAction.ts
+++ b/apps/rush-lib/src/cli/actions/PublishAction.ts
@@ -346,9 +346,15 @@ export class PublishAction extends BaseRushAction {
         args.push(`--force`);
       }
 
+      // TODO: Yarn's "publish" command line is fairly different from NPM and PNPM.  The right thing to do here
+      // would be to remap our options to the Yarn equivalents.  But until we get around to that, we'll simply invoke
+      // whatever NPM binary happens to be installed in the global path.
+      const packageManagerToolFilename: string = this.rushConfiguration.packageManager === 'yarn'
+        ? 'npm' : this.rushConfiguration.packageManagerToolFilename;
+
       PublishUtilities.execCommand(
         !!this._publish.value,
-        this.rushConfiguration.packageManagerToolFilename,
+        packageManagerToolFilename,
         args,
         packagePath,
         env);

--- a/common/changes/@microsoft/rush/pgonzal-yarn-publish_2018-10-17-03-04.json
+++ b/common/changes/@microsoft/rush/pgonzal-yarn-publish_2018-10-17-03-04.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Fix an issue where \"rush publish\" invoked the wrong command when using Yarn",
+      "packageName": "@microsoft/rush",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "pgonzal@users.noreply.github.com"
+}


### PR DESCRIPTION
The command line for `yarn publish` is incompatible with the options used by PNPM and NPM