### PR TITLE
[api-extractor] Fix an issue with TSDoc configuration and normalize tag case

### DIFF
--- a/apps/api-extractor/src/analyzer/AstImport.ts
+++ b/apps/api-extractor/src/analyzer/AstImport.ts
@@ -27,7 +27,7 @@ export enum AstImportKind {
 /**
  * Constructor parameters for AstImport
  *
- * @privateremarks
+ * @privateRemarks
  * Our naming convention is to use I____Parameters for constructor options and
  * I____Options for general function options.  However the word "parameters" is
  * confusingly similar to the terminology for function parameters modeled by API Extractor,

--- a/apps/api-extractor/src/analyzer/AstModule.ts
+++ b/apps/api-extractor/src/analyzer/AstModule.ts
@@ -23,7 +23,7 @@ export interface IAstModuleOptions {
 /**
  * An internal data structure that represents a source file that is analyzed by AstSymbolTable.
  *
- * @privateremarks
+ * @privateRemarks
  * Our naming convention is to use I____Parameters for constructor options and
  * I____Options for general function options.  However the word "parameters" is
  * confusingly similar to the terminology for function parameters modeled by API Extractor,

--- a/apps/api-extractor/src/api/IExtractorConfig.ts
+++ b/apps/api-extractor/src/api/IExtractorConfig.ts
@@ -377,44 +377,44 @@ export interface IExtractorConfig {
   compiler: IExtractorTsconfigCompilerConfig | IExtractorRuntimeCompilerConfig;
 
   /**
-   * {@inheritdoc IExtractorPoliciesConfig}
+   * {@inheritDoc IExtractorPoliciesConfig}
    */
   policies?: IExtractorPoliciesConfig;
 
   /**
-   * {@inheritdoc IExtractorValidationRulesConfig}
+   * {@inheritDoc IExtractorValidationRulesConfig}
    */
   validationRules?: IExtractorValidationRulesConfig;
 
   /**
-   * {@inheritdoc IExtractorProjectConfig}
+   * {@inheritDoc IExtractorProjectConfig}
    */
   project: IExtractorProjectConfig;
 
   /**
-   * {@inheritdoc IExtractorApiReviewFileConfig}
+   * {@inheritDoc IExtractorApiReviewFileConfig}
    */
   apiReviewFile?: IExtractorApiReviewFileConfig;
 
   /**
-   * {@inheritdoc IExtractorApiJsonFileConfig}
+   * {@inheritDoc IExtractorApiJsonFileConfig}
    */
   apiJsonFile?: IExtractorApiJsonFileConfig;
 
   /**
-   * {@inheritdoc IExtractorDtsRollupConfig}
+   * {@inheritDoc IExtractorDtsRollupConfig}
    * @beta
    */
   dtsRollup?: IExtractorDtsRollupConfig;
 
   /**
-   * {@inheritdoc IExtractorTsdocMetadataConfig}
+   * {@inheritDoc IExtractorTsdocMetadataConfig}
    * @beta
    */
   tsdocMetadata?: IExtractorTsdocMetadataConfig;
 
   /**
-   * {@inheritdoc IExtractorMessagesConfig}
+   * {@inheritDoc IExtractorMessagesConfig}
    */
   messages?: IExtractorMessagesConfig;
 

--- a/apps/api-extractor/src/collector/Collector.ts
+++ b/apps/api-extractor/src/collector/Collector.ts
@@ -32,6 +32,7 @@ import { DeclarationMetadata } from './DeclarationMetadata';
 import { SymbolMetadata } from './SymbolMetadata';
 import { TypeScriptInternals } from '../analyzer/TypeScriptInternals';
 import { MessageRouter } from './MessageRouter';
+import { AedocDefinitions } from '../aedoc/AedocDefinitions';
 
 /**
  * Options for Collector constructor.
@@ -125,7 +126,7 @@ export class Collector {
     this.program = options.program;
     this.typeChecker = options.program.getTypeChecker();
 
-    this._tsdocParser = new tsdoc.TSDocParser();
+    this._tsdocParser = new tsdoc.TSDocParser(AedocDefinitions.tsdocConfiguration);
     this.astSymbolTable = new AstSymbolTable(this.program, this.typeChecker, this.packageJsonLookup, this.logger);
   }
 

--- a/apps/api-extractor/src/collector/WorkingPackage.ts
+++ b/apps/api-extractor/src/collector/WorkingPackage.ts
@@ -57,7 +57,7 @@ export class WorkingPackage {
   public readonly entryPointSourceFile: ts.SourceFile;
 
   /**
-   * The `@packagedocumentation` comment, if any, for the working package.
+   * The `@packageDocumentation` comment, if any, for the working package.
    */
   public tsdocComment: tsdoc.DocComment | undefined;
 

--- a/apps/api-extractor/src/generators/DtsRollupGenerator.ts
+++ b/apps/api-extractor/src/generators/DtsRollupGenerator.ts
@@ -174,9 +174,9 @@ export class DtsRollupGenerator {
     let recurseChildren: boolean = true;
     switch (span.kind) {
       case ts.SyntaxKind.JSDocComment:
-        // If the @packagedocumentation comment seems to be attached to one of the regular API items,
+        // If the @packageDocumentation comment seems to be attached to one of the regular API items,
         // omit it.  It gets explictly emitted at the top of the file.
-        if (span.node.getText().match(/(?:\s|\*)@packagedocumentation(?:\s|\*)/g)) {
+        if (span.node.getText().match(/(?:\s|\*)@packageDocumentation(?:\s|\*)/gi)) {
           span.modification.skipAll();
         }
 

--- a/apps/api-extractor/src/generators/ReviewFileGenerator.ts
+++ b/apps/api-extractor/src/generators/ReviewFileGenerator.ts
@@ -261,7 +261,7 @@ export class ReviewFileGenerator {
     }
 
     if (declarationMetadata.isEventProperty) {
-      footerParts.push('@eventproperty');
+      footerParts.push('@eventProperty');
     }
 
     if (declarationMetadata.tsdocComment) {

--- a/apps/api-extractor/src/index.ts
+++ b/apps/api-extractor/src/index.ts
@@ -6,7 +6,7 @@
  * It helps with validation, documentation, and reviewing of the exported API
  * for a TypeScript library.
  *
- * @packagedocumentation
+ * @packageDocumentation
  */
 
 export { ReleaseTag } from './aedoc/ReleaseTag';

--- a/apps/rush-lib/src/api/RushConfiguration.ts
+++ b/apps/rush-lib/src/api/RushConfiguration.ts
@@ -751,14 +751,14 @@ export class RushConfiguration {
   }
 
   /**
-   * {@inheritdoc PnpmOptionsConfiguration}
+   * {@inheritDoc PnpmOptionsConfiguration}
    */
   public get pnpmOptions(): PnpmOptionsConfiguration {
     return this._pnpmOptions;
   }
 
   /**
-   * {@inheritdoc YarnOptionsConfiguration}
+   * {@inheritDoc YarnOptionsConfiguration}
    */
   public get yarnOptions(): YarnOptionsConfiguration {
     return this._yarnOptions;

--- a/apps/rush-lib/src/index.ts
+++ b/apps/rush-lib/src/index.ts
@@ -3,7 +3,7 @@
 
 /**
  * A library for writing scripts that interact with the Rush tool.
- * @packagedocumentation
+ * @packageDocumentation
  */
 
 export {

--- a/apps/rush-lib/src/logic/taskRunner/TaskRunner.ts
+++ b/apps/rush-lib/src/logic/taskRunner/TaskRunner.ts
@@ -108,7 +108,6 @@ export class TaskRunner {
    * Defines the list of dependencies for an individual task.
    * @param taskName - the string name of the task for which we are defining dependencies. A task with this
    * name must already have been registered.
-   * @taskDependencies
    */
   public addDependencies(taskName: string, taskDependencies: string[]): void {
     const task: ITask | undefined = this._tasks.get(taskName);

--- a/build-tests/api-documenter-test/etc/api-documenter-test.api.json
+++ b/build-tests/api-documenter-test/etc/api-documenter-test.api.json
@@ -6,7 +6,7 @@
   },
   "kind": "Package",
   "canonicalReference": "api-documenter-test",
-  "docComment": "/**\n * api-extractor-test-05\n *\n * This project tests various documentation generation scenarios and doc comment syntaxes.\n *\n * @packagedocumentation\n */\n",
+  "docComment": "/**\n * api-extractor-test-05\n *\n * This project tests various documentation generation scenarios and doc comment syntaxes.\n *\n * @packageDocumentation\n */\n",
   "name": "api-documenter-test",
   "members": [
     {
@@ -40,7 +40,7 @@
         {
           "kind": "Class",
           "canonicalReference": "(DocClass1:class)",
-          "docComment": "/**\n * This is an example class.\n *\n * @remarks\n *\n * These are some remarks.\n *\n * @defaultvalue\n *\n * a default value for this function\n *\n * @public\n */\n",
+          "docComment": "/**\n * This is an example class.\n *\n * @remarks\n *\n * These are some remarks.\n *\n * @defaultValue\n *\n * a default value for this function\n *\n * @public\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -327,7 +327,7 @@
             {
               "kind": "Property",
               "canonicalReference": "(malformedEvent:instance)",
-              "docComment": "/**\n * This event should have been marked as readonly.\n *\n * @eventproperty\n */\n",
+              "docComment": "/**\n * This event should have been marked as readonly.\n *\n * @eventProperty\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Reference",
@@ -357,7 +357,7 @@
             {
               "kind": "Property",
               "canonicalReference": "(modifiedEvent:instance)",
-              "docComment": "/**\n * This event is fired whenever the object is modified.\n *\n * @eventproperty\n */\n",
+              "docComment": "/**\n * This event is fired whenever the object is modified.\n *\n * @eventProperty\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",

--- a/build-tests/api-documenter-test/etc/api-documenter-test.api.ts
+++ b/build-tests/api-documenter-test/etc/api-documenter-test.api.ts
@@ -13,9 +13,9 @@ declare class DocClass1 extends DocBaseClass implements IDocInterface1, IDocInte
     exampleFunction(a: string, b: string): string;
     exampleFunction(x: number): number;
     interestingEdgeCases(): void;
-    // @eventproperty
+    // @eventProperty
     malformedEvent: SystemEvent;
-    // @eventproperty
+    // @eventProperty
     readonly modifiedEvent: SystemEvent;
     regularProperty: SystemEvent;
     static sumWithExample(x: number, y: number): number;

--- a/build-tests/api-documenter-test/src/DocClass1.ts
+++ b/build-tests/api-documenter-test/src/DocClass1.ts
@@ -66,7 +66,7 @@ export interface IDocInterface3 {
  *
  * @remarks
  * These are some remarks.
- * @defaultvalue a default value for this function
+ * @defaultValue a default value for this function
  * @public
  */
 export class DocClass1 extends DocBaseClass implements IDocInterface1, IDocInterface2 {
@@ -96,13 +96,13 @@ export class DocClass1 extends DocBaseClass implements IDocInterface1, IDocInter
 
   /**
    * This event is fired whenever the object is modified.
-   * @eventproperty
+   * @eventProperty
    */
   public readonly modifiedEvent: SystemEvent;
 
   /**
    * This event should have been marked as readonly.
-   * @eventproperty
+   * @eventProperty
    */
   public malformedEvent: SystemEvent;
 

--- a/build-tests/api-documenter-test/src/index.ts
+++ b/build-tests/api-documenter-test/src/index.ts
@@ -7,7 +7,7 @@
  * This project tests various documentation generation scenarios and
  * doc comment syntaxes.
  *
- * @packagedocumentation
+ * @packageDocumentation
  */
 
 export * from './DocClass1';

--- a/build-tests/api-extractor-lib1-test/src/index.ts
+++ b/build-tests/api-extractor-lib1-test/src/index.ts
@@ -7,7 +7,7 @@
  * @remarks
  * This library is consumed by api-extractor-scenarios.
  *
- * @packagedocumentation
+ * @packageDocumentation
  */
 
 class Lib1ForgottenExport {

--- a/build-tests/api-extractor-lib2-test/src/index.ts
+++ b/build-tests/api-extractor-lib2-test/src/index.ts
@@ -7,7 +7,7 @@
  * @remarks
  * This library is consumed by api-extractor-scenarios.
  *
- * @packagedocumentation
+ * @packageDocumentation
  */
 
 /** @public */

--- a/build-tests/api-extractor-lib3-test/src/index.ts
+++ b/build-tests/api-extractor-lib3-test/src/index.ts
@@ -7,7 +7,7 @@
  * @remarks
  * This library is consumed by api-extractor-scenarios.
  *
- * @packagedocumentation
+ * @packageDocumentation
  */
 
 export { Lib1Class } from 'api-extractor-lib1-test';

--- a/build-tests/api-extractor-test-01/dist/beta/api-extractor-test-01.d.ts
+++ b/build-tests/api-extractor-test-01/dist/beta/api-extractor-test-01.d.ts
@@ -6,7 +6,7 @@
  * It tests the basic types of definitions, and all the weird cases for following
  * chains of type aliases.
  *
- * @packagedocumentation
+ * @packageDocumentation
  */
 
 /// <reference types="jest" />
@@ -283,7 +283,7 @@ export declare class TypeReferencesInAedoc {
      * @returns An object of type {@link TypeReferencesInAedoc}.
      */
     getValue(arg1: TypeReferencesInAedoc): TypeReferencesInAedoc;
-    /** {@inheritdoc api-extractor-test-01#TypeReferencesInAedoc.getValue} */
+    /** {@inheritDoc api-extractor-test-01#TypeReferencesInAedoc.getValue} */
     getValue2(arg1: TypeReferencesInAedoc): TypeReferencesInAedoc;
     /**
      * @param arg - Malformed param reference.

--- a/build-tests/api-extractor-test-01/dist/internal/api-extractor-test-01.d.ts
+++ b/build-tests/api-extractor-test-01/dist/internal/api-extractor-test-01.d.ts
@@ -6,7 +6,7 @@
  * It tests the basic types of definitions, and all the weird cases for following
  * chains of type aliases.
  *
- * @packagedocumentation
+ * @packageDocumentation
  */
 
 /// <reference types="jest" />
@@ -304,7 +304,7 @@ export declare class TypeReferencesInAedoc {
      * @returns An object of type {@link TypeReferencesInAedoc}.
      */
     getValue(arg1: TypeReferencesInAedoc): TypeReferencesInAedoc;
-    /** {@inheritdoc api-extractor-test-01#TypeReferencesInAedoc.getValue} */
+    /** {@inheritDoc api-extractor-test-01#TypeReferencesInAedoc.getValue} */
     getValue2(arg1: TypeReferencesInAedoc): TypeReferencesInAedoc;
     /**
      * @param arg - Malformed param reference.

--- a/build-tests/api-extractor-test-01/dist/public/api-extractor-test-01.d.ts
+++ b/build-tests/api-extractor-test-01/dist/public/api-extractor-test-01.d.ts
@@ -6,7 +6,7 @@
  * It tests the basic types of definitions, and all the weird cases for following
  * chains of type aliases.
  *
- * @packagedocumentation
+ * @packageDocumentation
  */
 
 /// <reference types="jest" />
@@ -276,7 +276,7 @@ export declare class TypeReferencesInAedoc {
      * @returns An object of type {@link TypeReferencesInAedoc}.
      */
     getValue(arg1: TypeReferencesInAedoc): TypeReferencesInAedoc;
-    /** {@inheritdoc api-extractor-test-01#TypeReferencesInAedoc.getValue} */
+    /** {@inheritDoc api-extractor-test-01#TypeReferencesInAedoc.getValue} */
     getValue2(arg1: TypeReferencesInAedoc): TypeReferencesInAedoc;
     /**
      * @param arg - Malformed param reference.

--- a/build-tests/api-extractor-test-01/src/TypeReferencesInAedoc.ts
+++ b/build-tests/api-extractor-test-01/src/TypeReferencesInAedoc.ts
@@ -15,7 +15,7 @@ export class TypeReferencesInAedoc {
     return this;
   }
 
-  /** {@inheritdoc api-extractor-test-01#TypeReferencesInAedoc.getValue} */
+  /** {@inheritDoc api-extractor-test-01#TypeReferencesInAedoc.getValue} */
   public getValue2(arg1: TypeReferencesInAedoc): TypeReferencesInAedoc {
     return this;
   }

--- a/build-tests/api-extractor-test-01/src/index.ts
+++ b/build-tests/api-extractor-test-01/src/index.ts
@@ -9,7 +9,7 @@
  * It tests the basic types of definitions, and all the weird cases for following
  * chains of type aliases.
  *
- * @packagedocumentation
+ * @packageDocumentation
  */
 
 /**

--- a/build-tests/api-extractor-test-02/dist/beta/api-extractor-test-02.d.ts
+++ b/build-tests/api-extractor-test-02/dist/beta/api-extractor-test-02.d.ts
@@ -4,7 +4,7 @@
  * @remarks
  * This library consumes api-extractor-test-01 and is consumed by api-extractor-test-03.
  *
- * @packagedocumentation
+ * @packageDocumentation
  */
 
 import { ISimpleInterface } from 'api-extractor-test-01';

--- a/build-tests/api-extractor-test-02/dist/internal/api-extractor-test-02.d.ts
+++ b/build-tests/api-extractor-test-02/dist/internal/api-extractor-test-02.d.ts
@@ -4,7 +4,7 @@
  * @remarks
  * This library consumes api-extractor-test-01 and is consumed by api-extractor-test-03.
  *
- * @packagedocumentation
+ * @packageDocumentation
  */
 
 import { ISimpleInterface } from 'api-extractor-test-01';

--- a/build-tests/api-extractor-test-02/dist/public/api-extractor-test-02.d.ts
+++ b/build-tests/api-extractor-test-02/dist/public/api-extractor-test-02.d.ts
@@ -4,7 +4,7 @@
  * @remarks
  * This library consumes api-extractor-test-01 and is consumed by api-extractor-test-03.
  *
- * @packagedocumentation
+ * @packageDocumentation
  */
 
 import { ISimpleInterface } from 'api-extractor-test-01';

--- a/build-tests/api-extractor-test-02/src/index.ts
+++ b/build-tests/api-extractor-test-02/src/index.ts
@@ -9,7 +9,7 @@
  * @remarks
  * This library consumes api-extractor-test-01 and is consumed by api-extractor-test-03.
  *
- * @packagedocumentation
+ * @packageDocumentation
  */
 export { SubclassWithImport } from './SubclassWithImport';
 

--- a/build-tests/api-extractor-test-04/dist/beta/api-extractor-test-04.d.ts
+++ b/build-tests/api-extractor-test-04/dist/beta/api-extractor-test-04.d.ts
@@ -3,7 +3,7 @@
  *
  * Test scenarios for trimming alpha/beta/internal definitions from the generated *.d.ts files.
  *
- * @packagedocumentation
+ * @packageDocumentation
  */
 
 

--- a/build-tests/api-extractor-test-04/dist/internal/api-extractor-test-04.d.ts
+++ b/build-tests/api-extractor-test-04/dist/internal/api-extractor-test-04.d.ts
@@ -3,7 +3,7 @@
  *
  * Test scenarios for trimming alpha/beta/internal definitions from the generated *.d.ts files.
  *
- * @packagedocumentation
+ * @packageDocumentation
  */
 
 import { Lib1Interface } from 'api-extractor-lib1-test';

--- a/build-tests/api-extractor-test-04/dist/public/api-extractor-test-04.d.ts
+++ b/build-tests/api-extractor-test-04/dist/public/api-extractor-test-04.d.ts
@@ -3,7 +3,7 @@
  *
  * Test scenarios for trimming alpha/beta/internal definitions from the generated *.d.ts files.
  *
- * @packagedocumentation
+ * @packageDocumentation
  */
 
 

--- a/build-tests/api-extractor-test-04/src/index.ts
+++ b/build-tests/api-extractor-test-04/src/index.ts
@@ -6,7 +6,7 @@
  *
  * Test scenarios for trimming alpha/beta/internal definitions from the generated *.d.ts files.
  *
- * @packagedocumentation
+ * @packageDocumentation
  */
 
 export { AlphaClass } from './AlphaClass';

--- a/common/changes/@microsoft/api-extractor/octogonz-ae-tsdoc_2019-03-10-03-46.json
+++ b/common/changes/@microsoft/api-extractor/octogonz-ae-tsdoc_2019-03-10-03-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor",
+      "comment": "Fix an issue where spurious TSDoc warnings were issued because the TSDoc parser was configured improperly",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor",
+  "email": "octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/load-themed-styles/octogonz-ae-tsdoc_2019-03-10-03-46.json
+++ b/common/changes/@microsoft/load-themed-styles/octogonz-ae-tsdoc_2019-03-10-03-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/load-themed-styles",
+      "comment": "Fix some API doc comments to use correct TSDoc syntax",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/load-themed-styles",
+  "email": "octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/loader-load-themed-styles/octogonz-ae-tsdoc_2019-03-10-03-46.json
+++ b/common/changes/@microsoft/loader-load-themed-styles/octogonz-ae-tsdoc_2019-03-10-03-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@microsoft/loader-load-themed-styles",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/loader-load-themed-styles",
+  "email": "octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/node-core-library/octogonz-ae-tsdoc_2019-03-10-03-46.json
+++ b/common/changes/@microsoft/node-core-library/octogonz-ae-tsdoc_2019-03-10-03-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@microsoft/node-core-library",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/node-core-library",
+  "email": "octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/resolve-chunk-plugin/octogonz-ae-tsdoc_2019-03-10-03-46.json
+++ b/common/changes/@microsoft/resolve-chunk-plugin/octogonz-ae-tsdoc_2019-03-10-03-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@microsoft/resolve-chunk-plugin",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/resolve-chunk-plugin",
+  "email": "octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush/octogonz-ae-tsdoc_2019-03-10-03-46.json
+++ b/common/changes/@microsoft/rush/octogonz-ae-tsdoc_2019-03-10-03-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@microsoft/rush",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/set-webpack-public-path-plugin/octogonz-ae-tsdoc_2019-03-10-03-46.json
+++ b/common/changes/@microsoft/set-webpack-public-path-plugin/octogonz-ae-tsdoc_2019-03-10-03-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@microsoft/set-webpack-public-path-plugin",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/set-webpack-public-path-plugin",
+  "email": "octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/ts-command-line/octogonz-ae-tsdoc_2019-03-10-03-46.json
+++ b/common/changes/@microsoft/ts-command-line/octogonz-ae-tsdoc_2019-03-10-03-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@microsoft/ts-command-line",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/ts-command-line",
+  "email": "octogonz@users.noreply.github.com"
+}

--- a/libraries/load-themed-styles/src/index.ts
+++ b/libraries/load-themed-styles/src/index.ts
@@ -64,11 +64,12 @@ interface IStyleRecord {
 
 /**
  * object returned from resolveThemableArray function
- * @styleString:  this string is the processed styles in string
- * @themable:     this boolean indicates if this style array is themable
  */
 interface IThemableArrayResolveResult {
+  /** this string is the processed styles in string */
   styleString: string;
+
+  /** this boolean indicates if this style array is themable */
   themable: boolean;
 }
 
@@ -84,13 +85,13 @@ export const enum Mode {
 /**
  * Themable styles and non-themable styles are tracked separately
  * Specify ClearStyleOptions when calling clearStyles API to specify which group of registered styles should be cleared.
- * @onlyThemable: only themable styles will be cleared
- * @onlyNonThemable: only non-themable styles will be cleared
- * @all: both themable and non-themable styles will be cleared
  */
 export const enum ClearStyleOptions {
+  /** only themable styles will be cleared */
   onlyThemable = 1,
+  /** only non-themable styles will be cleared */
   onlyNonThemable = 2,
+  /** both themable and non-themable styles will be cleared */
   all = 3
 }
 
@@ -258,7 +259,7 @@ export function loadTheme(theme: ITheme | undefined): void {
 
 /**
  * Clear already registered style elements and style records in theme_State object
- * @option: specify which group of registered styles should be cleared.
+ * @param option - specify which group of registered styles should be cleared.
  * Default to be both themable and non-themable styles will be cleared
  */
 export function clearStyles(option: ClearStyleOptions = ClearStyleOptions.all): void {

--- a/libraries/node-core-library/src/Executable.ts
+++ b/libraries/node-core-library/src/Executable.ts
@@ -131,7 +131,7 @@ export class Executable {
    * @param options - Additional options
    * @returns the same data type as returned by the NodeJS child_process.spawnSync() API
    *
-   * @internalremarks
+   * @privateRemarks
    *
    * NOTE: The NodeJS spawnSync() returns SpawnSyncReturns<string> or SpawnSyncReturns<Buffer>
    * polymorphically based on the options.encoding parameter value.  This is a fairly confusing

--- a/libraries/node-core-library/src/PackageName.ts
+++ b/libraries/node-core-library/src/PackageName.ts
@@ -149,14 +149,14 @@ export class PackageName {
   }
 
   /**
-   * {@inheritdoc IParsedPackageName.scope}
+   * {@inheritDoc IParsedPackageName.scope}
    */
   public static getScope(packageName: string): string {
     return PackageName.parse(packageName).scope;
   }
 
   /**
-   * {@inheritdoc IParsedPackageName.unscopedName}
+   * {@inheritDoc IParsedPackageName.unscopedName}
    */
   public static getUnscopedName(packageName: string): string {
     return PackageName.parse(packageName).unscopedName;

--- a/libraries/node-core-library/src/StringBuilder.ts
+++ b/libraries/node-core-library/src/StringBuilder.ts
@@ -47,12 +47,12 @@ export class StringBuilder implements IStringBuilder {
     this._chunks = [];
   }
 
-  /** {@inheritdoc IStringBuilder.append} */
+  /** {@inheritDoc IStringBuilder.append} */
   public append(text: string): void {
     this._chunks.push(text);
   }
 
-  /** {@inheritdoc IStringBuilder.toString} */
+  /** {@inheritDoc IStringBuilder.toString} */
   public toString(): string {
     if (this._chunks.length === 0) {
       return '';

--- a/libraries/node-core-library/src/Terminal/ConsoleTerminalProvider.ts
+++ b/libraries/node-core-library/src/Terminal/ConsoleTerminalProvider.ts
@@ -35,7 +35,7 @@ export class ConsoleTerminalProvider implements ITerminalProvider {
   }
 
   /**
-   * {@inheritdoc ITerminalProvider.write}
+   * {@inheritDoc ITerminalProvider.write}
    */
   public write(data: string, severity: TerminalProviderSeverity): void {
     switch (severity) {
@@ -61,14 +61,14 @@ export class ConsoleTerminalProvider implements ITerminalProvider {
   }
 
   /**
-   * {@inheritdoc ITerminalProvider.eolCharacter}
+   * {@inheritDoc ITerminalProvider.eolCharacter}
    */
   public get eolCharacter(): string {
     return EOL;
   }
 
   /**
-   * {@inheritdoc ITerminalProvider.supportsColor}
+   * {@inheritDoc ITerminalProvider.supportsColor}
    */
   public get supportsColor(): boolean {
     return supportsColor;

--- a/libraries/node-core-library/src/Terminal/StringBufferTerminalProvider.ts
+++ b/libraries/node-core-library/src/Terminal/StringBufferTerminalProvider.ts
@@ -25,7 +25,7 @@ export class StringBufferTerminalProvider implements ITerminalProvider {
   }
 
   /**
-   * {@inheritdoc ITerminalProvider.write}
+   * {@inheritDoc ITerminalProvider.write}
    */
   public write(data: string, severity: TerminalProviderSeverity): void {
     switch (severity) {
@@ -53,14 +53,14 @@ export class StringBufferTerminalProvider implements ITerminalProvider {
   }
 
   /**
-   * {@inheritdoc ITerminalProvider.eolCharacter}
+   * {@inheritDoc ITerminalProvider.eolCharacter}
    */
   public get eolCharacter(): string {
     return '[n]';
   }
 
   /**
-   * {@inheritdoc ITerminalProvider.supportsColor}
+   * {@inheritDoc ITerminalProvider.supportsColor}
    */
   public get supportsColor(): boolean {
     return this._supportsColor;

--- a/libraries/node-core-library/src/index.ts
+++ b/libraries/node-core-library/src/index.ts
@@ -4,7 +4,7 @@
 /**
  * Core libraries that every NodeJS toolchain project should use.
  *
- * @packagedocumentation
+ * @packageDocumentation
  */
 
 export {

--- a/libraries/rushell/src/index.ts
+++ b/libraries/rushell/src/index.ts
@@ -4,7 +4,7 @@
 /**
  * Execute shell commands using a consistent syntax on every platform.
  *
- * @packagedocumentation
+ * @packageDocumentation
  */
 
 export {

--- a/libraries/ts-command-line/src/CommandLineAction.ts
+++ b/libraries/ts-command-line/src/CommandLineAction.ts
@@ -39,13 +39,13 @@ export abstract class CommandLineAction extends CommandLineParameterProvider {
   // Example: "do-something"
   private static _actionNameRegExp: RegExp = /^[a-z]+(-[a-z]+)*$/;
 
-  /** {@inheritdoc ICommandLineActionOptions.actionName} */
+  /** {@inheritDoc ICommandLineActionOptions.actionName} */
   public readonly actionName: string;
 
-  /** {@inheritdoc ICommandLineActionOptions.summary} */
+  /** {@inheritDoc ICommandLineActionOptions.summary} */
   public readonly summary: string;
 
-  /** {@inheritdoc ICommandLineActionOptions.documentation} */
+  /** {@inheritDoc ICommandLineActionOptions.documentation} */
   public readonly documentation: string;
 
   private _argumentParser: argparse.ArgumentParser | undefined;
@@ -95,7 +95,7 @@ export abstract class CommandLineAction extends CommandLineParameterProvider {
   }
 
   /**
-   * {@inheritdoc CommandLineParameterProvider._getArgumentParser}
+   * {@inheritDoc CommandLineParameterProvider._getArgumentParser}
    * @internal
    */
   protected _getArgumentParser(): argparse.ArgumentParser { // override
@@ -108,7 +108,7 @@ export abstract class CommandLineAction extends CommandLineParameterProvider {
   }
 
   /**
-   * {@inheritdoc CommandLineParameterProvider.onDefineParameters}
+   * {@inheritDoc CommandLineParameterProvider.onDefineParameters}
    */
   protected abstract onDefineParameters(): void;
 

--- a/libraries/ts-command-line/src/CommandLineDefinition.ts
+++ b/libraries/ts-command-line/src/CommandLineDefinition.ts
@@ -74,7 +74,7 @@ export interface ICommandLineChoiceDefinition extends IBaseCommandLineDefinition
   alternatives: string[];
 
   /**
-   * {@inheritdoc ICommandLineStringDefinition.defaultValue}
+   * {@inheritDoc ICommandLineStringDefinition.defaultValue}
    */
   defaultValue?: string;
 }
@@ -95,7 +95,7 @@ export interface ICommandLineFlagDefinition extends IBaseCommandLineDefinition {
  */
 export interface ICommandLineIntegerDefinition extends IBaseCommandLineDefinitionWithArgument {
   /**
-   * {@inheritdoc ICommandLineStringDefinition.defaultValue}
+   * {@inheritDoc ICommandLineStringDefinition.defaultValue}
    */
   defaultValue?: number;
 }

--- a/libraries/ts-command-line/src/CommandLineParameter.ts
+++ b/libraries/ts-command-line/src/CommandLineParameter.ts
@@ -51,19 +51,19 @@ export abstract class CommandLineParameter {
    */
   public _parserKey: string;
 
-  /** {@inheritdoc IBaseCommandLineDefinition.parameterLongName} */
+  /** {@inheritDoc IBaseCommandLineDefinition.parameterLongName} */
   public readonly longName: string;
 
-  /** {@inheritdoc IBaseCommandLineDefinition.parameterShortName} */
+  /** {@inheritDoc IBaseCommandLineDefinition.parameterShortName} */
   public readonly shortName: string | undefined;
 
-  /** {@inheritdoc IBaseCommandLineDefinition.description} */
+  /** {@inheritDoc IBaseCommandLineDefinition.description} */
   public readonly description: string;
 
-  /** {@inheritdoc IBaseCommandLineDefinition.required} */
+  /** {@inheritDoc IBaseCommandLineDefinition.required} */
   public readonly required: boolean;
 
-  /** {@inheritdoc IBaseCommandLineDefinition.environmentVariable} */
+  /** {@inheritDoc IBaseCommandLineDefinition.environmentVariable} */
   public readonly environmentVariable: string | undefined;
 
   /** @internal */
@@ -169,7 +169,7 @@ export abstract class CommandLineParameterWithArgument extends CommandLineParame
   // Matches the first character that *isn't* part of a valid upper-case argument name such as "URL_2"
   private static _invalidArgumentNameRegExp: RegExp = /[^A-Z_0-9]/;
 
-  /** {@inheritdoc IBaseCommandLineDefinitionWithArgument.argumentName} */
+  /** {@inheritDoc IBaseCommandLineDefinitionWithArgument.argumentName} */
   public readonly argumentName: string;
 
   /** @internal */
@@ -197,10 +197,10 @@ export abstract class CommandLineParameterWithArgument extends CommandLineParame
  * @public
  */
 export class CommandLineChoiceParameter extends CommandLineParameter {
-  /** {@inheritdoc ICommandLineChoiceDefinition.alternatives} */
+  /** {@inheritDoc ICommandLineChoiceDefinition.alternatives} */
   public readonly alternatives: ReadonlyArray<string>;
 
-  /** {@inheritdoc ICommandLineStringDefinition.defaultValue} */
+  /** {@inheritDoc ICommandLineStringDefinition.defaultValue} */
   public readonly defaultValue: string | undefined;
 
   private _value: string | undefined = undefined;
@@ -222,13 +222,13 @@ export class CommandLineChoiceParameter extends CommandLineParameter {
     this.validateDefaultValue(!!this.defaultValue);
   }
 
-  /** {@inheritdoc CommandLineParameter.kind} */
+  /** {@inheritDoc CommandLineParameter.kind} */
   public get kind(): CommandLineParameterKind {
     return CommandLineParameterKind.Choice;
   }
 
   /**
-   * {@inheritdoc CommandLineParameter._setValue}
+   * {@inheritDoc CommandLineParameter._setValue}
    * @internal
    */
   // tslint:disable-next-line:no-any
@@ -264,7 +264,7 @@ export class CommandLineChoiceParameter extends CommandLineParameter {
   }
 
   /**
-   * {@inheritdoc CommandLineParameter._getSupplementaryNotes}
+   * {@inheritDoc CommandLineParameter._getSupplementaryNotes}
    * @internal
    */
   public _getSupplementaryNotes(supplementaryNotes: string[]): void { // virtual
@@ -285,7 +285,7 @@ export class CommandLineChoiceParameter extends CommandLineParameter {
     return this._value;
   }
 
-  /** {@inheritdoc CommandLineParameter.appendToArgList} @override */
+  /** {@inheritDoc CommandLineParameter.appendToArgList} @override */
   public appendToArgList(argList: string[]): void {
     if (this.value !== undefined) {
       argList.push(this.longName);
@@ -306,13 +306,13 @@ export class CommandLineFlagParameter extends CommandLineParameter {
     super(definition);
   }
 
-  /** {@inheritdoc CommandLineParameter.kind} */
+  /** {@inheritDoc CommandLineParameter.kind} */
   public get kind(): CommandLineParameterKind {
     return CommandLineParameterKind.Flag;
   }
 
   /**
-   * {@inheritdoc CommandLineParameter._setValue}
+   * {@inheritDoc CommandLineParameter._setValue}
    * @internal
    */
   // tslint:disable-next-line:no-any
@@ -352,7 +352,7 @@ export class CommandLineFlagParameter extends CommandLineParameter {
     return this._value;
   }
 
-  /** {@inheritdoc CommandLineParameter.appendToArgList} @override */
+  /** {@inheritDoc CommandLineParameter.appendToArgList} @override */
   public appendToArgList(argList: string[]): void {
     if (this.value) {
       argList.push(this.longName);
@@ -365,7 +365,7 @@ export class CommandLineFlagParameter extends CommandLineParameter {
  * @public
  */
 export class CommandLineIntegerParameter extends CommandLineParameterWithArgument {
-  /** {@inheritdoc ICommandLineStringDefinition.defaultValue} */
+  /** {@inheritDoc ICommandLineStringDefinition.defaultValue} */
   public readonly defaultValue: number | undefined;
 
   private _value: number | undefined = undefined;
@@ -377,13 +377,13 @@ export class CommandLineIntegerParameter extends CommandLineParameterWithArgumen
     this.validateDefaultValue(!!this.defaultValue);
   }
 
-  /** {@inheritdoc CommandLineParameter.kind} */
+  /** {@inheritDoc CommandLineParameter.kind} */
   public get kind(): CommandLineParameterKind {
     return CommandLineParameterKind.Integer;
   }
 
   /**
-   * {@inheritdoc CommandLineParameter._setValue}
+   * {@inheritDoc CommandLineParameter._setValue}
    * @internal
    */
   // tslint:disable-next-line:no-any
@@ -419,7 +419,7 @@ export class CommandLineIntegerParameter extends CommandLineParameterWithArgumen
   }
 
   /**
-   * {@inheritdoc CommandLineParameter._getSupplementaryNotes}
+   * {@inheritDoc CommandLineParameter._getSupplementaryNotes}
    * @internal
    */
   public _getSupplementaryNotes(supplementaryNotes: string[]): void { // virtual
@@ -440,7 +440,7 @@ export class CommandLineIntegerParameter extends CommandLineParameterWithArgumen
     return this._value;
   }
 
-  /** {@inheritdoc CommandLineParameter.appendToArgList} @override */
+  /** {@inheritDoc CommandLineParameter.appendToArgList} @override */
   public appendToArgList(argList: string[]): void {
     if (this.value !== undefined) {
       argList.push(this.longName);
@@ -454,7 +454,7 @@ export class CommandLineIntegerParameter extends CommandLineParameterWithArgumen
  * @public
  */
 export class CommandLineStringParameter extends CommandLineParameterWithArgument {
-  /** {@inheritdoc ICommandLineStringDefinition.defaultValue} */
+  /** {@inheritDoc ICommandLineStringDefinition.defaultValue} */
   public readonly defaultValue: string | undefined;
 
   private _value: string | undefined = undefined;
@@ -467,13 +467,13 @@ export class CommandLineStringParameter extends CommandLineParameterWithArgument
     this.validateDefaultValue(!!this.defaultValue);
   }
 
-  /** {@inheritdoc CommandLineParameter.kind} */
+  /** {@inheritDoc CommandLineParameter.kind} */
   public get kind(): CommandLineParameterKind {
     return CommandLineParameterKind.String;
   }
 
   /**
-   * {@inheritdoc CommandLineParameter._setValue}
+   * {@inheritDoc CommandLineParameter._setValue}
    * @internal
    */
   // tslint:disable-next-line:no-any
@@ -506,7 +506,7 @@ export class CommandLineStringParameter extends CommandLineParameterWithArgument
   }
 
   /**
-   * {@inheritdoc CommandLineParameter._getSupplementaryNotes}
+   * {@inheritDoc CommandLineParameter._getSupplementaryNotes}
    * @internal
    */
   public _getSupplementaryNotes(supplementaryNotes: string[]): void { // virtual
@@ -529,7 +529,7 @@ export class CommandLineStringParameter extends CommandLineParameterWithArgument
     return this._value;
   }
 
-  /** {@inheritdoc CommandLineParameter.appendToArgList} @override */
+  /** {@inheritDoc CommandLineParameter.appendToArgList} @override */
   public appendToArgList(argList: string[]): void {
     if (this.value !== undefined) {
       argList.push(this.longName);
@@ -551,13 +551,13 @@ export class CommandLineStringListParameter extends CommandLineParameterWithArgu
     super(definition);
   }
 
-  /** {@inheritdoc CommandLineParameter.kind} */
+  /** {@inheritDoc CommandLineParameter.kind} */
   public get kind(): CommandLineParameterKind {
     return CommandLineParameterKind.StringList;
   }
 
   /**
-   * {@inheritdoc CommandLineParameter._setValue}
+   * {@inheritDoc CommandLineParameter._setValue}
    * @internal
    */
   // tslint:disable-next-line:no-any
@@ -608,7 +608,7 @@ export class CommandLineStringListParameter extends CommandLineParameterWithArgu
     return this._values;
   }
 
-  /** {@inheritdoc CommandLineParameter.appendToArgList} @override */
+  /** {@inheritDoc CommandLineParameter.appendToArgList} @override */
   public appendToArgList(argList: string[]): void {
     if (this.values.length > 0) {
       for (const value of this.values) {

--- a/libraries/ts-command-line/src/CommandLineParser.ts
+++ b/libraries/ts-command-line/src/CommandLineParser.ts
@@ -66,10 +66,10 @@ class CustomArgumentParser extends argparse.ArgumentParser {
  * @public
  */
 export abstract class CommandLineParser extends CommandLineParameterProvider {
-  /** {@inheritdoc ICommandLineParserOptions.toolFilename} */
+  /** {@inheritDoc ICommandLineParserOptions.toolFilename} */
   public readonly toolFilename: string;
 
-  /** {@inheritdoc ICommandLineParserOptions.toolDescription} */
+  /** {@inheritDoc ICommandLineParserOptions.toolDescription} */
   public readonly toolDescription: string;
 
   /**
@@ -238,7 +238,7 @@ export abstract class CommandLineParser extends CommandLineParameterProvider {
   }
 
   /**
-   * {@inheritdoc CommandLineParameterProvider._getArgumentParser}
+   * {@inheritDoc CommandLineParameterProvider._getArgumentParser}
    * @internal
    */
   protected _getArgumentParser(): argparse.ArgumentParser { // override

--- a/libraries/ts-command-line/src/index.ts
+++ b/libraries/ts-command-line/src/index.ts
@@ -4,7 +4,7 @@
 /**
  * An object-oriented command-line parser for TypeScript projects.
  *
- * @packagedocumentation
+ * @packageDocumentation
  */
 
 export {

--- a/stack/rush-stack-compiler-shared/src/shared/index.ts
+++ b/stack/rush-stack-compiler-shared/src/shared/index.ts
@@ -11,7 +11,7 @@
  * - [tslint](https://github.com/palantir/tslint#readme)
  * - [API Extractor](https://api-extractor.com/)
  *
- * @packagedocumentation
+ * @packageDocumentation
  */
 
 export { RushStackCompilerBase }  from './RushStackCompilerBase';

--- a/webpack/loader-load-themed-styles/src/LoadThemedStylesLoader.ts
+++ b/webpack/loader-load-themed-styles/src/LoadThemedStylesLoader.ts
@@ -4,7 +4,7 @@
 /**
  * This simple loader wraps the loading of CSS in script equivalent to
  *  require("load-themed-styles").loadStyles('... css text ...').
- * @packagedocumentation
+ * @packageDocumentation
  */
 
 import { loader } from 'webpack';

--- a/webpack/resolve-chunk-plugin/src/index.ts
+++ b/webpack/resolve-chunk-plugin/src/index.ts
@@ -4,7 +4,7 @@
 /**
  * This is a webpack plugin that looks for calls to `resolveChunk` with a chunk name, and returns the
  * chunk ID. It's useful for referencing a chunk without making webpack coalesce two chunks.
- * @packagedocumentation
+ * @packageDocumentation
  */
 
 export * from './ResolveChunkPlugin';

--- a/webpack/set-webpack-public-path-plugin/src/index.ts
+++ b/webpack/set-webpack-public-path-plugin/src/index.ts
@@ -5,7 +5,7 @@
  * This simple plugin sets the `__webpack_public_path__` variable to
  *  a value specified in the arguments, optionally appended to the SystemJs baseURL
  *  property.
- * @packagedocumentation
+ * @packageDocumentation
  */
 
 export * from './SetPublicPathPlugin';


### PR DESCRIPTION
API Extractor was incorrectly issuing warnings about proprietary tags such as `@internalRemarks` because the `AedocDefinitions.tsdocConfiguration` was not being passed down to the `TSDocParser`.  (This was overlooked because AE7 was not actually reporting TSDoc warnings until PR https://github.com/Microsoft/web-build-tools/pull/1120 was finally merged.)

This PR also updates a bunch of code comments to use TSDoc's camelCase (whereas the old AEDoc used all lowercase for its tags).