### PR TITLE
[api-extractor] Replace the old "tsdocFlavor" field with a dist/api-metadata.json output

### DIFF
--- a/apps/api-documenter/src/start.ts
+++ b/apps/api-documenter/src/start.ts
@@ -8,7 +8,7 @@ import { PackageJsonLookup } from '@microsoft/node-core-library';
 
 import { ApiDocumenterCommandLine } from './cli/ApiDocumenterCommandLine';
 
-const myPackageVersion: string = PackageJsonLookup.loadOwnPackageJson(__dirname, '..').version;
+const myPackageVersion: string = PackageJsonLookup.loadOwnPackageJson(__dirname).version;
 
 console.log(os.EOL + colors.bold(`api-documenter ${myPackageVersion} `
   + colors.cyan(' - http://aka.ms/extractor') + os.EOL));

--- a/apps/api-documenter/src/start.ts
+++ b/apps/api-documenter/src/start.ts
@@ -3,18 +3,14 @@
 
 import * as os from 'os';
 import * as colors from 'colors';
-import * as path from 'path';
 
-import { FileConstants } from '@microsoft/node-core-library';
+import { PackageJsonLookup } from '@microsoft/node-core-library';
 
 import { ApiDocumenterCommandLine } from './cli/ApiDocumenterCommandLine';
 
-const myPackageJsonFilename: string = path.resolve(path.join(
-  __dirname, '..', FileConstants.PackageJson)
-);
-const myPackageJson: { version: string } = require(myPackageJsonFilename);
+const myPackageVersion: string = PackageJsonLookup.loadOwnPackageJson(__dirname, '..').version;
 
-console.log(os.EOL + colors.bold(`api-documenter ${myPackageJson.version} `
+console.log(os.EOL + colors.bold(`api-documenter ${myPackageVersion} `
   + colors.cyan(' - http://aka.ms/extractor') + os.EOL));
 
 const parser: ApiDocumenterCommandLine = new ApiDocumenterCommandLine();

--- a/apps/api-extractor/.vscode/launch.json
+++ b/apps/api-extractor/.vscode/launch.json
@@ -15,7 +15,7 @@
         "run",
         "-l"
       ],
-      "sourceMaps": false
+      "sourceMaps": true
     },
     {
       "type": "node",

--- a/apps/api-extractor/src/ExtractorContext.ts
+++ b/apps/api-extractor/src/ExtractorContext.ts
@@ -74,11 +74,11 @@ export class ExtractorContext {
 
   public readonly validationRules: IExtractorValidationRulesConfig;
 
+  public readonly logger: ILogger;
+
   // If the entry point is "C:\Folder\project\src\index.ts" and the nearest package.json
   // is "C:\Folder\project\package.json", then the packageFolder is "C:\Folder\project"
   private _packageFolder: string;
-
-  private _logger: ILogger;
 
   constructor(options: IExtractorContextOptions) {
     this.packageJsonLookup = new PackageJsonLookup();
@@ -98,7 +98,7 @@ export class ExtractorContext {
 
     this.docItemLoader = new DocItemLoader(this._packageFolder);
 
-    this._logger = options.logger;
+    this.logger = options.logger;
 
     // This runs a full type analysis, and then augments the Abstract Syntax Tree (i.e. declarations)
     // with semantic information (i.e. symbols).  The "diagnostics" are a subset of the everyday
@@ -148,10 +148,10 @@ export class ExtractorContext {
 
       // Format the error so that VS Code can follow it.  For example:
       // "src\MyClass.ts(15,1): The JSDoc tag "@blah" is not supported by AEDoc"
-      this._logger.logError(`${shownPath}(${lineAndCharacter.line + 1},${lineAndCharacter.character + 1}): `
+      this.logger.logError(`${shownPath}(${lineAndCharacter.line + 1},${lineAndCharacter.character + 1}): `
         + message);
     } else {
-      this._logger.logError(message);
+      this.logger.logError(message);
     }
   }
 

--- a/apps/api-extractor/src/ExtractorContext.ts
+++ b/apps/api-extractor/src/ExtractorContext.ts
@@ -51,7 +51,8 @@ export interface IExtractorContextOptions {
  * abstract syntax tree.
  */
 export class ExtractorContext {
-  public typeChecker: ts.TypeChecker;
+  public readonly program: ts.Program;
+  public readonly typeChecker: ts.TypeChecker;
   public package: AstPackage;
 
   /**
@@ -107,6 +108,7 @@ export class ExtractorContext {
       this.reportError(`TypeScript: ${errorText}`, diagnostic.file, diagnostic.start);
     }
 
+    this.program = options.program;
     this.typeChecker = options.program.getTypeChecker();
 
     const rootFile: ts.SourceFile | undefined = options.program.getSourceFile(options.entryPointFile);

--- a/apps/api-extractor/src/extractor/Extractor.ts
+++ b/apps/api-extractor/src/extractor/Extractor.ts
@@ -125,7 +125,7 @@ export class Extractor {
    * The NPM package version for the currently executing instance of the "\@microsoft/api-extractor" library.
    */
   public static get version(): string {
-    return PackageJsonLookup.loadOwnPackageJson(__dirname, '../..').version;
+    return PackageJsonLookup.loadOwnPackageJson(__dirname).version;
   }
 
   /**

--- a/apps/api-extractor/src/extractor/Extractor.ts
+++ b/apps/api-extractor/src/extractor/Extractor.ts
@@ -26,6 +26,7 @@ import { ApiFileGenerator } from '../generators/ApiFileGenerator';
 import { DtsRollupGenerator, DtsRollupKind } from '../generators/dtsRollup/DtsRollupGenerator';
 import { MonitoredLogger } from './MonitoredLogger';
 import { TypeScriptMessageFormatter } from '../utils/TypeScriptMessageFormatter';
+import { PackageMetadataManager } from '../generators/dtsRollup/PackageMetadataManager';
 
 /**
  * Options for {@link Extractor.processProject}.
@@ -406,6 +407,9 @@ export class Extractor {
     }
 
     this._generateRollupDtsFiles(context);
+
+    // Write the tsdoc-metadata.json file for this project
+    PackageMetadataManager.writeTsdocMetadataFile(context.packageFolder);
 
     if (this._localBuild) {
       // For a local build, fail if there were errors (but ignore warnings)

--- a/apps/api-extractor/src/extractor/Extractor.ts
+++ b/apps/api-extractor/src/extractor/Extractor.ts
@@ -10,7 +10,8 @@ import {
   JsonFile,
   JsonSchema,
   Path,
-  FileSystem
+  FileSystem,
+  PackageJsonLookup
 } from '@microsoft/node-core-library';
 import {
   IExtractorConfig,
@@ -118,6 +119,13 @@ export class Extractor {
   private readonly _localBuild: boolean;
   private readonly _monitoredLogger: MonitoredLogger;
   private readonly _absoluteRootFolder: string;
+
+  /**
+   * The NPM package version for the currently executing instance of the "\@microsoft/api-extractor" library.
+   */
+  public static get version(): string {
+    return PackageJsonLookup.loadOwnPackageJson(__dirname, '../..').version;
+  }
 
   /**
    * Given a list of absolute file paths, return a list containing only the declaration
@@ -486,7 +494,7 @@ export class Extractor {
     this._monitoredLogger.logVerbose(`Writing package typings: ${mainDtsRollupFullPath}`);
 
     dtsRollupGenerator.writeTypingsFile(mainDtsRollupFullPath, dtsKind);
-}
+  }
 
   private _getShortFilePath(absolutePath: string): string {
     if (!path.isAbsolute(absolutePath)) {

--- a/apps/api-extractor/src/generators/dtsRollup/AstSymbolTable.ts
+++ b/apps/api-extractor/src/generators/dtsRollup/AstSymbolTable.ts
@@ -13,6 +13,7 @@ import { AstSymbol } from './AstSymbol';
 import { AstImport } from './AstImport';
 import { AstEntryPoint, IExportedMember } from './AstEntryPoint';
 import { PackageMetadataManager } from './PackageMetadataManager';
+import { ILogger } from '../../extractor/ILogger';
 
 /**
  * AstSymbolTable is the workhorse that builds AstSymbol and AstDeclaration objects.
@@ -55,11 +56,13 @@ export class AstSymbolTable {
   private readonly _astEntryPointsBySourceFile: Map<ts.SourceFile, AstEntryPoint>
     = new Map<ts.SourceFile, AstEntryPoint>();
 
-  public constructor(program: ts.Program, typeChecker: ts.TypeChecker, packageJsonLookup: PackageJsonLookup) {
+  public constructor(program: ts.Program, typeChecker: ts.TypeChecker, packageJsonLookup: PackageJsonLookup,
+    logger: ILogger) {
+
     this._program = program;
     this._typeChecker = typeChecker;
     this._packageJsonLookup = packageJsonLookup;
-    this._packageMetadataManager = new PackageMetadataManager(packageJsonLookup);
+    this._packageMetadataManager = new PackageMetadataManager(packageJsonLookup, logger);
   }
 
   /**

--- a/apps/api-extractor/src/generators/dtsRollup/AstSymbolTable.ts
+++ b/apps/api-extractor/src/generators/dtsRollup/AstSymbolTable.ts
@@ -78,21 +78,6 @@ export class AstSymbolTable {
         throw new Error('Unable to find a root declaration for ' + sourceFile.fileName);
       }
 
-      if (this._program.isSourceFileFromExternalLibrary(sourceFile)) {
-        if (!this._packageMetadataManager.isAedocSupportedFor(sourceFile.fileName)) {
-          const packageJsonPath: string | undefined = this._packageJsonLookup
-            .tryGetPackageJsonFilePathFor(sourceFile.fileName);
-
-          if (packageJsonPath) {
-            throw new Error(`Please add a field such as "tsdoc": { "tsdocFlavor": "AEDoc" } to this file:\n`
-              + packageJsonPath);
-          } else {
-            throw new Error(`The specified entry point does not appear to have an associated package.json file:\n`
-              + sourceFile.fileName);
-          }
-        }
-      }
-
       const exportSymbols: ts.Symbol[] = this._typeChecker.getExportsOfModule(rootFileSymbol) || [];
 
       const exportedMembers: IExportedMember[] = [];

--- a/apps/api-extractor/src/generators/dtsRollup/DtsRollupGenerator.ts
+++ b/apps/api-extractor/src/generators/dtsRollup/DtsRollupGenerator.ts
@@ -75,7 +75,8 @@ export class DtsRollupGenerator {
     this._context = context;
     this._typeChecker = context.typeChecker;
     this._tsdocParser = new tsdoc.TSDocParser();
-    this._astSymbolTable = new AstSymbolTable(this._context.typeChecker, this._context.packageJsonLookup);
+    this._astSymbolTable = new AstSymbolTable(this._context.program, this._context.typeChecker,
+      this._context.packageJsonLookup);
   }
 
   /**

--- a/apps/api-extractor/src/generators/dtsRollup/DtsRollupGenerator.ts
+++ b/apps/api-extractor/src/generators/dtsRollup/DtsRollupGenerator.ts
@@ -76,7 +76,7 @@ export class DtsRollupGenerator {
     this._typeChecker = context.typeChecker;
     this._tsdocParser = new tsdoc.TSDocParser();
     this._astSymbolTable = new AstSymbolTable(this._context.program, this._context.typeChecker,
-      this._context.packageJsonLookup);
+      this._context.packageJsonLookup, context.logger);
   }
 
   /**

--- a/apps/api-extractor/src/generators/dtsRollup/PackageMetadataManager.ts
+++ b/apps/api-extractor/src/generators/dtsRollup/PackageMetadataManager.ts
@@ -11,6 +11,7 @@ import {
   NewlineKind
 } from '@microsoft/node-core-library';
 import { Extractor } from '../../extractor/Extractor';
+import { ILogger } from '../../extractor/ILogger';
 
 /**
  * Represents analyzed information for a package.json file.
@@ -56,6 +57,7 @@ export class PackageMetadataManager {
   public static tsdocMetadataFilename: string = 'tsdoc-metadata.json';
 
   private readonly _packageJsonLookup: PackageJsonLookup;
+  private readonly _logger: ILogger;
   private readonly _packageMetadataByPackageJsonPath: Map<string, PackageMetadata>
     = new Map<string, PackageMetadata>();
 
@@ -86,8 +88,9 @@ export class PackageMetadataManager {
     });
   }
 
-  public constructor(packageJsonLookup: PackageJsonLookup) {
+  public constructor(packageJsonLookup: PackageJsonLookup, logger: ILogger) {
     this._packageJsonLookup = packageJsonLookup;
+    this._logger = logger;
   }
 
   /**
@@ -116,12 +119,10 @@ export class PackageMetadataManager {
       const tsdocMetadataPath: string = path.join(packageJsonFolder,
         'dist', PackageMetadataManager.tsdocMetadataFilename);
 
-        if (FileSystem.exists(tsdocMetadataPath)) {
-        console.log('Found: ' + tsdocMetadataPath);
+      if (FileSystem.exists(tsdocMetadataPath)) {
+        this._logger.logVerbose('Found metadata in ' + tsdocMetadataPath);
         // If the file exists at all, assume it was written by API Extractor
         aedocSupported = true;
-      } else {
-        console.log('NOT FOUND: ' + tsdocMetadataPath);
       }
 
       packageMetadata = new PackageMetadata(packageJsonFilePath, packageJson, aedocSupported);

--- a/apps/api-extractor/src/generators/dtsRollup/PackageMetadataManager.ts
+++ b/apps/api-extractor/src/generators/dtsRollup/PackageMetadataManager.ts
@@ -42,6 +42,15 @@ export class PackageMetadata {
 /**
  * This class maintains a cache of analyzed information obtained from package.json
  * files.  It is built on top of the PackageJsonLookup class.
+ *
+ * @remarks
+ *
+ * IMPORTANT: Don't use PackageMetadataManager to analyze source files from the current project:
+ * 1. Files such as tsdoc-metadata.json may not have been built yet, and thus may contain incorrect information.
+ * 2. The current project is not guaranteed to have a package.json file at all.  For example, API Extractor can
+ *    be invoked on a bare .d.ts file.
+ *
+ * Use ts.program.isSourceFileFromExternalLibrary() to test source files before passing the to PackageMetadataManager.
  */
 export class PackageMetadataManager {
   public static tsdocMetadataFilename: string = 'tsdoc-metadata.json';

--- a/apps/api-extractor/src/generators/dtsRollup/PackageMetadataManager.ts
+++ b/apps/api-extractor/src/generators/dtsRollup/PackageMetadataManager.ts
@@ -1,10 +1,16 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
+import * as path from 'path';
+
 import {
   PackageJsonLookup,
-  IPackageJson
+  IPackageJson,
+  FileSystem,
+  JsonFile,
+  NewlineKind
 } from '@microsoft/node-core-library';
+import { Extractor } from '../../extractor/Extractor';
 
 /**
  * Represents analyzed information for a package.json file.
@@ -26,23 +32,10 @@ export class PackageMetadata {
    */
   public readonly aedocSupported: boolean;
 
-  private readonly _packageJsonLookup: PackageJsonLookup;
-
-  public constructor(packageJsonPath: string, packageJsonLookup: PackageJsonLookup) {
-    this._packageJsonLookup = packageJsonLookup;
+  public constructor(packageJsonPath: string, packageJson: IPackageJson, aedocSupported: boolean) {
     this.packageJsonPath = packageJsonPath;
-
-    this.packageJson = this._packageJsonLookup.loadPackageJson(packageJsonPath);
-
-    this.aedocSupported = false;
-
-    if (this.packageJson.tsdoc) {
-      if (this.packageJson.tsdoc.tsdocFlavor) {
-        if (this.packageJson.tsdoc.tsdocFlavor.toUpperCase() === 'AEDOC') {
-          this.aedocSupported = true;
-        }
-      }
-    }
+    this.packageJson = packageJson;
+    this.aedocSupported = aedocSupported;
   }
 }
 
@@ -51,9 +44,38 @@ export class PackageMetadata {
  * files.  It is built on top of the PackageJsonLookup class.
  */
 export class PackageMetadataManager {
+  public static tsdocMetadataFilename: string = 'tsdoc-metadata.json';
+
   private readonly _packageJsonLookup: PackageJsonLookup;
   private readonly _packageMetadataByPackageJsonPath: Map<string, PackageMetadata>
     = new Map<string, PackageMetadata>();
+
+  public static writeTsdocMetadataFile(packageJsonFolder: string): void {
+    // This feature is still being standardized: https://github.com/Microsoft/tsdoc/issues/7
+    // In the future we will use the @microsoft/tsdoc library to read this file.
+    const tsdocMetadataPath: string = path.join(packageJsonFolder,
+      'dist', PackageMetadataManager.tsdocMetadataFilename);
+
+    const fileObject: Object = {
+      tsdocVersion: '0.12',
+      toolPackages: [
+        {
+           packageName: '@microsoft/api-extractor',
+           packageVersion: Extractor.version
+        }
+      ]
+    };
+
+    const fileContent: string =
+      '// This file is read by tools that parse documentation comments conforming to the TSDoc standard.\n'
+      + '// It should be published with your NPM package.  It should not be tracked by Git.\n'
+      + JsonFile.stringify(fileObject);
+
+    FileSystem.writeFile(tsdocMetadataPath, fileContent, {
+      convertLineEndings: NewlineKind.CrLf,
+      ensureFolderExists: true
+    });
+  }
 
   public constructor(packageJsonLookup: PackageJsonLookup) {
     this._packageJsonLookup = packageJsonLookup;
@@ -72,16 +94,36 @@ export class PackageMetadataManager {
     }
     let packageMetadata: PackageMetadata | undefined
       = this._packageMetadataByPackageJsonPath.get(packageJsonFilePath);
+
     if (!packageMetadata) {
-      packageMetadata = new PackageMetadata(packageJsonFilePath, this._packageJsonLookup);
+      const packageJson: IPackageJson = this._packageJsonLookup.loadPackageJson(packageJsonFilePath);
+
+      const packageJsonFolder: string = path.dirname(packageJsonFilePath);
+
+      // This feature is still being standardized: https://github.com/Microsoft/tsdoc/issues/7
+      // In the future we will use the @microsoft/tsdoc library to read this file.
+      let aedocSupported: boolean = false;
+
+      const tsdocMetadataPath: string = path.join(packageJsonFolder,
+        'dist', PackageMetadataManager.tsdocMetadataFilename);
+
+        if (FileSystem.exists(tsdocMetadataPath)) {
+        console.log('Found: ' + tsdocMetadataPath);
+        // If the file exists at all, assume it was written by API Extractor
+        aedocSupported = true;
+      } else {
+        console.log('NOT FOUND: ' + tsdocMetadataPath);
+      }
+
+      packageMetadata = new PackageMetadata(packageJsonFilePath, packageJson, aedocSupported);
       this._packageMetadataByPackageJsonPath.set(packageJsonFilePath, packageMetadata);
     }
+
     return packageMetadata;
   }
 
   /**
-   * Returns true if the source file has an associated PackageMetadata object
-   * with aedocSupported=true.
+   * Returns true if the source file is part of a package whose .d.ts files support AEDoc annotations.
    */
   public isAedocSupportedFor(sourceFilePath: string): boolean {
     const packageMetadata: PackageMetadata | undefined = this.tryFetchPackageMetadata(sourceFilePath);

--- a/apps/api-extractor/src/start.ts
+++ b/apps/api-extractor/src/start.ts
@@ -8,7 +8,7 @@ import { PackageJsonLookup } from '@microsoft/node-core-library';
 
 import { ApiExtractorCommandLine } from './cli/ApiExtractorCommandLine';
 
-const myPackageVersion: string = PackageJsonLookup.loadOwnPackageJson(__dirname, '..').version;
+const myPackageVersion: string = PackageJsonLookup.loadOwnPackageJson(__dirname).version;
 
 console.log(os.EOL + colors.bold(`api-extractor ${myPackageVersion} `
   + colors.cyan(' - http://aka.ms/extractor') + os.EOL));

--- a/apps/api-extractor/src/start.ts
+++ b/apps/api-extractor/src/start.ts
@@ -4,11 +4,10 @@
 import * as os from 'os';
 import * as colors from 'colors';
 
-import { PackageJsonLookup } from '@microsoft/node-core-library';
-
 import { ApiExtractorCommandLine } from './cli/ApiExtractorCommandLine';
+import { Extractor } from './extractor/Extractor';
 
-const myPackageVersion: string = PackageJsonLookup.loadOwnPackageJson(__dirname).version;
+const myPackageVersion: string = Extractor.version;
 
 console.log(os.EOL + colors.bold(`api-extractor ${myPackageVersion} `
   + colors.cyan(' - http://aka.ms/extractor') + os.EOL));

--- a/apps/api-extractor/src/start.ts
+++ b/apps/api-extractor/src/start.ts
@@ -3,18 +3,14 @@
 
 import * as os from 'os';
 import * as colors from 'colors';
-import * as path from 'path';
 
-import { FileConstants } from '@microsoft/node-core-library';
+import { PackageJsonLookup } from '@microsoft/node-core-library';
 
 import { ApiExtractorCommandLine } from './cli/ApiExtractorCommandLine';
 
-const myPackageJsonFilename: string = path.resolve(path.join(
-  __dirname, '..', FileConstants.PackageJson)
-);
-const myPackageJson: { version: string } = require(myPackageJsonFilename);
+const myPackageVersion: string = PackageJsonLookup.loadOwnPackageJson(__dirname, '..').version;
 
-console.log(os.EOL + colors.bold(`api-extractor ${myPackageJson.version} `
+console.log(os.EOL + colors.bold(`api-extractor ${myPackageVersion} `
   + colors.cyan(' - http://aka.ms/extractor') + os.EOL));
 
 const parser: ApiExtractorCommandLine = new ApiExtractorCommandLine();

--- a/apps/rush-lib/src/api/Rush.ts
+++ b/apps/rush-lib/src/api/Rush.ts
@@ -60,7 +60,7 @@ export class Rush {
    * This is the same as the Rush tool version for that release.
    */
   public static get version(): string {
-    return PackageJsonLookup.loadOwnPackageJson(__dirname, '../..').version;
+    return PackageJsonLookup.loadOwnPackageJson(__dirname).version;
   }
 
   private static _printStartupBanner(isManaged: boolean): void {

--- a/apps/rush-lib/src/api/Rush.ts
+++ b/apps/rush-lib/src/api/Rush.ts
@@ -2,12 +2,8 @@
 // See LICENSE in the project root for license information.
 
 import { EOL } from 'os';
-import * as path from 'path';
 import * as colors from 'colors';
-import {
-  IPackageJson,
-  FileConstants
-} from '@microsoft/node-core-library';
+import { PackageJsonLookup } from '@microsoft/node-core-library';
 
 import { RushCommandLineParser } from '../cli/RushCommandLineParser';
 import { RushConstants } from '../logic/RushConstants';
@@ -20,8 +16,6 @@ import { CommandLineMigrationAdvisor } from '../cli/CommandLineMigrationAdvisor'
  * @public
  */
 export class Rush {
-  private static _version: string;
-
   /**
    * This API is used by the `@microsoft/rush` front end to launch the "rush" command-line.
    * Third-party tools should not use this API.  Instead, they should execute the "rush" binary
@@ -66,13 +60,7 @@ export class Rush {
    * This is the same as the Rush tool version for that release.
    */
   public static get version(): string {
-    if (!Rush._version) {
-      const myPackageJsonFilename: string = path.resolve(path.join(__dirname, '..', '..', FileConstants.PackageJson));
-      const myPackageJson: IPackageJson = require(myPackageJsonFilename);
-      Rush._version = myPackageJson.version;
-    }
-
-    return Rush._version;
+    return PackageJsonLookup.loadOwnPackageJson(__dirname, '../..').version;
   }
 
   private static _printStartupBanner(isManaged: boolean): void {

--- a/apps/rush/src/start.ts
+++ b/apps/rush/src/start.ts
@@ -49,7 +49,7 @@ import { MinimalRushConfiguration } from './MinimalRushConfiguration';
 // Load the configuration
 const configuration: MinimalRushConfiguration | undefined = MinimalRushConfiguration.loadFromDefaultLocation();
 
-const currentPackageVersion: string = PackageJsonLookup.loadOwnPackageJson(__dirname, '..').version;
+const currentPackageVersion: string = PackageJsonLookup.loadOwnPackageJson(__dirname).version;
 
 let rushVersionToLoad: string | undefined = undefined;
 

--- a/apps/rush/src/start.ts
+++ b/apps/rush/src/start.ts
@@ -35,12 +35,9 @@ else if (!semver.satisfies(nodeVersion, '^6.9.0')
     + ` Please consider installing a stable release.`));
 }
 
-import * as path from 'path';
 import {
-  JsonFile,
-  IPackageJson,
   Text,
-  FileConstants
+  PackageJsonLookup
 } from '@microsoft/node-core-library';
 import { EnvironmentVariableNames } from '@microsoft/rush-lib';
 import * as rushLib from '@microsoft/rush-lib';
@@ -51,7 +48,8 @@ import { MinimalRushConfiguration } from './MinimalRushConfiguration';
 
 // Load the configuration
 const configuration: MinimalRushConfiguration | undefined = MinimalRushConfiguration.loadFromDefaultLocation();
-const currentPackageJson: IPackageJson = JsonFile.load(path.join(__dirname, '..', FileConstants.PackageJson));
+
+const currentPackageVersion: string = PackageJsonLookup.loadOwnPackageJson(__dirname, '..').version;
 
 let rushVersionToLoad: string | undefined = undefined;
 
@@ -102,8 +100,8 @@ if (rushVersionToLoad && semver.lt(rushVersionToLoad, '5.0.0-dev.18')) {
 
 // If we're inside a repo folder, and it's requesting a different version, then use the RushVersionManager to
 // install it
-if (rushVersionToLoad && rushVersionToLoad !== currentPackageJson.version) {
-  const versionSelector: RushVersionSelector = new RushVersionSelector(currentPackageJson.version);
+if (rushVersionToLoad && rushVersionToLoad !== currentPackageVersion) {
+  const versionSelector: RushVersionSelector = new RushVersionSelector(currentPackageVersion);
   versionSelector.ensureRushVersionInstalled(rushVersionToLoad, configuration)
     .catch((error: Error) => {
       console.log(colors.red('Error: ' + error.message));
@@ -114,5 +112,5 @@ if (rushVersionToLoad && rushVersionToLoad !== currentPackageJson.version) {
   // Rush is "managed" if its version and configuration are dictated by a repo's rush.json
   const isManaged: boolean = !!configuration;
 
-  RushCommandSelector.execute(currentPackageJson.version, isManaged, rushLib);
+  RushCommandSelector.execute(currentPackageVersion, isManaged, rushLib);
 }

--- a/common/changes/@microsoft/api-documenter/pgonzal-tsdoc-metadata_2018-11-27-06-51.json
+++ b/common/changes/@microsoft/api-documenter/pgonzal-tsdoc-metadata_2018-11-27-06-51.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@microsoft/api-documenter",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/api-documenter",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/api-extractor/pgonzal-tsdoc-metadata_2018-11-27-06-51.json
+++ b/common/changes/@microsoft/api-extractor/pgonzal-tsdoc-metadata_2018-11-27-06-51.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor",
+      "comment": "Introduce a new build output \"dist/tsdoc-metdata.json\", which completely replaces the old \"tsdocFlavor\" field in package.json",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/node-core-library/pgonzal-tsdoc-metadata_2018-11-27-06-51.json
+++ b/common/changes/@microsoft/node-core-library/pgonzal-tsdoc-metadata_2018-11-27-06-51.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/node-core-library",
+      "comment": "Add new API PackageJsonLookup.loadOwnPackageJson()",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@microsoft/node-core-library",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush-stack/pgonzal-tsdoc-metadata_2018-11-27-06-51.json
+++ b/common/changes/@microsoft/rush-stack/pgonzal-tsdoc-metadata_2018-11-27-06-51.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@microsoft/rush-stack",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush-stack",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush/pgonzal-tsdoc-metadata_2018-11-27-06-51.json
+++ b/common/changes/@microsoft/rush/pgonzal-tsdoc-metadata_2018-11-27-06-51.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@microsoft/rush",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/reviews/api/api-extractor.api.ts
+++ b/common/reviews/api/api-extractor.api.ts
@@ -20,6 +20,7 @@ class Extractor {
   static jsonSchema: JsonSchema;
   processProject(options?: IAnalyzeProjectOptions): boolean;
   static processProjectFromConfigFile(jsonConfigFile: string, options?: IExtractorOptions): void;
+  static readonly version: string;
 }
 
 // @public

--- a/common/reviews/api/node-core-library.api.ts
+++ b/common/reviews/api/node-core-library.api.ts
@@ -344,7 +344,7 @@ enum NewlineKind {
 class PackageJsonLookup {
   constructor(parameters?: IPackageJsonLookupParameters);
   clearCache(): void;
-  static loadOwnPackageJson(dirnameOfCaller: string, pathToPackageJsonFolder: string): IPackageJson;
+  static loadOwnPackageJson(dirnameOfCaller: string): IPackageJson;
   loadPackageJson(jsonFilename: string): IPackageJson;
   tryGetPackageFolderFor(fileOrFolderPath: string): string | undefined;
   tryGetPackageJsonFilePathFor(fileOrFolderPath: string): string | undefined;

--- a/common/reviews/api/node-core-library.api.ts
+++ b/common/reviews/api/node-core-library.api.ts
@@ -344,6 +344,7 @@ enum NewlineKind {
 class PackageJsonLookup {
   constructor(parameters?: IPackageJsonLookupParameters);
   clearCache(): void;
+  static loadOwnPackageJson(dirnameOfCaller: string, pathToPackageJsonFolder: string): IPackageJson;
   loadPackageJson(jsonFilename: string): IPackageJson;
   tryGetPackageFolderFor(fileOrFolderPath: string): string | undefined;
   tryGetPackageJsonFilePathFor(fileOrFolderPath: string): string | undefined;

--- a/libraries/node-core-library/src/test/PackageJsonLookup.test.ts
+++ b/libraries/node-core-library/src/test/PackageJsonLookup.test.ts
@@ -10,6 +10,10 @@ describe('PackageJsonLookup', () => {
 
   describe('basic tests', () => {
 
+    test('', () => {
+      expect(PackageJsonLookup.loadOwnPackageJson(__dirname, '../..').name).toEqual('@microsoft/node-core-library');
+    });
+
     test('tryLoadPackageJsonFor() test', () => {
       const packageJsonLookup: PackageJsonLookup = new PackageJsonLookup();
       const sourceFilePath: string = path.join(__dirname, './test-data/example-package');

--- a/libraries/node-core-library/src/test/PackageJsonLookup.test.ts
+++ b/libraries/node-core-library/src/test/PackageJsonLookup.test.ts
@@ -11,7 +11,7 @@ describe('PackageJsonLookup', () => {
   describe('basic tests', () => {
 
     test('', () => {
-      expect(PackageJsonLookup.loadOwnPackageJson(__dirname, '../..').name).toEqual('@microsoft/node-core-library');
+      expect(PackageJsonLookup.loadOwnPackageJson(__dirname).name).toEqual('@microsoft/node-core-library');
     });
 
     test('tryLoadPackageJsonFor() test', () => {

--- a/stack/rush-stack/src/start.ts
+++ b/stack/rush-stack/src/start.ts
@@ -3,20 +3,15 @@
 
 import * as os from 'os';
 import * as colors from 'colors';
-import * as path from 'path';
 import {
-  JsonFile,
-  FileConstants
+  PackageJsonLookup
 } from '@microsoft/node-core-library';
 
 import { RushStackCommandLine } from './cli/RushStackCommandLine';
 
-const myPackageJsonFilename: string = path.resolve(path.join(
-  __dirname, '..', FileConstants.PackageJson)
-);
-const myPackageJson: { version: string } = JsonFile.load(myPackageJsonFilename);
+const currentPackageVersion: string = PackageJsonLookup.loadOwnPackageJson(__dirname, '..').version;
 
-console.log(os.EOL + colors.bold(`rush-stack ${myPackageJson.version} `
+console.log(os.EOL + colors.bold(`rush-stack ${currentPackageVersion} `
   + colors.cyan(' - http://rushstack.io') + os.EOL));
 
 const parser: RushStackCommandLine = new RushStackCommandLine();

--- a/stack/rush-stack/src/start.ts
+++ b/stack/rush-stack/src/start.ts
@@ -9,7 +9,7 @@ import {
 
 import { RushStackCommandLine } from './cli/RushStackCommandLine';
 
-const currentPackageVersion: string = PackageJsonLookup.loadOwnPackageJson(__dirname, '..').version;
+const currentPackageVersion: string = PackageJsonLookup.loadOwnPackageJson(__dirname).version;
 
 console.log(os.EOL + colors.bold(`rush-stack ${currentPackageVersion} `
   + colors.cyan(' - http://rushstack.io') + os.EOL));


### PR DESCRIPTION
This is based on the discussion in https://github.com/Microsoft/tsdoc/issues/7 .

Instead of the `tsdocFlavor` field in **package.json**:

```json
{
  "name": "widget-lib",
  "version": "1.0.0",
  "main": "lib/index.d.ts",
  "typings": "lib/index.js",
  "tsdoc": {
    "tsdocFlavor": "AEDoc"
  }
}
```

...we now recognize that an external package is TSDoc-compatible by looking for a file **dist/tsdoc-metadata.json** with contents like this:

```ts
{
  "tsdocVersion": "0.12",
  "toolPackages": [
    {
       "packageName": "@microsoft/api-extractor",
       "packageVersion": "7.0.0"
    }
  ]
}
```

This is a prototype until an official implementation is provided by the **\@microsoft/tsdoc** library.