### PR TITLE
[api-extractor] Rollback incorrectly published version 8.0.0 -> 7.0.19

### DIFF
--- a/apps/api-extractor/CHANGELOG.json
+++ b/apps/api-extractor/CHANGELOG.json
@@ -2,11 +2,11 @@
   "name": "@microsoft/api-extractor",
   "entries": [
     {
-      "version": "8.0.0",
-      "tag": "@microsoft/api-extractor_v8.0.0",
+      "version": "7.0.19",
+      "tag": "@microsoft/api-extractor_v7.0.19",
       "date": "Mon, 18 Feb 2019 17:13:23 GMT",
       "comments": {
-        "major": [
+        "minor": [
           {
             "comment": "New way to resolve & generate TSDoc metadata file"
           }

--- a/apps/api-extractor/CHANGELOG.md
+++ b/apps/api-extractor/CHANGELOG.md
@@ -1,11 +1,11 @@
 # Change Log - @microsoft/api-extractor
 
-This log was last generated on Mon, 18 Feb 2019 17:13:23 GMT and should not be manually modified.
+This log was last generated on Sun, 24 Feb 2019 20:07:24 GMT and should not be manually modified.
 
-## 8.0.0
+## 7.0.19
 Mon, 18 Feb 2019 17:13:23 GMT
 
-### Breaking changes
+### Minor changes
 
 - New way to resolve & generate TSDoc metadata file
 


### PR DESCRIPTION
Due to [an incorrect change log in PR 1011](https://github.com/Microsoft/web-build-tools/pull/1011/files#diff-c335bf48a413c4fe1fc365d223f6d232), we accidentally published API Extractor as version 8.0.0 instead of 7.0.19.

We will unpublish 8.0.0 and republish it as 7.0.19.