### PR TITLE
[rush]  Allow the ".git" file extension to be appended to the repository.url setting

### DIFF
--- a/apps/rush-lib/src/utilities/VersionControl.ts
+++ b/apps/rush-lib/src/utilities/VersionControl.ts
@@ -82,7 +82,15 @@ export class VersionControl {
           const remoteUrl: string = child_process.execSync(`git remote get-url ${remoteName}`)
             .toString()
             .trim();
-          return remoteUrl === repositoryUrl;
+          if (remoteUrl === repositoryUrl) {
+            return true;
+          }
+          // When you copy a URL from the GitHub web site, they append the ".git" file extension to the URL.
+          // So we allow that to be specified in rush.json, even though the file extension gets dropped
+          // by "git clone".
+          if (remoteUrl + '.git' === repositoryUrl) {
+            return true;
+          }
         }
         return false;
       });

--- a/common/changes/@microsoft/rush/octogonz-rush-allow-dot-git_2019-03-17-19-46.json
+++ b/common/changes/@microsoft/rush/octogonz-rush-allow-dot-git_2019-03-17-19-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Improve \"rush change\" to ignore the \".git\" file extension when appended to the \"repository.url\" setting in rush.json",
+      "packageName": "@microsoft/rush",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}


### PR DESCRIPTION
After we upgraded to Rush 5.6.0, `rush change` was reporting this error:

```
Unable to find a git remote matching the repository URL (undefined). Detected changes are likely to be incorrect.
```

The reason is that our `repository.url` has the ".git" file extension:

```json
    "url": "https://github.com/Microsoft/web-build-tools.git"
```

This is because the URL was copy+pasted from the GitHub web site's "Clone" button.  But the file extension is redundant and is dropped by `git clone`, so it doesn't appear in the list of remotes.

This PR relaxes the `rush change` comparison to ignore the `.git` file extension.