### PR TITLE
[api-extractor] Add wrapper method to read config file for processing

### DIFF
--- a/apps/api-extractor/src/extractor/Extractor.ts
+++ b/apps/api-extractor/src/extractor/Extractor.ts
@@ -158,6 +158,17 @@ export class Extractor {
     return analysisFilePaths;
   }
 
+  /**
+   * Invokes the API Extractor engine, using the api extractor configuration file.
+   * @param apifile - Path to api extractor json config file.
+   * @param options - IExtractor options.
+   */
+  public static processProjectFromConfigFile(jsonConfigFile: string, options?: IExtractorOptions): void {
+    const configObject: IExtractorConfig = JsonFile.loadAndValidate(jsonConfigFile, Extractor.jsonSchema);
+    const extractor: Extractor = new Extractor(configObject, options);
+    extractor.processProject();
+  }
+
   private static _applyConfigDefaults(config: IExtractorConfig): IExtractorConfig {
     // Use the provided config to override the defaults
     const normalized: IExtractorConfig  = lodash.merge(

--- a/apps/api-extractor/src/extractor/Extractor.ts
+++ b/apps/api-extractor/src/extractor/Extractor.ts
@@ -160,7 +160,7 @@ export class Extractor {
 
   /**
    * Invokes the API Extractor engine, using the api extractor configuration file.
-   * @param apifile - Path to api extractor json config file.
+   * @param jsonConfigFile - Path to api extractor json config file.
    * @param options - IExtractor options.
    */
   public static processProjectFromConfigFile(jsonConfigFile: string, options?: IExtractorOptions): void {

--- a/common/changes/@microsoft/api-extractor/sunilsurana-issue912_2018-10-30-05-58.json
+++ b/common/changes/@microsoft/api-extractor/sunilsurana-issue912_2018-10-30-05-58.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/api-extractor",
-      "comment": "Fix for issue 912. Adding lib support to read json config file.",
+      "comment": "Added an api to invoke api extractor processor by supplying api extractor json config file.",
       "type": "minor"
     }
   ],

--- a/common/changes/@microsoft/api-extractor/sunilsurana-issue912_2018-10-30-05-58.json
+++ b/common/changes/@microsoft/api-extractor/sunilsurana-issue912_2018-10-30-05-58.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor",
+      "comment": "Fix for issue 912. Adding lib support to read json config file.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor",
+  "email": "sunilsurana@users.noreply.github.com"
+}

--- a/common/reviews/api/api-extractor.api.ts
+++ b/common/reviews/api/api-extractor.api.ts
@@ -19,6 +19,7 @@ class Extractor {
   static generateFilePathsForAnalysis(inputFilePaths: string[]): string[];
   static jsonSchema: JsonSchema;
   processProject(options?: IAnalyzeProjectOptions): boolean;
+  static processProjectFromConfigFile(jsonConfigFile: string, options?: IExtractorOptions): void;
 }
 
 // @public


### PR DESCRIPTION
**PR changes**
Added a public static method in ApiExtractor class which will take the apiextractor json file path. It will load and validate and create apiextractor object and process it.

**Issue description**
If someone is integrating api extractor using library the client has to supply the config object. There was no support of passing the apiextractor config json file.

Fixes https://github.com/Microsoft/web-build-tools/issues/912