### PR TITLE
[rush] Prepare to publish Rush 5.5.1

### DIFF
--- a/apps/rush-lib/src/api/RushGlobalFolder.ts
+++ b/apps/rush-lib/src/api/RushGlobalFolder.ts
@@ -30,10 +30,10 @@ export class RushGlobalFolder {
   }
 
   public constructor() {
-    this._rushNodeSpecificUserFolder = path.join(Utilities.getHomeDirectory(), '.rush');
+    this._rushUserFolder = path.join(Utilities.getHomeDirectory(), '.rush');
     const normalizedNodeVersion: string = process.version.match(/^[a-z0-9\-\.]+$/i)
       ? process.version
       : 'unknown-version';
-    this._rushUserFolder = path.join(this._rushNodeSpecificUserFolder, `node-${normalizedNodeVersion}`);
+    this._rushNodeSpecificUserFolder = path.join(this._rushUserFolder, `node-${normalizedNodeVersion}`);
   }
 }

--- a/apps/rush-lib/src/logic/InstallManager.ts
+++ b/apps/rush-lib/src/logic/InstallManager.ts
@@ -1010,7 +1010,7 @@ export class InstallManager {
 
   private _queryIfReleaseIsPublished(registryUrl: string): Promise<boolean> {
     let queryUrl: string = registryUrl;
-    if (queryUrl[- 1] !== '/') {
+    if (queryUrl[-1] !== '/') {
       queryUrl += '/';
     }
     // Note that the "@" symbol does not normally get URL-encoded

--- a/apps/rush-lib/src/logic/PurgeManager.ts
+++ b/apps/rush-lib/src/logic/PurgeManager.ts
@@ -56,7 +56,7 @@ export class PurgeManager {
     console.log('Purging ' + this._rushConfiguration.commonTempFolder);
 
     this._commonTempFolderRecycler.moveAllItemsInFolder(this._rushConfiguration.commonTempFolder,
-      this._getMembersToExclude(this._rushConfiguration.commonTempFolder));
+      this._getMembersToExclude(this._rushConfiguration.commonTempFolder, true));
   }
 
   /**
@@ -66,13 +66,22 @@ export class PurgeManager {
   public purgeUnsafe(): void {
     this.purgeNormal();
 
-    // Also delete everything under ~/.rush/node-v4.5.6/ except for the recycler folder itself
-    console.log('Purging ' + this._rushGlobalFolder.nodeSpecificPath);
+    // We will delete everything under ~/.rush/ except for the recycler folder itself
+    console.log('Purging ' + this._rushGlobalFolder.path);
+
+    // If Rush itself is running under a folder such as  ~/.rush/node-v4.5.6/rush-1.2.3,
+    // we cannot delete that folder.
+
+    // First purge the node-specific folder, e.g. ~/.rush/node-v4.5.6/* except for rush-1.2.3:
     this._rushUserFolderRecycler.moveAllItemsInFolder(this._rushGlobalFolder.nodeSpecificPath,
-      this._getMembersToExclude(this._rushGlobalFolder.nodeSpecificPath));
+      this._getMembersToExclude(this._rushGlobalFolder.nodeSpecificPath, true));
+
+    // Then purge the the global folder, e.g. ~/.rush/* except for node-v4.5.6
+    this._rushUserFolderRecycler.moveAllItemsInFolder(this._rushGlobalFolder.path,
+      this._getMembersToExclude(this._rushGlobalFolder.path, false));
   }
 
-  private _getMembersToExclude(folderToRecycle: string): string[] {
+  private _getMembersToExclude(folderToRecycle: string, showWarning: boolean): string[] {
     // Don't recycle the recycler
     const membersToExclude: string[] = [RushConstants.rushRecyclerFolderName];
 
@@ -92,9 +101,11 @@ export class PurgeManager {
       if (firstPart.length > 0 && firstPart !== '..') {
         membersToExclude.push(firstPart);
 
-        // Warn that we won't dispose this folder
-        console.log(colors.yellow('The active process\'s folder will not be deleted: '
-          + path.join(folderToRecycle, firstPart)));
+        if (showWarning) {
+          // Warn that we won't dispose this folder
+          console.log(colors.yellow('The active process\'s folder will not be deleted: '
+            + path.join(folderToRecycle, firstPart)));
+        }
       }
     }
 

--- a/build-tests/api-extractor-test-01/package.json
+++ b/build-tests/api-extractor-test-01/package.json
@@ -15,7 +15,7 @@
     "@microsoft/api-extractor": "6.1.2",
     "@types/jest": "21.1.10",
     "@types/node": "8.5.8",
-    "fs-extra": "~7.0.0",
+    "fs-extra": "~7.0.1",
     "typescript": "~3.0.3"
   }
 }

--- a/build-tests/api-extractor-test-02/package.json
+++ b/build-tests/api-extractor-test-02/package.json
@@ -17,7 +17,7 @@
     "@types/node": "8.5.8",
     "api-extractor-test-01": "1.0.0",
     "semver": "~5.3.0",
-    "fs-extra": "~7.0.0",
+    "fs-extra": "~7.0.1",
     "typescript": "~3.0.3"
   }
 }

--- a/build-tests/api-extractor-test-03/package.json
+++ b/build-tests/api-extractor-test-03/package.json
@@ -10,7 +10,7 @@
     "@types/jest": "21.1.10",
     "@types/node": "8.5.8",
     "api-extractor-test-02": "1.0.0",
-    "fs-extra": "~7.0.0",
+    "fs-extra": "~7.0.1",
     "typescript": "~3.0.3"
   }
 }

--- a/build-tests/api-extractor-test-04/package.json
+++ b/build-tests/api-extractor-test-04/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@microsoft/api-extractor": "6.1.2",
-    "fs-extra": "~7.0.0",
+    "fs-extra": "~7.0.1",
     "typescript": "~3.0.3"
   }
 }

--- a/build-tests/api-extractor-test-05/package.json
+++ b/build-tests/api-extractor-test-05/package.json
@@ -16,7 +16,7 @@
     "@microsoft/api-documenter": "1.5.51",
     "@types/jest": "21.1.10",
     "@types/node": "8.5.8",
-    "fs-extra": "~7.0.0",
+    "fs-extra": "~7.0.1",
     "typescript": "~3.0.3"
   }
 }

--- a/common/changes/@microsoft/node-core-library/pgonzal-prepare-rush-5.5.1_2018-11-07-18-27.json
+++ b/common/changes/@microsoft/node-core-library/pgonzal-prepare-rush-5.5.1_2018-11-07-18-27.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/node-core-library",
+      "comment": "Upgrade fs-extra to eliminate the \"ERROR: ENOTEMPTY: directory not empty, rmdir\" error that sometimes occurred with FileSystem.deleteFolder()",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/node-core-library",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush/ianc-node-specific-rush-install_2018-11-06-19-58.json
+++ b/common/changes/@microsoft/rush/ianc-node-specific-rush-install_2018-11-06-19-58.json
@@ -1,7 +1,7 @@
 {
   "changes": [
     {
-      "comment": "Install rush and package managers in a node version-specific folder under the user's home directory.",
+      "comment": "Install rush and package managers in a node version-specific folder under the user's home directory",
       "packageName": "@microsoft/rush",
       "type": "none"
     }

--- a/common/changes/@microsoft/rush/pgonzal-prepare-rush-5.5.1_2018-11-07-18-27.json
+++ b/common/changes/@microsoft/rush/pgonzal-prepare-rush-5.5.1_2018-11-07-18-27.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Upgrade fs-extra to eliminate the annoying \"ERROR: ENOTEMPTY: directory not empty, rmdir\" error that occasionally occurred during \"rush link\"",
+      "packageName": "@microsoft/rush",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/config/rush/shrinkwrap.yaml
+++ b/common/config/rush/shrinkwrap.yaml
@@ -94,7 +94,7 @@ dependencies:
   del: 2.2.2
   end-of-stream: 1.1.0
   express: 4.16.4
-  fs-extra: 7.0.0
+  fs-extra: 7.0.1
   git-repo-info: 1.1.4
   glob: 7.0.6
   glob-escape: 0.0.2
@@ -151,8 +151,8 @@ dependencies:
   sinon-chai: 2.8.0
   strict-uri-encode: 2.0.0
   sudo: 1.0.3
-  tar: 4.4.6
-  through2: 2.0.3
+  tar: 4.4.7
+  through2: 2.0.5
   ts-jest: 22.4.6
   tslint: 5.11.0
   tslint-microsoft-contrib: 5.2.1
@@ -271,7 +271,7 @@ packages:
       pretty-hrtime: 1.0.3
       rimraf: 2.5.4
       semver: 5.3.0
-      through2: 2.0.3
+      through2: 2.0.5
       vinyl: 2.2.0
       yargs: 4.6.0
       z-schema: 3.18.4
@@ -347,8 +347,8 @@ packages:
       '@pnpm/package-bins': 1.0.0
       '@pnpm/types': 1.8.0
       '@types/mz': 0.0.32
-      '@types/node': 10.12.2
-      '@types/ramda': 0.25.40
+      '@types/node': 10.12.3
+      '@types/ramda': 0.25.41
       '@zkochan/cmd-shim': 2.2.4
       arr-flatten: 1.1.0
       is-windows: 1.0.2
@@ -371,8 +371,8 @@ packages:
       '@pnpm/package-bins': 1.0.0
       '@pnpm/types': 1.8.0
       '@types/mz': 0.0.32
-      '@types/node': 10.12.2
-      '@types/ramda': 0.25.40
+      '@types/node': 10.12.3
+      '@types/ramda': 0.25.41
       '@zkochan/cmd-shim': 2.2.4
       arr-flatten: 1.1.0
       is-windows: 1.0.2
@@ -392,7 +392,7 @@ packages:
       integrity: sha512-thVgwrQ5rMcPYI6a0IPOt2pnlF1n5zX7BN4CrFeBp0/JCGsZAht/VOPv9bD3cZ+j0vDemEwE23BfhOWxmxq2yQ==
   /@pnpm/logger/1.0.2:
     dependencies:
-      '@types/node': 10.12.2
+      '@types/node': 10.12.3
       bole: 3.0.2
       ndjson: 1.5.0
     dev: false
@@ -586,10 +586,10 @@ packages:
     dev: false
     resolution:
       integrity: sha1-spbM5xRP+rd7hAkMqtTx5Lvqjgk=
-  /@types/node/10.12.2:
+  /@types/node/10.12.3:
     dev: false
     resolution:
-      integrity: sha512-53ElVDSnZeFUUFIYzI8WLQ25IhWzb6vbddNp8UHlXQyU0ET2RhV5zg0NfubzU7iNMh5bBXb0htCzfvrSVNgzaQ==
+      integrity: sha512-sfGmOtSMSbQ/AKG8V9xD1gmjquC9awIIZ/Kj309pHb2n3bcRAcGMQv5nJ6gCXZVsneGE4+ve8DXKRCsrg3TFzg==
   /@types/node/8.5.8:
     dev: false
     resolution:
@@ -604,10 +604,10 @@ packages:
     dev: false
     resolution:
       integrity: sha1-vShOV8hPEyXacCur/IKlMoGQwMU=
-  /@types/ramda/0.25.40:
+  /@types/ramda/0.25.41:
     dev: false
     resolution:
-      integrity: sha512-2wJUkK/jY//CECZZrFb1LBreCkwuA9RY4P1GpGV35vLg/cJQUFs0dSUEvQANPjnoa4Kv8hsVFvM0v8xS5cPydg==
+      integrity: sha512-R6IkySFkrCN6Xd3exKX1PI2hvkmpbDZBKYz7u4uuYas8NeUCmcHkccYo6OWKtWIkYipjGBQP2ZzlTT+R3bUY6Q==
   /@types/resolve/0.0.8:
     dependencies:
       '@types/node': 8.5.8
@@ -836,7 +836,7 @@ packages:
       integrity: sha1-x1K9IQvvZ5UBtsbLf8hPj0cVjMQ=
   /acorn-globals/4.3.0:
     dependencies:
-      acorn: 6.0.2
+      acorn: 6.0.4
       acorn-walk: 6.1.0
     dev: false
     resolution:
@@ -861,13 +861,13 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==
-  /acorn/6.0.2:
+  /acorn/6.0.4:
     dev: false
     engines:
       node: '>=0.4.0'
     hasBin: true
     resolution:
-      integrity: sha512-GXmKIvbrN3TV7aVqAzVFaMW8F8wzVX7voEBRO3bDA64+EX37YSayggRJP5Xig6HYHBkWKpFg9W5gg6orklubhg==
+      integrity: sha512-VY4i5EKSKkofY2I+6QLTbTTN/UvEQPCo6eiwzzSaSWfpaDhOmStMCMod6wmuPciNq+XS0faCglFu2lHZpdHUtg==
   /after/0.8.2:
     dev: false
     resolution:
@@ -880,9 +880,9 @@ packages:
       node: '>= 4.0.0'
     resolution:
       integrity: sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==
-  /ajv-keywords/3.2.0/ajv@6.5.4:
+  /ajv-keywords/3.2.0/ajv@6.5.5:
     dependencies:
-      ajv: 6.5.4
+      ajv: 6.5.5
     dev: false
     id: registry.npmjs.org/ajv-keywords/3.2.0
     peerDependencies:
@@ -898,7 +898,7 @@ packages:
     dev: false
     resolution:
       integrity: sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=
-  /ajv/6.5.4:
+  /ajv/6.5.5:
     dependencies:
       fast-deep-equal: 2.0.1
       fast-json-stable-stringify: 2.0.0
@@ -906,7 +906,7 @@ packages:
       uri-js: 4.2.2
     dev: false
     resolution:
-      integrity: sha512-4Wyjt8+t6YszqaXnLDfMmG/8AlO5Zbcsy3ATHncCzjW/NoPzAId8AK6749Ybjmdt+kUY1gP60fCu46oDxPv/mg==
+      integrity: sha512-7q7gtRQDJSyuEHjuVgHoUa2VuemFiCMrfQc9Tc08XTAc4Zj/5U1buQJ0HU6i7fKjXU09SVgSmxa4sLvuvS8Iyg==
   /align-text/0.1.4:
     dependencies:
       kind-of: 3.2.2
@@ -1234,7 +1234,7 @@ packages:
   /autoprefixer/9.1.5:
     dependencies:
       browserslist: 4.3.4
-      caniuse-lite: 1.0.30000903
+      caniuse-lite: 1.0.30000906
       normalize-range: 0.1.2
       num2fraction: 1.2.2
       postcss: 7.0.5
@@ -1677,7 +1677,7 @@ packages:
       integrity: sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==
   /browserslist/4.3.4:
     dependencies:
-      caniuse-lite: 1.0.30000903
+      caniuse-lite: 1.0.30000906
       electron-to-chromium: 1.3.83
       node-releases: 1.0.3
     dev: false
@@ -1808,10 +1808,10 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=
-  /caniuse-lite/1.0.30000903:
+  /caniuse-lite/1.0.30000906:
     dev: false
     resolution:
-      integrity: sha512-T1XVJEpGCoaq7MDw7/6hCdYUukmSaS+1l/OQJkLtw7Cr2+/+d67tNGKEbyiqf7Ck8x6EhNFUxjYFXXka0N/w5g==
+      integrity: sha512-ME7JFX6h0402om/nC/8Lw+q23QvPe2ust9U0ntLmkX9F2zaGwq47fZkjlyHKirFBuq1EM+T/LXBcDdW4bvkCTA==
   /capture-exit/1.2.0:
     dependencies:
       rsvp: 3.6.2
@@ -2716,7 +2716,7 @@ packages:
       integrity: sha512-j1DWIcktw4hRwrv6nWx++5nFH2X64x16MAG2P0Lmi5Dvdfi3I+Jhc7JKJIdAmDJa+5aZ/imHV7dWRPy2Cqjh3A==
   /enhanced-resolve/3.4.1:
     dependencies:
-      graceful-fs: 4.1.14
+      graceful-fs: 4.1.15
       memory-fs: 0.4.1
       object-assign: 4.1.1
       tapable: 0.2.8
@@ -3517,7 +3517,7 @@ packages:
       integrity: sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=
   /fs-extra/1.0.0:
     dependencies:
-      graceful-fs: 4.1.14
+      graceful-fs: 4.1.15
       jsonfile: 2.4.0
       klaw: 1.3.1
     dev: false
@@ -3525,7 +3525,7 @@ packages:
       integrity: sha1-zTzl9+fLYUWIP8rjGR6Yd/hYeVA=
   /fs-extra/5.0.0:
     dependencies:
-      graceful-fs: 4.1.14
+      graceful-fs: 4.1.15
       jsonfile: 4.0.0
       universalify: 0.1.2
     dev: false
@@ -3533,22 +3533,22 @@ packages:
       integrity: sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==
   /fs-extra/6.0.0:
     dependencies:
-      graceful-fs: 4.1.14
+      graceful-fs: 4.1.15
       jsonfile: 4.0.0
       universalify: 0.1.2
     dev: false
     resolution:
       integrity: sha512-lk2cUCo8QzbiEWEbt7Cw3m27WMiRG321xsssbcIpfMhpRjrlC08WBOVQqj1/nQYYNnPtyIhP1oqLO3QwT2tPCw==
-  /fs-extra/7.0.0:
+  /fs-extra/7.0.1:
     dependencies:
-      graceful-fs: 4.1.14
+      graceful-fs: 4.1.15
       jsonfile: 4.0.0
       universalify: 0.1.2
     dev: false
     engines:
       node: '>=6 <7 || >=8'
     resolution:
-      integrity: sha512-EglNDLRpmaTWiD/qraZn6HREAEAHJcJOmxNEYwq6xeMKnVMAy3GUcFB+wXt2C6k4CNvB/mP1y/U3dzvKKj5OtQ==
+      integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==
   /fs-minipass/1.2.5:
     dependencies:
       minipass: 2.3.5
@@ -3573,7 +3573,7 @@ packages:
       integrity: sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==
   /fstream/1.0.11:
     dependencies:
-      graceful-fs: 4.1.14
+      graceful-fs: 4.1.15
       inherits: 2.0.3
       mkdirp: 0.5.1
       rimraf: 2.6.2
@@ -3855,12 +3855,10 @@ packages:
       node: '>=0.4.0'
     resolution:
       integrity: sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=
-  /graceful-fs/4.1.14:
+  /graceful-fs/4.1.15:
     dev: false
-    engines:
-      node: '>=6'
     resolution:
-      integrity: sha512-ns/IGcSmmGNPP085JCheg0Nombh1QPvSCnlx+2V+byQWRQEIL4ZB5jXJMNIHOFVS1roi85HIi5Ka0h43iWXfcQ==
+      integrity: sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==
   /growl/1.10.5:
     dev: false
     engines:
@@ -3890,7 +3888,7 @@ packages:
   /gulp-flatten/0.2.0:
     dependencies:
       gulp-util: 3.0.8
-      through2: 2.0.3
+      through2: 2.0.5
     dev: false
     engines:
       node: '>=0.10'
@@ -3900,7 +3898,7 @@ packages:
     dependencies:
       gulp-match: 1.0.3
       ternary-stream: 2.0.1
-      through2: 2.0.3
+      through2: 2.0.5
     dev: false
     engines:
       node: '>= 0.10.0'
@@ -3912,7 +3910,7 @@ packages:
       istanbul: 0.4.5
       istanbul-threshold-checker: 0.1.0
       lodash: 4.17.11
-      through2: 2.0.3
+      through2: 2.0.5
     dev: false
     resolution:
       integrity: sha1-Kyoby+uWpix45pgh0QTW/KMu+wk=
@@ -3960,7 +3958,7 @@ packages:
       npm-run-path: 2.0.2
       plugin-error: 1.0.1
       supports-color: 5.5.0
-      through2: 2.0.3
+      through2: 2.0.5
     dev: false
     engines:
       node: '>=6'
@@ -3971,7 +3969,7 @@ packages:
       colors: 1.2.5
       opn: 5.2.0
       plugin-log: 0.1.0
-      through2: 2.0.3
+      through2: 2.0.5
     dev: false
     engines:
       node: '>=4'
@@ -4021,7 +4019,7 @@ packages:
       multipipe: 0.1.2
       object-assign: 3.0.0
       replace-ext: 0.0.1
-      through2: 2.0.3
+      through2: 2.0.5
       vinyl: 0.5.3
     deprecated: 'gulp-util is deprecated - replace it, following the guidelines at https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5'
     dev: false
@@ -4086,15 +4084,15 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=
-  /har-validator/5.1.0:
+  /har-validator/5.1.2:
     dependencies:
-      ajv: 5.5.2
+      ajv: 6.5.5
       har-schema: 2.0.0
     dev: false
     engines:
-      node: '>=4'
+      node: '>=6'
     resolution:
-      integrity: sha512-+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==
+      integrity: sha512-OFxb5MZXCUMx43X7O8LK4FKggEQx6yC5QPmOcBnYbJ9UjxEcMcrMbaR0af5HZpqeFopw2GwQRQi34ZXI7YLM5w==
   /has-ansi/0.1.0:
     dependencies:
       ansi-regex: 0.2.1
@@ -4985,7 +4983,7 @@ packages:
       chalk: 2.4.1
       exit: 0.1.2
       glob: 7.1.3
-      graceful-fs: 4.1.14
+      graceful-fs: 4.1.15
       import-local: 1.0.0
       is-ci: 1.2.1
       istanbul-api: 1.3.7
@@ -5074,7 +5072,7 @@ packages:
   /jest-haste-map/22.4.3:
     dependencies:
       fb-watchman: 2.0.0
-      graceful-fs: 4.1.14
+      graceful-fs: 4.1.15
       jest-docblock: 22.4.3
       jest-serializer: 22.4.3
       jest-worker: 22.4.3
@@ -5088,7 +5086,7 @@ packages:
       chalk: 2.4.1
       co: 4.6.0
       expect: 22.4.3
-      graceful-fs: 4.1.14
+      graceful-fs: 4.1.15
       is-generator-fn: 1.0.0
       jest-diff: 22.4.3
       jest-matcher-utils: 22.4.3
@@ -5168,7 +5166,7 @@ packages:
       chalk: 2.4.1
       convert-source-map: 1.6.0
       exit: 0.1.2
-      graceful-fs: 4.1.14
+      graceful-fs: 4.1.15
       jest-config: 22.4.4
       jest-haste-map: 22.4.3
       jest-regex-util: 22.4.3
@@ -5205,7 +5203,7 @@ packages:
     dependencies:
       callsites: 2.0.0
       chalk: 2.4.1
-      graceful-fs: 4.1.14
+      graceful-fs: 4.1.15
       is-ci: 1.2.1
       jest-message-util: 22.4.3
       mkdirp: 0.5.1
@@ -5350,13 +5348,13 @@ packages:
   /jsonfile/2.4.0:
     dev: false
     optionalDependencies:
-      graceful-fs: 4.1.14
+      graceful-fs: 4.1.15
     resolution:
       integrity: sha1-NzaitCi4e72gzIO1P6PWM6NcKug=
   /jsonfile/4.0.0:
     dev: false
     optionalDependencies:
-      graceful-fs: 4.1.14
+      graceful-fs: 4.1.15
     resolution:
       integrity: sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=
   /jsonify/0.0.0:
@@ -5481,7 +5479,7 @@ packages:
       dom-serialize: 2.2.1
       expand-braces: 0.1.2
       glob: 7.0.6
-      graceful-fs: 4.1.14
+      graceful-fs: 4.1.15
       http-proxy: 1.17.0
       isbinaryfile: 3.0.3
       lodash: 3.10.1
@@ -5534,7 +5532,7 @@ packages:
   /klaw/1.3.1:
     dev: false
     optionalDependencies:
-      graceful-fs: 4.1.14
+      graceful-fs: 4.1.15
     resolution:
       integrity: sha1-QIhDO0azsbolnXh4XY6W9zugJDk=
   /lazy-cache/1.0.4:
@@ -5600,7 +5598,7 @@ packages:
       integrity: sha512-XPQH8Z2GDP/Hwz2PCDrh2mth4yFejwA1OZ/81Ti3LgKyhDcEjsSsqFWZojHG0va/duGd+WyosY7eXLDoOyqcPw==
   /load-json-file/1.1.0:
     dependencies:
-      graceful-fs: 4.1.14
+      graceful-fs: 4.1.15
       parse-json: 2.2.0
       pify: 2.3.0
       pinkie-promise: 2.0.1
@@ -5612,7 +5610,7 @@ packages:
       integrity: sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=
   /load-json-file/2.0.0:
     dependencies:
-      graceful-fs: 4.1.14
+      graceful-fs: 4.1.15
       parse-json: 2.2.0
       pify: 2.3.0
       strip-bom: 3.0.0
@@ -6347,7 +6345,7 @@ packages:
       json-stringify-safe: 5.0.1
       minimist: 1.2.0
       split2: 2.2.0
-      through2: 2.0.3
+      through2: 2.0.5
     dev: false
     hasBin: true
     resolution:
@@ -6384,7 +6382,7 @@ packages:
     dependencies:
       fstream: 1.0.11
       glob: 7.0.6
-      graceful-fs: 4.1.14
+      graceful-fs: 4.1.15
       mkdirp: 0.5.1
       nopt: 3.0.6
       npmlog: 4.1.2
@@ -6979,7 +6977,7 @@ packages:
       integrity: sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=
   /path-type/1.1.0:
     dependencies:
-      graceful-fs: 4.1.14
+      graceful-fs: 4.1.15
       pify: 2.3.0
       pinkie-promise: 2.0.1
     dev: false
@@ -7372,7 +7370,7 @@ packages:
       slash: 1.0.0
     dev: false
     optionalDependencies:
-      graceful-fs: 4.1.14
+      graceful-fs: 4.1.15
     resolution:
       integrity: sha512-/1dZ7TRZvGrYqE0UAfN6qQb5GYBsNcqS1C0tNK601CFOJmtHI7NIGXwetEPU/OtoFHZL3hDxm4rolFFVE9Bnmg==
   /read-package-tree/5.1.6:
@@ -7465,14 +7463,14 @@ packages:
     dependencies:
       debuglog: 1.0.1
       dezalgo: 1.0.3
-      graceful-fs: 4.1.14
+      graceful-fs: 4.1.15
       once: 1.4.0
     dev: false
     resolution:
       integrity: sha1-n6+jfShr5dksuuve4DDcm19AZ0c=
   /readdirp/2.2.1:
     dependencies:
-      graceful-fs: 4.1.14
+      graceful-fs: 4.1.15
       micromatch: 3.1.10
       readable-stream: 2.3.6
     dev: false
@@ -7667,7 +7665,7 @@ packages:
       extend: 3.0.2
       forever-agent: 0.6.1
       form-data: 2.3.3
-      har-validator: 5.1.0
+      har-validator: 5.1.2
       http-signature: 1.2.0
       is-typedarray: 1.0.0
       isstream: 0.1.2
@@ -8255,7 +8253,7 @@ packages:
       integrity: sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==
   /split2/2.2.0:
     dependencies:
-      through2: 2.0.3
+      through2: 2.0.5
     dev: false
     resolution:
       integrity: sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==
@@ -8562,7 +8560,7 @@ packages:
     dev: false
     resolution:
       integrity: sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=
-  /tar/4.4.6:
+  /tar/4.4.7:
     dependencies:
       chownr: 1.1.1
       fs-minipass: 1.2.5
@@ -8575,13 +8573,13 @@ packages:
     engines:
       node: '>=4.5'
     resolution:
-      integrity: sha512-tMkTnh9EdzxyfW+6GK6fCahagXsnYk6kE6S9Gr9pjVdys769+laCTbodXDhPAjzVtEBazRgP0gYqOjnk9dQzLg==
+      integrity: sha512-mR3MzsCdN0IEWjZRuF/J9gaWHnTwOvzjqPTcvi1xXgfKTDQRp39gRETPQEfPByAdEOGmZfx1HrRsn8estaEvtA==
   /ternary-stream/2.0.1:
     dependencies:
       duplexify: 3.6.1
       fork-stream: 0.0.4
       merge-stream: 1.0.1
-      through2: 2.0.3
+      through2: 2.0.5
     dev: false
     engines:
       node: '>= 0.10.0'
@@ -8641,13 +8639,13 @@ packages:
     dev: false
     resolution:
       integrity: sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=
-  /through2/2.0.3:
+  /through2/2.0.5:
     dependencies:
       readable-stream: 2.3.6
       xtend: 4.0.1
     dev: false
     resolution:
-      integrity: sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=
+      integrity: sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==
   /tildify/1.2.0:
     dependencies:
       os-homedir: 1.0.2
@@ -9291,7 +9289,7 @@ packages:
   /watchpack/1.6.0:
     dependencies:
       chokidar: 2.0.4
-      graceful-fs: 4.1.14
+      graceful-fs: 4.1.15
       neo-async: 2.6.0
     dev: false
     resolution:
@@ -9341,8 +9339,8 @@ packages:
     dependencies:
       acorn: 5.7.3
       acorn-dynamic-import: 2.0.2
-      ajv: 6.5.4
-      ajv-keywords: /ajv-keywords/3.2.0/ajv@6.5.4
+      ajv: 6.5.5
+      ajv-keywords: /ajv-keywords/3.2.0/ajv@6.5.5
       async: 2.6.1
       enhanced-resolve: 3.4.1
       escope: 3.6.0
@@ -9473,7 +9471,7 @@ packages:
       integrity: sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
   /write-file-atomic/2.3.0:
     dependencies:
-      graceful-fs: 4.1.14
+      graceful-fs: 4.1.15
       imurmurhash: 0.1.4
       signal-exit: 3.0.2
     dev: false
@@ -9698,66 +9696,66 @@ packages:
     dev: false
     name: '@rush-temp/api-documenter'
     resolution:
-      integrity: sha512-vZLfZ8DrBbEEh5jMTOQW3VjA2WRaToTM2Y97pB2FBsohCNTDhhOo/PJs7cqh+fAvux/Q0xWD9pnBEqMeEXSsVg==
+      integrity: sha512-YXcOxdIRLQ/C/vuTFjH0mno8J5Wi4Bj7WfiQTWavuoKqv5GMq9u0+GApc9zhlVIuiGh1mAQnIig2nfmdgccyhg==
       tarball: 'file:projects/api-documenter.tgz'
     version: 0.0.0
   'file:projects/api-extractor-test-01.tgz':
     dependencies:
       '@types/jest': 21.1.10
       '@types/node': 8.5.8
-      fs-extra: 7.0.0
+      fs-extra: 7.0.1
       typescript: 3.0.3
     dev: false
     name: '@rush-temp/api-extractor-test-01'
     resolution:
-      integrity: sha512-KfRUIgmqD2k6QHeSWCSwz1mkpQlXZgDvRLUOPWa6JjeO9TGvH4Has0KY6u9cnDY1LK9BzH8BGuc9WCwNhF8PUQ==
+      integrity: sha512-toR+/IpyJhncDhbC6N3F4xNul9nLRBItNow3YIfbbom3gpOcxF3gMWuvJHukWWAy+qpel0fPFA4pdQ1cnGwXdA==
       tarball: 'file:projects/api-extractor-test-01.tgz'
     version: 0.0.0
   'file:projects/api-extractor-test-02.tgz':
     dependencies:
       '@types/node': 8.5.8
       '@types/semver': 5.3.33
-      fs-extra: 7.0.0
+      fs-extra: 7.0.1
       semver: 5.3.0
       typescript: 3.0.3
     dev: false
     name: '@rush-temp/api-extractor-test-02'
     resolution:
-      integrity: sha512-i+vSuIDAwihpIanNNln22EJym36jbw1uhERWdO86ZsupnTrVP5IX9+7D7ImPalrmP/usXhlTMf/Md/YkiGqCvg==
+      integrity: sha512-mnujMXaIyScgO0R+cUzqvr6EL90i/zNaNUxqRJjmmJzEvIwaaNZ2eCe+cOQMmgd2fewjYP8pgQi/zDuchdcZUA==
       tarball: 'file:projects/api-extractor-test-02.tgz'
     version: 0.0.0
   'file:projects/api-extractor-test-03.tgz':
     dependencies:
       '@types/jest': 21.1.10
       '@types/node': 8.5.8
-      fs-extra: 7.0.0
+      fs-extra: 7.0.1
       typescript: 3.0.3
     dev: false
     name: '@rush-temp/api-extractor-test-03'
     resolution:
-      integrity: sha512-DzpImCK/Vy+T87UeTRIB2fpMcOuXUcL7ge1SU99iewyzvJR3tTfQPDSs46MxpWuKt7icAROJ3Ihf5mO0OMe+tw==
+      integrity: sha512-CL8ExJzI/DbICdN4A1lxKGrp8OsS22YeVSdVGk1dJfJOh3sa4CtJoWAeIX7TiXpc5uIlX6iXRotAbDI4HQWIfQ==
       tarball: 'file:projects/api-extractor-test-03.tgz'
     version: 0.0.0
   'file:projects/api-extractor-test-04.tgz':
     dependencies:
-      fs-extra: 7.0.0
+      fs-extra: 7.0.1
       typescript: 3.0.3
     dev: false
     name: '@rush-temp/api-extractor-test-04'
     resolution:
-      integrity: sha512-YTzrGIzyllKam+Tx3xf7bMrNbCqB/HBdUN8t1i0GVAVdG48Pw0bOZZZ4FVYOfw+EI5zHvtHzdYXn3tCXwNYtYQ==
+      integrity: sha512-+OVWZRTNJmkJ7D8tK/Yg38x8KEY0kUQPcVYC6oTx2s7RtHH3FUTOYq01koZQVdcOH4ucwUaYqfBTLQfB3DtESg==
       tarball: 'file:projects/api-extractor-test-04.tgz'
     version: 0.0.0
   'file:projects/api-extractor-test-05.tgz':
     dependencies:
       '@types/jest': 21.1.10
       '@types/node': 8.5.8
-      fs-extra: 7.0.0
+      fs-extra: 7.0.1
       typescript: 3.0.3
     dev: false
     name: '@rush-temp/api-extractor-test-05'
     resolution:
-      integrity: sha512-xMRRsKz5bM1G8kWLn0rg80nBJ9qDyQA5aj7C3qe+gimnZCGFaNAOvicYmNDpDDKAcGGw2l43d5cqX1fluQPJnw==
+      integrity: sha512-38rDuU1ivlmZqaBsOI/ZE+ZMcZICj54jnME/ZOxWxKIZ/fZAzJYj/GkIYKqCXIG6pjnH17tP6j2JE+MatHvRJQ==
       tarball: 'file:projects/api-extractor-test-05.tgz'
     version: 0.0.0
   'file:projects/api-extractor.tgz':
@@ -9779,7 +9777,7 @@ packages:
     dev: false
     name: '@rush-temp/api-extractor'
     resolution:
-      integrity: sha512-7tcrURYE+2jNqeqFn7phqraKEHhXKnBrwMFWwpDUBZ8igNiKOUOnqytIAh6Ir4CoFJpar9u2yqwooQYoUgZTYA==
+      integrity: sha512-kL/GKihrWwtViyk7k4Rjaj1ncrKkT65zwVc3b/n1mEBGIlFpNuZ0XOtT79wmKovm89DBY43GFpaatnu5A9MFTw==
       tarball: 'file:projects/api-extractor.tgz'
     version: 0.0.0
   'file:projects/gulp-core-build-karma.tgz':
@@ -9810,7 +9808,7 @@ packages:
     dev: false
     name: '@rush-temp/gulp-core-build-karma'
     resolution:
-      integrity: sha512-TKNoF1A9rIbUBYQxU503b0RhDfeyvk27JtlNMROC0phZav2kkaYRZNPs5iQUWZdGo7yXGLVcMGX+YDc6gZfdBA==
+      integrity: sha512-csU8qWGioLNXfbEUOSjWmwGgpqR0JnJyLYrSNpFtFagvpR2IluoB51CwqucH4INj9GGFyWk6KBmh+bMR6dgMyw==
       tarball: 'file:projects/gulp-core-build-karma.tgz'
     version: 0.0.0
   'file:projects/gulp-core-build-mocha.tgz':
@@ -9831,7 +9829,7 @@ packages:
     dev: false
     name: '@rush-temp/gulp-core-build-mocha'
     resolution:
-      integrity: sha512-aHxSxTGq2ZekfUaitGKElT0lzsp9IvUXW16CG4mvZ3+wMl9wq32IDEzQzVgYN680aOKw/4rDyab3mflb8LU/Rg==
+      integrity: sha512-kQWYWoTR1Wzzof5nBHn6146adyX/QvLoATIMsEW2KXc30fEavEWmt1BCWY6HeqHLylHbBVs/aduIofkdro8U5A==
       tarball: 'file:projects/gulp-core-build-mocha.tgz'
     version: 0.0.0
   'file:projects/gulp-core-build-sass.tgz':
@@ -9851,7 +9849,7 @@ packages:
     dev: false
     name: '@rush-temp/gulp-core-build-sass'
     resolution:
-      integrity: sha512-frvds/9vl34EIBhvf2O9t5WzltUTa12XTrXYf+jQmMJiUPH/HFwc2E7P2LrSgemXAxj4FJEtnFkposp65qEPgw==
+      integrity: sha512-wp0vntkXFSPhChGbHVaEz2SuoohFHZCrAWlLxUquX2QzuXeBL/bEfEzCA6BJwCido4CVeZqtkhTPwDDbgqtFoQ==
       tarball: 'file:projects/gulp-core-build-sass.tgz'
     version: 0.0.0
   'file:projects/gulp-core-build-serve.tgz':
@@ -9878,7 +9876,7 @@ packages:
     dev: false
     name: '@rush-temp/gulp-core-build-serve'
     resolution:
-      integrity: sha512-tvJTAnLjhHLbzOEoOUSQgLWqrSTIt9nFzBueQm8vMrJg/2E8bjGBp01Dn1MMDBzQB2gpF6YW4bppWF9Dds4MDQ==
+      integrity: sha512-J1warQ467DPgWqg6Sy0JjN+0FVKrKNz6d5xTiq29Iz8t9yiPu3Z3uV76b8+LRrhSn/zsDJKV2ChAdaiN0TtOyA==
       tarball: 'file:projects/gulp-core-build-serve.tgz'
     version: 0.0.0
   'file:projects/gulp-core-build-typescript.tgz':
@@ -9899,7 +9897,7 @@ packages:
     dev: false
     name: '@rush-temp/gulp-core-build-typescript'
     resolution:
-      integrity: sha512-xoAQdQFOlN5ao1Law4QtLBPZqgGrr24oCh8OWNf6jQz984hSdudk5hyuT6gU93ScJln+idlp/GwoszpGcXUEqA==
+      integrity: sha512-9r2wJlPW5qphyBziSMo2VqbeZxbCmSV/ZbTAVuCBSn32IW1371fB/H/bUi5o+9tYE+OclHgnMtlWnKSsRn3FRA==
       tarball: 'file:projects/gulp-core-build-typescript.tgz'
     version: 0.0.0
   'file:projects/gulp-core-build-webpack.tgz':
@@ -9917,7 +9915,7 @@ packages:
     dev: false
     name: '@rush-temp/gulp-core-build-webpack'
     resolution:
-      integrity: sha512-IaCO5R4OWR/IJ6Bo/n/xwqPdE/3R4yPUli1BnayPDZb8ZQDZ33oBmKWMkR8hDWoxxzj8DDR1yC0wbh3DOhQMtg==
+      integrity: sha512-iURAq/j0ig6Yo8s7NAT1tsZtx2WNgYX2B20C/KEFQ3O7VUfa8Guxh7AXW3Q4d9uKMuvaJLX/MhGIwTdqmoYF+g==
       tarball: 'file:projects/gulp-core-build-webpack.tgz'
     version: 0.0.0
   'file:projects/gulp-core-build.tgz':
@@ -9959,14 +9957,14 @@ packages:
       orchestrator: 0.3.8
       pretty-hrtime: 1.0.3
       semver: 5.3.0
-      through2: 2.0.3
+      through2: 2.0.5
       vinyl: 2.2.0
       yargs: 4.6.0
       z-schema: 3.18.4
     dev: false
     name: '@rush-temp/gulp-core-build'
     resolution:
-      integrity: sha512-1iKyfr4Nvh5YiWUUv28kuC2CCRcXnLYYO+9O6R/s1e5fQTp+VLqDr6p3SkJ+HlEiPKHKmmLMdxfvKMKPkPQT4Q==
+      integrity: sha512-nC49V2yBGlG1/3VvEJGtdRdhD8qJ2upIm3naLLhxjDiBWsUcIpdpAQXojl7NxjSN7peO20ZtWBJMCGC22kP/pQ==
       tarball: 'file:projects/gulp-core-build.tgz'
     version: 0.0.0
   'file:projects/load-themed-styles.tgz':
@@ -9979,7 +9977,7 @@ packages:
     dev: false
     name: '@rush-temp/load-themed-styles'
     resolution:
-      integrity: sha512-1v8lR6s9sr7woyKdVDWa7Eh0DFfy9pGHuEOfOyUQOadN3ZNzq89u8zsAO2KwPiD6atZo2qgIz+UwyvrmOXUIMA==
+      integrity: sha512-udbDnyUVXVWZuHzi+tgqlepofN19Ja5Oh4RaLAl5GVfuAy5L8EFReAwsAjjI4SSY7d1Wbdztn6FzfuEbgOJeLA==
       tarball: 'file:projects/load-themed-styles.tgz'
     version: 0.0.0
   'file:projects/loader-load-themed-styles.tgz':
@@ -9994,7 +9992,7 @@ packages:
     dev: false
     name: '@rush-temp/loader-load-themed-styles'
     resolution:
-      integrity: sha512-qBdWfMalgLDiV1HPTjQ7n4gqWiOWWXhXif8ZH1CF7dHuCqnAQ9oVWeyFkKRUvoVK492kz5eN6r5VwfbxTcLkrg==
+      integrity: sha512-PHAYXmPDwdNew17CGlpv4UNn8c7eFWd9L+0Yf5H3tsS2GgL1TrQJAO+aM+/kIpqcdLfKHmdNtrm9S0N706URAQ==
       tarball: 'file:projects/loader-load-themed-styles.tgz'
     version: 0.0.0
   'file:projects/loader-raw-script.tgz':
@@ -10008,7 +10006,7 @@ packages:
     dev: false
     name: '@rush-temp/loader-raw-script'
     resolution:
-      integrity: sha512-KmR4zJzNvl/uBTwc4fXeVhET8BLo9mF384qCTG1d+q0fiAGyvhZTU94GZZvNE8HFvOwtfMARCCBoYSIyG+yDRg==
+      integrity: sha512-iWrrPXGE8Hd7kHNG5tJIpio/Nc2VtdXrIAkq2UMoAkCNkk+afsLESKKbbWB1s0obALTg+qcgdsBCKkOHCIhYiw==
       tarball: 'file:projects/loader-raw-script.tgz'
     version: 0.0.0
   'file:projects/loader-set-webpack-public-path.tgz':
@@ -10024,7 +10022,7 @@ packages:
     dev: false
     name: '@rush-temp/loader-set-webpack-public-path'
     resolution:
-      integrity: sha512-Di13aICvE6LyqxPL2LgUvZ8evp5T263qX35jPrPBrL53JGbovjjQXGsr043I7ZzOVMtbMFMWdqql4ApKF942Pw==
+      integrity: sha512-aLMPGbnFFuOINDjtzYVKex9EXa9J5LX9fgcG/axHtwP/c7540Abi7Ot+Sxg2pvpBAdeJ7Jo2JVFKXkvFQMf1Qg==
       tarball: 'file:projects/loader-set-webpack-public-path.tgz'
     version: 0.0.0
   'file:projects/node-core-library.tgz':
@@ -10036,7 +10034,7 @@ packages:
       '@types/node': 8.5.8
       '@types/z-schema': 3.16.31
       colors: 1.2.5
-      fs-extra: 7.0.0
+      fs-extra: 7.0.1
       gulp: 3.9.1
       jju: 1.3.0
       tslint-microsoft-contrib: 5.2.1
@@ -10044,7 +10042,7 @@ packages:
     dev: false
     name: '@rush-temp/node-core-library'
     resolution:
-      integrity: sha512-bRot4BrHKNLbxJDj9k2c/MG/QNPEtTNjzHRO8DiRHUrx2a5W0OVvgddbjQJaLxf8uYcuc937XoFiyF488L+aMg==
+      integrity: sha512-w6uonJ9Im+rRSfxHuYBMi7LctcywBYAC7A/BKJlyu6Zd0y3TWR5nmR3yNoSm6v8fz+yk3i45enA6Y2L+1OmF5w==
       tarball: 'file:projects/node-core-library.tgz'
     version: 0.0.0
   'file:projects/node-library-build-test.tgz':
@@ -10057,7 +10055,7 @@ packages:
     dev: false
     name: '@rush-temp/node-library-build-test'
     resolution:
-      integrity: sha512-ashpgrfm4tbE1jSMlo0L4rnKUFjLuiTxu31RLE2R421NDqR8ioZo4skMBw25spSrNhVjtrjmnqQelv3+JN/PrA==
+      integrity: sha512-PxmTrfX0QanC39eeXWMYwmm9H9yVTU8rjXYyV69F7DUAeCF7UccNHuC6BSc0ZuKYCY1SryB9NJJpjIcLoegtIA==
       tarball: 'file:projects/node-library-build-test.tgz'
     version: 0.0.0
   'file:projects/node-library-build.tgz':
@@ -10068,7 +10066,7 @@ packages:
     dev: false
     name: '@rush-temp/node-library-build'
     resolution:
-      integrity: sha512-7tTSBG63M4R+b8Y2zx+Ru0pkYKzyGLoIobWU0M8ZvPMALfDzKi3qvXZQ0D+z1pUiwOfO8L6fVjeLMpWWf2SK4Q==
+      integrity: sha512-ImBWToTvphuufTdLcKrB7BUBkl4Ox/FqzeO+bL3mmbnA5wDRn6Mnmdap+opKpavs2NiZTZIJQbT98C0ymYf3Yg==
       tarball: 'file:projects/node-library-build.tgz'
     version: 0.0.0
   'file:projects/package-deps-hash.tgz':
@@ -10081,7 +10079,7 @@ packages:
     dev: false
     name: '@rush-temp/package-deps-hash'
     resolution:
-      integrity: sha512-tgTXExVz2EFtdphZACiIfCD5TVfbiBLmA+VgIcEhfcFByg8jAL2uL76RMj1QYJGwHVciVy7d30ZkxLMh+TC7Bg==
+      integrity: sha512-fdFQJlUzZJZYyfxZiFV+9i1Io9bfTe2/PLKJXSj7dOeu8FSb7uOl1JqcHLRsMXJx69U0y7mtIYwkTGT3if0EvQ==
       tarball: 'file:projects/package-deps-hash.tgz'
     version: 0.0.0
   'file:projects/resolve-chunk-plugin.tgz':
@@ -10094,7 +10092,7 @@ packages:
     dev: false
     name: '@rush-temp/resolve-chunk-plugin'
     resolution:
-      integrity: sha512-0pfJznbTPSxSBgpW982Qesuu7pRy98YmHOmqzMUDEhTLw8XpatvvmjzxOJuWhGZi2n1VHrzLxoWu9dEyeIR4yA==
+      integrity: sha512-Dmj66lq68Nh7f1A6b1QA8zSXDN6TktfL0WylFh7Xe6gnrHrMlO/Yi+hrrTMHde58wVU8JiSNW9Sbjcw3XOhdcw==
       tarball: 'file:projects/resolve-chunk-plugin.tgz'
     version: 0.0.0
   'file:projects/rush-lib.tgz':
@@ -10130,13 +10128,13 @@ packages:
       read-package-tree: 5.1.6
       semver: 5.3.0
       strict-uri-encode: 2.0.0
-      tar: 4.4.6
+      tar: 4.4.7
       wordwrap: 1.0.0
       z-schema: 3.18.4
     dev: false
     name: '@rush-temp/rush-lib'
     resolution:
-      integrity: sha512-WF4/5ISzyPimMR62fHgyaAK+f0jw0z/3oFrn3hmKbZ1foVUCrGnT9IyUGMsl47to0vc1cldTsMB5qnk5vtY2Mw==
+      integrity: sha512-/gxCPYWvvCxy1zHXJYTLwA6vvCGnb5lt5xHnSCQZvm7Da0Jw6N0cMNNAx/S6zgpE6AlOy96YpEHs6wFrzZvi/g==
       tarball: 'file:projects/rush-lib.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler.tgz':
@@ -10151,14 +10149,14 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler'
     resolution:
-      integrity: sha512-9uibJc1UZr+62+E3lpp1KpMjaIZZPPHmjkrBgn3R5c27uVc4BUOUGZOeb35q6seXvsttYKVU5/DlHuOj0Wrf4w==
+      integrity: sha512-+9+96lalZnaFQ4O+AKlPgcFeKnopwbZ2/TclI4KUMhgrXWa0es9hV+sFAKMvI0U0/G6lNqLXhz580nIrfDKACA==
       tarball: 'file:projects/rush-stack-compiler.tgz'
     version: 0.0.0
   'file:projects/rush-stack-library-test.tgz':
     dev: false
     name: '@rush-temp/rush-stack-library-test'
     resolution:
-      integrity: sha512-sU48ZXK9GXo7xOqeh+gGoQTnB/DpkDUqDo/hxkpUb3Aem3ullwYXCvLkfailZFH7VMbDLQRX+cvSpu1R8aHHkw==
+      integrity: sha512-oioKhTrLygR1yZBmjLx09I/CR9JBYjrUq0mNZmqB19oeZv12qaFECnYe5/vHkKbvObNOZErKnWlM5TWMgd1YeQ==
       tarball: 'file:projects/rush-stack-library-test.tgz'
     version: 0.0.0
   'file:projects/rush-stack.tgz':
@@ -10170,7 +10168,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack'
     resolution:
-      integrity: sha512-/jGPnI5KB0AVNUHtWnG9dk608HyvXL3cq1BPBtfmOoQgXT2drMmDa5CfEWKuwnNOrI/t7kZ1Nr0uf5oeUqmsoA==
+      integrity: sha512-ttcsS7+XE5ywjKXbxbC4lTwC2iVytz8JcsqkdqMbbJCvFAMJ54zWVIRC2SGgy77FHqflyztVQvsuO7jXEYglAQ==
       tarball: 'file:projects/rush-stack.tgz'
     version: 0.0.0
   'file:projects/rush.tgz':
@@ -10188,7 +10186,7 @@ packages:
     dev: false
     name: '@rush-temp/rush'
     resolution:
-      integrity: sha512-d6vaVkRgKsMexSqWPmEmQuLpPjll4i5hEet1nJhkuW02OFZ6AssZM1aBINP9B8+CC5339BxwgwLqYTbC2smAUw==
+      integrity: sha512-7rkH9oYsuUhkEXrjqIb/1ruhoFSgAbd1M5bLXotd+5yeZzvwf9iYQ6+bmcs2lrFCa4CXhGo0iFfp4TQv06bfAw==
       tarball: 'file:projects/rush.tgz'
     version: 0.0.0
   'file:projects/rushell.tgz':
@@ -10201,7 +10199,7 @@ packages:
     dev: false
     name: '@rush-temp/rushell'
     resolution:
-      integrity: sha512-zKXz2zbMAgIpLy+vRuXzsq43bFodcXVnI51TYZznI8S3461k9oBW/ev+RqHLqlIwVhDqMERM/uy47J/Gt8ySEA==
+      integrity: sha512-CV/L6S5x//MqBDyF7ybaum/oe4kKwrz15MEfaJ6idoPv3BrXYG/EWi3xv78HU0JQdHO5zKwxEAcalbKGhAahsA==
       tarball: 'file:projects/rushell.tgz'
     version: 0.0.0
   'file:projects/set-webpack-public-path-plugin.tgz':
@@ -10220,7 +10218,7 @@ packages:
     dev: false
     name: '@rush-temp/set-webpack-public-path-plugin'
     resolution:
-      integrity: sha512-eUS2/d9oO+CNJiDTjtCzaHyysLvtGIDehtJxGPN+27MKVWRRXK5b/HzaW5vthEaZyyIA+0k+ytopIWpZUdqArg==
+      integrity: sha512-IBY1vW8EgTSunpLCOGzCTmXoBd21zghErVrTEjKC8ZwQi51OQ41WhZa/dPrWoA2Q8Ly4aRAiQSJ65aYCMn4I4Q==
       tarball: 'file:projects/set-webpack-public-path-plugin.tgz'
     version: 0.0.0
   'file:projects/stream-collator.tgz':
@@ -10235,7 +10233,7 @@ packages:
     dev: false
     name: '@rush-temp/stream-collator'
     resolution:
-      integrity: sha512-Vjkgff/ZmYUhewXfXwUbsusL8NC47N6ATZzEcUkwgQMEiLf7A+KOkDjNMjpgUtTBoa5OWIjXG5a0SHz8VZRQZQ==
+      integrity: sha512-lxFYoQLfYCivgEUJDO4RJnvyEDkzB+hDdIvxvKEFbFrQ7d0Cg4B8lT3PBIN3ocDT7+rlISB30eItICobROt/kQ==
       tarball: 'file:projects/stream-collator.tgz'
     version: 0.0.0
   'file:projects/ts-command-line.tgz':
@@ -10263,7 +10261,7 @@ packages:
     dev: false
     name: '@rush-temp/web-library-build-test'
     resolution:
-      integrity: sha512-ZC8ENfiTtjwr3egZo95yO6hgDztJu5MOS+ii/yxM1/kFi8jPNvi94g2FosxLCMukvG3mDbdFPNUZQGZVBLHTjA==
+      integrity: sha512-q7yyJ6I+1vkMc9HH6CXz+EChvhgpS16V99ywiW2tpJZAGQpDVnZzcLp+Yv0YAkNWhA+kVbZyEpRb/0lARwbX4Q==
       tarball: 'file:projects/web-library-build-test.tgz'
     version: 0.0.0
   'file:projects/web-library-build.tgz':
@@ -10275,7 +10273,7 @@ packages:
     dev: false
     name: '@rush-temp/web-library-build'
     resolution:
-      integrity: sha512-6AXBlhWp6XWmDYJQe1mWJMqvyH5HPlh+eCkOgo9GzjtXA6Ll0x60QhP6KQVeuB/79/1oqtuwJvYEM1JnOfTEfg==
+      integrity: sha512-bbeBY+qDXlvKVglrqaj1FKY6DsomUOd74fc1LwncnNJhGydjcx9Yua8gk4JSYlVfDf3zhtQjEmj117voqz5WGw==
       tarball: 'file:projects/web-library-build.tgz'
     version: 0.0.0
 registry: 'https://registry.npmjs.org/'
@@ -10377,7 +10375,7 @@ specifiers:
   del: ^2.2.2
   end-of-stream: ~1.1.0
   express: ~4.16.2
-  fs-extra: ~7.0.0
+  fs-extra: ~7.0.1
   git-repo-info: ~1.1.4
   glob: ~7.0.5
   glob-escape: ~0.0.1

--- a/common/config/rush/version-policies.json
+++ b/common/config/rush/version-policies.json
@@ -81,8 +81,8 @@
   {
     "policyName": "rush",
     "definitionName": "lockStepVersion",
-    "version": "5.4.0",
-    "nextBump": "minor",
+    "version": "5.5.0",
+    "nextBump": "patch",
     "mainProject": "@microsoft/rush"
   }
 ]

--- a/libraries/node-core-library/package.json
+++ b/libraries/node-core-library/package.json
@@ -18,7 +18,7 @@
     "@types/fs-extra": "5.0.4",
     "@types/node": "8.5.8",
     "@types/z-schema": "3.16.31",
-    "fs-extra": "~7.0.0",
+    "fs-extra": "~7.0.1",
     "jju": "~1.3.0",
     "z-schema": "~3.18.3",
     "colors": "~1.2.1"


### PR DESCRIPTION
Fix a few issues found during testing.

Note that we are skipping 5.5.0, because that release was published incorrectly and later unpublished