### PR TITLE
[rush] Remove the "rush check" step from the travis.yml template

### DIFF
--- a/apps/rush/README.md
+++ b/apps/rush/README.md
@@ -13,7 +13,7 @@
 
 - **A single NPM install:** In one step, Rush installs all the dependencies for all your projects into a common folder.  This is not just a "package.json" file at the root of your repo (which might set you up to accidentally `require()` a sibling's dependencies).  Instead, Rush uses symlinks to reconstruct an accurate "node_modules" folder for each project, without any of the limitations or glitches that seem to plague other approaches.
 
-  ⏵ **This algorithm supports the [PNPM, NPM, and Yarn]({% link pages/maintainer/package_managers.md %}) package managers.**
+  ⏵ **This algorithm supports the [PNPM, NPM, and Yarn](https://rushjs.io/pages/maintainer/package_managers/) package managers.**
 
 - **Automatic local linking:** Inside a Rush repo, all your projects are automatically symlinked to each other. When you make a change, you can see the downstream effects without publishing anything, and without any `npm link` headaches.  If you don't want certain projects to get linked, that's supported, too.
 

--- a/common/changes/@microsoft/rush/ianc-prepare-for-rush-publish_2019-03-15-01-55.json
+++ b/common/changes/@microsoft/rush/ianc-prepare-for-rush-publish_2019-03-15-01-55.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Remove the \"rush check\" step from the travis.yml template, since this is now handled by \"ensureConsistentVersions\" from rush.json",
+      "packageName": "@microsoft/rush",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "octogonz@users.noreply.github.com"
+}

--- a/common/config/azure-pipelines/templates/build.yaml
+++ b/common/config/azure-pipelines/templates/build.yaml
@@ -10,7 +10,7 @@ steps:
   displayName: 'git config name'
 - script: 'node common\scripts\install-run-rush.js change --verify'
   displayName: 'Verify Change Logs'
-- script: 'node common\scripts\install-run-rush.js install --bypass-policy'
+- script: 'node common\scripts\install-run-rush.js install'
   displayName: 'Rush Install'
 - script: 'node common\scripts\install-run-rush.js rebuild --verbose --production'
   displayName: 'Rush Rebuild'

--- a/common/config/azure-pipelines/templates/build.yaml
+++ b/common/config/azure-pipelines/templates/build.yaml
@@ -10,8 +10,6 @@ steps:
   displayName: 'git config name'
 - script: 'node common\scripts\install-run-rush.js change --verify'
   displayName: 'Verify Change Logs'
-- script: 'node common\scripts\install-run-rush.js check'
-  displayName: 'Rush Check'
 - script: 'node common\scripts\install-run-rush.js install --bypass-policy'
   displayName: 'Rush Install'
 - script: 'node common\scripts\install-run-rush.js rebuild --verbose --production'

--- a/common/config/azure-pipelines/templates/buildAndPublish.yaml
+++ b/common/config/azure-pipelines/templates/buildAndPublish.yaml
@@ -4,7 +4,5 @@ steps:
 - template: ./build.yaml
 - script: 'node common\scripts\install-run-rush.js version --bump --version-policy $(VersionPolicy) --target-branch $(Build.SourceBranchName)'
   displayName: 'Rush Version'
-- script: 'node common\scripts\install-run-rush.js check'
-  displayName: 'Rush Check'
 - script: 'node common\scripts\install-run-rush.js publish --apply --publish --include-all --target-branch $(Build.SourceBranchName) --npm-auth-token $(npmToken) --add-commit-details'
   displayName: 'Rush Publish'

--- a/common/config/rush/version-policies.json
+++ b/common/config/rush/version-policies.json
@@ -82,7 +82,7 @@
     "policyName": "rush",
     "definitionName": "lockStepVersion",
     "version": "5.6.0",
-    "nextBump": "minor",
+    "nextBump": "patch",
     "mainProject": "@microsoft/rush"
   }
 ]


### PR DESCRIPTION
This is now handled automatically by  the `ensureConsistentVersions` setting in rush.json