### PR TITLE
[api-extractor] Emit "export { }" directive in .d.ts rollup files to prevent incorrect imports

### DIFF
--- a/apps/api-extractor/src/generators/DtsRollupGenerator.ts
+++ b/apps/api-extractor/src/generators/DtsRollupGenerator.ts
@@ -128,6 +128,11 @@ export class DtsRollupGenerator {
         }
       }
     }
+
+    // Emit "export { }" which is a special directive that prevents consumers from importing declarations
+    // that don't have an explicit "export" modifier.
+    indentedWriter.writeLine();
+    indentedWriter.writeLine('export { }');
   }
 
   /**

--- a/build-tests/api-extractor-test-01/dist/beta/api-extractor-test-01.d.ts
+++ b/build-tests/api-extractor-test-01/dist/beta/api-extractor-test-01.d.ts
@@ -300,3 +300,5 @@ declare const unexportedCustomSymbol: unique symbol;
  * @public
  */
 export declare function virtual(target: Object, propertyKey: string | symbol, descriptor: TypedPropertyDescriptor<any>): void;
+
+export { }

--- a/build-tests/api-extractor-test-01/dist/internal/api-extractor-test-01.d.ts
+++ b/build-tests/api-extractor-test-01/dist/internal/api-extractor-test-01.d.ts
@@ -322,3 +322,5 @@ export declare const VARIABLE: string;
  * @public
  */
 export declare function virtual(target: Object, propertyKey: string | symbol, descriptor: TypedPropertyDescriptor<any>): void;
+
+export { }

--- a/build-tests/api-extractor-test-01/dist/public/api-extractor-test-01.d.ts
+++ b/build-tests/api-extractor-test-01/dist/public/api-extractor-test-01.d.ts
@@ -293,3 +293,5 @@ declare const unexportedCustomSymbol: unique symbol;
  * @public
  */
 export declare function virtual(target: Object, propertyKey: string | symbol, descriptor: TypedPropertyDescriptor<any>): void;
+
+export { }

--- a/build-tests/api-extractor-test-02/dist/beta/api-extractor-test-02.d.ts
+++ b/build-tests/api-extractor-test-02/dist/beta/api-extractor-test-02.d.ts
@@ -52,3 +52,5 @@ export declare function importedModuleAsReturnType(): semver1.SemVer | undefined
 export declare class SubclassWithImport extends RenamedReexportedClass3 implements ISimpleInterface {
     test(): void;
 }
+
+export { }

--- a/build-tests/api-extractor-test-02/dist/internal/api-extractor-test-02.d.ts
+++ b/build-tests/api-extractor-test-02/dist/internal/api-extractor-test-02.d.ts
@@ -52,3 +52,5 @@ export declare function importedModuleAsReturnType(): semver1.SemVer | undefined
 export declare class SubclassWithImport extends RenamedReexportedClass3 implements ISimpleInterface {
     test(): void;
 }
+
+export { }

--- a/build-tests/api-extractor-test-02/dist/public/api-extractor-test-02.d.ts
+++ b/build-tests/api-extractor-test-02/dist/public/api-extractor-test-02.d.ts
@@ -52,3 +52,5 @@ export declare function importedModuleAsReturnType(): semver1.SemVer | undefined
 export declare class SubclassWithImport extends RenamedReexportedClass3 implements ISimpleInterface {
     test(): void;
 }
+
+export { }

--- a/build-tests/api-extractor-test-05/etc/api-extractor-test-05.api.json
+++ b/build-tests/api-extractor-test-05/etc/api-extractor-test-05.api.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
-    "toolVersion": "7.0.6",
+    "toolVersion": "7.0.7",
     "schemaVersion": 1000
   },
   "kind": "Package",

--- a/common/changes/@microsoft/api-extractor/pgonzal-ae-accidental-imports_2018-12-19-21-14.json
+++ b/common/changes/@microsoft/api-extractor/pgonzal-ae-accidental-imports_2018-12-19-21-14.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor",
+      "comment": "Fix an issue where it was possible to import forgotten declarations from a .d.ts rollup, even though they did not have an explicit \"export\" modifier",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor",
+  "email": "pgonzal@users.noreply.github.com"
+}


### PR DESCRIPTION
When creating .d.ts rollup files, sometimes API Extractor needs to include declarations that the developer forgot to export from the entry point.  (For example, a class that is returned by a function call.) The `export` keyword is omitted, since these declarations cannot be imported from the entry point.  However, due to a quirk of the TypeScript compiler, the declarations can still be imported, unless a special `export { }` directive is included in the .d.ts file.