### PR TITLE
[rush] Fix issue where "rush install" sometimes would incorrectly ask for "rush update" when using Yarn

### DIFF
--- a/apps/rush-lib/src/api/PackageJsonEditor.ts
+++ b/apps/rush-lib/src/api/PackageJsonEditor.ts
@@ -93,10 +93,16 @@ export class PackageJsonEditor {
     return this._filePath;
   }
 
+  /**
+   * The list of dependencies of type DependencyType.Regular, DependencyType.Optional, or DependencyType.Peer.
+   */
   public get dependencyList(): ReadonlyArray<PackageJsonDependency> {
     return [...this._dependencies.values()];
   }
 
+  /**
+   * The list of dependencies of type DependencyType.Dev.
+   */
   public get devDependencyList(): ReadonlyArray<PackageJsonDependency> {
     return [...this._devDependencies.values()];
   }

--- a/apps/rush-lib/src/api/PackageJsonEditor.ts
+++ b/apps/rush-lib/src/api/PackageJsonEditor.ts
@@ -5,7 +5,8 @@ import * as semver from 'semver';
 
 import {
   IPackageJson,
-  JsonFile
+  JsonFile,
+  Sort
 } from '@microsoft/node-core-library';
 
 /**
@@ -154,11 +155,11 @@ export class PackageJsonEditor {
 
     try {
       Object.keys(dependencies || {}).forEach((packageName: string) => {
-        if (optionalDependencies[packageName]) {
+        if (Object.prototype.hasOwnProperty.call(optionalDependencies, packageName)) {
           throw new Error(`The package "${packageName}" cannot be listed in both `
             + `"dependencies" and "optionalDependencies"`);
         }
-        if (peerDependencies[packageName]) {
+        if (Object.prototype.hasOwnProperty.call(peerDependencies, packageName)) {
           throw new Error(`The package "${packageName}" cannot be listed in both `
             + `"dependencies" and "peerDependencies"`);
         }
@@ -168,7 +169,7 @@ export class PackageJsonEditor {
       });
 
       Object.keys(optionalDependencies || {}).forEach((packageName: string) => {
-        if (peerDependencies[packageName]) {
+        if (Object.prototype.hasOwnProperty.call(peerDependencies, packageName)) {
           throw new Error(`The package "${packageName}" cannot be listed in both `
             + `"optionalDependencies" and "peerDependencies"`);
         }
@@ -186,6 +187,9 @@ export class PackageJsonEditor {
         this._devDependencies.set(packageName,
           new PackageJsonDependency(packageName, devDependencies[packageName], DependencyType.Dev, _onChange));
       });
+
+      Sort.sortMapKeys(this._dependencies);
+      Sort.sortMapKeys(this._devDependencies);
 
     } catch (e) {
       throw new Error(`Error loading "${filepath}": ${e.message}`);

--- a/apps/rush-lib/src/logic/InstallManager.ts
+++ b/apps/rush-lib/src/logic/InstallManager.ts
@@ -111,7 +111,8 @@ export class InstallManager {
   private _commonTempFolderRecycler: AsyncRecycler;
 
   /**
-   * Returns a map of all direct dependencies that only have a single semantic version specifier
+   * Returns a map of all direct dependencies that only have a single semantic version specifier.
+   * Returns a map: dependency name --> version specifier
    */
   public static collectImplicitlyPreferredVersions(rushConfiguration: RushConfiguration): Map<string, string> {
     // First, collect all the direct dependencies of all local projects, and their versions:
@@ -381,6 +382,7 @@ export class InstallManager {
       shrinkwrapIsUpToDate = false;
     }
 
+    // dependency name --> version specifier
     const allExplicitPreferredVersions: Map<string, string> = this._rushConfiguration.commonVersions
       .getAllPreferredVersions();
 
@@ -429,6 +431,8 @@ export class InstallManager {
     // Find the implicitly preferred versions
     // These are any first-level dependencies for which we only consume a single version range
     // (e.g. every package that depends on react uses an identical specifier)
+
+    // dependency name --> version specifier
     const allPreferredVersions: Map<string, string> =
       InstallManager.collectImplicitlyPreferredVersions(this._rushConfiguration);
 
@@ -469,65 +473,69 @@ export class InstallManager {
         dependencies: {}
       };
 
-      // Collect pairs of (packageName, packageVersion) to be added as temp package dependencies
-      const pairs: { packageName: string, packageVersion: string }[] = [];
+      // Collect pairs of (packageName, packageVersion) to be added as dependencies of the @rush-temp package.json
+      const tempDependencies: Map<string, string> = new Map<string, string>();
 
+      // These can be regular, optional, or peer dependencies (but NOT dev dependencies).
+      // (A given packageName will never appear more than once in this list.)
       for (const dependency of packageJson.dependencyList) {
 
-        // If there are any optional dependencies, copy them over directly
+        // If there are any optional dependencies, copy them directly into the optionalDependencies field.
         if (dependency.dependencyType === DependencyType.Optional) {
           if (!tempPackageJson.optionalDependencies) {
             tempPackageJson.optionalDependencies = {};
           }
           tempPackageJson.optionalDependencies[dependency.name] = dependency.version;
         } else {
-          pairs.push({ packageName: dependency.name, packageVersion: dependency.version });
+          tempDependencies.set(dependency.name, dependency.version);
         }
       }
 
       for (const dependency of packageJson.devDependencyList) {
-        // If there are devDependencies, we need to merge them with the regular
-        // dependencies.  If the same library appears in both places, then the
-        // regular dependency takes precedence over the devDependency.
-        // It also takes precedence over a duplicate in optionalDependencies,
-        // but NPM will take care of that for us.  (Frankly any kind of duplicate
-        // should be an error, but NPM is pretty lax about this.)
-        pairs.push({ packageName: dependency.name, packageVersion: dependency.version });
+        // If there are devDependencies, we need to merge them with the regular dependencies.  If the same
+        // library appears in both places, then the dev dependency wins (because presumably it's saying what you
+        // want right now for development, not the range that you support for consumers).
+        tempDependencies.set(dependency.name, dependency.version);
       }
+      const sortedTempDependencyNames: string[] = [... tempDependencies.keys()];
+      sortedTempDependencyNames.sort(); // alphabetize them to minimize churn in the tarball
 
-      for (const pair of pairs) {
+      for (const packageName of sortedTempDependencyNames) {
+        const packageVersion: string = tempDependencies.get(packageName)!;
+
         // Is there a locally built Rush project that could satisfy this dependency?
         // If so, then we will symlink to the project folder rather than to common/temp/node_modules.
         // In this case, we don't want "npm install" to process this package, but we do need
         // to record this decision for "rush link" later, so we add it to a special 'rushDependencies' field.
         const localProject: RushConfigurationProject | undefined =
-          this._rushConfiguration.getProjectByName(pair.packageName);
-        if (localProject) {
+          this._rushConfiguration.getProjectByName(packageName);
 
+        if (localProject) {
           // Don't locally link if it's listed in the cyclicDependencyProjects
-          if (!rushProject.cyclicDependencyProjects.has(pair.packageName)) {
+          if (!rushProject.cyclicDependencyProjects.has(packageName)) {
 
             // Also, don't locally link if the SemVer doesn't match
             const localProjectVersion: string = localProject.packageJsonEditor.version;
-            if (semver.satisfies(localProjectVersion, pair.packageVersion)) {
+            if (semver.satisfies(localProjectVersion, packageVersion)) {
 
-              // We will locally link this package
+              // We will locally link this package, so instead add it to our special "rushDependencies"
+              // field in the package.json file.
               if (!tempPackageJson.rushDependencies) {
                 tempPackageJson.rushDependencies = {};
               }
-              tempPackageJson.rushDependencies[pair.packageName] = pair.packageVersion;
+              tempPackageJson.rushDependencies[packageName] = packageVersion;
               continue;
             }
           }
         }
 
         // We will NOT locally link this package; add it as a regular dependency.
-        tempPackageJson.dependencies![pair.packageName] = pair.packageVersion;
+        tempPackageJson.dependencies![packageName] = packageVersion;
 
         if (shrinkwrapFile) {
-          if (!shrinkwrapFile.tryEnsureCompatibleDependency(pair.packageName, pair.packageVersion,
+          if (!shrinkwrapFile.tryEnsureCompatibleDependency(packageName, packageVersion,
             rushProject.tempProjectName)) {
-              shrinkwrapWarnings.push(`"${pair.packageName}" (${pair.packageVersion}) required by`
+              shrinkwrapWarnings.push(`"${packageName}" (${packageVersion}) required by`
                 + ` "${rushProject.packageName}"`);
             shrinkwrapIsUpToDate = false;
           }

--- a/common/changes/@microsoft/node-core-library/pgonzal-yarn-bug_2018-10-25-07-31.json
+++ b/common/changes/@microsoft/node-core-library/pgonzal-yarn-bug_2018-10-25-07-31.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/node-core-library",
+      "comment": "Add Sort API",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@microsoft/node-core-library",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush/pgonzal-yarn-bug_2018-10-25-03-42.json
+++ b/common/changes/@microsoft/rush/pgonzal-yarn-bug_2018-10-25-03-42.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Fix an issue where \"rush install\" sometimes would incorrectly ask for \"rush update\", when using the Yarn package manager",
+      "packageName": "@microsoft/rush",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush/pgonzal-yarn-bug_2018-10-25-07-31.json
+++ b/common/changes/@microsoft/rush/pgonzal-yarn-bug_2018-10-25-07-31.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Improve sorting of @rush-temp projects, which may reduce churn of hashes in the shrinkwrap file",
+      "packageName": "@microsoft/rush",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/reviews/api/node-core-library.api.ts
+++ b/common/reviews/api/node-core-library.api.ts
@@ -397,6 +397,15 @@ class ProtectableMap<K, V> {
   readonly size: number;
 }
 
+// @public
+class Sort {
+  static compareByValue(x: any, y: any): number;
+  static isSorted<T>(array: T[], comparer?: (x: any, y: any) => number): boolean;
+  static isSortedBy<T>(array: T[], keySelector: (element: T) => any, comparer?: (x: any, y: any) => number): boolean;
+  static sortBy<T>(array: T[], keySelector: (element: T) => any, comparer?: (x: any, y: any) => number): void;
+  static sortMapKeys<K, V>(map: Map<K, V>, keyComparer?: (x: K, y: K) => number): void;
+}
+
 // @beta
 class StringBuilder {
   constructor();

--- a/common/reviews/api/rush-lib.api.ts
+++ b/common/reviews/api/rush-lib.api.ts
@@ -154,9 +154,7 @@ class PackageJsonDependency {
 class PackageJsonEditor {
   // (undocumented)
   addOrUpdateDependency(packageName: string, newVersion: string, dependencyType: DependencyType): void;
-  // (undocumented)
   readonly dependencyList: ReadonlyArray<PackageJsonDependency>;
-  // (undocumented)
   readonly devDependencyList: ReadonlyArray<PackageJsonDependency>;
   // (undocumented)
   readonly filePath: string;

--- a/libraries/node-core-library/src/Sort.ts
+++ b/libraries/node-core-library/src/Sort.ts
@@ -1,0 +1,127 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+/**
+ * Operations for sorting collections.
+ *
+ * @public
+ */
+export class Sort {
+  /**
+   * Compares `x` and `y` using the JavaScript `>` and `<` operators.  This function is suitable for usage as
+   * the callback for `array.sort()`.
+   * @returns -1 if `x` is smaller than `y`, 1 if `x` is greater than `y`, or 0 if the values are equal.
+   *
+   * @example
+   *
+   * ```ts
+   * let array: number[] = [3, 6, 2];
+   * array.sort(Sort.compareByValue);  // [2, 3, 6]
+   * ```
+   */
+  // tslint:disable-next-line:no-any
+  public static compareByValue(x: any, y: any): number {
+    if (x === y) {
+      return 0;
+    }
+    if (x === undefined) {
+      return -1;
+    }
+    if (x === null) {
+      return -1;
+    }
+    if (x < y) {
+      return -1;
+    }
+    if (x > y) {
+      return 1;
+    }
+    return 0;
+  }
+
+  /**
+   * Sorts the array according to a key which is obtained from the array elements.
+   *
+   * @example
+   *
+   * ```ts
+   * let array: string[] = [ 'ccc', 'bb', 'a' ];
+   * Sort.sortBy(array, x => x.length);  // [ 'a', 'bb', 'ccc' ]
+   * ```
+   */
+  // tslint:disable-next-line:no-any
+  public static sortBy<T>(array: T[], keySelector: (element: T) => any, comparer: (x: any, y: any) => number
+    = Sort.compareByValue): void {
+    array.sort((x, y) => comparer(keySelector(x), keySelector(y)));
+  }
+
+  /**
+   * Returns true if the array is already sorted.
+   */
+  // tslint:disable-next-line:no-any
+  public static isSorted<T>(array: T[], comparer: (x: any, y: any) => number = Sort.compareByValue): boolean {
+    let previous: T | undefined = undefined;
+    for (const element of array) {
+      if (comparer(previous, element) > 0) {
+        return false;
+      }
+      previous = element;
+    }
+    return true;
+  }
+
+  /**
+   * Returns true if the array is already sorted by the specified key.
+   *
+   * @example
+   *
+   * ```ts
+   * let array: string[] = [ 'a', 'bb', 'ccc' ];
+   * Sort.isSortedBy(array, x => x.length); // true
+   * ```
+   */
+  // tslint:disable-next-line:no-any
+  public static isSortedBy<T>(array: T[], keySelector: (element: T) => any, comparer: (x: any, y: any) => number
+    = Sort.compareByValue): boolean {
+
+    let previousKey: T | undefined = undefined;
+    for (const element of array) {
+      const key: T = keySelector(element);
+      if (comparer(previousKey, key) > 0) {
+        return false;
+      }
+      previousKey = key;
+    }
+    return true;
+  }
+
+  /**
+   * Sorts the entries in a Map object according to the keys.
+   *
+   * @example
+   *
+   * ```ts
+   * let map: Map<string, number> = new Map<string, number>();
+   * map.set('zebra', 1);
+   * map.set('goose', 2);
+   * map.set('aardvark', 3);
+   * Sort.sortMapKeys(map);
+   * console.log(JSON.stringify(Array.from(map.keys()))); // ["aardvark","goose","zebra"]
+   * ```
+   */
+  // tslint:disable-next-line:no-any
+  public static sortMapKeys<K, V>(map: Map<K, V>, keyComparer: (x: K, y: K) => number = Sort.compareByValue): void {
+    const pairs: [K, V][] = Array.from(map.entries());
+
+    // Sorting a map is expensive, so first check whether it's already sorted.
+    if (Sort.isSortedBy(pairs, x => x[0], keyComparer)) {
+      return;
+    }
+
+    Sort.sortBy(pairs, x => x[0], keyComparer);
+    map.clear();
+    for (const pair of pairs) {
+      map.set(pair[0], pair[1]);
+    }
+  }
+}

--- a/libraries/node-core-library/src/index.ts
+++ b/libraries/node-core-library/src/index.ts
@@ -54,6 +54,7 @@ export {
 export { PackageName, IParsedPackageName, IParsedPackageNameOrError } from './PackageName';
 export { Path } from './Path';
 export { Text, NewlineKind } from './Text';
+export { Sort } from './Sort';
 export {
   FileSystem,
   IFileSystemReadFolderOptions,


### PR DESCRIPTION
A package.json can specify a peer dependency (to indicate a general supported range) and also a dev dependency (to request a specific version for development).  Consider **react** and **react-dom** in this example:

```js
  "dependencies": {
    "prop-types": "^15.5.8"
  },
  "devDependencies": {
    "@types/prop-types": "15.5.1",
    "@types/react": "16.4.14",
    "@types/react-dom": "16.0.7",
    "react": "16.3.1",
    "react-dom": "16.3.1"
  },
  "peerDependencies": {
    "react": "^16.0.0",
    "react-dom": "^16.0.0"
  },
```

In this situation, when using Yarn, `rush install` would complain that the shrinkwrap file did not satisfy the dependencies, even immediately after running `rush update`. 

As part of this PR, I also noticed the the `@rush-temp` projects had a nondeterministic ordering of dependencies in their **package.json** files.  This could be a potential source of churn for hashes in the shrinkwrap file, so I added a `Sort` API and used it to sort them.