### PR TITLE
[rush] Fix an issue with rush publish --pack with yarn.

### DIFF
--- a/apps/rush-lib/src/cli/actions/PublishAction.ts
+++ b/apps/rush-lib/src/cli/actions/PublishAction.ts
@@ -473,10 +473,14 @@ export class PublishAction extends BaseRushAction {
   private _calculateTarballName(project: RushConfigurationProject): string {
     // Same logic as how npm forms the tarball name
     const packageName: string = project.packageName;
-    const name: string = packageName[0] === '@' ?
-      packageName.substr(1).replace(/\//g, '-') : packageName;
+    const name: string = packageName[0] === '@' ? packageName.substr(1).replace(/\//g, '-') : packageName;
 
-    return `${name}-${project.packageJson.version}.tgz`;
+    if (this.rushConfiguration.packageManager === 'yarn') {
+      // yarn tarballs have a "v" before the version number
+      return `${name}-v${project.packageJson.version}.tgz`;
+    } else {
+      return `${name}-${project.packageJson.version}.tgz`;
+    }
   }
 
   private _setDependenciesBeforePublish(): void {

--- a/common/changes/@microsoft/rush/ianc-fixing-issue-with-yarn-pack_2019-02-28-00-29.json
+++ b/common/changes/@microsoft/rush/ianc-fixing-issue-with-yarn-pack_2019-02-28-00-29.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Fix an issue with \"rush publish --pack\" when using yarn.",
+      "packageName": "@microsoft/rush",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "iclanton@users.noreply.github.com"
+}


### PR DESCRIPTION
This PR fixes an issue where `rush publish --pack` doesn't work when Yarn is the package manager. Yarn adds a "v" before the version number when it creates tarballs, and the rename operation in Rush doesn't account for this.