### PR TITLE
Remove deprecated lint rule

### DIFF
--- a/apps/rush-lib/src/cli/RushCommandLineParser.ts
+++ b/apps/rush-lib/src/cli/RushCommandLineParser.ts
@@ -10,7 +10,6 @@ import { CommandLineParser, CommandLineFlagParameter, CommandLineAction } from '
 import { RushConfiguration } from '../api/RushConfiguration';
 import { RushConstants } from '../logic/RushConstants';
 import { CommandLineConfiguration } from '../api/CommandLineConfiguration';
-import { CommandJson } from '../api/CommandLineJson';
 import { Utilities } from '../utilities/Utilities';
 import { BaseScriptAction } from '../cli/scriptActions/BaseScriptAction';
 

--- a/apps/rush-lib/src/cli/scriptActions/BaseScriptAction.ts
+++ b/apps/rush-lib/src/cli/scriptActions/BaseScriptAction.ts
@@ -4,7 +4,6 @@
 import { CommandLineParameter } from '@microsoft/ts-command-line';
 import { BaseRushAction, IBaseRushActionOptions } from '../actions/BaseRushAction';
 import { CommandLineConfiguration } from '../../api/CommandLineConfiguration';
-import { ParameterJson } from '../../api/CommandLineJson';
 import { RushConstants } from '../../logic/RushConstants';
 
 /**

--- a/apps/rush-lib/src/scripts/install-run-rush.ts
+++ b/apps/rush-lib/src/scripts/install-run-rush.ts
@@ -49,8 +49,9 @@ function run(): void {
     ...packageBinArgs /* [build, --to, myproject] */
   ]: string[] = process.argv;
 
-  // override warning about unused variables
-  nodePath || scriptPath;
+  if (!nodePath || !scriptPath) {
+    throw new Error('Unexpected exception: could not detect node path or script path');
+  }
 
   if (process.argv.length < 3) {
     console.log('Usage: install-run-rush.js <command> [args...]');

--- a/apps/rush-lib/src/scripts/install-run-rush.ts
+++ b/apps/rush-lib/src/scripts/install-run-rush.ts
@@ -44,10 +44,13 @@ function getRushVersion(): string {
 
 function run(): void {
   const [
-    nodePath, /* Ex: /bin/node */ // tslint:disable-line:no-unused-variable
-    scriptPath, /* /repo/common/scripts/install-run-rush.js */ // tslint:disable-line:no-unused-variable
+    nodePath, /* Ex: /bin/node */
+    scriptPath, /* /repo/common/scripts/install-run-rush.js */
     ...packageBinArgs /* [build, --to, myproject] */
   ]: string[] = process.argv;
+
+  // override warning about unused variables
+  nodePath || scriptPath;
 
   if (process.argv.length < 3) {
     console.log('Usage: install-run-rush.js <command> [args...]');

--- a/apps/rush-lib/src/scripts/install-run.ts
+++ b/apps/rush-lib/src/scripts/install-run.ts
@@ -436,8 +436,9 @@ function run(): void {
     ...packageBinArgs /* [-f, myproject/lib] */
   ]: string[] = process.argv;
 
-  // override warning about nodePath not being used
-  nodePath;
+  if (!nodePath) {
+    throw new Error('Unexpected exception: could not detect node path');
+  }
 
   if (path.basename(scriptPath).toLowerCase() !== 'install-run.js') {
     // If install-run.js wasn't directly invoked, don't execute the rest of this function. Return control

--- a/apps/rush-lib/src/scripts/install-run.ts
+++ b/apps/rush-lib/src/scripts/install-run.ts
@@ -429,12 +429,15 @@ export function runWithErrorAndStatusCode(fn: () => number): void {
 
 function run(): void {
   const [
-    nodePath, /* Ex: /bin/node */ // tslint:disable-line:no-unused-variable
+    nodePath, /* Ex: /bin/node */
     scriptPath, /* /repo/common/scripts/install-run-rush.js */
     rawPackageSpecifier, /* qrcode@^1.2.0 */
     packageBinName, /* qrcode */
     ...packageBinArgs /* [-f, myproject/lib] */
   ]: string[] = process.argv;
+
+  // override warning about nodePath not being used
+  nodePath;
 
   if (path.basename(scriptPath).toLowerCase() !== 'install-run.js') {
     // If install-run.js wasn't directly invoked, don't execute the rest of this function. Return control

--- a/apps/rush/src/MinimalRushConfiguration.ts
+++ b/apps/rush/src/MinimalRushConfiguration.ts
@@ -17,7 +17,6 @@ interface IMinimalRushConfigurationJson {
  * decide which version of Rush should be installed/used.
  */
 export class MinimalRushConfiguration {
-  private _rushJsonFilename: string;
   private _rushVersion: string;
   private _commonRushConfigFolder: string;
 
@@ -41,7 +40,6 @@ export class MinimalRushConfiguration {
 
   private constructor(minimalRushConfigurationJson: IMinimalRushConfigurationJson, rushJsonFilename: string) {
     this._rushVersion = minimalRushConfigurationJson.rushVersion || minimalRushConfigurationJson.rushMinimumVersion;
-    this._rushJsonFilename = rushJsonFilename;
     this._commonRushConfigFolder = path.join(path.dirname(rushJsonFilename),
       RushConstants.commonFolderName, 'config', 'rush');
   }

--- a/common/changes/@microsoft/gulp-core-build/nickpape-turn-off-lint-rule_2018-11-06-23-42.json
+++ b/common/changes/@microsoft/gulp-core-build/nickpape-turn-off-lint-rule_2018-11-06-23-42.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@microsoft/gulp-core-build",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/gulp-core-build",
+  "email": "nickpape-msft@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush-stack-compiler/nickpape-turn-off-lint-rule_2018-11-05-23-34.json
+++ b/common/changes/@microsoft/rush-stack-compiler/nickpape-turn-off-lint-rule_2018-11-05-23-34.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush-stack-compiler",
+      "comment": "Disable deprecated lint rules in favor of compiler check.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@microsoft/rush-stack-compiler",
+  "email": "nickpape@microsoft.com"
+}

--- a/common/changes/@microsoft/rush/nickpape-turn-off-lint-rule_2018-11-06-23-42.json
+++ b/common/changes/@microsoft/rush/nickpape-turn-off-lint-rule_2018-11-06-23-42.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@microsoft/rush",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "nickpape-msft@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/stream-collator/nickpape-turn-off-lint-rule_2018-11-06-23-42.json
+++ b/common/changes/@microsoft/stream-collator/nickpape-turn-off-lint-rule_2018-11-06-23-42.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@microsoft/stream-collator",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/stream-collator",
+  "email": "nickpape-msft@users.noreply.github.com"
+}

--- a/core-build/gulp-core-build/src/GulpProxy.ts
+++ b/core-build/gulp-core-build/src/GulpProxy.ts
@@ -13,11 +13,8 @@ export class GulpProxy extends Orchestrator implements gulp.Gulp {
   public dest: gulp.DestMethod;
   public watch: gulp.WatchMethod;
 
-  private _gulp: gulp.Gulp;
-
   constructor(gulpInstance: gulp.Gulp) {
     super();
-    this._gulp = gulpInstance;
     this.src = gulpInstance.src;
     this.dest = gulpInstance.dest;
     this.watch = gulpInstance.watch;

--- a/core-build/gulp-core-build/src/utilities/test/FileDeletionUtility.test.ts
+++ b/core-build/gulp-core-build/src/utilities/test/FileDeletionUtility.test.ts
@@ -9,6 +9,7 @@ describe('FileDeletionUtility', () => {
     it('can be constructed', () => {
       // tslint:disable-next-line:no-unused-variable
       const test: FileDeletionUtility = new FileDeletionUtility();
+      assert.isNotNull(test);
     });
   });
   describe('isParentDirectory', () => {

--- a/libraries/stream-collator/src/test/Interleaver.test.ts
+++ b/libraries/stream-collator/src/test/Interleaver.test.ts
@@ -37,9 +37,8 @@ describe('Interleaver tests', () => {
   describe('Testing register and close', () => {
     it('cannot be directly instantiated', (done: MochaDone) => {
       assert.throws(() => {
-        /* tslint:disable:no-unused-variable */
         const a: Interleaver = new Interleaver();
-        /* tslint:enable:no-unused-variable */
+        assert.isNotNull(a);
       });
       done();
     });

--- a/stack/rush-stack-compiler/includes/tsconfig-base.json
+++ b/stack/rush-stack-compiler/includes/tsconfig-base.json
@@ -11,6 +11,7 @@
     "inlineSources": true,
     "experimentalDecorators": true,
     "strictNullChecks": true,
+    "noUnusedLocals": true,
     "types": []
   },
   "include": [

--- a/stack/rush-stack-compiler/includes/tslint.json
+++ b/stack/rush-stack-compiler/includes/tslint.json
@@ -69,7 +69,6 @@
     "no-trailing-whitespace": true,
     "no-unnecessary-semicolons": true,
     "no-unused-expression": true,
-    "no-unused-variable": true,
     "no-use-before-declare": true,
     "no-with-statement": true,
     "no-var-keyword": true,


### PR DESCRIPTION
It is causing issues in SP-Client:

Error - [tslint] no-unused-variable is deprecated. Since TypeScript 2.9. Please use the built-in compiler checks instead.