### PR TITLE
[api extractor] support module variable and type

### DIFF
--- a/apps/api-extractor/src/api/ApiItem.ts
+++ b/apps/api-extractor/src/api/ApiItem.ts
@@ -452,6 +452,32 @@ export interface IApiPackage {
 }
 
 /**
+ * A variable of module (or namespace)
+ * @alpha
+ */
+export interface IApiModuleVariable extends IApiBaseDefinition {
+  /**
+   * {@inheritdoc IApiBaseDefinition.kind}
+   */
+  kind: 'module variable';
+
+  /**
+   * a text summary of the variable definition
+   */
+  signature: string;
+
+  /**
+   * The data type of the variable
+   */
+  type: string;
+
+  /**
+   * The initialized value of the variable
+   */
+  value: string;
+}
+
+/**
  * A member of a class.
  * @alpha
  */
@@ -461,4 +487,5 @@ export type ApiMember = IApiProperty | IApiMethod | IApiConstructor;
  * @alpha
  */
 export type ApiItem = IApiProperty | ApiMember | IApiFunction | IApiConstructor |
-   IApiClass | IApiEnum | IApiEnumMember | IApiInterface | IApiNamespace | IApiPackage;
+   IApiClass | IApiEnum | IApiEnumMember | IApiInterface | IApiNamespace | IApiPackage |
+   IApiModuleVariable;

--- a/apps/api-extractor/src/api/ApiItem.ts
+++ b/apps/api-extractor/src/api/ApiItem.ts
@@ -400,6 +400,22 @@ export interface IApiInterface extends IApiBaseDefinition {
 }
 
 /**
+ * IApiTypeAlias represents a "type" alias declaration.
+ * @alpha
+ */
+export interface IApiTypeAlias extends IApiBaseDefinition {
+  /**
+   * {@inheritdoc IApiBaseDefinition.kind}
+   */
+  kind: 'type alias';
+
+  /**
+   * The data type of the type alias
+   */
+  type: string;
+}
+
+/**
  * IApiInterface represents an exported interface.
  * @alpha
  */
@@ -486,6 +502,6 @@ export type ApiMember = IApiProperty | IApiMethod | IApiConstructor;
 /**
  * @alpha
  */
-export type ApiItem = IApiProperty | ApiMember | IApiFunction | IApiConstructor |
+export type ApiItem = IApiProperty | ApiMember | IApiFunction | IApiConstructor | IApiTypeAlias |
    IApiClass | IApiEnum | IApiEnumMember | IApiInterface | IApiNamespace | IApiPackage |
    IApiModuleVariable;

--- a/apps/api-extractor/src/api/ApiJsonConverter.ts
+++ b/apps/api-extractor/src/api/ApiJsonConverter.ts
@@ -13,6 +13,7 @@ export class ApiJsonConverter {
   private static _KIND_ENUM: string = 'enum';
   private static _KIND_ENUM_VALUE: string = 'enum value';
   private static _KIND_INTERFACE: string = 'interface';
+  private static _KIND_TYPEALIAS: string = 'type alias';
   private static _KIND_FUNCTION: string = 'function';
   private static _KIND_PACKAGE: string = 'package';
   private static _KIND_PROPERTY: string = 'property';
@@ -51,6 +52,8 @@ export class ApiJsonConverter {
         return AstItemKind.Namespace;
       case (this._KIND_MODULEVARIABLE):
         return AstItemKind.ModuleVariable;
+      case (this._KIND_TYPEALIAS):
+        return AstItemKind.TypeAlias;
       default:
         throw new Error('Unsupported kind when converting JSON item kind to API item kind.');
     }
@@ -83,6 +86,8 @@ export class ApiJsonConverter {
         return this._KIND_NAMESPACE;
       case (AstItemKind.ModuleVariable):
         return this._KIND_MODULEVARIABLE;
+      case (AstItemKind.TypeAlias):
+        return this._KIND_TYPEALIAS;
       default:
         throw new Error('Unsupported API item kind when converting to string used in API JSON file.');
     }

--- a/apps/api-extractor/src/api/api-json.schema.json
+++ b/apps/api-extractor/src/api/api-json.schema.json
@@ -1047,7 +1047,8 @@
                 { "$ref": "#/definitions/interfaceApiItem" },
                 { "$ref": "#/definitions/namespaceApiItem" },
                 { "$ref": "#/definitions/enumApiItem" },
-                { "$ref": "#/definitions/functionApiItem" }
+                { "$ref": "#/definitions/functionApiItem" },
+                { "$ref": "#/definitions/typeAliasApiItem" }
               ]
             }
           },
@@ -1072,6 +1073,47 @@
       },
       "additionalProperties": false,
       "required": [ "kind", "exports", "summary", "isBeta" ]
+    },
+
+    //---------------------------------------------------------------------------------------------
+    "typeAliasApiItem": {
+      "description": "A TypeScript TypeAlias definition",
+      "type": "object",
+
+      "properties": {
+        "kind": {
+          "description": "The kind of API definition",
+          "type": "string",
+          "enum": [ "type alias" ]
+        },
+        "type": {
+          "description": "The data type of this type alias",
+          "type": "string"
+        },
+        "summary": {
+          "description": "A short description of the item",
+          "type": "array",
+          "items": { "$ref": "#/definitions/markupBasicElement" }
+        },
+        "isBeta": {
+          "description": "Whether the API method is beta",
+          "type": "boolean"
+        },
+
+        // Optional properties:
+        "remarks": {
+          "description": "Detailed additional notes regarding the item",
+          "type": "array",
+          "items": { "$ref": "#/definitions/markupStructuredElement" }
+        },
+        "deprecatedMessage": {
+          "description": "If present, indicates that the item is deprecated and describes the recommended alternative",
+          "type": "array",
+          "items": { "$ref": "#/definitions/markupBasicElement" }
+        }
+      },
+      "additionalProperties": false,
+      "required": [ "kind", "type", "summary", "isBeta"]
     }
   },
 
@@ -1115,7 +1157,8 @@
              { "$ref": "#/definitions/namespaceApiItem" },
              { "$ref": "#/definitions/enumApiItem" },
              { "$ref": "#/definitions/functionApiItem" },
-             { "$ref": "#/definitions/moduleVariableApiItem" }
+             { "$ref": "#/definitions/moduleVariableApiItem" },
+             { "$ref": "#/definitions/typeAliasApiItem" }
            ]
          }
       },

--- a/apps/api-extractor/src/api/api-json.schema.json
+++ b/apps/api-extractor/src/api/api-json.schema.json
@@ -1114,7 +1114,8 @@
              { "$ref": "#/definitions/interfaceApiItem" },
              { "$ref": "#/definitions/namespaceApiItem" },
              { "$ref": "#/definitions/enumApiItem" },
-             { "$ref": "#/definitions/functionApiItem" }
+             { "$ref": "#/definitions/functionApiItem" },
+             { "$ref": "#/definitions/moduleVariableApiItem" }
            ]
          }
       },

--- a/apps/api-extractor/src/ast/AstItem.ts
+++ b/apps/api-extractor/src/ast/AstItem.ts
@@ -75,7 +75,11 @@ export enum AstItemKind {
   /**
    * A Typescript BlockScopedVariable.
    */
-  ModuleVariable = 12
+  ModuleVariable = 12,
+  /**
+   * A Typescript type alias, i.e. the "type" keyword.
+   */
+  TypeAlias = 13
 }
 
 /**

--- a/apps/api-extractor/src/ast/AstModule.ts
+++ b/apps/api-extractor/src/ast/AstModule.ts
@@ -11,6 +11,7 @@ import { AstStructuredType } from './AstStructuredType';
 import { AstEnum } from './AstEnum';
 import { AstFunction } from './AstFunction';
 import { AstModuleVariable } from './AstModuleVariable';
+import { AstTypeAlias } from './AstTypeAlias';
 
 /**
   * This is an abstract base class for AstPackage and AstNamespace.
@@ -46,6 +47,8 @@ export abstract class AstModule extends AstItemContainer {
         this.addMemberItem(new AstEnum(options));
       } else if (followedSymbol.flags & ts.SymbolFlags.BlockScopedVariable) {
         this.addMemberItem(new AstModuleVariable(options));
+      } else if (followedSymbol.flags & ts.SymbolFlags.TypeAlias) {
+        this.addMemberItem(new AstTypeAlias(options));
       } else {
         this.reportWarning(`Unsupported export: ${exportSymbol.name}`);
       }

--- a/apps/api-extractor/src/ast/AstModule.ts
+++ b/apps/api-extractor/src/ast/AstModule.ts
@@ -10,6 +10,7 @@ import { TypeScriptHelpers } from '../utils/TypeScriptHelpers';
 import { AstStructuredType } from './AstStructuredType';
 import { AstEnum } from './AstEnum';
 import { AstFunction } from './AstFunction';
+import { AstModuleVariable } from './AstModuleVariable';
 
 /**
   * This is an abstract base class for AstPackage and AstNamespace.
@@ -43,6 +44,8 @@ export abstract class AstModule extends AstItemContainer {
         this.addMemberItem(new AstFunction(options));
       } else if (followedSymbol.flags & ts.SymbolFlags.Enum) {
         this.addMemberItem(new AstEnum(options));
+      } else if (followedSymbol.flags & ts.SymbolFlags.BlockScopedVariable) {
+        this.addMemberItem(new AstModuleVariable(options));
       } else {
         this.reportWarning(`Unsupported export: ${exportSymbol.name}`);
       }

--- a/apps/api-extractor/src/ast/AstTypeAlias.ts
+++ b/apps/api-extractor/src/ast/AstTypeAlias.ts
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import * as ts from 'typescript';
+import { AstItem, AstItemKind, IAstItemOptions } from './AstItem';
+
+/**
+ * This class is part of the AstItem abstract syntax tree. It represents a TypeScript enum value.
+ * The parent container will always be an AstEnum instance.
+ */
+export class AstTypeAlias extends AstItem {
+  public type: string;
+
+  constructor(options: IAstItemOptions) {
+    super(options);
+    this.kind = AstItemKind.TypeAlias;
+
+    const typeAliasDeclaration: ts.TypeAliasDeclaration = options.declaration as ts.TypeAliasDeclaration;
+    if (typeAliasDeclaration.type) {
+      this.type = typeAliasDeclaration.type.getText();
+    } else {
+      this.type = '';
+    }
+  }
+}

--- a/apps/api-extractor/src/generators/ApiFileGenerator.ts
+++ b/apps/api-extractor/src/generators/ApiFileGenerator.ts
@@ -15,6 +15,7 @@ import { AstNamespace } from '../ast/AstNamespace';
 import { AstModuleVariable } from '../ast/AstModuleVariable';
 import { IndentedWriter } from '../utils/IndentedWriter';
 import { ReleaseTag } from '../aedoc/ReleaseTag';
+import { AstTypeAlias } from '../ast/AstTypeAlias';
 
 /**
  * For a library such as "example-package", ApiFileGenerator generates the "example-package.api.ts"
@@ -179,6 +180,11 @@ export class ApiFileGenerator extends AstItemVisitor {
   protected visitAstFunction(astFunction: AstFunction): void {
     this._writeAedocSynopsis(astFunction);
     this._indentedWriter.write(astFunction.getDeclarationLine());
+  }
+
+  protected visitAstTypeAlias(astTypeAlias: AstTypeAlias, refObject?: Object): void {
+    this._writeAedocSynopsis(astTypeAlias);
+    this._indentedWriter.write(`type ${astTypeAlias.name} = ${astTypeAlias.type};`);
   }
 
   /**

--- a/apps/api-extractor/src/generators/ApiJsonGenerator.ts
+++ b/apps/api-extractor/src/generators/ApiJsonGenerator.ts
@@ -25,6 +25,7 @@ import { IAedocParameter } from '../aedoc/ApiDocumentation';
 import { IApiReturnValue, IApiParameter, IApiNameMap } from '../api/ApiItem';
 import { ApiJsonConverter } from '../api/ApiJsonConverter';
 import { ApiJsonFile } from '../api/ApiJsonFile';
+import { AstTypeAlias } from '../ast/AstTypeAlias';
 
 /**
  * For a library such as "example-package", ApiFileGenerator generates the "example-package.api.json"
@@ -319,6 +320,19 @@ export class ApiJsonGenerator extends AstItemVisitor {
     }
 
     refObject![astMethod.name] = newNode;
+  }
+
+  protected visitAstTypeAlias(astTypeAlias: AstTypeAlias, refObject?: Object): void {
+    const newNode: Object = {
+      kind: ApiJsonConverter.convertKindToJson(astTypeAlias.kind),
+      type: astTypeAlias.type,
+      deprecatedMessage: astTypeAlias.inheritedDeprecatedMessage || [],
+      summary: astTypeAlias.documentation.summary || [],
+      remarks: astTypeAlias.documentation.remarks || [],
+      isBeta: astTypeAlias.inheritedReleaseTag === ReleaseTag.Beta
+    };
+
+    refObject![astTypeAlias.name] = newNode;
   }
 
   private _createParameters(astFunction: AstMethod | AstFunction): IApiNameMap<IApiParameter> {

--- a/apps/api-extractor/src/generators/AstItemVisitor.ts
+++ b/apps/api-extractor/src/generators/AstItemVisitor.ts
@@ -12,6 +12,7 @@ import { AstMethod } from '../ast/AstMethod';
 import { AstNamespace } from '../ast/AstNamespace';
 import { AstProperty } from '../ast/AstProperty';
 import { AstModuleVariable } from '../ast/AstModuleVariable';
+import { AstTypeAlias } from '../ast/AstTypeAlias';
 
 /**
   * This is a helper class that provides a standard way to walk the AstItem
@@ -37,6 +38,8 @@ export abstract class AstItemVisitor {
       this.visitAstNamespace(astItem as AstNamespace, refObject);
     } else if (astItem instanceof AstModuleVariable) {
       this.visitAstModuleVariable(astItem as AstModuleVariable, refObject);
+    } else if (astItem instanceof AstTypeAlias) {
+      this.visitAstTypeAlias(astItem, refObject);
     } else {
       throw new Error('Not implemented');
     }
@@ -57,6 +60,8 @@ export abstract class AstItemVisitor {
   protected abstract visitAstNamespace(astNamespace: AstNamespace, refObject?: Object): void;
 
   protected abstract visitAstModuleVariable(astModuleVariable: AstModuleVariable, refObject?: Object): void;
+
+  protected abstract visitAstTypeAlias(astTypeAlias: AstTypeAlias, refObject?: Object): void;
 
   protected visitAstMethod(astMethod: AstMethod, refObject?: Object): void {
     this.visitAstMember(astMethod, refObject);


### PR DESCRIPTION
Supports:

- the module variable case (when "namespaceSupport" is configured as "permissive"):
```typescript
export const foo: number = 1;
export let bar: { m: boolean; } = { m: 1};
```
(But does not support old es5 `var` keywords).

- the "type" declaration case:
```typescript
export type A = number;
export type B = A & { m: boolean; };
```

With these two cases support, at least all of the exported items are listed inside the apis (along with later [api-documenter](https://github.com/adventure-yunfei/web-build-tools/tree/feature/api-documenter/support-module-variable-and-type) feature support).

Please let me know if this PR is proper, since these features may not be common, and seems api-extractor 7 is coming?

If the PR can be merged, I'll continue to run `rush build` and try to provide more test cases (I've tested with my entire project, and [a demo project](https://github.com/adventure-yunfei/api-documenter-example-case)).

