### PR TITLE
api-documenter: handle inline tags

### DIFF
--- a/apps/api-documenter/src/markdown/MarkdownEmitter.ts
+++ b/apps/api-documenter/src/markdown/MarkdownEmitter.ts
@@ -169,6 +169,9 @@ export class MarkdownEmitter {
         this.writePlainText(docErrorText.text, context);
         break;
       }
+      case DocNodeKind.InlineTag: {
+        break;
+      }
       default:
         throw new Error('Unsupported element kind: ' + docNode.kind);
     }

--- a/common/changes/@microsoft/api-documenter/supportInlineTag_2019-01-14-17-55.json
+++ b/common/changes/@microsoft/api-documenter/supportInlineTag_2019-01-14-17-55.json
@@ -3,7 +3,7 @@
     {
       "packageName": "@microsoft/api-documenter",
       "comment": "MarkdownEmitter: break for inline tags",
-      "type": "minor"
+      "type": "patch"
     }
   ],
   "packageName": "@microsoft/api-documenter",

--- a/common/changes/@microsoft/api-documenter/supportInlineTag_2019-01-14-17-55.json
+++ b/common/changes/@microsoft/api-documenter/supportInlineTag_2019-01-14-17-55.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-documenter",
+      "comment": "MarkdownEmitter: break for inline tags",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@microsoft/api-documenter",
+  "email": "naethell@microsoft.com"
+}


### PR DESCRIPTION
This change prevents the markdown emitter from throwing an error for inline tags when writing nodes.