### PR TITLE
[api-extractor] Fix an issue where EcmaScript symbols weren't being emitted in .d.ts rollups

### DIFF
--- a/apps/api-extractor/src/generators/dtsRollup/AstSymbolTable.ts
+++ b/apps/api-extractor/src/generators/dtsRollup/AstSymbolTable.ts
@@ -197,6 +197,7 @@ export class AstSymbolTable {
       // is this a reference to another AstSymbol?
       case ts.SyntaxKind.TypeReference: // general type references
       case ts.SyntaxKind.ExpressionWithTypeArguments: // special case for e.g. the "extends" keyword
+      case ts.SyntaxKind.ComputedPropertyName:  // used for EcmaScript "symbols", e.g. "[toPrimitive]".
         {
           // Sometimes the type reference will involve multiple identifiers, e.g. "a.b.C".
           // In this case, we only need to worry about importing the first identifier,

--- a/apps/api-extractor/src/generators/dtsRollup/DtsRollupGenerator.ts
+++ b/apps/api-extractor/src/generators/dtsRollup/DtsRollupGenerator.ts
@@ -346,6 +346,11 @@ export class DtsRollupGenerator {
           const listPrefix: string = list.getSourceFile().text
             .substring(list.getStart(), list.declarations[0].getStart());
           span.modification.prefix = 'declare ' + listPrefix + span.modification.prefix;
+
+          if (dtsEntry.exported) {
+            span.modification.prefix = 'export ' + span.modification.prefix;
+          }
+
           span.modification.suffix = ';';
         }
         break;

--- a/build-tests/api-extractor-test-01/dist/beta/api-extractor-test-01.d.ts
+++ b/build-tests/api-extractor-test-01/dist/beta/api-extractor-test-01.d.ts
@@ -72,6 +72,15 @@ export declare class ClassExportedAsDefault {
 }
 
 /**
+ * @public
+ */
+export declare class ClassWithSymbols {
+    readonly [unexportedCustomSymbol]: number;
+    readonly [locallyExportedCustomSymbol]: string;
+    [fullyExportedCustomSymbol](): void;
+}
+
+/**
  * This class illustrates some cases involving type literals.
  * @public
  */
@@ -128,6 +137,8 @@ export declare class ForgottenExportConsumer2 {
 export declare class ForgottenExportConsumer3 {
     test2(): IForgottenDirectDependency | undefined;
 }
+
+declare const fullyExportedCustomSymbol: unique symbol;
 
 /**
  * This class is directly consumed by ForgottenExportConsumer3.

--- a/build-tests/api-extractor-test-01/dist/beta/api-extractor-test-01.d.ts
+++ b/build-tests/api-extractor-test-01/dist/beta/api-extractor-test-01.d.ts
@@ -138,7 +138,7 @@ export declare class ForgottenExportConsumer3 {
     test2(): IForgottenDirectDependency | undefined;
 }
 
-declare const fullyExportedCustomSymbol: unique symbol;
+export declare const fullyExportedCustomSymbol: unique symbol;
 
 /**
  * This class is directly consumed by ForgottenExportConsumer3.
@@ -194,6 +194,8 @@ export declare interface IInterfaceAsDefaultExport {
 export declare interface ISimpleInterface {
 }
 
+declare const locallyExportedCustomSymbol: unique symbol;
+
 /**
  * This class gets aliased twice before being exported from the package.
  * @public
@@ -221,6 +223,8 @@ export declare class TypeReferencesInAedoc {
      */
     getValue3(arg1: TypeReferencesInAedoc): TypeReferencesInAedoc;
 }
+
+declare const unexportedCustomSymbol: unique symbol;
 
 /**
  * Example decorator

--- a/build-tests/api-extractor-test-01/dist/internal/api-extractor-test-01.d.ts
+++ b/build-tests/api-extractor-test-01/dist/internal/api-extractor-test-01.d.ts
@@ -72,6 +72,15 @@ export declare class ClassExportedAsDefault {
 }
 
 /**
+ * @public
+ */
+export declare class ClassWithSymbols {
+    readonly [unexportedCustomSymbol]: number;
+    readonly [locallyExportedCustomSymbol]: string;
+    [fullyExportedCustomSymbol](): void;
+}
+
+/**
  * This class illustrates some cases involving type literals.
  * @public
  */
@@ -128,6 +137,8 @@ export declare class ForgottenExportConsumer2 {
 export declare class ForgottenExportConsumer3 {
     test2(): IForgottenDirectDependency | undefined;
 }
+
+declare const fullyExportedCustomSymbol: unique symbol;
 
 /**
  * This class is directly consumed by ForgottenExportConsumer3.

--- a/build-tests/api-extractor-test-01/dist/internal/api-extractor-test-01.d.ts
+++ b/build-tests/api-extractor-test-01/dist/internal/api-extractor-test-01.d.ts
@@ -138,7 +138,7 @@ export declare class ForgottenExportConsumer3 {
     test2(): IForgottenDirectDependency | undefined;
 }
 
-declare const fullyExportedCustomSymbol: unique symbol;
+export declare const fullyExportedCustomSymbol: unique symbol;
 
 /**
  * This class is directly consumed by ForgottenExportConsumer3.
@@ -214,6 +214,8 @@ export declare interface IMergedInterfaceReferencee {
 export declare interface ISimpleInterface {
 }
 
+declare const locallyExportedCustomSymbol: unique symbol;
+
 /**
  * This class gets aliased twice before being exported from the package.
  * @public
@@ -241,6 +243,8 @@ export declare class TypeReferencesInAedoc {
      */
     getValue3(arg1: TypeReferencesInAedoc): TypeReferencesInAedoc;
 }
+
+declare const unexportedCustomSymbol: unique symbol;
 
 /**
  * Example decorator

--- a/build-tests/api-extractor-test-01/dist/public/api-extractor-test-01.d.ts
+++ b/build-tests/api-extractor-test-01/dist/public/api-extractor-test-01.d.ts
@@ -131,7 +131,7 @@ export declare class ForgottenExportConsumer2 {
 
 /* Excluded from this release type: ForgottenExportConsumer3 */
 
-declare const fullyExportedCustomSymbol: unique symbol;
+export declare const fullyExportedCustomSymbol: unique symbol;
 
 /**
  * This class is directly consumed by ForgottenExportConsumer3.
@@ -187,6 +187,8 @@ export declare interface IInterfaceAsDefaultExport {
 export declare interface ISimpleInterface {
 }
 
+declare const locallyExportedCustomSymbol: unique symbol;
+
 /**
  * This class gets aliased twice before being exported from the package.
  * @public
@@ -214,6 +216,8 @@ export declare class TypeReferencesInAedoc {
      */
     getValue3(arg1: TypeReferencesInAedoc): TypeReferencesInAedoc;
 }
+
+declare const unexportedCustomSymbol: unique symbol;
 
 /**
  * Example decorator

--- a/build-tests/api-extractor-test-01/dist/public/api-extractor-test-01.d.ts
+++ b/build-tests/api-extractor-test-01/dist/public/api-extractor-test-01.d.ts
@@ -72,6 +72,15 @@ export declare class ClassExportedAsDefault {
 }
 
 /**
+ * @public
+ */
+export declare class ClassWithSymbols {
+    readonly [unexportedCustomSymbol]: number;
+    readonly [locallyExportedCustomSymbol]: string;
+    [fullyExportedCustomSymbol](): void;
+}
+
+/**
  * This class illustrates some cases involving type literals.
  * @public
  */
@@ -121,6 +130,8 @@ export declare class ForgottenExportConsumer2 {
 }
 
 /* Excluded from this release type: ForgottenExportConsumer3 */
+
+declare const fullyExportedCustomSymbol: unique symbol;
 
 /**
  * This class is directly consumed by ForgottenExportConsumer3.

--- a/build-tests/api-extractor-test-01/etc/api-extractor-test-01.api.ts
+++ b/build-tests/api-extractor-test-01/etc/api-extractor-test-01.api.ts
@@ -29,6 +29,12 @@ class AmbientConsumer {
 class ClassExportedAsDefault {
 }
 
+// @public (undocumented)
+class ClassWithSymbols {
+  // (undocumented)
+  readonly __computed: number;
+}
+
 // @public
 class ClassWithTypeLiterals {
   method1(vector: {
@@ -112,3 +118,4 @@ class TypeReferencesInAedoc {
 // @public
 export function virtual(target: Object, propertyKey: string | symbol, descriptor: TypedPropertyDescriptor<any>): void;
 
+// WARNING: Unsupported export: fullyExportedCustomSymbol

--- a/build-tests/api-extractor-test-01/src/EcmaScriptSymbols.ts
+++ b/build-tests/api-extractor-test-01/src/EcmaScriptSymbols.ts
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+const unexportedCustomSymbol: unique symbol = Symbol('unexportedCustomSymbol');
+export const locallyExportedCustomSymbol: unique symbol = Symbol('locallyExportedCustomSymbol');
+export const fullyExportedCustomSymbol: unique symbol = Symbol('fullyExportedCustomSymbol');
+
+/**
+ * @public
+ */
+export class ClassWithSymbols {
+  public readonly [unexportedCustomSymbol]: number = 123;
+
+  public get [locallyExportedCustomSymbol](): string {
+    return 'hello';
+  }
+
+  public [fullyExportedCustomSymbol](): void {
+  }
+}

--- a/build-tests/api-extractor-test-01/src/index.ts
+++ b/build-tests/api-extractor-test-01/src/index.ts
@@ -92,6 +92,8 @@ export {
   default as ClassExportedAsDefault
 } from './DefaultExportEdgeCase';
 
+export { ClassWithSymbols, fullyExportedCustomSymbol } from './EcmaScriptSymbols';
+
 export { ForgottenExportConsumer1 } from './ForgottenExportConsumer1';
 export { ForgottenExportConsumer2 } from './ForgottenExportConsumer2';
 export { ForgottenExportConsumer3 } from './ForgottenExportConsumer3';

--- a/build-tests/api-extractor-test-04/dist/beta/api-extractor-test-04.d.ts
+++ b/build-tests/api-extractor-test-04/dist/beta/api-extractor-test-04.d.ts
@@ -121,4 +121,4 @@ export declare enum RegularEnum {
     /* Excluded from this release type: _InternalMember */
 }
 
-declare const variableDeclaration: string;
+export declare const variableDeclaration: string;

--- a/build-tests/api-extractor-test-04/dist/internal/api-extractor-test-04.d.ts
+++ b/build-tests/api-extractor-test-04/dist/internal/api-extractor-test-04.d.ts
@@ -224,4 +224,4 @@ export declare enum RegularEnum {
     _InternalMember = 102
 }
 
-declare const variableDeclaration: string;
+export declare const variableDeclaration: string;

--- a/build-tests/api-extractor-test-04/dist/public/api-extractor-test-04.d.ts
+++ b/build-tests/api-extractor-test-04/dist/public/api-extractor-test-04.d.ts
@@ -50,4 +50,4 @@ export declare class PublicClass {
 
 /* Excluded from this release type: RegularEnum */
 
-declare const variableDeclaration: string;
+export declare const variableDeclaration: string;

--- a/common/changes/@microsoft/api-extractor/pgonzal-ae-symbol-rollups_2018-11-01-18-33.json
+++ b/common/changes/@microsoft/api-extractor/pgonzal-ae-symbol-rollups_2018-11-01-18-33.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor",
+      "comment": "Fix an issue where EcmaScript symbols (\"computed property names\") were missing from .d.ts rollups",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor",
+  "email": "pgonzal@users.noreply.github.com"
+}


### PR DESCRIPTION
Example input:
```ts

const unexportedCustomSymbol: unique symbol = Symbol('unexportedCustomSymbol');

// Exported by this file, but not exported from index.ts
export const locallyExportedCustomSymbol: unique symbol = Symbol('locallyExportedCustomSymbol');

/** @public */
export const fullyExportedCustomSymbol: unique symbol = Symbol('fullyExportedCustomSymbol');

 /** @public */
export class ClassWithSymbols {
  public readonly [unexportedCustomSymbol]: number = 123;

  public get [locallyExportedCustomSymbol](): string {
    return 'hello';
  }

  public [fullyExportedCustomSymbol](): void {
  }
}
```

Before this PR:
-  `fullyExportedCustomSymbol` was included in the .d.ts rollup, but was missing the `export` keyword
- The `unexportedCustomSymbol` and `locallyExportedCustomSymbol` were not included at all, causing a syntax error
