### PR TITLE
Expose safeForSimultaneousRushProcesses to custom commands

### DIFF
--- a/apps/rush-lib/assets/rush-init/common/config/rush/command-line.json
+++ b/apps/rush-lib/assets/rush-init/common/config/rush/command-line.json
@@ -47,6 +47,16 @@
       "description": "This is an example custom command that runs separately for each project",
 
       /**
+       * By default, Rush operations acquire a lock file which prevents multiple commands from executing simultaneously
+       * in the same repo folder.  (For example, it would be a mistake to run "rush install" and "rush build" at the
+       * same time.)  If your command makes sense to run concurrently with other operations,
+       * set "safeForSimultaneousRushProcesses" to true to disable this protection.
+       *
+       * In particular, this is needed for custom scripts that invoke other Rush commands.
+       */
+      "safeForSimultaneousRushProcesses": false,
+
+      /**
        * (Required) If true, then this command is safe to be run in parallel, i.e. executed
        * simultaneously for multiple projects.  Similar to "rush build", regardless of parallelism
        * projects will not start processing until their dependencies have completed processing.
@@ -71,6 +81,8 @@
       "name": "my-global-command",
       "summary": "Example global custom command",
       "description": "This is an example custom command that runs once for the entire repo",
+
+      "safeForSimultaneousRushProcesses": false,
 
       /**
        * A script that will be invoked using the OS shell. The working directory will be the folder

--- a/apps/rush-lib/src/api/CommandLineJson.ts
+++ b/apps/rush-lib/src/api/CommandLineJson.ts
@@ -12,6 +12,7 @@ export interface IBaseCommandJson {
    * If omitted, the summary will be used instead.
    */
   description?: string;
+  safeForSimultaneousRushProcesses: boolean;
 }
 
 /**

--- a/apps/rush-lib/src/cli/RushCommandLineParser.ts
+++ b/apps/rush-lib/src/cli/RushCommandLineParser.ts
@@ -198,6 +198,7 @@ export class RushCommandLineParser extends CommandLineParser {
             actionName: command.name,
             summary: command.summary,
             documentation: command.description || command.summary,
+            safeForSimultaneousRushProcesses: command.safeForSimultaneousRushProcesses,
 
             parser: this,
             commandLineConfiguration: commandLineConfiguration,
@@ -211,6 +212,7 @@ export class RushCommandLineParser extends CommandLineParser {
             actionName: command.name,
             summary: command.summary,
             documentation: command.description || command.summary,
+            safeForSimultaneousRushProcesses: command.safeForSimultaneousRushProcesses,
 
             parser: this,
             commandLineConfiguration: commandLineConfiguration,

--- a/apps/rush-lib/src/cli/actions/BaseRushAction.ts
+++ b/apps/rush-lib/src/cli/actions/BaseRushAction.ts
@@ -19,9 +19,11 @@ import { Utilities } from '../../utilities/Utilities';
 
 export interface IBaseRushActionOptions extends ICommandLineActionOptions {
   /**
-   * If true, no locking mechanism will be enforced when this action is run.
-   * Note this defaults to false (which is a safer assumption in case this value
-   *  is omitted).
+   * By default, Rush operations acquire a lock file which prevents multiple commands from executing simultaneously
+   * in the same repo folder.  (For example, it would be a mistake to run "rush install" and "rush build" at the
+   * same time.)  If your command makes sense to run concurrently with other operations,
+   * set safeForSimultaneousRushProcesses=true to disable this protection.  In particular, this is needed for
+   * custom scripts that invoke other Rush commands.
    */
   safeForSimultaneousRushProcesses?: boolean;
 

--- a/apps/rush-lib/src/schemas/command-line.schema.json
+++ b/apps/rush-lib/src/schemas/command-line.schema.json
@@ -41,6 +41,11 @@
           "title": "Custom Command Description",
           "description": "A detailed description of the command, which appears when requesting help for the command (e.g. \"rush --help my-command\"). If omitted, the summary will be used.",
           "type": "string"
+        },
+        "safeForSimultaneousRushProcesses": {
+          "title": "Safe For Simultaneous Rush Processes",
+          "description": "Can this command trigger additional rush processes, useful if you want a rush command to trigger another rush command.",
+          "type": "boolean"
         }
       }
     },
@@ -78,6 +83,7 @@
             "name": { "$ref": "#/definitions/anything" },
             "summary": { "$ref": "#/definitions/anything" },
             "description": { "$ref": "#/definitions/anything" },
+            "safeForSimultaneousRushProcesses": { "$ref": "#/definitions/anything" },
 
             "enableParallelism": { "$ref": "#/definitions/anything" },
             "ignoreMissingScript": { "$ref": "#/definitions/anything" }
@@ -114,6 +120,7 @@
             "name": { "$ref": "#/definitions/anything" },
             "summary": { "$ref": "#/definitions/anything" },
             "description": { "$ref": "#/definitions/anything" },
+            "safeForSimultaneousRushProcesses": { "$ref": "#/definitions/anything" },
 
             "shellCommand": { "$ref": "#/definitions/anything" }
           }

--- a/apps/rush-lib/src/schemas/command-line.schema.json
+++ b/apps/rush-lib/src/schemas/command-line.schema.json
@@ -44,7 +44,7 @@
         },
         "safeForSimultaneousRushProcesses": {
           "title": "Safe For Simultaneous Rush Processes",
-          "description": "Can this command trigger additional rush processes, useful if you want a rush command to trigger another rush command.",
+          "description": "By default, Rush operations acquire a lock file which prevents multiple commands from executing simultaneously in the same repo folder.  (For example, it would be a mistake to run \"rush install\" and \"rush build\" at the same time.)  If your command makes sense to run concurrently with other operations, set safeForSimultaneousRushProcesses=true to disable this protection.  In particular, this is needed for custom scripts that invoke other Rush commands.",
           "type": "boolean"
         }
       }

--- a/common/changes/@microsoft/rush/ssrush_2018-10-19-16-25.json
+++ b/common/changes/@microsoft/rush/ssrush_2018-10-19-16-25.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Expose safeForSimultaneousRushProcesses to custom commands",
+      "packageName": "@microsoft/rush",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "acoates-ms@users.noreply.github.com"
+}


### PR DESCRIPTION
This fixes #887 by allowing commands opt into being allowed to launch other rush commands.

