### PR TITLE
[rush] Improve change detection in "rush change."

### DIFF
--- a/apps/rush-lib/assets/rush-init/rush.json
+++ b/apps/rush-lib/assets/rush-init/rush.json
@@ -169,9 +169,19 @@
 
   "repository": {
     /**
-     * This setting is sometimes needed when using "rush change" with multiple Git remotes.
-     * It specifies the remote url for the official Git repository.  If this URL is provided,
-     * "rush change" will use it to find the right remote to compare against.
+     * The URL of this Git repository, used by "rush change" to determine the base branch for your PR.
+     *
+     * The "rush change" command attempts to determine which files are affected by your PR diff.
+     * If you merged or cherry-picked commits from the master branch into your PR branch, those commits
+     * should be excluded from this diff (since they belong to some other PR).  In order to do that,
+     * Rush needs to know where to find the base branch for your PR.  This information cannot be
+     * determined from Git alone, since the "pull request" feature is not a Git concept.  Ideally
+     * Rush should use a vendor-specific protocol to query the information from GitHub, Azure DevOps, etc.
+     * But to keep things simple, "rush change" simply assumes that your PR is against the "master" branch
+     * of the Git remote indicated by the respository.url setting in rush.json.  If you are working in
+     * a GitHub "fork" of the real repo, this setting will help Rush determine the master branch
+     * to compare against, and in this situation "rush change" will also automatically invoke "git fetch"
+     * to retrieve the latest activity for that branch.
      */
     /*[LINE "HYPOTHETICAL"]*/ "url": "https://github.com/Microsoft/rush-example"
   },

--- a/apps/rush-lib/assets/rush-init/rush.json
+++ b/apps/rush-lib/assets/rush-init/rush.json
@@ -171,17 +171,17 @@
     /**
      * The URL of this Git repository, used by "rush change" to determine the base branch for your PR.
      *
-     * The "rush change" command attempts to determine which files are affected by your PR diff.
+     * The "rush change" command needs to determine which files are affected by your PR diff.
      * If you merged or cherry-picked commits from the master branch into your PR branch, those commits
      * should be excluded from this diff (since they belong to some other PR).  In order to do that,
      * Rush needs to know where to find the base branch for your PR.  This information cannot be
      * determined from Git alone, since the "pull request" feature is not a Git concept.  Ideally
-     * Rush should use a vendor-specific protocol to query the information from GitHub, Azure DevOps, etc.
+     * Rush would use a vendor-specific protocol to query the information from GitHub, Azure DevOps, etc.
      * But to keep things simple, "rush change" simply assumes that your PR is against the "master" branch
      * of the Git remote indicated by the respository.url setting in rush.json.  If you are working in
-     * a GitHub "fork" of the real repo, this setting will help Rush determine the master branch
-     * to compare against, and in this situation "rush change" will also automatically invoke "git fetch"
-     * to retrieve the latest activity for that branch.
+     * a GitHub "fork" of the real repo, this setting will be different from the repository URL of your
+     * your PR branch, and in this situation "rush change" will also automatically invoke "git fetch"
+     * to retrieve the latest activity for the remote master branch.
      */
     /*[LINE "HYPOTHETICAL"]*/ "url": "https://github.com/Microsoft/rush-example"
   },

--- a/apps/rush-lib/src/api/RushConfiguration.ts
+++ b/apps/rush-lib/src/api/RushConfiguration.ts
@@ -70,7 +70,7 @@ export interface IEventHooksJson {
  */
 export interface IRushRepositoryJson {
   /**
-   * The remote url of the repository. This helps "rush change" finds the right remote to compare against.
+   * The remote url of the repository. This helps "rush change" find the right remote to compare against.
    */
   url: string;
 }
@@ -692,7 +692,7 @@ export class RushConfiguration {
   }
 
   /**
-   * The remote url of the repository. This helps "rush change" finds the right remote to compare against.
+   * The remote url of the repository. This helps "rush change" find the right remote to compare against.
    */
   public get repositoryUrl(): string {
     return this._repositoryUrl;

--- a/apps/rush-lib/src/api/RushConfiguration.ts
+++ b/apps/rush-lib/src/api/RushConfiguration.ts
@@ -70,7 +70,7 @@ export interface IEventHooksJson {
  */
 export interface IRushRepositoryJson {
   /**
-   * The remote url of the repository. It helps 'Rush change' finds the right remote to compare against.
+   * The remote url of the repository. This helps "rush change" finds the right remote to compare against.
    */
   url: string;
 }
@@ -692,7 +692,7 @@ export class RushConfiguration {
   }
 
   /**
-   * The remote url of the repository. It helps 'Rush change' finds the right remote to compare against.
+   * The remote url of the repository. This helps "rush change" finds the right remote to compare against.
    */
   public get repositoryUrl(): string {
     return this._repositoryUrl;

--- a/apps/rush-lib/src/cli/actions/ChangeAction.ts
+++ b/apps/rush-lib/src/cli/actions/ChangeAction.ts
@@ -149,6 +149,7 @@ export class ChangeAction extends BaseRushAction {
       this._targetBranchName = this._targetBranchParameter.value ||
         VersionControl.getRemoteMasterBranch(this.rushConfiguration.repositoryUrl);
     }
+
     return this._targetBranchName;
   }
 
@@ -180,7 +181,7 @@ export class ChangeAction extends BaseRushAction {
   }
 
   private _getChangeFiles(): string[] {
-    return VersionControl.getChangedFiles(`common/changes/`, this._targetBranch).map(relativePath => {
+    return VersionControl.getChangedFiles(this._targetBranch, `common/changes/`).map(relativePath => {
       return path.join(this.rushConfiguration.rushJsonFolder, relativePath);
     });
   }

--- a/apps/rush-lib/src/cli/actions/ChangeAction.ts
+++ b/apps/rush-lib/src/cli/actions/ChangeAction.ts
@@ -36,6 +36,7 @@ export class ChangeAction extends BaseRushAction {
   private _changeFileData: Map<string, IChangeFile>;
   private _changeComments: Map<string, string[]>;
   private _verifyParameter: CommandLineFlagParameter;
+  private _noFetchParameter: CommandLineFlagParameter;
   private _targetBranchParameter: CommandLineStringParameter;
   private _targetBranchName: string;
   private _projectHostMap: Map<string, string>;
@@ -85,6 +86,12 @@ export class ChangeAction extends BaseRushAction {
       parameterShortName: '-v',
       description: 'Verify the change file has been generated and that it is a valid JSON file'
     });
+
+    this._noFetchParameter = this.defineFlagParameter({
+      parameterLongName: '--no-fetch',
+      description: 'Skips fetching the baseline branch before running "git diff" to detect changes.'
+    });
+
     this._targetBranchParameter = this.defineStringParameter({
       parameterLongName: '--target-branch',
       parameterShortName: '-b',
@@ -154,7 +161,10 @@ export class ChangeAction extends BaseRushAction {
   }
 
   private _getChangedPackageNames(): string[] {
-    const changedFolders: Array<string | undefined> | undefined = VersionControl.getChangedFolders(this._targetBranch);
+    const changedFolders: Array<string | undefined> | undefined = VersionControl.getChangedFolders(
+      this._targetBranch,
+      this._noFetchParameter.value
+    );
     if (!changedFolders) {
       return [];
     }
@@ -181,7 +191,7 @@ export class ChangeAction extends BaseRushAction {
   }
 
   private _getChangeFiles(): string[] {
-    return VersionControl.getChangedFiles(this._targetBranch, `common/changes/`).map(relativePath => {
+    return VersionControl.getChangedFiles(this._targetBranch, true, `common/changes/`).map(relativePath => {
       return path.join(this.rushConfiguration.rushJsonFolder, relativePath);
     });
   }

--- a/apps/rush-lib/src/cli/test/__snapshots__/CommandLineHelp.test.ts.snap
+++ b/apps/rush-lib/src/cli/test/__snapshots__/CommandLineHelp.test.ts.snap
@@ -140,7 +140,7 @@ Optional arguments:
 `;
 
 exports[`CommandLineHelp prints the help for each action: change 1`] = `
-"usage: rush change [-h] [-v] [-b BRANCH]
+"usage: rush change [-h] [-v] [--no-fetch] [-b BRANCH]
 
 Asks a series of questions and then generates a <branchname>-<timestamp>.json 
 file in the common folder. The \`publish\` command will consume these files and 
@@ -163,6 +163,8 @@ Optional arguments:
   -h, --help            Show this help message and exit.
   -v, --verify          Verify the change file has been generated and that it 
                         is a valid JSON file
+  --no-fetch            Skips fetching the baseline branch before running 
+                        \\"git diff\\" to detect changes.
   -b BRANCH, --target-branch BRANCH
                         If this parameter is specified, compare current 
                         branch with the target branch to get changes. If this 

--- a/apps/rush-lib/src/schemas/rush.schema.json
+++ b/apps/rush-lib/src/schemas/rush.schema.json
@@ -141,7 +141,7 @@
       "type": "object",
       "properties": {
         "url": {
-          "description": "The remote url of the repository. If a value is provided, \"Rush change\" will use it to find the right remote to compare against.",
+          "description": "The remote url of the repository. If a value is provided, \"rush change\" will use it to find the right remote to compare against.",
           "type": "string"
         }
       },

--- a/apps/rush-lib/src/utilities/VersionControl.ts
+++ b/apps/rush-lib/src/utilities/VersionControl.ts
@@ -10,8 +10,14 @@ const DEFAULT_REMOTE: string = 'origin';
 const DEFAULT_FULLY_QUALIFIED_BRANCH: string = `${DEFAULT_REMOTE}/${DEFAULT_BRANCH}`;
 
 export class VersionControl {
-  public static getChangedFolders(targetBranch: string): Array<string | undefined> | undefined {
-    VersionControl._fetchNonDefaultBranch(targetBranch);
+  public static getChangedFolders(
+    targetBranch: string,
+    skipFetch: boolean = false
+  ): Array<string | undefined> | undefined {
+    if (!skipFetch) {
+      VersionControl._fetchNonDefaultBranch(targetBranch);
+    }
+
     const output: string = child_process.execSync(`git diff ${targetBranch}... --dirstat=files,0`).toString();
     return output.split('\n').map((line) => {
       if (line) {
@@ -25,8 +31,11 @@ export class VersionControl {
     });
   }
 
-  public static getChangedFiles(targetBranch: string, prefix?: string): string[] {
-    VersionControl._fetchNonDefaultBranch(targetBranch);
+  public static getChangedFiles(targetBranch: string, skipFetch: boolean = false, prefix?: string): string[] {
+    if (!skipFetch) {
+      VersionControl._fetchNonDefaultBranch(targetBranch);
+    }
+
     const output: string = child_process.execSync(
       `git diff ${targetBranch}... --name-only --no-renames --diff-filter=A`
     ).toString();

--- a/apps/rush-lib/src/utilities/VersionControl.ts
+++ b/apps/rush-lib/src/utilities/VersionControl.ts
@@ -31,7 +31,14 @@ export class VersionControl {
     });
   }
 
-  public static getChangedFiles(targetBranch: string, skipFetch: boolean = false, prefix?: string): string[] {
+  /**
+   * @param pathPrefix - An optional path prefix "git diff"s should be filtered by.
+   * @returns
+   * An array of paths of repo-root-relative paths of files that are different from
+   * those in the provided {@param targetBranch}. If a {@param pathPrefix} is provided,
+   * this function only returns reuslts under the that path.
+   */
+  public static getChangedFiles(targetBranch: string, skipFetch: boolean = false, pathPrefix?: string): string[] {
     if (!skipFetch) {
       VersionControl._fetchNonDefaultBranch(targetBranch);
     }
@@ -39,7 +46,7 @@ export class VersionControl {
     const output: string = child_process.execSync(
       `git diff ${targetBranch}... --name-only --no-renames --diff-filter=A`
     ).toString();
-    const regex: RegExp | undefined = prefix ? new RegExp(`^${prefix}`, 'i') : undefined;
+    const regex: RegExp | undefined = pathPrefix ? new RegExp(`^${pathPrefix}`, 'i') : undefined;
     return output.split('\n').map((line) => {
       if (line) {
         const trimmedLine: string = line.trim();

--- a/apps/rush-lib/src/utilities/VersionControl.ts
+++ b/apps/rush-lib/src/utilities/VersionControl.ts
@@ -81,20 +81,22 @@ export class VersionControl {
       });
     } else {
       console.log(colors.yellow(
-        'A remote URL has not been specified in rush.json. Setting the baseline remote URL is recommended.'
+        'A git remote URL has not been specified in rush.json. Setting the baseline remote URL is recommended.'
       ));
       return DEFAULT_FULLY_QUALIFIED_BRANCH;
     }
 
     if (matchingRemotes.length > 0) {
       if (matchingRemotes.length > 1) {
-        console.log(`More than one remote matches the repository URL. Using the first remote (${matchingRemotes[0]}).`);
+        console.log(
+          `More than one git remote matches the repository URL. Using the first remote (${matchingRemotes[0]}).`
+        );
       }
 
       return `${matchingRemotes[0]}/${DEFAULT_BRANCH}`;
     } else {
       console.log(colors.yellow(
-        `Unable to find a remote matching the repository URL (${matchingRemotes[0]}). ` +
+        `Unable to find a git remote matching the repository URL (${matchingRemotes[0]}). ` +
         'Detected changes are likely to be incorrect.'
       ));
       return DEFAULT_FULLY_QUALIFIED_BRANCH;
@@ -136,7 +138,7 @@ export class VersionControl {
     const firstSlashIndex: number = remoteBranchName.indexOf('/');
     if (firstSlashIndex === -1) {
       throw new Error(
-        `Unexpected remote branch format: ${remoteBranchName}. ` +
+        `Unexpected git remote branch format: ${remoteBranchName}. ` +
         'Expected branch to be in the <remote>/<branch name> format.'
       );
     }
@@ -159,7 +161,7 @@ export class VersionControl {
       const fetchResult: boolean = VersionControl._tryFetchRemoteBranch(remoteBranchName);
       if (!fetchResult) {
         console.log(colors.yellow(
-          `Error fetching remote branch ${remoteBranchName}. Detected changed files may be incorrect.`
+          `Error fetching git remote branch ${remoteBranchName}. Detected changed files may be incorrect.`
         ));
       }
     }

--- a/common/changes/@microsoft/rush/ianc-safer-rush-change_2019-02-08-02-22.json
+++ b/common/changes/@microsoft/rush/ianc-safer-rush-change_2019-02-08-02-22.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Improve \"rush change\"'s baseline remote detection.",
+      "packageName": "@microsoft/rush",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/rush.json
+++ b/rush.json
@@ -166,17 +166,17 @@
     /**
      * The URL of this Git repository, used by "rush change" to determine the base branch for your PR.
      *
-     * The "rush change" command attempts to determine which files are affected by your PR diff.
+     * The "rush change" command needs to determine which files are affected by your PR diff.
      * If you merged or cherry-picked commits from the master branch into your PR branch, those commits
      * should be excluded from this diff (since they belong to some other PR).  In order to do that,
      * Rush needs to know where to find the base branch for your PR.  This information cannot be
      * determined from Git alone, since the "pull request" feature is not a Git concept.  Ideally
-     * Rush should use a vendor-specific protocol to query the information from GitHub, Azure DevOps, etc.
+     * Rush would use a vendor-specific protocol to query the information from GitHub, Azure DevOps, etc.
      * But to keep things simple, "rush change" simply assumes that your PR is against the "master" branch
      * of the Git remote indicated by the respository.url setting in rush.json.  If you are working in
-     * a GitHub "fork" of the real repo, this setting will help Rush determine the master branch
-     * to compare against, and in this situation "rush change" will also automatically invoke "git fetch"
-     * to retrieve the latest activity for that branch.
+     * a GitHub "fork" of the real repo, this setting will be different from the repository URL of your
+     * your PR branch, and in this situation "rush change" will also automatically invoke "git fetch"
+     * to retrieve the latest activity for the remote master branch.
      */
     "url": "https://github.com/Microsoft/web-build-tools.git"
   },

--- a/rush.json
+++ b/rush.json
@@ -164,9 +164,19 @@
 
   "repository": {
     /**
-     * This setting is sometimes needed when using "rush change" with multiple Git remotes.
-     * It specifies the remote url for the official Git repository.  If this URL is provided,
-     * "rush change" will use it to find the right remote to compare against.
+     * The URL of this Git repository, used by "rush change" to determine the base branch for your PR.
+     *
+     * The "rush change" command attempts to determine which files are affected by your PR diff.
+     * If you merged or cherry-picked commits from the master branch into your PR branch, those commits
+     * should be excluded from this diff (since they belong to some other PR).  In order to do that,
+     * Rush needs to know where to find the base branch for your PR.  This information cannot be
+     * determined from Git alone, since the "pull request" feature is not a Git concept.  Ideally
+     * Rush should use a vendor-specific protocol to query the information from GitHub, Azure DevOps, etc.
+     * But to keep things simple, "rush change" simply assumes that your PR is against the "master" branch
+     * of the Git remote indicated by the respository.url setting in rush.json.  If you are working in
+     * a GitHub "fork" of the real repo, this setting will help Rush determine the master branch
+     * to compare against, and in this situation "rush change" will also automatically invoke "git fetch"
+     * to retrieve the latest activity for that branch.
      */
     "url": "https://github.com/Microsoft/web-build-tools.git"
   },


### PR DESCRIPTION
This PR improves the way "rush change" detects the baseline remote, improves the handling of the case where the baseline remote can't be found, and tries to fetch from the remote before detecting changed projects.