### PR TITLE
[api-documenter] Removing the OfficeYamlDocumenter logic to correct escape characters within code ticks

### DIFF
--- a/apps/api-documenter/src/yaml/OfficeYamlDocumenter.ts
+++ b/apps/api-documenter/src/yaml/OfficeYamlDocumenter.ts
@@ -77,7 +77,6 @@ export class OfficeYamlDocumenter extends YamlDocumenter {
       yamlItem.remarks = this._fixupApiSet(yamlItem.remarks, yamlItem.uid);
       yamlItem.remarks = this._fixBoldAndItalics(yamlItem.remarks);
       yamlItem.remarks = this._fixCodeTicks(yamlItem.remarks);
-      yamlItem.remarks = this._fixEscapedCode(yamlItem.remarks);
     }
     if (yamlItem.syntax && yamlItem.syntax.parameters) {
       yamlItem.syntax.parameters.forEach(part => {
@@ -132,19 +131,6 @@ export class OfficeYamlDocumenter extends YamlDocumenter {
 
   private _fixCodeTicks(text: string): string {
     return Text.replaceAll(text, '\\`', '`');
-  }
-
-  private _fixEscapedCode(text: string): string {
-    const backtickIndex: number = text.indexOf('`');
-    if (text.indexOf('`', backtickIndex) > 0) {
-      text = Text.replaceAll(text, '=&gt;', '=>');
-      let x: number = text.indexOf('\\', backtickIndex);
-      while (x >= 0) {
-        text = text.replace(/\\([^\\])/, '$1');
-        x = text.indexOf('\\', x + 1);
-      }
-    }
-    return text;
   }
 
   private _generateExampleSnippetText(snippets: string[]): string {

--- a/common/changes/@microsoft/api-documenter/AlexJ-Escape_2018-11-08-18-59.json
+++ b/common/changes/@microsoft/api-documenter/AlexJ-Escape_2018-11-08-18-59.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-documenter",
+      "comment": "Removing the OfficeYamlDocumenter logic to correct escape characters within code ticks",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/api-documenter",
+  "email": "AlexJerabek@users.noreply.github.com"
+}


### PR DESCRIPTION
The updated use of TSDoc renders this workaround unnecessary.