### PR TITLE
[node-core-library] Add InternalError.breakInDebugger property

### DIFF
--- a/apps/api-extractor/src/cli/ApiExtractorCommandLine.ts
+++ b/apps/api-extractor/src/cli/ApiExtractorCommandLine.ts
@@ -5,6 +5,8 @@ import * as colors from 'colors';
 import * as os from 'os';
 
 import { CommandLineParser, CommandLineFlagParameter } from '@microsoft/ts-command-line';
+import { InternalError } from '@microsoft/node-core-library';
+
 import { RunAction } from './RunAction';
 
 export class ApiExtractorCommandLine extends CommandLineParser {
@@ -27,6 +29,10 @@ export class ApiExtractorCommandLine extends CommandLineParser {
   }
 
   protected onExecute(): Promise<void> { // override
+    if (this._debugParameter.value) {
+      InternalError.breakInDebugger = true;
+    }
+
     return super.onExecute().catch((error) => {
 
       if (this._debugParameter.value) {

--- a/apps/rush-lib/src/cli/RushCommandLineParser.ts
+++ b/apps/rush-lib/src/cli/RushCommandLineParser.ts
@@ -6,6 +6,7 @@ import * as os from 'os';
 import * as path from 'path';
 
 import { CommandLineParser, CommandLineFlagParameter, CommandLineAction } from '@microsoft/ts-command-line';
+import { InternalError } from '@microsoft/node-core-library';
 
 import { RushConfiguration } from '../api/RushConfiguration';
 import { RushConstants } from '../logic/RushConstants';
@@ -80,6 +81,10 @@ export class RushCommandLineParser extends CommandLineParser {
     // Ideally we should do this for all the Rush actions, but "rush build" is the most critical one
     // -- if it falsely appears to succeed, we could merge bad PRs, publish empty packages, etc.
     process.exitCode = 1;
+
+    if (this._debugParameter.value) {
+      InternalError.breakInDebugger = true;
+    }
 
     return this._wrapOnExecute().catch((error: Error) => {
       this._reportErrorAndSetExitCode(error);

--- a/common/changes/@microsoft/api-extractor/master_2019-02-08-22-09.json
+++ b/common/changes/@microsoft/api-extractor/master_2019-02-08-22-09.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor",
+      "comment": "The `--debug` parameter now automatically breaks in the debugger when InternalError is thrown",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/node-core-library/master_2019-02-08-22-09.json
+++ b/common/changes/@microsoft/node-core-library/master_2019-02-08-22-09.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/node-core-library",
+      "comment": "Add new API `InternalError.breakInDebugger`",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@microsoft/node-core-library",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush/master_2019-02-08-22-09.json
+++ b/common/changes/@microsoft/rush/master_2019-02-08-22-09.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "The `--debug` parameter now automatically breaks in the debugger when InternalError is thrown",
+      "packageName": "@microsoft/rush",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/reviews/api/node-core-library.api.ts
+++ b/common/reviews/api/node-core-library.api.ts
@@ -217,6 +217,7 @@ interface IJsonSchemaValidateOptions {
 // @public
 class InternalError extends Error {
   constructor(message: string);
+  static breakInDebugger: boolean;
   // @override (undocumented)
   toString(): string;
   readonly unformattedMessage: string;

--- a/libraries/node-core-library/src/InternalError.ts
+++ b/libraries/node-core-library/src/InternalError.ts
@@ -12,6 +12,16 @@
  */
 export class InternalError extends Error {
   /**
+   * If true, a JavScript `debugger;` statement will be invoked whenever the `InternalError` constructor is called.
+   *
+   * @remarks
+   * Generally applications should not be catching and ignoring an `InternalError`.  Instead, the error should
+   * be reported and typically the application will terminate.  Thus, if `InternalError` is constructed, it's
+   * almost always something we want to examine in a debugger.
+   */
+  public static breakInDebugger: boolean = true;
+
+  /**
    * The underlying error message, without the additional boilerplate for an `InternalError`.
    */
   public readonly unformattedMessage: string;
@@ -39,6 +49,10 @@ export class InternalError extends Error {
     (this as any).__proto__ = InternalError.prototype; // tslint:disable-line:no-any
 
     this.unformattedMessage = message;
+
+    if (InternalError.breakInDebugger) {
+      debugger; // tslint:disable-line:no-debugger
+    }
   }
 
   /** @override */


### PR DESCRIPTION
For Rush and API Extractor, the `--debug` parameter now automatically breaks in the debugger whenever `InternalError` is thrown.  This makes debugging easier.