### PR TITLE
[api-documenter] fix _getTypeNameWithDot and link implements and extends to uid

### DIFF
--- a/apps/api-documenter/src/yaml/YamlDocumenter.ts
+++ b/apps/api-documenter/src/yaml/YamlDocumenter.ts
@@ -314,11 +314,11 @@ export class YamlDocumenter {
     const apiStructure: IApiClass | IApiInterface = docItem.apiItem as IApiClass | IApiInterface;
 
     if (apiStructure.extends) {
-      yamlItem.extends = [ apiStructure.extends ];
+      yamlItem.extends = [ this._linkToUidIfPossible(apiStructure.extends) ];
     }
 
     if (apiStructure.implements) {
-      yamlItem.implements = [ apiStructure.implements ];
+      yamlItem.implements = [ this._linkToUidIfPossible(apiStructure.implements) ];
     }
 
     if (apiStructure.isSealed) {
@@ -547,7 +547,7 @@ export class YamlDocumenter {
     if (hierarchy.length > 0 && hierarchy[0].kind === DocItemKind.Package) {
       hierarchy.shift(); // ignore the package qualifier
     }
-    if (hierarchy.length < 1) {
+    if (hierarchy.length < 2) {
       return undefined;
     }
     return hierarchy.map(x => x.name).join('.');

--- a/common/changes/@microsoft/api-documenter/addUIDsToExtends_2018-11-27-23-57.json
+++ b/common/changes/@microsoft/api-documenter/addUIDsToExtends_2018-11-27-23-57.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-documenter",
+      "comment": "add uid to implements and extends blocks, fix uid references",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/api-documenter",
+  "email": "naethell@microsoft.com"
+}


### PR DESCRIPTION
A couple changes to **YamlDocumenter**.

`_getTypeNameWithDot` should break if `hierarchy.length` is less than 2. 

I also added links to uids in the YAML file generation for extends and implements blocks.