### PR TITLE
Fix typo of "timestamp" in rush change action manual page

### DIFF
--- a/apps/rush-lib/src/cli/actions/ChangeAction.ts
+++ b/apps/rush-lib/src/cli/actions/ChangeAction.ts
@@ -44,7 +44,7 @@ export class ChangeAction extends BaseRushAction {
 
   constructor(parser: RushCommandLineParser) {
     const documentation: string[] = [
-      'Asks a series of questions and then generates a <branchname>-<timstamp>.json file ' +
+      'Asks a series of questions and then generates a <branchname>-<timestamp>.json file ' +
       'in the common folder. The `publish` command will consume these files and perform the proper ' +
       'version bumps. Note these changes will eventually be published in a changelog.md file in each package.',
       '',

--- a/apps/rush-lib/src/cli/test/__snapshots__/CommandLineHelp.test.ts.snap
+++ b/apps/rush-lib/src/cli/test/__snapshots__/CommandLineHelp.test.ts.snap
@@ -142,7 +142,7 @@ Optional arguments:
 exports[`CommandLineHelp prints the help for each action: change 1`] = `
 "usage: rush change [-h] [-v] [-b BRANCH]
 
-Asks a series of questions and then generates a <branchname>-<timstamp>.json 
+Asks a series of questions and then generates a <branchname>-<timestamp>.json 
 file in the common folder. The \`publish\` command will consume these files and 
 perform the proper version bumps. Note these changes will eventually be 
 published in a changelog.md file in each package. The possible types of 

--- a/common/changes/@microsoft/rush/keco-fix-typos_2019-01-11-00-09.json
+++ b/common/changes/@microsoft/rush/keco-fix-typos_2019-01-11-00-09.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Fix typo of timestamp in rush change manual page",
+      "packageName": "@microsoft/rush",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "kevintcoughlin@users.noreply.github.com"
+}


### PR DESCRIPTION
Fixes a typo of "timestamp" in rush's change action manual page and updates the relevant snapshot file.

Related PR: https://github.com/Microsoft/rushjs.io-website/pull/27