### PR TITLE
Api extractor changes to support extends feature in api extractor config

### DIFF
--- a/apps/api-extractor/src/cli/RunAction.ts
+++ b/apps/api-extractor/src/cli/RunAction.ts
@@ -5,7 +5,6 @@ import * as colors from 'colors';
 import * as os from 'os';
 import * as path from 'path';
 import {
-  JsonFile,
   PackageJsonLookup,
   FileSystem,
   IPackageJson
@@ -136,7 +135,7 @@ export class RunAction extends CommandLineAction {
       console.log(`Using configuration from ${configFilename}` + os.EOL + os.EOL);
     }
 
-    const config: IExtractorConfig = JsonFile.loadAndValidate(configFilename, Extractor.jsonSchema);
+    const config: IExtractorConfig = Extractor.loadConfigObject(configFilename);
     const extractor: Extractor = new Extractor(
       config,
       {

--- a/apps/api-extractor/src/extractor/Extractor.ts
+++ b/apps/api-extractor/src/extractor/Extractor.ts
@@ -164,9 +164,48 @@ export class Extractor {
    * @param options - IExtractor options.
    */
   public static processProjectFromConfigFile(jsonConfigFile: string, options?: IExtractorOptions): void {
-    const configObject: IExtractorConfig = JsonFile.loadAndValidate(jsonConfigFile, Extractor.jsonSchema);
+    const configObject: IExtractorConfig = this.loadConfigObject(jsonConfigFile);
     const extractor: Extractor = new Extractor(configObject, options);
     extractor.processProject();
+  }
+
+  /**
+   * Loads the api extractor config file in Extractor Config object.
+   * @param jsonConfigFile - Path to api extractor json config file.
+   */
+  public static loadConfigObject(jsonConfigFile: string): IExtractorConfig {
+    // Set to keep track of config files which have been processed.
+    const pathSet: Set<string> = new Set<string>();
+    // Get absolute path of config file.
+    let currentConfigFilePath: string = path.resolve(jsonConfigFile);
+    pathSet.add(currentConfigFilePath);
+
+    let extractorConfig: IExtractorConfig = JsonFile.load(jsonConfigFile);
+
+    while (extractorConfig.extends) {
+      // Populate the api extractor config path defined in extends relative to current config path.
+      currentConfigFilePath = path.resolve(path.dirname(currentConfigFilePath), extractorConfig.extends);
+
+      // Check if this file was already processed.
+      if (pathSet.has(currentConfigFilePath)) {
+        throw new Error('The api extractor config files contains a cycle. '
+        + currentConfigFilePath + ' is being processed again. '
+        + 'Please check the extends values in config files.');
+      }
+      pathSet.add(currentConfigFilePath);
+
+      // Remove extends property from config for current config.
+      delete extractorConfig.extends;
+
+      // Load the extractor config defined in extends property.
+      const baseConfig: IExtractorConfig = JsonFile.load(currentConfigFilePath);
+      lodash.merge(baseConfig, extractorConfig);
+      extractorConfig = baseConfig;
+    }
+
+    // Validate if the extractor config generated adheres to schema.
+    Extractor.jsonSchema.validateObject(extractorConfig, jsonConfigFile);
+    return extractorConfig;
   }
 
   private static _applyConfigDefaults(config: IExtractorConfig): IExtractorConfig {

--- a/apps/api-extractor/src/extractor/IExtractorConfig.ts
+++ b/apps/api-extractor/src/extractor/IExtractorConfig.ts
@@ -261,6 +261,8 @@ export interface IExtractorDtsRollupConfig {
  * @public
  */
 export interface IExtractorConfig {
+  extends?: string;
+
   /**
    * Determines how the TypeScript compiler will be invoked.
    * The compiler.configType selects the type of configuration;

--- a/apps/api-extractor/src/extractor/api-extractor.schema.json
+++ b/apps/api-extractor/src/extractor/api-extractor.schema.json
@@ -8,6 +8,11 @@
       "type": "string"
     },
 
+    "extends": {
+      "description": "Optional field. Path to json config file from which config should be extended",
+      "type": "string"
+    },
+
     "compiler": {
       "description": "Determines how the TypeScript compiler will be invoked. The compiler.configType selects the type of configuration. Different options are available according to the configuration type.",
       "type": "object",

--- a/common/reviews/api/api-extractor.api.ts
+++ b/common/reviews/api/api-extractor.api.ts
@@ -18,6 +18,7 @@ class Extractor {
   analyzeProject(options?: IAnalyzeProjectOptions): void;
   static generateFilePathsForAnalysis(inputFilePaths: string[]): string[];
   static jsonSchema: JsonSchema;
+  static loadConfigObject(jsonConfigFile: string): IExtractorConfig;
   processProject(options?: IAnalyzeProjectOptions): boolean;
   static processProjectFromConfigFile(jsonConfigFile: string, options?: IExtractorOptions): void;
 }
@@ -194,6 +195,8 @@ interface IExtractorConfig {
   compiler: IExtractorTsconfigCompilerConfig | IExtractorRuntimeCompilerConfig;
   // @beta
   dtsRollup?: IExtractorDtsRollupConfig;
+  // (undocumented)
+  extends?: string;
   policies?: IExtractorPoliciesConfig;
   project: IExtractorProjectConfig;
   validationRules?: IExtractorValidationRulesConfig;


### PR DESCRIPTION
What this PR includes. (Fix for [link](https://github.com/Microsoft/web-build-tools/issues/899))
- Support extends feature for extending api-extractor.json config file from other config files.
- Detect if there is a loop in chaining of files
- Loads merge is used to merge base config object with derived object.

What this PR doesnt cover
- Module resolution. For eg if you specify "package/file.json" in extends property it will point to <current_configfile_dir>/package/file.json. Expected behavior is it should point to ./node_modules/package/file.json.