### PR TITLE
[api-extractor] When reporting error line numbers, use source maps to find the original .ts file

### DIFF
--- a/apps/api-extractor/package.json
+++ b/apps/api-extractor/package.json
@@ -38,16 +38,17 @@
     "@types/z-schema": "3.16.31",
     "colors": "~1.2.1",
     "lodash": "~4.17.5",
+    "resolve": "1.8.1",
+    "source-map": "~0.6.1",
     "typescript": "~3.1.6",
-    "z-schema": "~3.18.3",
-    "resolve": "1.8.1"
+    "z-schema": "~3.18.3"
   },
   "devDependencies": {
+    "@microsoft/node-library-build": "6.0.29",
     "@microsoft/rush-stack-compiler-3.2": "0.2.2",
-    "tslint-microsoft-contrib": "~5.2.1",
+    "@types/jest": "23.3.11",
     "@types/lodash": "4.14.116",
     "gulp": "~3.9.1",
-    "@microsoft/node-library-build": "6.0.29",
-    "@types/jest": "23.3.11"
+    "tslint-microsoft-contrib": "~5.2.1"
   }
 }

--- a/apps/api-extractor/src/collector/MessageRouter.ts
+++ b/apps/api-extractor/src/collector/MessageRouter.ts
@@ -21,6 +21,7 @@ import {
 } from '../api/IExtractorConfig';
 import { AedocDefinitions } from '../aedoc/AedocDefinitions';
 import { ILogger } from '../api/ILogger';
+import { SourceMapper } from './SourceMapper';
 
 interface IReportingRule {
   logLevel: ExtractorMessageLogLevel;
@@ -37,6 +38,8 @@ export class MessageRouter {
   // Messages that got written to the API review file
   private readonly _messagesAddedToApiReviewFile: Set<ExtractorMessage>;
 
+  private readonly _sourceMapper: SourceMapper;
+
   // Normalized representation of the routing rules from api-extractor.json
   private _reportingRuleByMessageId: Map<string, IReportingRule> = new Map<string, IReportingRule>();
   private _compilerDefaultRule: IReportingRule = { logLevel: ExtractorMessageLogLevel.None,
@@ -50,6 +53,7 @@ export class MessageRouter {
     this._messages = [];
     this._associatedMessagesForAstDeclaration = new Map<AstDeclaration, ExtractorMessage[]>();
     this._messagesAddedToApiReviewFile = new Set<ExtractorMessage>();
+    this._sourceMapper = new SourceMapper();
 
     this._applyMessagesConfig(messagesConfig);
   }
@@ -151,6 +155,7 @@ export class MessageRouter {
       options.sourceFileColumn = lineAndCharacter.character + 1;
     }
 
+    this._sourceMapper.updateExtractorMessageOptions(options);
     this._messages.push(new ExtractorMessage(options));
   }
 
@@ -185,14 +190,17 @@ export class MessageRouter {
       const lineAndCharacter: ts.LineAndCharacter = sourceFile.getLineAndCharacterOfPosition(
         message.textRange.pos);
 
-      const extractorMessage: ExtractorMessage = new ExtractorMessage({
+      const options: IExtractorMessageOptions = {
         category: ExtractorMessageCategory.TSDoc,
         messageId: message.messageId,
         text: message.unformattedText,
         sourceFilePath: sourceFile.fileName,
         sourceFileLine: lineAndCharacter.line + 1,
         sourceFileColumn: lineAndCharacter.character + 1
-      });
+      };
+
+      this._sourceMapper.updateExtractorMessageOptions(options);
+      const extractorMessage: ExtractorMessage = new ExtractorMessage(options);
 
       if (astDeclaration) {
         this._associateMessageWithAstDeclaration(extractorMessage, astDeclaration);
@@ -236,7 +244,9 @@ export class MessageRouter {
       sourceFileColumn: lineAndCharacter.character + 1
     };
 
+    this._sourceMapper.updateExtractorMessageOptions(options);
     const extractorMessage: ExtractorMessage = new ExtractorMessage(options);
+
     this._messages.push(extractorMessage);
     return extractorMessage;
   }

--- a/apps/api-extractor/src/collector/MessageRouter.ts
+++ b/apps/api-extractor/src/collector/MessageRouter.ts
@@ -155,7 +155,8 @@ export class MessageRouter {
       options.sourceFileColumn = lineAndCharacter.character + 1;
     }
 
-    this._sourceMapper.updateExtractorMessageOptions(options);
+    // NOTE: Since compiler errors pertain to issues specific to the .d.ts files,
+    // we do not apply source mappings for them.
     this._messages.push(new ExtractorMessage(options));
   }
 

--- a/apps/api-extractor/src/collector/MessageRouter.ts
+++ b/apps/api-extractor/src/collector/MessageRouter.ts
@@ -174,7 +174,7 @@ export class MessageRouter {
 
     const extractorMessage: ExtractorMessage = this.addAnalyzerIssueForPosition(
       messageId, messageText, astDeclaration.declaration.getSourceFile(),
-      astDeclaration.declaration.pos);
+      astDeclaration.declaration.getStart());
 
     this._associateMessageWithAstDeclaration(extractorMessage, astDeclaration);
   }

--- a/apps/api-extractor/src/collector/SourceMapper.ts
+++ b/apps/api-extractor/src/collector/SourceMapper.ts
@@ -25,9 +25,9 @@ interface IOriginalFileInfo {
 }
 
 export class SourceMapper {
-  // Map from .d.ts file path --> ISourceMap if a source map was found, or false if not found
-  private _sourceMapByFilePath: Map<string, ISourceMap | false>
-    = new Map<string, ISourceMap | false>();
+  // Map from .d.ts file path --> ISourceMap if a source map was found, or null if not found
+  private _sourceMapByFilePath: Map<string, ISourceMap | null>
+    = new Map<string, ISourceMap | null>();
 
   // Cache the FileSystem.exists() result for mapped .ts files
   private _originalFileInfoByPath: Map<string, IOriginalFileInfo> = new Map<string, IOriginalFileInfo>();
@@ -46,7 +46,7 @@ export class SourceMapper {
       throw new InternalError('The referenced path was not found: ' + options.sourceFilePath);
     }
 
-    let sourceMap: ISourceMap | false | undefined = this._sourceMapByFilePath.get(options.sourceFilePath);
+    let sourceMap: ISourceMap | null | undefined = this._sourceMapByFilePath.get(options.sourceFilePath);
 
     if (sourceMap === undefined) {
       // Normalize the path and redo the lookup
@@ -84,7 +84,7 @@ export class SourceMapper {
           sourceMap = { sourceMapConsumer, mappingItems};
         } else {
           // No source map for this filename
-          sourceMap = false;
+          sourceMap = null; // tslint:disable-line:no-null-keyword
         }
 
         this._sourceMapByFilePath.set(normalizedPath, sourceMap);
@@ -95,7 +95,7 @@ export class SourceMapper {
       }
     }
 
-    if (sourceMap === false) {
+    if (sourceMap === null) {
       // No source map for this filename
       return;
     }

--- a/apps/api-extractor/src/collector/SourceMapper.ts
+++ b/apps/api-extractor/src/collector/SourceMapper.ts
@@ -1,0 +1,157 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import * as path from 'path';
+import { SourceMapConsumer, RawSourceMap, MappingItem, Position } from 'source-map';
+import { IExtractorMessageOptions } from '../api/ExtractorMessage';
+import { FileSystem, InternalError, JsonFile } from '@microsoft/node-core-library';
+
+interface ISourceMap {
+  sourceMapConsumer: SourceMapConsumer;
+
+  // SourceMapConsumer.originalPositionFor() is useless because the mapping contains numerous gaps,
+  // and the API provides no way to find the nearest match.  So instead we extract all the mapping items
+  // and search them ourself.
+  mappingItems: MappingItem[];
+}
+
+export class SourceMapper {
+  // Map from IExtractorMessageOptions.sourceFilePath --> ISourceMap if a source map was found,
+  // or false if not found
+  private _sourceMapByFilePath: Map<string, ISourceMap | false>
+    = new Map<string, ISourceMap | false>();
+
+  // Cache the FileSystem.exists() result for mapped file paths
+  private _existenceByMappedFilePath: Map<string, boolean> = new Map<string, boolean>();
+
+  /**
+   * If the `IExtractorMessageOptions` refers to a `.d.ts` file, look for a `.d.ts.map` and
+   * if possible update the coordinates to refer to the original `.ts` file.
+   */
+  public updateExtractorMessageOptions(options: IExtractorMessageOptions): void {
+    if (!options.sourceFilePath) {
+      return;
+    }
+
+    if (!FileSystem.exists(options.sourceFilePath)) {
+      // Sanity check
+      throw new InternalError('The referenced path was not found: ' + options.sourceFilePath);
+    }
+
+    let sourceMap: ISourceMap | false | undefined = this._sourceMapByFilePath.get(options.sourceFilePath);
+
+    if (sourceMap === undefined) {
+      // Normalize the path and redo the lookup
+      const normalizedPath: string = FileSystem.getRealPath(options.sourceFilePath);
+
+      sourceMap = this._sourceMapByFilePath.get(normalizedPath);
+      if (sourceMap !== undefined) {
+        // Copy the result to the new key
+        this._sourceMapByFilePath.set(options.sourceFilePath, sourceMap);
+      } else {
+        // Given "folder/file.d.ts", check for a corresponding "folder/file.d.ts.map"
+        const sourceMapPath: string = normalizedPath + '.map';
+        if (FileSystem.exists(sourceMapPath)) {
+          // Load up the source map
+          const rawSourceMap: RawSourceMap = JsonFile.load(sourceMapPath) as RawSourceMap;
+          const sourceMapConsumer: SourceMapConsumer = new SourceMapConsumer(rawSourceMap);
+
+          const mappingItems: MappingItem[] = [];
+
+          // Extract the list of mapping items
+          sourceMapConsumer.eachMapping(
+            (mappingItem: MappingItem) => {
+              mappingItems.push(mappingItem);
+            },
+            this,
+            SourceMapConsumer.GENERATED_ORDER
+          );
+
+          sourceMap = {
+            sourceMapConsumer,
+            mappingItems
+          };
+        } else {
+          sourceMap = false;
+        }
+
+        this._sourceMapByFilePath.set(options.sourceFilePath, sourceMap);
+        this._sourceMapByFilePath.set(normalizedPath, sourceMap);
+      }
+    }
+
+    if (sourceMap === false) {
+      // No source map
+      return;
+    }
+
+    const nearestMappingItem: MappingItem | undefined = SourceMapper._findNearestMappingItem(sourceMap.mappingItems,
+      {
+        line: options.sourceFileLine || 1,
+        // The source-map package inexplicably uses 1-based line numbers but 0-based column numbers
+        column: (options.sourceFileColumn || 1) - 1
+      }
+    );
+
+    if (nearestMappingItem === undefined) {
+      // The source map provides no mapping for this location
+      return;
+    }
+
+    const mappedFilePath: string = path.resolve(path.dirname(options.sourceFilePath), nearestMappingItem.source);
+
+    // Does the mapped file exist?
+    let mappedFileExists: boolean | undefined = this._existenceByMappedFilePath.get(mappedFilePath);
+    if (mappedFileExists === undefined) {
+      mappedFileExists = FileSystem.exists(mappedFilePath);
+      this._existenceByMappedFilePath.set(mappedFilePath, mappedFileExists);
+    }
+
+    if (!mappedFileExists) {
+      // Don't translate coordinates to a file that doesn't exist
+      return;
+    }
+
+    // Success -- update the options
+    options.sourceFilePath = mappedFilePath;
+    options.sourceFileLine = nearestMappingItem.originalLine;
+    options.sourceFileColumn = nearestMappingItem.originalColumn + 1;
+  }
+
+  private static _findNearestMappingItem(mappingItems: MappingItem[], position: Position): MappingItem | undefined {
+    if (mappingItems.length === 0) {
+      return undefined;
+    }
+
+    let startIndex: number = 0;
+    let endIndex: number = mappingItems.length - 1;
+
+    while (startIndex <= endIndex) {
+      const middleIndex: number = startIndex + Math.floor((endIndex - startIndex) / 2);
+
+      const diff: number = SourceMapper._compareMappingItem(mappingItems[middleIndex], position);
+
+      if (diff === 0) {
+        return mappingItems[middleIndex];
+      }
+
+      if (diff < 0) {
+        startIndex = middleIndex + 1;
+      } else {
+        endIndex = middleIndex - 1;
+      }
+    }
+
+    // If we didn't find a match, then endIndex < startIndex.
+    // Take endIndex because it's the smaller value.
+    return mappingItems[endIndex];
+  }
+
+  private static _compareMappingItem(mappingItem: MappingItem, position: Position): number {
+    const diff: number = mappingItem.generatedLine - position.line;
+    if (diff !== 0) {
+      return diff;
+    }
+    return mappingItem.generatedColumn - position.column;
+  }
+}

--- a/common/changes/@microsoft/api-extractor/octogonz-ae-source-maps_2019-03-04-00-59.json
+++ b/common/changes/@microsoft/api-extractor/octogonz-ae-source-maps_2019-03-04-00-59.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor",
+      "comment": "Error messages now cite the original .ts source file, if a source map is present. (To enable this, specify `\"declarationMap\": true` in tsconfig.json.)",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/config/rush/browser-approved-packages.json
+++ b/common/config/rush/browser-approved-packages.json
@@ -1,10 +1,5 @@
 // DO NOT ADD COMMENTS IN THIS FILE.  They will be lost when the Rush tool resaves it.
 {
   "$schema": "https://developer.microsoft.com/json-schemas/rush/v5/approved-packages.schema.json",
-  "packages": [
-    {
-      "name": "@microsoft/rush-stack-compiler-3.3",
-      "allowedCategories": [ "tests" ]
-    }
-  ]
+  "packages": []
 }

--- a/common/config/rush/nonbrowser-approved-packages.json
+++ b/common/config/rush/nonbrowser-approved-packages.json
@@ -87,6 +87,10 @@
       "allowedCategories": [ "libraries", "tests" ]
     },
     {
+      "name": "@microsoft/rush-stack-compiler-3.3",
+      "allowedCategories": [ "tests" ]
+    },
+    {
       "name": "@microsoft/rush-stack-compiler-shared",
       "allowedCategories": [ "libraries" ]
     },
@@ -432,6 +436,10 @@
     },
     {
       "name": "sinon-chai",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
+      "name": "source-map",
       "allowedCategories": [ "libraries" ]
     },
     {

--- a/common/config/rush/shrinkwrap.yaml
+++ b/common/config/rush/shrinkwrap.yaml
@@ -152,6 +152,7 @@ dependencies:
   resolve: 1.8.1
   semver: 5.3.0
   sinon: 1.17.7
+  source-map: 0.6.1
   strict-uri-encode: 2.0.0
   sudo: 1.0.3
   tar: 4.4.8
@@ -436,7 +437,7 @@ packages:
       '@pnpm/package-bins': 1.0.0
       '@pnpm/types': 1.8.0
       '@types/mz': 0.0.32
-      '@types/node': 10.12.27
+      '@types/node': 10.12.29
       '@types/ramda': 0.25.51
       '@zkochan/cmd-shim': 2.2.4
       arr-flatten: 1.1.0
@@ -460,7 +461,7 @@ packages:
       '@pnpm/package-bins': 1.0.0
       '@pnpm/types': 1.8.0
       '@types/mz': 0.0.32
-      '@types/node': 10.12.27
+      '@types/node': 10.12.29
       '@types/ramda': 0.25.51
       '@zkochan/cmd-shim': 2.2.4
       arr-flatten: 1.1.0
@@ -481,7 +482,7 @@ packages:
       integrity: sha512-thVgwrQ5rMcPYI6a0IPOt2pnlF1n5zX7BN4CrFeBp0/JCGsZAht/VOPv9bD3cZ+j0vDemEwE23BfhOWxmxq2yQ==
   /@pnpm/logger/1.0.2:
     dependencies:
-      '@types/node': 10.12.27
+      '@types/node': 10.12.29
       bole: 3.0.2
       ndjson: 1.5.0
     dev: false
@@ -661,10 +662,10 @@ packages:
     dev: false
     resolution:
       integrity: sha1-spbM5xRP+rd7hAkMqtTx5Lvqjgk=
-  /@types/node/10.12.27:
+  /@types/node/10.12.29:
     dev: false
     resolution:
-      integrity: sha512-e9wgeY6gaY21on3ve0xAjgBVjGDWq/xUteK0ujsE53bUoxycMkqfnkUgMt6ffZtykZ5X12Mg3T7Pw4TRCObDKg==
+      integrity: sha512-J/tnbnj8HcsBgCe2apZbdUpQ7hs4d7oZNTYA5bekWdP0sr2NGsOpI/HRdDroEi209tEvTcTtxhD0FfED3DhEcw==
   /@types/node/8.5.8:
     dev: false
     resolution:
@@ -938,9 +939,9 @@ packages:
       node: '>= 4.0.0'
     resolution:
       integrity: sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==
-  /ajv-keywords/3.4.0/ajv@6.9.2:
+  /ajv-keywords/3.4.0/ajv@6.10.0:
     dependencies:
-      ajv: 6.9.2
+      ajv: 6.10.0
     dev: false
     id: registry.npmjs.org/ajv-keywords/3.4.0
     peerDependencies:
@@ -956,7 +957,7 @@ packages:
     dev: false
     resolution:
       integrity: sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=
-  /ajv/6.9.2:
+  /ajv/6.10.0:
     dependencies:
       fast-deep-equal: 2.0.1
       fast-json-stable-stringify: 2.0.0
@@ -964,7 +965,7 @@ packages:
       uri-js: 4.2.2
     dev: false
     resolution:
-      integrity: sha512-4UFy0/LgDo7Oa/+wOAlj44tp9K78u38E5/359eSrqEp1Z5PdVfimCcs7SluXMP755RUQu6d2b4AvF0R1C9RZjg==
+      integrity: sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==
   /align-text/0.1.4:
     dependencies:
       kind-of: 3.2.2
@@ -1689,7 +1690,7 @@ packages:
       integrity: sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=
   /browserify-zlib/0.2.0:
     dependencies:
-      pako: 1.0.8
+      pako: 1.0.10
     dev: false
     resolution:
       integrity: sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==
@@ -1697,7 +1698,7 @@ packages:
     dependencies:
       caniuse-lite: 1.0.30000939
       electron-to-chromium: 1.3.113
-      node-releases: 1.1.8
+      node-releases: 1.1.9
     dev: false
     hasBin: true
     resolution:
@@ -3874,7 +3875,7 @@ packages:
       integrity: sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=
   /har-validator/5.1.3:
     dependencies:
-      ajv: 6.9.2
+      ajv: 6.10.0
       har-schema: 2.0.0
     dev: false
     engines:
@@ -6171,12 +6172,12 @@ packages:
     dev: false
     resolution:
       integrity: sha512-SUDEb+o71XR5lXSTyivXd9J7fCloE3SyP4lSgt3lU2oSANiox+SxlNRGPjDKrwU1YN3ix2KN/VGGCg0t01rttQ==
-  /node-releases/1.1.8:
+  /node-releases/1.1.9:
     dependencies:
       semver: 5.3.0
     dev: false
     resolution:
-      integrity: sha512-gQm+K9mGCiT/NXHy+V/ZZS1N/LOaGGqRAAJJs3X9Ah1g+CIbRcBgNyoNYQ+SEtcyAtB9KqDruu+fF7nWjsqRaA==
+      integrity: sha512-oic3GT4OtbWWKfRolz5Syw0Xus0KRFxeorLNj0s93ofX6PWyuzKjsiGxsCtWktBwwmTF6DdRRf2KreGqeOk5KA==
   /node-sass/4.9.3:
     dependencies:
       async-foreach: 0.1.3
@@ -6535,10 +6536,10 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=
-  /pako/1.0.8:
+  /pako/1.0.10:
     dev: false
     resolution:
-      integrity: sha512-6i0HVbUfcKaTv+EG8ZTr75az7GFXcLYk9UyLEg7Notv/Ma+z/UG3TCoz6GiNeOrn1E/e63I0X/Hpw18jHOTUnA==
+      integrity: sha512-0DTvPVU3ed8+HNXOu5Bs+o//Mbdj9VNQMUOe9oKCwh8l0GNwpTDMKCWbRjgtD291AWnkAgkqA/LOnQS8AmS1tw==
   /parse-asn1/5.1.4:
     dependencies:
       asn1.js: 4.10.1
@@ -8880,8 +8881,8 @@ packages:
     dependencies:
       acorn: 5.7.3
       acorn-dynamic-import: 2.0.2
-      ajv: 6.9.2
-      ajv-keywords: /ajv-keywords/3.4.0/ajv@6.9.2
+      ajv: 6.10.0
+      ajv-keywords: /ajv-keywords/3.4.0/ajv@6.10.0
       async: 2.6.2
       enhanced-resolve: 3.4.1
       escope: 3.6.0
@@ -9324,13 +9325,14 @@ packages:
       gulp: 3.9.1
       lodash: 4.17.11
       resolve: 1.8.1
+      source-map: 0.6.1
       tslint-microsoft-contrib: 5.2.1
       typescript: 3.1.6
       z-schema: 3.18.4
     dev: false
     name: '@rush-temp/api-extractor'
     resolution:
-      integrity: sha512-cFzMdCm9bWiXuf+NEJCMICwHM9G+MyIEihd5P7GPwQXSLcduw4yJcN4CIkkb7WWRrE77x9oldxw8QBOd0fUk0A==
+      integrity: sha512-CHPWl1Y6vqx9Li30FvlsgYMv4DecfgKGYdMcGEmamQOqUgSbWG9GWFXKmeJTz3mUgl/gD3wtHXcDg8NTvnJjIw==
       tarball: 'file:projects/api-extractor.tgz'
     version: 0.0.0
   'file:projects/gulp-core-build-mocha.tgz':
@@ -10141,6 +10143,7 @@ specifiers:
   resolve: 1.8.1
   semver: ~5.3.0
   sinon: ~1.17.3
+  source-map: ~0.6.1
   strict-uri-encode: ~2.0.0
   sudo: ~1.0.3
   tar: ~4.4.1


### PR DESCRIPTION
API Extractor analyzes .d.ts files, not .ts files.  When errors are reported, it's annoying for the coordinates to refer to the .d.ts file, since the person has to manually find the corresponding .ts file.

This PR makes use of "declaration maps" (new in TypeScript 3).  It's the same concept as [source maps](https://docs.google.com/document/d/1U1RGAehQwRypUTovF1KRlpiOFze0b-_2gc6fAH0KY0k/edit) except applied to `.d.ts` files instead of `.js` files.

To enable generation of `.d.ts.map` files, add set `declarationMap` in to your **tsconfig.json**.  For example:

```js
{
  "compilerOptions": {
    "target": "es6",
    "module": "commonjs",
    "declaration": true,
    "sourceMap": true,       // <---- Generates file.js.map
    "declarationMap": true,  // <---- Generate file.d.ts.map
    "strictNullChecks": true,
   . . .
}
```

Notes about the implementation:
- In general, source maps have many gaps in them.  (See [this visualizer](http://sokra.github.io/source-map-visualization/) for examples.)  To work around that, API Extractor finds the nearest matching position and then guesses by adding the line/column delta.
- If the guess takes us to a line/column that is out of bounds, then we fall back to the nearest source map entry.
- We do not apply source maps to compiler error messages, since those usually refer to issues in the .d.ts file itself
- I chose to use an older release of the **source-map** package, since the latest release uses [a strange performance optimization](https://github.com/mozilla/source-map/issues/331) that involves asynchronously loading a WASM binary
