### PR TITLE
[api-extractor] Improve the API review files to include import and export signatures

### DIFF
--- a/apps/api-extractor/build-tests.cmd
+++ b/apps/api-extractor/build-tests.cmd
@@ -1,3 +1,3 @@
 @ECHO OFF
 @SETLOCAL
-rush build -t api-extractor-test-01 -t api-extractor-test-02 -t api-extractor-test-03 -t api-extractor-test-04 -t api-extractor-test-05 -t api-extractor-test-06
+rush build -t api-extractor-lib1-test -t api-extractor-lib2-test -t api-extractor-lib3-test -t api-extractor-scenarios -t api-extractor-test-01 -t api-extractor-test-02 -t api-extractor-test-03 -t api-extractor-test-04 -t api-documenter-test

--- a/apps/api-extractor/src/generators/DtsEmitHelpers.ts
+++ b/apps/api-extractor/src/generators/DtsEmitHelpers.ts
@@ -1,0 +1,57 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import * as ts from 'typescript';
+
+import { InternalError } from '@microsoft/node-core-library';
+import { CollectorEntity } from '../collector/CollectorEntity';
+import { AstImport, AstImportKind } from '../analyzer/AstImport';
+import { StringWriter } from './StringWriter';
+import { Collector } from '../collector/Collector';
+
+/**
+ * Some common code shared between DtsRollupGenerator and ReviewFileGenerator.
+ */
+export class DtsEmitHelpers {
+  public static emitImport(stringWriter: StringWriter, collectorEntity: CollectorEntity, astImport: AstImport): void {
+    switch (astImport.importKind) {
+      case AstImportKind.NamedImport:
+        if (collectorEntity.nameForEmit !== astImport.exportName) {
+          stringWriter.write(`import { ${astImport.exportName} as ${collectorEntity.nameForEmit} }`);
+        } else {
+          stringWriter.write(`import { ${astImport.exportName} }`);
+        }
+        stringWriter.writeLine(` from '${astImport.modulePath}';`);
+        break;
+      case AstImportKind.StarImport:
+        stringWriter.writeLine(`import * as ${collectorEntity.nameForEmit} from '${astImport.modulePath}';`);
+        break;
+      case AstImportKind.EqualsImport:
+        stringWriter.writeLine(`import ${collectorEntity.nameForEmit} = require('${astImport.modulePath}');`);
+        break;
+      default:
+        throw new InternalError('Unimplemented AstImportKind');
+    }
+  }
+
+  public static emitNamedExport(stringWriter: StringWriter, exportName: string,
+    collectorEntity: CollectorEntity): void {
+
+    if (exportName === ts.InternalSymbolName.Default) {
+      stringWriter.writeLine(`export default ${collectorEntity.nameForEmit};`);
+    } else if (collectorEntity.nameForEmit !== exportName) {
+      stringWriter.writeLine(`export { ${collectorEntity.nameForEmit} as ${exportName} }`);
+    } else {
+      stringWriter.writeLine(`export { ${exportName} }`);
+    }
+  }
+
+  public static emitStarExports(stringWriter: StringWriter, collector: Collector): void {
+    if (collector.starExportedExternalModulePaths.length > 0) {
+      stringWriter.writeLine();
+      for (const starExportedExternalModulePath of collector.starExportedExternalModulePaths) {
+        stringWriter.writeLine(`export * from "${starExportedExternalModulePath}";`);
+      }
+    }
+  }
+}

--- a/apps/api-extractor/src/generators/ReviewFileGenerator.ts
+++ b/apps/api-extractor/src/generators/ReviewFileGenerator.ts
@@ -137,6 +137,8 @@ export class ReviewFileGenerator {
 
       case ts.SyntaxKind.ExportKeyword:
       case ts.SyntaxKind.DefaultKeyword:
+      case ts.SyntaxKind.DeclareKeyword:
+        // Delete any explicit "export" or "declare" keywords -- we will re-add them below
         span.modification.skipAll();
         break;
 
@@ -194,7 +196,7 @@ export class ReviewFileGenerator {
           }
           const listPrefix: string = list.getSourceFile().text
             .substring(list.getStart(), list.declarations[0].getStart());
-          span.modification.prefix = 'declare ' + listPrefix + span.modification.prefix;
+          span.modification.prefix = listPrefix + span.modification.prefix;
           span.modification.suffix = ';';
 
           if (entity.shouldInlineExport) {

--- a/apps/api-extractor/src/generators/ReviewFileGenerator.ts
+++ b/apps/api-extractor/src/generators/ReviewFileGenerator.ts
@@ -16,6 +16,7 @@ import { AstImport } from '../analyzer/AstImport';
 import { AstSymbol } from '../analyzer/AstSymbol';
 import { ExtractorMessage } from '../api/ExtractorMessage';
 import { StringWriter } from './StringWriter';
+import { DtsEmitHelpers } from './DtsEmitHelpers';
 
 export class ReviewFileGenerator {
   /**
@@ -45,6 +46,20 @@ export class ReviewFileGenerator {
     // Write the opening delimiter for the Markdown code fence
     stringWriter.writeLine('```ts\n');
 
+    // Emit the imports
+    let importsEmitted: boolean = false;
+    for (const entity of collector.entities) {
+      if (entity.astEntity instanceof AstImport) {
+        DtsEmitHelpers.emitImport(stringWriter, entity, entity.astEntity);
+        importsEmitted = true;
+      }
+    }
+
+    if (importsEmitted) {
+      stringWriter.writeLine();
+    }
+
+    // Emit the regular declarations
     for (const entity of collector.entities) {
       if (entity.exported) {
         if (entity.astEntity instanceof AstSymbol) {
@@ -58,30 +73,18 @@ export class ReviewFileGenerator {
             span.writeModifiedText(stringWriter.stringBuilder);
             stringWriter.writeLine('\n');
           }
-        } else {
-          // This definition is reexported from another package, so write it as an "export" line
-          // In general, we don't report on external packages; if that's important we assume API Extractor
-          // would be enabled for the upstream project.  But see GitHub issue #896 for a possible exception.
-          const astImport: AstImport = entity.astEntity;
+        }
 
-          if (astImport.exportName === '*') {
-            stringWriter.write(`export * as ${entity.nameForEmit}`);
-          } else if (entity.nameForEmit !== astImport.exportName) {
-            stringWriter.write(`export { ${astImport.exportName} as ${entity.nameForEmit} }`);
-          } else {
-            stringWriter.write(`export { ${astImport.exportName} }`);
+        for (const exportName of entity.exportNames) {
+          if (!entity.shouldInlineExport) {
+            DtsEmitHelpers.emitNamedExport(stringWriter, exportName, entity);
+            stringWriter.writeLine();
           }
-          stringWriter.writeLine(` from '${astImport.modulePath}';`);
         }
       }
     }
 
-    if (collector.starExportedExternalModulePaths.length > 0) {
-      stringWriter.writeLine();
-      for (const starExportedExternalModulePath of collector.starExportedExternalModulePaths) {
-        stringWriter.writeLine(`export * from "${starExportedExternalModulePath}";`);
-      }
-    }
+    DtsEmitHelpers.emitStarExports(stringWriter, collector);
 
     // Write the unassociated warnings at the bottom of the file
     const unassociatedMessages: ExtractorMessage[] = collector.messageRouter
@@ -120,6 +123,8 @@ export class ReviewFileGenerator {
       return;
     }
 
+    const previousSpan: Span | undefined = span.previousSibling;
+
     let recurseChildren: boolean = true;
     let sortChildren: boolean = false;
 
@@ -133,6 +138,30 @@ export class ReviewFileGenerator {
       case ts.SyntaxKind.ExportKeyword:
       case ts.SyntaxKind.DefaultKeyword:
         span.modification.skipAll();
+        break;
+
+      case ts.SyntaxKind.InterfaceKeyword:
+      case ts.SyntaxKind.ClassKeyword:
+      case ts.SyntaxKind.EnumKeyword:
+      case ts.SyntaxKind.NamespaceKeyword:
+      case ts.SyntaxKind.ModuleKeyword:
+      case ts.SyntaxKind.TypeKeyword:
+      case ts.SyntaxKind.FunctionKeyword:
+        // Replace the stuff we possibly deleted above
+        let replacedModifiers: string = '';
+
+        if (entity.shouldInlineExport) {
+          replacedModifiers = 'export ' + replacedModifiers;
+        }
+
+        if (previousSpan && previousSpan.kind === ts.SyntaxKind.SyntaxList) {
+          // If there is a previous span of type SyntaxList, then apply it before any other modifiers
+          // (e.g. "abstract") that appear there.
+          previousSpan.modification.prefix = replacedModifiers + previousSpan.modification.prefix;
+        } else {
+          // Otherwise just stick it in front of this span
+          span.modification.prefix = replacedModifiers + span.modification.prefix;
+        }
         break;
 
       case ts.SyntaxKind.SyntaxList:
@@ -166,8 +195,11 @@ export class ReviewFileGenerator {
           const listPrefix: string = list.getSourceFile().text
             .substring(list.getStart(), list.declarations[0].getStart());
           span.modification.prefix = 'declare ' + listPrefix + span.modification.prefix;
-
           span.modification.suffix = ';';
+
+          if (entity.shouldInlineExport) {
+            span.modification.prefix = 'export ' + span.modification.prefix;
+          }
         }
         break;
 

--- a/build-tests/api-documenter-test/etc/api-documenter-test.api.md
+++ b/build-tests/api-documenter-test/etc/api-documenter-test.api.md
@@ -5,14 +5,14 @@
 ```ts
 
 // @public
-declare const constVariable: number;
+export const constVariable: number;
 
 // @public
-declare class DocBaseClass {
+export class DocBaseClass {
 }
 
 // @public
-declare class DocClass1 extends DocBaseClass implements IDocInterface1, IDocInterface2 {
+export class DocClass1 extends DocBaseClass implements IDocInterface1, IDocInterface2 {
     constructor(name: string);
     // @deprecated (undocumented)
     deprecatedExample(): void;
@@ -29,46 +29,46 @@ declare class DocClass1 extends DocBaseClass implements IDocInterface1, IDocInte
 }
 
 // @public
-declare enum DocEnum {
+export enum DocEnum {
     One = 1,
     Two = 2,
     Zero = 0
 }
 
 // @public
-declare type ExampleTypeAlias = Promise<boolean>;
+export type ExampleTypeAlias = Promise<boolean>;
 
 // @public
-declare function globalFunction(x: number): number;
+export function globalFunction(x: number): number;
 
 // @public (undocumented)
-interface IDocInterface1 {
+export interface IDocInterface1 {
     regularProperty: SystemEvent;
 }
 
 // @public (undocumented)
-interface IDocInterface2 extends IDocInterface1 {
+export interface IDocInterface2 extends IDocInterface1 {
     // @deprecated (undocumented)
     deprecatedExample(): void;
 }
 
 // @public
-interface IDocInterface3 {
+export interface IDocInterface3 {
     (x: number): number;
     [x: string]: string;
     new (): IDocInterface1;
 }
 
 // @public
-declare namespace OuterNamespace {
-    namespace InnerNamespace {
-        function nestedFunction(x: number): number;
+export namespace OuterNamespace {
+    export namespace InnerNamespace {
+        export function nestedFunction(x: number): number;
     }
     let nestedVariable: boolean;
 }
 
 // @public
-declare class SystemEvent {
+export class SystemEvent {
     addHandler(handler: () => void): void;
 }
 

--- a/build-tests/api-documenter-test/tsconfig.json
+++ b/build-tests/api-documenter-test/tsconfig.json
@@ -5,6 +5,7 @@
     "module": "commonjs",
     "declaration": true,
     "sourceMap": true,
+    "declarationMap": true,
     "experimentalDecorators": true,
     "strictNullChecks": true,
     "types": [

--- a/build-tests/api-extractor-lib1-test/etc/api-extractor-lib1-test.api.md
+++ b/build-tests/api-extractor-lib1-test/etc/api-extractor-lib1-test.api.md
@@ -7,11 +7,11 @@
 // Warning: (ae-forgotten-export) The symbol "Lib1ForgottenExport" needs to be exported by the entry point index.d.ts
 // 
 // @public (undocumented)
-declare class Lib1Class extends Lib1ForgottenExport {
+export class Lib1Class extends Lib1ForgottenExport {
 }
 
 // @alpha (undocumented)
-interface Lib1Interface {
+export interface Lib1Interface {
 }
 
 

--- a/build-tests/api-extractor-lib1-test/tsconfig.json
+++ b/build-tests/api-extractor-lib1-test/tsconfig.json
@@ -5,6 +5,7 @@
     "module": "commonjs",
     "declaration": true,
     "sourceMap": true,
+    "declarationMap": true,
     "experimentalDecorators": true,
     "strictNullChecks": true,
     "types": [

--- a/build-tests/api-extractor-lib2-test/etc/api-extractor-lib2-test.api.md
+++ b/build-tests/api-extractor-lib2-test/etc/api-extractor-lib2-test.api.md
@@ -5,11 +5,11 @@
 ```ts
 
 // @public (undocumented)
-declare class Lib2Class {
+export class Lib2Class {
 }
 
 // @alpha (undocumented)
-interface Lib2Interface {
+export interface Lib2Interface {
 }
 
 

--- a/build-tests/api-extractor-lib2-test/tsconfig.json
+++ b/build-tests/api-extractor-lib2-test/tsconfig.json
@@ -5,6 +5,7 @@
     "module": "commonjs",
     "declaration": true,
     "sourceMap": true,
+    "declarationMap": true,
     "experimentalDecorators": true,
     "strictNullChecks": true,
     "types": [

--- a/build-tests/api-extractor-lib3-test/etc/api-extractor-lib3-test.api.md
+++ b/build-tests/api-extractor-lib3-test/etc/api-extractor-lib3-test.api.md
@@ -4,6 +4,9 @@
 
 ```ts
 
-export { Lib1Class } from 'api-extractor-lib1-test';
+import { Lib1Class } from 'api-extractor-lib1-test';
+
+export { Lib1Class }
+
 
 ```

--- a/build-tests/api-extractor-lib3-test/tsconfig.json
+++ b/build-tests/api-extractor-lib3-test/tsconfig.json
@@ -5,6 +5,7 @@
     "module": "commonjs",
     "declaration": true,
     "sourceMap": true,
+    "declarationMap": true,
     "experimentalDecorators": true,
     "strictNullChecks": true,
     "types": [

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/ambientNameConflict/api-extractor-scenarios.api.md
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/ambientNameConflict/api-extractor-scenarios.api.md
@@ -7,7 +7,7 @@
 // Warning: (ae-forgotten-export) The symbol "Promise" needs to be exported by the entry point index.d.ts
 // 
 // @public (undocumented)
-declare function ambientNameConflict(p1: Promise<void>, p2: Promise_2<void>): void;
+export function ambientNameConflict(p1: Promise<void>, p2: Promise_2<void>): void;
 
 
 // (No @packageDocumentation comment for this package)

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/apiItemKinds/api-extractor-scenarios.api.md
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/apiItemKinds/api-extractor-scenarios.api.md
@@ -5,13 +5,13 @@
 ```ts
 
 // @public (undocumented)
-declare abstract class AbstractClass {
+export abstract class AbstractClass {
     // (undocumented)
     abstract member(): void;
 }
 
 // @public (undocumented)
-declare class ClassWithTypeLiterals {
+export class ClassWithTypeLiterals {
     method1(vector: {
         x: number;
         y: number;
@@ -23,7 +23,7 @@ declare class ClassWithTypeLiterals {
 }
 
 // @public (undocumented)
-declare const enum ConstEnum {
+export const enum ConstEnum {
     // (undocumented)
     One = 1,
     // (undocumented)
@@ -33,13 +33,13 @@ declare const enum ConstEnum {
 }
 
 // @public (undocumented)
-interface IInterface {
+export interface IInterface {
     // (undocumented)
     member: string;
 }
 
 // @public (undocumented)
-declare namespace NamespaceContainingVariable {
+export namespace NamespaceContainingVariable {
     let // (undocumented)
     variable: object[];
     let // (undocumented)
@@ -47,20 +47,20 @@ declare namespace NamespaceContainingVariable {
 }
 
 // @public (undocumented)
-declare enum RegularEnum {
+export enum RegularEnum {
     One = 1,
     Two = 2,
     Zero = 0
 }
 
 // @public (undocumented)
-declare class SimpleClass {
+export class SimpleClass {
     // (undocumented)
     member(): void;
 }
 
 // @public (undocumented)
-declare const VARIABLE: string;
+export const VARIABLE: string;
 
 
 // (No @packageDocumentation comment for this package)

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/circularImport/api-extractor-scenarios.api.md
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/circularImport/api-extractor-scenarios.api.md
@@ -5,13 +5,13 @@
 ```ts
 
 // @public (undocumented)
-declare class IFile {
+export class IFile {
     // (undocumented)
     containingFolder: IFolder;
 }
 
 // @public (undocumented)
-declare class IFolder {
+export class IFolder {
     // (undocumented)
     containingFolder: IFolder | undefined;
     // (undocumented)

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/circularImport2/api-extractor-scenarios.api.md
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/circularImport2/api-extractor-scenarios.api.md
@@ -5,21 +5,21 @@
 ```ts
 
 // @public (undocumented)
-declare class A {
+export class A {
 }
 
 // @public (undocumented)
-declare class B {
+export class B {
 }
 
 // @public (undocumented)
-declare class IFile {
+export class IFile {
     // (undocumented)
     containingFolder: IFolder;
 }
 
 // @public (undocumented)
-declare class IFolder {
+export class IFolder {
     // (undocumented)
     containingFolder: IFolder | undefined;
     // (undocumented)

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/defaultExportOfEntryPoint/api-extractor-scenarios.api.md
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/defaultExportOfEntryPoint/api-extractor-scenarios.api.md
@@ -8,6 +8,8 @@
 class DefaultClass {
 }
 
+export default DefaultClass;
+
 
 // (No @packageDocumentation comment for this package)
 

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/defaultExportOfEntryPoint2/api-extractor-scenarios.api.md
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/defaultExportOfEntryPoint2/api-extractor-scenarios.api.md
@@ -5,7 +5,9 @@
 ```ts
 
 // @public (undocumented)
-declare const defaultFunctionStatement: () => void;
+const defaultFunctionStatement: () => void;
+
+export default defaultFunctionStatement;
 
 
 // (No @packageDocumentation comment for this package)

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/defaultExportOfEntryPoint3/api-extractor-scenarios.api.md
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/defaultExportOfEntryPoint3/api-extractor-scenarios.api.md
@@ -7,6 +7,8 @@
 // @public (undocumented)
 function defaultFunctionDeclaration(): void;
 
+export default defaultFunctionDeclaration;
+
 
 // (No @packageDocumentation comment for this package)
 

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/defaultExportOfEntryPoint4/api-extractor-scenarios.api.md
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/defaultExportOfEntryPoint4/api-extractor-scenarios.api.md
@@ -5,7 +5,9 @@
 ```ts
 
 // @public (undocumented)
-declare const _default: "literal";
+const _default: "literal";
+
+export default _default;
 
 
 // (No @packageDocumentation comment for this package)

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/exportDuplicate/api-extractor-scenarios.api.md
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/exportDuplicate/api-extractor-scenarios.api.md
@@ -5,12 +5,20 @@
 ```ts
 
 // @public (undocumented)
-declare class A {
+class A {
 }
 
+export { A as B }
+
+export { A as C }
+
 // @public (undocumented)
-declare class X {
+class X {
 }
+
+export { X }
+
+export { X as Y }
 
 
 // (No @packageDocumentation comment for this package)

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/exportEquals/api-extractor-scenarios.api.md
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/exportEquals/api-extractor-scenarios.api.md
@@ -4,8 +4,10 @@
 
 ```ts
 
+import { Context } from '@microsoft/teams-js';
+
 // @public (undocumented)
-interface ITeamsContext {
+export interface ITeamsContext {
     // (undocumented)
     context: Context;
 }

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/exportImportedExternal/api-extractor-scenarios.api.md
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/exportImportedExternal/api-extractor-scenarios.api.md
@@ -4,9 +4,18 @@
 
 ```ts
 
-export { Lib1Class } from 'api-extractor-lib1-test';
-export { Lib1Interface } from 'api-extractor-lib1-test';
-export { Lib2Class } from 'api-extractor-lib2-test';
+import { Lib1Class } from 'api-extractor-lib1-test';
+import { Lib1Interface } from 'api-extractor-lib1-test';
+import { Lib2Class } from 'api-extractor-lib2-test';
+
+export { Lib1Class }
+
+export { Lib1Interface }
+
+export { Lib2Class as DoubleRenamedLib2Class }
+
+export { Lib2Class as RenamedLib2Class }
+
 
 // (No @packageDocumentation comment for this package)
 

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/exportImportedExternal2/api-extractor-scenarios.api.md
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/exportImportedExternal2/api-extractor-scenarios.api.md
@@ -4,7 +4,10 @@
 
 ```ts
 
-export { Lib1Class } from 'api-extractor-lib3-test';
+import { Lib1Class } from 'api-extractor-lib3-test';
+
+export { Lib1Class }
+
 
 // (No @packageDocumentation comment for this package)
 

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/exportStar/api-extractor-scenarios.api.md
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/exportStar/api-extractor-scenarios.api.md
@@ -5,15 +5,15 @@
 ```ts
 
 // @public (undocumented)
-declare class A {
+export class A {
 }
 
 // @public (undocumented)
-declare class B {
+export class B {
 }
 
 // @public (undocumented)
-declare class C {
+export class C {
 }
 
 

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/exportStar2/api-extractor-scenarios.api.md
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/exportStar2/api-extractor-scenarios.api.md
@@ -5,7 +5,7 @@
 ```ts
 
 // @public (undocumented)
-declare class A {
+export class A {
 }
 
 

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/exportStar3/api-extractor-scenarios.api.md
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/exportStar3/api-extractor-scenarios.api.md
@@ -4,12 +4,17 @@
 
 ```ts
 
+import { Lib1Class } from 'api-extractor-lib1-test';
+import { Lib2Interface as RenamedLib2Interface } from 'api-extractor-lib2-test';
+
 // @public (undocumented)
-declare class A {
+export class A {
 }
 
-export { Lib1Class } from 'api-extractor-lib1-test';
-export { Lib2Interface as RenamedLib2Interface } from 'api-extractor-lib2-test';
+export { Lib1Class }
+
+export { RenamedLib2Interface }
+
 
 // (No @packageDocumentation comment for this package)
 

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/importEquals/api-extractor-scenarios.api.md
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/importEquals/api-extractor-scenarios.api.md
@@ -4,8 +4,10 @@
 
 ```ts
 
+import colors = require('colors');
+
 // @public (undocumented)
-declare function useColors(): typeof colors.zebra;
+export function useColors(): typeof colors.zebra;
 
 
 // (No @packageDocumentation comment for this package)

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/inconsistentReleaseTags/api-extractor-scenarios.api.md
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/inconsistentReleaseTags/api-extractor-scenarios.api.md
@@ -5,10 +5,10 @@
 ```ts
 
 // @alpha
-declare function alphaFunctionReturnsBeta(): IBeta;
+export function alphaFunctionReturnsBeta(): IBeta;
 
 // @beta (undocumented)
-interface IBeta {
+export interface IBeta {
     // (undocumented)
     x: number;
 }
@@ -16,7 +16,7 @@ interface IBeta {
 // Warning: (ae-incompatible-release-tags) The symbol "publicFunctionReturnsBeta" is marked as @public, but its signature references "IBeta" which is marked as @beta
 // 
 // @public
-declare function publicFunctionReturnsBeta(): IBeta;
+export function publicFunctionReturnsBeta(): IBeta;
 
 
 // (No @packageDocumentation comment for this package)

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/typeOf/api-extractor-scenarios.api.md
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/typeOf/api-extractor-scenarios.api.md
@@ -4,13 +4,15 @@
 
 ```ts
 
+import { Lib1Class } from 'api-extractor-lib1-test';
+
 // @public
-declare function f(): typeof Lib1Class | undefined;
+export function f(): typeof Lib1Class | undefined;
 
 // Warning: (ae-forgotten-export) The symbol "ForgottenExport" needs to be exported by the entry point index.d.ts
 // 
 // @public
-declare function g(): typeof ForgottenExport | undefined;
+export function g(): typeof ForgottenExport | undefined;
 
 
 // (No @packageDocumentation comment for this package)

--- a/build-tests/api-extractor-scenarios/tsconfig.json
+++ b/build-tests/api-extractor-scenarios/tsconfig.json
@@ -5,6 +5,7 @@
     "module": "commonjs",
     "declaration": true,
     "sourceMap": true,
+    "declarationMap": true,
     "experimentalDecorators": true,
     "strictNullChecks": true,
     "types": [

--- a/build-tests/api-extractor-test-01/etc/api-extractor-test-01.api.md
+++ b/build-tests/api-extractor-test-01/etc/api-extractor-test-01.api.md
@@ -5,25 +5,25 @@
 ```ts
 
 // @public
-abstract class AbstractClass {
+export abstract class AbstractClass {
     // (undocumented)
     abstract test(): void;
 }
 
 // @public
-declare abstract class AbstractClass2 {
+export abstract class AbstractClass2 {
     // (undocumented)
     abstract test2(): void;
 }
 
 // @public
-declare abstract class AbstractClass3 {
+export abstract class AbstractClass3 {
     // (undocumented)
     abstract test3(): void;
 }
 
 // @public
-declare class AmbientConsumer {
+export class AmbientConsumer {
     builtinDefinition1(): Map<string, string>;
     builtinDefinition2(): Promise<void>;
     definitelyTyped(): jest.Context;
@@ -31,11 +31,11 @@ declare class AmbientConsumer {
 }
 
 // @public
-class ClassExportedAsDefault {
+export class ClassExportedAsDefault {
 }
 
 // @public
-declare class ClassWithAccessModifiers {
+export class ClassWithAccessModifiers {
     defaultPublicMethod(): void;
     protected protectedField: number;
     protected readonly protectedGetter: string;
@@ -44,7 +44,7 @@ declare class ClassWithAccessModifiers {
 }
 
 // @public (undocumented)
-declare class ClassWithSymbols {
+export class ClassWithSymbols {
     // (undocumented)
     readonly [unexportedCustomSymbol]: number;
     // (undocumented)
@@ -54,7 +54,7 @@ declare class ClassWithSymbols {
 }
 
 // @public
-declare class ClassWithTypeLiterals {
+export class ClassWithTypeLiterals {
     method1(vector: {
         x: number;
         y: number;
@@ -66,7 +66,7 @@ declare class ClassWithTypeLiterals {
 }
 
 // @public (undocumented)
-declare const enum ConstEnum {
+export const enum ConstEnum {
     // (undocumented)
     One = 1,
     // (undocumented)
@@ -76,17 +76,17 @@ declare const enum ConstEnum {
 }
 
 // @public
-declare class DecoratorTest {
+export class DecoratorTest {
     test(): void;
 }
 
 // @public (undocumented)
-declare class DefaultExportEdgeCase {
+export class DefaultExportEdgeCase {
     reference: ClassExportedAsDefault;
 }
 
 // @public (undocumented)
-declare class ForgottenExportConsumer1 {
+export class ForgottenExportConsumer1 {
     // Warning: (ae-forgotten-export) The symbol "IForgottenExport" needs to be exported by the entry point index.d.ts
     // 
     // (undocumented)
@@ -94,7 +94,7 @@ declare class ForgottenExportConsumer1 {
 }
 
 // @public (undocumented)
-declare class ForgottenExportConsumer2 {
+export class ForgottenExportConsumer2 {
     // Warning: (ae-forgotten-export) The symbol "IForgottenExport" needs to be exported by the entry point index.d.ts
     // 
     // (undocumented)
@@ -102,7 +102,7 @@ declare class ForgottenExportConsumer2 {
 }
 
 // @beta
-declare class ForgottenExportConsumer3 {
+export class ForgottenExportConsumer3 {
     // Warning: (ae-forgotten-export) The symbol "IForgottenDirectDependency" needs to be exported by the entry point index.d.ts
     // 
     // (undocumented)
@@ -110,15 +110,15 @@ declare class ForgottenExportConsumer3 {
 }
 
 // @public (undocumented)
-declare const fullyExportedCustomSymbol: unique symbol;
+export const fullyExportedCustomSymbol: unique symbol;
 
 // @public
-interface IInterfaceAsDefaultExport {
+export interface IInterfaceAsDefaultExport {
     member: string;
 }
 
 // @alpha
-interface IMergedInterface {
+export interface IMergedInterface {
     // (undocumented)
     reference: IMergedInterfaceReferencee;
     // (undocumented)
@@ -126,7 +126,7 @@ interface IMergedInterface {
 }
 
 // @alpha
-interface IMergedInterface {
+export interface IMergedInterface {
     // (undocumented)
     reference: IMergedInterfaceReferencee;
     // (undocumented)
@@ -134,21 +134,21 @@ interface IMergedInterface {
 }
 
 // @alpha (undocumented)
-interface IMergedInterfaceReferencee {
+export interface IMergedInterfaceReferencee {
 }
 
 // @public
-interface ISimpleInterface {
+export interface ISimpleInterface {
 }
 
 // @public (undocumented)
-declare namespace NamespaceContainingVariable {
+export namespace NamespaceContainingVariable {
     let // @internal (undocumented)
     variable: object[];
 }
 
 // @public
-declare class ReexportedClass {
+export class ReexportedClass {
     // (undocumented)
     getSelfReference(): ReexportedClass;
     // (undocumented)
@@ -156,18 +156,18 @@ declare class ReexportedClass {
 }
 
 // @public (undocumented)
-declare class ReferenceLibDirective extends Intl.PluralRules {
+export class ReferenceLibDirective extends Intl.PluralRules {
 }
 
 // @public (undocumented)
-declare enum RegularEnum {
+export enum RegularEnum {
     One = 1,
     Two = 2,
     Zero = 0
 }
 
 // @public
-declare class TypeReferencesInAedoc {
+export class TypeReferencesInAedoc {
     getValue(arg1: TypeReferencesInAedoc): TypeReferencesInAedoc;
     // (undocumented)
     getValue2(arg1: TypeReferencesInAedoc): TypeReferencesInAedoc;
@@ -176,10 +176,10 @@ declare class TypeReferencesInAedoc {
 }
 
 // @alpha (undocumented)
-declare const VARIABLE: string;
+export const VARIABLE: string;
 
 // @public
-declare function virtual(target: Object, propertyKey: string | symbol, descriptor: TypedPropertyDescriptor<any>): void;
+export function virtual(target: Object, propertyKey: string | symbol, descriptor: TypedPropertyDescriptor<any>): void;
 
 
 ```

--- a/build-tests/api-extractor-test-01/tsconfig.json
+++ b/build-tests/api-extractor-test-01/tsconfig.json
@@ -5,6 +5,7 @@
     "module": "commonjs",
     "declaration": true,
     "sourceMap": true,
+    "declarationMap": true,
     "experimentalDecorators": true,
     "strictNullChecks": true,
     "types": [

--- a/build-tests/api-extractor-test-02/etc/api-extractor-test-02.api.md
+++ b/build-tests/api-extractor-test-02/etc/api-extractor-test-02.api.md
@@ -4,31 +4,36 @@
 
 ```ts
 
+import { ISimpleInterface } from 'api-extractor-test-01';
+import { ReexportedClass as RenamedReexportedClass3 } from 'api-extractor-test-01';
+import * as semver1 from 'semver';
+
 // @public
-interface GenericInterface<T> {
+export interface GenericInterface<T> {
     // (undocumented)
     member: T;
 }
 
 // @public (undocumented)
-declare function importDeduping1(arg1: ISimpleInterface, arg2: ISimpleInterface): void;
+export function importDeduping1(arg1: ISimpleInterface, arg2: ISimpleInterface): void;
 
 // @public (undocumented)
-declare function importDeduping2(arg1: ISimpleInterface, arg2: ISimpleInterface): void;
+export function importDeduping2(arg1: ISimpleInterface, arg2: ISimpleInterface): void;
 
 // @public
-declare class ImportedModuleAsBaseClass extends semver1.SemVer {
+export class ImportedModuleAsBaseClass extends semver1.SemVer {
 }
 
 // @public
-declare function importedModuleAsGenericParameter(): GenericInterface<semver1.SemVer> | undefined;
+export function importedModuleAsGenericParameter(): GenericInterface<semver1.SemVer> | undefined;
 
 // @public
-declare function importedModuleAsReturnType(): semver1.SemVer | undefined;
+export function importedModuleAsReturnType(): semver1.SemVer | undefined;
 
-export { ReexportedClass as RenamedReexportedClass3 } from 'api-extractor-test-01';
+export { RenamedReexportedClass3 }
+
 // @public
-declare class SubclassWithImport extends RenamedReexportedClass3 implements ISimpleInterface {
+export class SubclassWithImport extends RenamedReexportedClass3 implements ISimpleInterface {
     // (undocumented)
     test(): void;
 }

--- a/build-tests/api-extractor-test-02/tsconfig.json
+++ b/build-tests/api-extractor-test-02/tsconfig.json
@@ -5,6 +5,7 @@
     "module": "commonjs",
     "declaration": true,
     "sourceMap": true,
+    "declarationMap": true,
     "experimentalDecorators": true,
     "strictNullChecks": true,
     "types": [

--- a/build-tests/api-extractor-test-03/tsconfig.json
+++ b/build-tests/api-extractor-test-03/tsconfig.json
@@ -5,6 +5,7 @@
     "module": "commonjs",
     "declaration": true,
     "sourceMap": true,
+    "declarationMap": true,
     "experimentalDecorators": true,
     "strictNullChecks": true,
     "types": [

--- a/build-tests/api-extractor-test-04/etc/api-extractor-test-04.api.md
+++ b/build-tests/api-extractor-test-04/etc/api-extractor-test-04.api.md
@@ -4,15 +4,17 @@
 
 ```ts
 
+import { Lib1Interface } from 'api-extractor-lib1-test';
+
 // @alpha
-declare class AlphaClass {
+export class AlphaClass {
     // @internal
     _internalMember(): void;
     undecoratedMember(): void;
 }
 
 // @beta
-declare class BetaClass implements BetaInterface {
+export class BetaClass implements BetaInterface {
     // @alpha
     alphaMember(): void;
     // @internal
@@ -21,7 +23,7 @@ declare class BetaClass implements BetaInterface {
 }
 
 // @beta
-interface BetaInterface {
+export interface BetaInterface {
     // @alpha
     alphaMember(): void;
     // @internal
@@ -30,7 +32,7 @@ interface BetaInterface {
 }
 
 // @beta
-declare const enum ConstEnum {
+export const enum ConstEnum {
     // @alpha
     AlphaMember = "AlphaMember",
     BetaMember2 = "BetaMember2",
@@ -39,16 +41,16 @@ declare const enum ConstEnum {
 }
 
 // @beta
-declare namespace EntangledNamespace {
-    namespace N2 {
+export namespace EntangledNamespace {
+    export namespace N2 {
         // @alpha
-        class ClassX {
+        export class ClassX {
             static a: string;
         }
     }
-    namespace N3 {
+    export namespace N3 {
         // @internal
-        class _ClassY {
+        export class _ClassY {
             b: EntangledNamespace.N2.ClassX;
             c(): typeof N2.ClassX.a;
         }
@@ -56,28 +58,29 @@ declare namespace EntangledNamespace {
 }
 
 // @alpha
-declare type ExportedAlias = AlphaClass;
+export type ExportedAlias = AlphaClass;
 
 // @internal
-declare class InternalClass {
+export class InternalClass {
     undecoratedMember(): void;
 }
 
 // @internal
-interface IPublicClassInternalParameters {
+export interface IPublicClassInternalParameters {
 }
 
 // @public
-interface IPublicComplexInterface {
+export interface IPublicComplexInterface {
     // @internal
     [key: string]: IPublicClassInternalParameters;
     // @internal
     new (): any;
 }
 
-export { Lib1Interface } from 'api-extractor-lib1-test';
+export { Lib1Interface }
+
 // @public
-declare class PublicClass {
+export class PublicClass {
     // @internal (undocumented)
     constructor(parameters: IPublicClassInternalParameters);
     // @alpha
@@ -92,7 +95,7 @@ declare class PublicClass {
 }
 
 // @beta
-declare enum RegularEnum {
+export enum RegularEnum {
     // @alpha
     AlphaMember = 101,
     BetaMember = 100,
@@ -101,7 +104,7 @@ declare enum RegularEnum {
 }
 
 // @beta
-declare const variableDeclaration: string;
+export const variableDeclaration: string;
 
 
 ```

--- a/build-tests/api-extractor-test-04/preview-consumer/tsconfig.json
+++ b/build-tests/api-extractor-test-04/preview-consumer/tsconfig.json
@@ -5,6 +5,7 @@
     "module": "commonjs",
     "declaration": true,
     "sourceMap": true,
+    "declarationMap": true,
     "experimentalDecorators": true,
     "strictNullChecks": true,
     "lib": [

--- a/build-tests/api-extractor-test-04/tsconfig.json
+++ b/build-tests/api-extractor-test-04/tsconfig.json
@@ -5,6 +5,7 @@
     "module": "commonjs",
     "declaration": true,
     "sourceMap": true,
+    "declarationMap": true,
     "experimentalDecorators": true,
     "strictNullChecks": true,
     "types": [

--- a/common/changes/@microsoft/api-extractor/octogonz-ae-review-exports_2019-03-20-21-24.json
+++ b/common/changes/@microsoft/api-extractor/octogonz-ae-review-exports_2019-03-20-21-24.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor",
+      "comment": "Improve the API review file generation to include imports and support multiple exports",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/reviews/api/gulp-core-build-mocha.api.md
+++ b/common/reviews/api/gulp-core-build-mocha.api.md
@@ -4,18 +4,25 @@
 
 ```ts
 
+import * as Gulp from 'gulp';
+import { GulpTask } from '@microsoft/gulp-core-build';
+import { IBuildConfig } from '@microsoft/gulp-core-build';
+import { IExecutable } from '@microsoft/gulp-core-build';
+
 // @public (undocumented)
-declare const _default: IExecutable;
+const _default: IExecutable;
+
+export default _default;
 
 // Warning: (ae-forgotten-export) The symbol "InstrumentTask" needs to be exported by the entry point index.d.ts
 // 
 // @public (undocumented)
-declare const instrument: InstrumentTask;
+export const instrument: InstrumentTask;
 
 // Warning: (ae-forgotten-export) The symbol "MochaTask" needs to be exported by the entry point index.d.ts
 // 
 // @public (undocumented)
-declare const mocha: MochaTask;
+export const mocha: MochaTask;
 
 
 // (No @packageDocumentation comment for this package)

--- a/common/reviews/api/gulp-core-build-sass.api.md
+++ b/common/reviews/api/gulp-core-build-sass.api.md
@@ -4,10 +4,18 @@
 
 ```ts
 
+import * as CleanCss from 'clean-css';
+import * as Gulp from 'gulp';
+import { GulpTask } from '@microsoft/gulp-core-build';
+
 // Warning: (ae-forgotten-export) The symbol "SassTask" needs to be exported by the entry point index.d.ts
 // 
 // @public (undocumented)
-declare const sass: SassTask;
+const sass: SassTask;
+
+export default sass;
+
+export { sass }
 
 
 // (No @packageDocumentation comment for this package)

--- a/common/reviews/api/gulp-core-build-serve.api.md
+++ b/common/reviews/api/gulp-core-build-serve.api.md
@@ -4,25 +4,32 @@
 
 ```ts
 
+import * as Gulp from 'gulp';
+import { GulpTask } from '@microsoft/gulp-core-build';
+
 // Warning: (ae-forgotten-export) The symbol "ReloadTask" needs to be exported by the entry point index.d.ts
 // 
 // @public (undocumented)
-declare const reload: ReloadTask;
+export const reload: ReloadTask;
 
 // Warning: (ae-forgotten-export) The symbol "ServeTask" needs to be exported by the entry point index.d.ts
 // 
 // @public (undocumented)
-declare const serve: ServeTask;
+const serve: ServeTask;
+
+export default serve;
+
+export { serve }
 
 // Warning: (ae-forgotten-export) The symbol "TrustCertTask" needs to be exported by the entry point index.d.ts
 // 
 // @public (undocumented)
-declare const trustDevCert: TrustCertTask;
+export const trustDevCert: TrustCertTask;
 
 // Warning: (ae-forgotten-export) The symbol "UntrustCertTask" needs to be exported by the entry point index.d.ts
 // 
 // @public (undocumented)
-declare const untrustDevCert: UntrustCertTask;
+export const untrustDevCert: UntrustCertTask;
 
 
 // (No @packageDocumentation comment for this package)

--- a/common/reviews/api/gulp-core-build-typescript.api.md
+++ b/common/reviews/api/gulp-core-build-typescript.api.md
@@ -4,34 +4,41 @@
 
 ```ts
 
+import { ConsoleTerminalProvider } from '@microsoft/node-core-library';
+import { GulpTask } from '@microsoft/gulp-core-build';
+import { IBuildConfig } from '@microsoft/gulp-core-build';
+import { Terminal } from '@microsoft/node-core-library';
+import { TerminalProviderSeverity } from '@microsoft/node-core-library';
+import * as TRushStackCompiler from '@microsoft/rush-stack-compiler-3.2';
+
 // Warning: (ae-forgotten-export) The symbol "ApiExtractorTask" needs to be exported by the entry point index.d.ts
 // 
 // @public (undocumented)
-declare const apiExtractor: ApiExtractorTask;
+export const apiExtractor: ApiExtractorTask;
 
 // Warning: (ae-forgotten-export) The symbol "IRSCTaskConfig" needs to be exported by the entry point index.d.ts
 // 
 // @public (undocumented)
-interface ITscCmdTaskConfig extends IRSCTaskConfig {
+export interface ITscCmdTaskConfig extends IRSCTaskConfig {
     customArgs?: string[];
     removeCommentsFromJavaScript?: boolean;
     staticMatch?: string[];
 }
 
 // @public (undocumented)
-interface ITslintCmdTaskConfig extends IRSCTaskConfig {
+export interface ITslintCmdTaskConfig extends IRSCTaskConfig {
     displayAsError?: boolean;
 }
 
 // Warning: (ae-incompatible-release-tags) The symbol "tscCmd" is marked as @public, but its signature references "TscCmdTask" which is marked as @beta
 // 
 // @public (undocumented)
-declare const tscCmd: TscCmdTask;
+export const tscCmd: TscCmdTask;
 
 // Warning: (ae-forgotten-export) The symbol "RSCTask" needs to be exported by the entry point index.d.ts
 // 
 // @beta (undocumented)
-declare class TscCmdTask extends RSCTask<ITscCmdTaskConfig> {
+export class TscCmdTask extends RSCTask<ITscCmdTaskConfig> {
     // (undocumented)
     constructor();
     // (undocumented)
@@ -45,10 +52,10 @@ declare class TscCmdTask extends RSCTask<ITscCmdTaskConfig> {
 // Warning: (ae-incompatible-release-tags) The symbol "tslintCmd" is marked as @public, but its signature references "TslintCmdTask" which is marked as @beta
 // 
 // @public (undocumented)
-declare const tslintCmd: TslintCmdTask;
+export const tslintCmd: TslintCmdTask;
 
 // @beta (undocumented)
-declare class TslintCmdTask extends RSCTask<ITslintCmdTaskConfig> {
+export class TslintCmdTask extends RSCTask<ITslintCmdTaskConfig> {
     // (undocumented)
     constructor();
     // (undocumented)

--- a/common/reviews/api/gulp-core-build-webpack.api.md
+++ b/common/reviews/api/gulp-core-build-webpack.api.md
@@ -4,14 +4,19 @@
 
 ```ts
 
+import * as Gulp from 'gulp';
+import { GulpTask } from '@microsoft/gulp-core-build';
+import { IBuildConfig } from '@microsoft/gulp-core-build';
+import * as Webpack from 'webpack';
+
 // @public (undocumented)
-interface IWebpackResources {
+export interface IWebpackResources {
     // (undocumented)
     webpack: typeof Webpack;
 }
 
 // @public (undocumented)
-interface IWebpackTaskConfig {
+export interface IWebpackTaskConfig {
     config?: Webpack.Configuration;
     configPath: string;
     printStats?: boolean;
@@ -20,10 +25,14 @@ interface IWebpackTaskConfig {
 }
 
 // @public (undocumented)
-declare const webpack: WebpackTask;
+const webpack: WebpackTask;
+
+export default webpack;
+
+export { webpack }
 
 // @public (undocumented)
-declare class WebpackTask<TExtendedConfig = {}> extends GulpTask<IWebpackTaskConfig & TExtendedConfig> {
+export class WebpackTask<TExtendedConfig = {}> extends GulpTask<IWebpackTaskConfig & TExtendedConfig> {
     // (undocumented)
     constructor(extendedName?: string, extendedConfig?: TExtendedConfig);
     // (undocumented)

--- a/common/reviews/api/gulp-core-build.api.md
+++ b/common/reviews/api/gulp-core-build.api.md
@@ -4,17 +4,21 @@
 
 ```ts
 
-// @public
-declare function addSuppression(suppression: string | RegExp): void;
-
-// @public (undocumented)
-declare const clean: IExecutable;
-
-// @public (undocumented)
-declare const cleanFlag: IExecutable;
+import gulp = require('gulp');
+import * as gulp_2 from 'gulp';
+import Orchestrator = require('orchestrator');
 
 // @public
-declare class CleanFlagTask extends CleanTask {
+export function addSuppression(suppression: string | RegExp): void;
+
+// @public (undocumented)
+export const clean: IExecutable;
+
+// @public (undocumented)
+export const cleanFlag: IExecutable;
+
+// @public
+export class CleanFlagTask extends CleanTask {
     // (undocumented)
     constructor();
     // (undocumented)
@@ -24,16 +28,16 @@ declare class CleanFlagTask extends CleanTask {
 }
 
 // @public
-declare class CleanTask extends GulpTask<void> {
+export class CleanTask extends GulpTask<void> {
     constructor();
     executeTask(gulp: typeof gulp_2, completeCallback: (error?: string | Error) => void): void;
 }
 
 // @public (undocumented)
-declare const copyStaticAssets: CopyStaticAssetsTask;
+export const copyStaticAssets: CopyStaticAssetsTask;
 
 // @public
-declare class CopyStaticAssetsTask extends GulpTask<ICopyStaticAssetsTaskConfig> {
+export class CopyStaticAssetsTask extends GulpTask<ICopyStaticAssetsTaskConfig> {
     // (undocumented)
     constructor();
     // (undocumented)
@@ -43,47 +47,47 @@ declare class CopyStaticAssetsTask extends GulpTask<ICopyStaticAssetsTaskConfig>
 }
 
 // @public
-declare class CopyTask extends GulpTask<ICopyConfig> {
+export class CopyTask extends GulpTask<ICopyConfig> {
     constructor();
     executeTask(gulp: typeof gulp_2, completeCallback: (error?: string | Error) => void): Promise<Object> | NodeJS.ReadWriteStream | void;
     loadSchema(): Object;
 }
 
 // @public
-declare function coverageData(coverage: number, threshold: number, filePath: string): void;
+export function coverageData(coverage: number, threshold: number, filePath: string): void;
 
 // @public
-declare function error(...args: Array<string>): void;
+export function error(...args: Array<string>): void;
 
 // @public
-declare function fileError(taskName: string, filePath: string, line: number, column: number, errorCode: string, message: string): void;
+export function fileError(taskName: string, filePath: string, line: number, column: number, errorCode: string, message: string): void;
 
 // @public
-declare function fileLog(write: (text: string) => void, taskName: string, filePath: string, line: number, column: number, errorCode: string, message: string): void;
+export function fileLog(write: (text: string) => void, taskName: string, filePath: string, line: number, column: number, errorCode: string, message: string): void;
 
 // @public
-declare function fileWarning(taskName: string, filePath: string, line: number, column: number, errorCode: string, message: string): void;
+export function fileWarning(taskName: string, filePath: string, line: number, column: number, errorCode: string, message: string): void;
 
 // @public
-declare function functionalTestRun(name: string, result: TestResultState, duration: number): void;
+export function functionalTestRun(name: string, result: TestResultState, duration: number): void;
 
 // @public
-declare class GenerateShrinkwrapTask extends GulpTask<void> {
+export class GenerateShrinkwrapTask extends GulpTask<void> {
     constructor();
     executeTask(gulp: gulp.Gulp, completeCallback: (error?: string | Error) => void): NodeJS.ReadWriteStream | void;
 }
 
 // @public
-declare function getConfig(): IBuildConfig;
+export function getConfig(): IBuildConfig;
 
 // @public
-declare function getErrors(): string[];
+export function getErrors(): string[];
 
 // @public
-declare function getWarnings(): string[];
+export function getWarnings(): string[];
 
 // @public
-declare abstract class GulpTask<TTaskConfig> implements IExecutable {
+export abstract class GulpTask<TTaskConfig> implements IExecutable {
     constructor(name: string, initialTaskConfig?: Partial<TTaskConfig>);
     buildConfig: IBuildConfig;
     cleanMatch: string[];
@@ -115,7 +119,7 @@ declare abstract class GulpTask<TTaskConfig> implements IExecutable {
 }
 
 // @public (undocumented)
-interface IBuildConfig {
+export interface IBuildConfig {
     args: {
         [name: string]: string | boolean;
     };
@@ -147,7 +151,7 @@ interface IBuildConfig {
 }
 
 // @public
-interface ICopyConfig {
+export interface ICopyConfig {
     copyTo: {
         [destPath: string]: string[];
     };
@@ -155,7 +159,7 @@ interface ICopyConfig {
 }
 
 // @public
-interface ICopyStaticAssetsTaskConfig {
+export interface ICopyStaticAssetsTaskConfig {
     // (undocumented)
     excludeExtensions?: string[];
     // (undocumented)
@@ -167,13 +171,13 @@ interface ICopyStaticAssetsTaskConfig {
 }
 
 // @public
-interface ICustomGulpTask {
+export interface ICustomGulpTask {
     // (undocumented)
     (gulp: typeof gulp_2 | GulpProxy, buildConfig: IBuildConfig, done?: (failure?: Object) => void): Promise<Object> | NodeJS.ReadWriteStream | void;
 }
 
 // @public (undocumented)
-interface IExecutable {
+export interface IExecutable {
     execute: (config: IBuildConfig) => Promise<void>;
     getCleanMatch?: (config: IBuildConfig, taskConfig?: any) => string[];
     isEnabled?: (buildConfig: IBuildConfig) => boolean;
@@ -182,7 +186,7 @@ interface IExecutable {
 }
 
 // @alpha
-interface IJestConfig {
+export interface IJestConfig {
     cache?: boolean;
     collectCoverageFrom?: string[];
     coverage?: boolean;
@@ -196,18 +200,18 @@ interface IJestConfig {
 }
 
 // @public
-declare function initialize(gulp: typeof gulp_2): void;
+export function initialize(gulp: typeof gulp_2): void;
 
 // @internal
-declare function _isJestEnabled(rootFolder: string): boolean;
+export function _isJestEnabled(rootFolder: string): boolean;
 
 // Warning: (ae-incompatible-release-tags) The symbol "jest" is marked as @public, but its signature references "JestTask" which is marked as @alpha
 // 
 // @public (undocumented)
-declare const jest: JestTask;
+export const jest: JestTask;
 
 // @alpha
-declare class JestTask extends GulpTask<IJestConfig> {
+export class JestTask extends GulpTask<IJestConfig> {
     // (undocumented)
     constructor();
     // (undocumented)
@@ -218,37 +222,37 @@ declare class JestTask extends GulpTask<IJestConfig> {
 }
 
 // @public
-declare function log(...args: Array<string>): void;
+export function log(...args: Array<string>): void;
 
 // @public
-declare function logSummary(value: string): void;
+export function logSummary(value: string): void;
 
 // @public
-declare function mergeConfig(config: Partial<IBuildConfig>): void;
+export function mergeConfig(config: Partial<IBuildConfig>): void;
 
 // @public
-declare function parallel(...tasks: Array<IExecutable[] | IExecutable>): IExecutable;
+export function parallel(...tasks: Array<IExecutable[] | IExecutable>): IExecutable;
 
 // @public
-declare function replaceConfig(config: IBuildConfig): void;
+export function replaceConfig(config: IBuildConfig): void;
 
 // @public
-declare function reset(): void;
+export function reset(): void;
 
 // @public
-declare function serial(...tasks: Array<IExecutable[] | IExecutable>): IExecutable;
+export function serial(...tasks: Array<IExecutable[] | IExecutable>): IExecutable;
 
 // @public
-declare function setConfig(config: Partial<IBuildConfig>): void;
+export function setConfig(config: Partial<IBuildConfig>): void;
 
 // @public
-declare function subTask(taskName: string, fn: ICustomGulpTask): IExecutable;
+export function subTask(taskName: string, fn: ICustomGulpTask): IExecutable;
 
 // @public
-declare function task(taskName: string, taskExecutable: IExecutable): IExecutable;
+export function task(taskName: string, taskExecutable: IExecutable): IExecutable;
 
 // @public
-declare enum TestResultState {
+export enum TestResultState {
     // (undocumented)
     Failed = 1,
     // (undocumented)
@@ -260,19 +264,19 @@ declare enum TestResultState {
 }
 
 // @public
-declare class ValidateShrinkwrapTask extends GulpTask<void> {
+export class ValidateShrinkwrapTask extends GulpTask<void> {
     constructor();
     executeTask(gulp: gulp.Gulp, completeCallback: (error: string) => void): NodeJS.ReadWriteStream | void;
     }
 
 // @public
-declare function verbose(...args: Array<string>): void;
+export function verbose(...args: Array<string>): void;
 
 // @public
-declare function warn(...args: Array<string>): void;
+export function warn(...args: Array<string>): void;
 
 // @public
-declare function watch(watchMatch: string | string[], taskExecutable: IExecutable): IExecutable;
+export function watch(watchMatch: string | string[], taskExecutable: IExecutable): IExecutable;
 
 
 // (No @packageDocumentation comment for this package)

--- a/common/reviews/api/node-library-build.api.md
+++ b/common/reviews/api/node-library-build.api.md
@@ -4,20 +4,23 @@
 
 ```ts
 
-// @public (undocumented)
-declare const buildTasks: IExecutable;
+import { CopyTask } from '@microsoft/gulp-core-build';
+import { IExecutable } from '@microsoft/gulp-core-build';
 
 // @public (undocumented)
-declare const defaultTasks: IExecutable;
+export const buildTasks: IExecutable;
 
 // @public (undocumented)
-declare const postCopy: CopyTask;
+export const defaultTasks: IExecutable;
 
 // @public (undocumented)
-declare const preCopy: CopyTask;
+export const postCopy: CopyTask;
 
 // @public (undocumented)
-declare const testTasks: IExecutable;
+export const preCopy: CopyTask;
+
+// @public (undocumented)
+export const testTasks: IExecutable;
 
 
 export * from "@microsoft/gulp-core-build";

--- a/common/reviews/api/package-deps-hash.api.md
+++ b/common/reviews/api/package-deps-hash.api.md
@@ -5,10 +5,10 @@
 ```ts
 
 // @public
-declare function getPackageDeps(packagePath?: string, excludedPaths?: string[]): IPackageDeps;
+export function getPackageDeps(packagePath?: string, excludedPaths?: string[]): IPackageDeps;
 
 // @public (undocumented)
-interface IPackageDeps {
+export interface IPackageDeps {
     // (undocumented)
     files: {
         [key: string]: string;

--- a/common/reviews/api/resolve-chunk-plugin.api.md
+++ b/common/reviews/api/resolve-chunk-plugin.api.md
@@ -4,8 +4,10 @@
 
 ```ts
 
+import * as Webpack from 'webpack';
+
 // @public
-declare class ResolveChunkPlugin implements Webpack.Plugin {
+export class ResolveChunkPlugin implements Webpack.Plugin {
     apply(compiler: Webpack.Compiler): void;
     }
 

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -4,8 +4,10 @@
 
 ```ts
 
+import { IPackageJson } from '@microsoft/node-core-library';
+
 // @public
-declare class ApprovedPackagesConfiguration {
+export class ApprovedPackagesConfiguration {
     // (undocumented)
     constructor(jsonFilename: string);
     // (undocumented)
@@ -21,13 +23,13 @@ declare class ApprovedPackagesConfiguration {
 }
 
 // @public
-declare class ApprovedPackagesItem {
+export class ApprovedPackagesItem {
     allowedCategories: Set<string>;
     packageName: string;
 }
 
 // @public
-declare class ApprovedPackagesPolicy {
+export class ApprovedPackagesPolicy {
     // Warning: (ae-forgotten-export) The symbol "IRushConfigurationJson" needs to be exported by the entry point index.d.ts
     // 
     // @internal (undocumented)
@@ -40,7 +42,7 @@ declare class ApprovedPackagesPolicy {
     }
 
 // @beta
-declare enum BumpType {
+export enum BumpType {
     // (undocumented)
     'major' = 5,
     // (undocumented)
@@ -56,12 +58,12 @@ declare enum BumpType {
 }
 
 // @public
-declare class ChangeManager {
+export class ChangeManager {
     static createEmptyChangeFiles(rushConfiguration: RushConfiguration, projectName: string, emailAddress: string): string | undefined;
 }
 
 // @public
-declare class CommonVersionsConfiguration {
+export class CommonVersionsConfiguration {
     readonly allowedAlternativeVersions: Map<string, ReadonlyArray<string>>;
     readonly filePath: string;
     getAllPreferredVersions(): Map<string, string>;
@@ -72,7 +74,7 @@ declare class CommonVersionsConfiguration {
     }
 
 // @beta (undocumented)
-declare const enum DependencyType {
+export const enum DependencyType {
     // (undocumented)
     Dev = "devDependencies",
     // (undocumented)
@@ -84,7 +86,7 @@ declare const enum DependencyType {
 }
 
 // @public
-declare const enum EnvironmentVariableNames {
+export const enum EnvironmentVariableNames {
     RUSH_ABSOLUTE_SYMLINKS = "RUSH_ABSOLUTE_SYMLINKS",
     RUSH_PREVIEW_VERSION = "RUSH_PREVIEW_VERSION",
     RUSH_TEMP_FOLDER = "RUSH_TEMP_FOLDER",
@@ -92,7 +94,7 @@ declare const enum EnvironmentVariableNames {
 }
 
 // @beta
-declare enum Event {
+export enum Event {
     postRushBuild = 4,
     postRushInstall = 2,
     preRushBuild = 3,
@@ -100,7 +102,7 @@ declare enum Event {
 }
 
 // @beta
-declare class EventHooks {
+export class EventHooks {
     // Warning: (ae-forgotten-export) The symbol "IEventHooksJson" needs to be exported by the entry point index.d.ts
     // 
     // @internal (undocumented)
@@ -109,7 +111,7 @@ declare class EventHooks {
     }
 
 // @beta
-declare class IndividualVersionPolicy extends VersionPolicy {
+export class IndividualVersionPolicy extends VersionPolicy {
     // Warning: (ae-forgotten-export) The symbol "IIndividualVersionJson" needs to be exported by the entry point index.d.ts
     // 
     // @internal (undocumented)
@@ -123,13 +125,13 @@ declare class IndividualVersionPolicy extends VersionPolicy {
 }
 
 // @public
-interface ITryFindRushJsonLocationOptions {
+export interface ITryFindRushJsonLocationOptions {
     showVerbose?: boolean;
     startingFolder?: string;
 }
 
 // @internal
-declare class _LastInstallFlag {
+export class _LastInstallFlag {
     constructor(folderPath: string, state?: Object);
     clear(): void;
     create(): void;
@@ -138,7 +140,7 @@ declare class _LastInstallFlag {
     }
 
 // @beta
-declare class LockStepVersionPolicy extends VersionPolicy {
+export class LockStepVersionPolicy extends VersionPolicy {
     // Warning: (ae-forgotten-export) The symbol "ILockStepVersionJson" needs to be exported by the entry point index.d.ts
     // 
     // @internal (undocumented)
@@ -155,7 +157,7 @@ declare class LockStepVersionPolicy extends VersionPolicy {
     }
 
 // @beta (undocumented)
-declare class PackageJsonDependency {
+export class PackageJsonDependency {
     // (undocumented)
     constructor(name: string, version: string, type: DependencyType, onChange: () => void);
     // (undocumented)
@@ -169,7 +171,7 @@ declare class PackageJsonDependency {
     }
 
 // @beta (undocumented)
-declare class PackageJsonEditor {
+export class PackageJsonEditor {
     // (undocumented)
     addOrUpdateDependency(packageName: string, newVersion: string, dependencyType: DependencyType): void;
     readonly dependencyList: ReadonlyArray<PackageJsonDependency>;
@@ -193,10 +195,10 @@ declare class PackageJsonEditor {
 }
 
 // @public
-declare type PackageManager = 'pnpm' | 'npm' | 'yarn';
+export type PackageManager = 'pnpm' | 'npm' | 'yarn';
 
 // @public
-declare class PnpmOptionsConfiguration {
+export class PnpmOptionsConfiguration {
     // Warning: (ae-forgotten-export) The symbol "IPnpmOptionsJson" needs to be exported by the entry point index.d.ts
     // 
     // @internal (undocumented)
@@ -205,14 +207,14 @@ declare class PnpmOptionsConfiguration {
 }
 
 // @public
-declare class Rush {
+export class Rush {
     static launch(launcherVersion: string, isManaged: boolean): void;
     static launchRushX(launcherVersion: string, isManaged: boolean): void;
     static readonly version: string;
 }
 
 // @public
-declare class RushConfiguration {
+export class RushConfiguration {
     readonly approvedPackagesPolicy: ApprovedPackagesPolicy;
     readonly changesFolder: string;
     // @deprecated
@@ -274,7 +276,7 @@ declare class RushConfiguration {
     }
 
 // @public
-declare class RushConfigurationProject {
+export class RushConfigurationProject {
     // Warning: (ae-forgotten-export) The symbol "IRushConfigurationProjectJson" needs to be exported by the entry point index.d.ts
     // 
     // @internal (undocumented)
@@ -302,7 +304,7 @@ declare class RushConfigurationProject {
     }
 
 // @internal
-declare class _RushGlobalFolder {
+export class _RushGlobalFolder {
     // (undocumented)
     constructor();
     readonly nodeSpecificPath: string;
@@ -310,7 +312,7 @@ declare class _RushGlobalFolder {
     }
 
 // @beta
-declare abstract class VersionPolicy {
+export abstract class VersionPolicy {
     // @internal (undocumented)
     constructor(versionPolicyJson: IVersionPolicyJson);
     abstract bump(bumpType?: BumpType, identifier?: string): void;
@@ -330,7 +332,7 @@ declare abstract class VersionPolicy {
     }
 
 // @beta
-declare class VersionPolicyConfiguration {
+export class VersionPolicyConfiguration {
     // @internal (undocumented)
     constructor(jsonFileName: string);
     bump(versionPolicyName?: string, bumpType?: BumpType, identifier?: string, shouldCommit?: boolean): void;
@@ -341,7 +343,7 @@ declare class VersionPolicyConfiguration {
     }
 
 // @beta
-declare enum VersionPolicyDefinitionName {
+export enum VersionPolicyDefinitionName {
     // (undocumented)
     'individualVersion' = 1,
     // (undocumented)
@@ -349,7 +351,7 @@ declare enum VersionPolicyDefinitionName {
 }
 
 // @public
-declare class YarnOptionsConfiguration {
+export class YarnOptionsConfiguration {
     // Warning: (ae-forgotten-export) The symbol "IYarnOptionsJson" needs to be exported by the entry point index.d.ts
     // 
     // @internal (undocumented)

--- a/common/reviews/api/rushell.api.md
+++ b/common/reviews/api/rushell.api.md
@@ -5,12 +5,12 @@
 ```ts
 
 // @beta
-interface IRushellExecuteResult {
+export interface IRushellExecuteResult {
     value: string;
 }
 
 // @beta
-declare class Rushell {
+export class Rushell {
     // (undocumented)
     execute(script: string): IRushellExecuteResult;
 }

--- a/common/reviews/api/set-webpack-public-path-plugin.api.md
+++ b/common/reviews/api/set-webpack-public-path-plugin.api.md
@@ -4,11 +4,13 @@
 
 ```ts
 
-// @public
-declare function getGlobalRegisterCode(debug?: boolean): string;
+import * as Webpack from 'webpack';
 
 // @public
-interface ISetWebpackPublicPathOptions {
+export function getGlobalRegisterCode(debug?: boolean): string;
+
+// @public
+export interface ISetWebpackPublicPathOptions {
     getPostProcessScript?: (varName: string) => string;
     preferLastFoundScript?: boolean;
     publicPath?: string;
@@ -19,7 +21,7 @@ interface ISetWebpackPublicPathOptions {
 }
 
 // @public
-interface ISetWebpackPublicPathPluginOptions extends ISetWebpackPublicPathOptions {
+export interface ISetWebpackPublicPathPluginOptions extends ISetWebpackPublicPathOptions {
     scriptName?: {
         name: string;
         isTokenized: boolean;
@@ -27,10 +29,10 @@ interface ISetWebpackPublicPathPluginOptions extends ISetWebpackPublicPathOption
 }
 
 // @public (undocumented)
-declare const registryVariableName: string;
+export const registryVariableName: string;
 
 // @public
-declare class SetPublicPathPlugin implements Webpack.Plugin {
+export class SetPublicPathPlugin implements Webpack.Plugin {
     // (undocumented)
     constructor(options: ISetWebpackPublicPathPluginOptions);
     // (undocumented)

--- a/common/reviews/api/stream-collator.api.md
+++ b/common/reviews/api/stream-collator.api.md
@@ -5,7 +5,7 @@
 ```ts
 
 // @public
-declare class Interleaver {
+export class Interleaver {
     static registerTask(taskName: string, quietMode?: boolean): ITaskWriter;
     static reset(): void;
     static setStdOut(stdout: {
@@ -14,7 +14,7 @@ declare class Interleaver {
     }
 
 // @public
-interface ITaskWriter {
+export interface ITaskWriter {
     // (undocumented)
     close(): void;
     // (undocumented)

--- a/common/reviews/api/web-library-build-test.api.md
+++ b/common/reviews/api/web-library-build-test.api.md
@@ -5,13 +5,13 @@
 ```ts
 
 // @public (undocumented)
-declare function add(num1: number, num2: number): number;
+export function add(num1: number, num2: number): number;
 
 // @public (undocumented)
-declare function log(message: string): void;
+export function log(message: string): void;
 
 // @public (undocumented)
-declare function logClass(): void;
+export function logClass(): void;
 
 
 // (No @packageDocumentation comment for this package)

--- a/common/reviews/api/web-library-build.api.md
+++ b/common/reviews/api/web-library-build.api.md
@@ -4,34 +4,41 @@
 
 ```ts
 
-// @public (undocumented)
-declare const buildTasks: IExecutable;
+import { CopyTask } from '@microsoft/gulp-core-build';
+import { GenerateShrinkwrapTask } from '@microsoft/gulp-core-build';
+import { GulpTask } from '@microsoft/gulp-core-build';
+import gulpType = require('gulp');
+import { IExecutable } from '@microsoft/gulp-core-build';
+import { ValidateShrinkwrapTask } from '@microsoft/gulp-core-build';
 
 // @public (undocumented)
-declare const bundleTasks: IExecutable;
+export const buildTasks: IExecutable;
 
 // @public (undocumented)
-declare const defaultTasks: IExecutable;
+export const bundleTasks: IExecutable;
 
 // @public (undocumented)
-declare const generateShrinkwrapTask: GenerateShrinkwrapTask;
+export const defaultTasks: IExecutable;
 
 // @public (undocumented)
-declare const postCopy: CopyTask;
+export const generateShrinkwrapTask: GenerateShrinkwrapTask;
+
+// @public (undocumented)
+export const postCopy: CopyTask;
 
 // Warning: (ae-forgotten-export) The symbol "PostProcessSourceMaps" needs to be exported by the entry point index.d.ts
 // 
 // @public (undocumented)
-declare const postProcessSourceMapsTask: PostProcessSourceMaps;
+export const postProcessSourceMapsTask: PostProcessSourceMaps;
 
 // @public (undocumented)
-declare const preCopy: CopyTask;
+export const preCopy: CopyTask;
 
 // @public (undocumented)
-declare const testTasks: IExecutable;
+export const testTasks: IExecutable;
 
 // @public (undocumented)
-declare const validateShrinkwrapTask: ValidateShrinkwrapTask;
+export const validateShrinkwrapTask: ValidateShrinkwrapTask;
 
 
 export * from "@microsoft/gulp-core-build";


### PR DESCRIPTION
Example from the [exportDuplicate](https://github.com/Microsoft/web-build-tools/blob/master/build-tests/api-extractor-scenarios/src/exportDuplicate/index.ts) test input:

**Before:**

```ts

// @public (undocumented)
declare class A {
}

// @public (undocumented)
declare class X {
}
```

**After:**

```ts
// @public (undocumented)
class A {
}

export { A as B }

export { A as C }

// @public (undocumented)
class X {
}

export { X }

export { X as Y }
```
