### PR TITLE
Bump cyclic dependencies

### DIFF
--- a/apps/api-extractor-model/package.json
+++ b/apps/api-extractor-model/package.json
@@ -22,8 +22,8 @@
     "@types/node": "8.5.8"
   },
   "devDependencies": {
-    "@microsoft/node-library-build": "6.0.44",
-    "@microsoft/rush-stack-compiler-3.2": "0.2.17",
+    "@microsoft/node-library-build": "6.0.49",
+    "@microsoft/rush-stack-compiler-3.2": "0.3.1",
     "@types/jest": "23.3.11",
     "gulp": "~3.9.1",
     "tslint-microsoft-contrib": "~5.2.1"

--- a/apps/api-extractor-model/src/items/ApiDeclaredItem.ts
+++ b/apps/api-extractor-model/src/items/ApiDeclaredItem.ts
@@ -5,7 +5,7 @@ import { ApiDocumentedItem, IApiDocumentedItemJson, IApiDocumentedItemOptions } 
 import { Excerpt, ExcerptToken, IExcerptTokenRange, IExcerptToken } from '../mixins/Excerpt';
 
 /**
- * Constructor options for {@link (ApiDeclaredItem:interface)}.
+ * Constructor options for {@link ApiDeclaredItem}.
  * @public
  */
 export interface IApiDeclaredItemOptions extends IApiDocumentedItemOptions {

--- a/apps/api-extractor-model/src/mixins/ApiItemContainerMixin.ts
+++ b/apps/api-extractor-model/src/mixins/ApiItemContainerMixin.ts
@@ -36,7 +36,8 @@ const _membersByName: unique symbol = Symbol('ApiItemContainerMixin._membersByNa
  *
  * Examples of `ApiItemContainerMixin` child classes include `ApiModel`, `ApiPackage`, `ApiEntryPoint`,
  * and `ApiEnum`.  But note that `Parameter` is not considered a "member" of an `ApiMethod`; this relationship
- * is modeled using {@link ApiParameterListMixin.parameters} instead of {@link ApiItemContainerMixin.members}.
+ * is modeled using {@link (ApiParameterListMixin:interface).parameters} instead
+ * of {@link (ApiItemContainerMixin:interface).members}.
  *
  * @public
  */
@@ -70,7 +71,7 @@ export interface ApiItemContainerMixin extends ApiItem {
 }
 
 /**
- * Mixin function for {@link (ApiDeclaredItem:interface)}.
+ * Mixin function for {@link ApiDeclaredItem}.
  *
  * @param baseClass - The base class to be extended
  * @returns A child class that extends baseClass, adding the {@link (ApiItemContainerMixin:interface)} functionality.

--- a/apps/api-extractor-model/src/mixins/Excerpt.ts
+++ b/apps/api-extractor-model/src/mixins/Excerpt.ts
@@ -47,7 +47,7 @@ export class ExcerptToken {
 }
 
 /**
- * This class is used by {@link (ApiDeclaredItem:interface)} to represent a source code excerpt containing
+ * This class is used by {@link ApiDeclaredItem} to represent a source code excerpt containing
  * a TypeScript declaration.
  *
  * @remarks

--- a/apps/api-extractor-model/src/model/ApiModel.ts
+++ b/apps/api-extractor-model/src/model/ApiModel.ts
@@ -17,8 +17,8 @@ import { DocDeclarationReference } from '@microsoft/tsdoc';
  * important information needed to generate documentation, without any reliance on the TypeScript compiler engine.
  *
  * An `ApiModel` acts as the root of a tree of objects that all inherit from the `ApiItem` base class.
- * The tree children are determined by the {@link ApiItemContainerMixin} mixin base class.  The model contains
- * packages.  Packages have an entry point (today, only one).  And the entry point can contain various types
+ * The tree children are determined by the {@link (ApiItemContainerMixin:interface)} mixin base class.  The model
+ * contains packages.  Packages have an entry point (today, only one).  And the entry point can contain various types
  * of API declarations.  The container relationships might look like this:
  *
  * ```

--- a/apps/api-extractor-model/src/model/ApiPackage.ts
+++ b/apps/api-extractor-model/src/model/ApiPackage.ts
@@ -68,7 +68,13 @@ export interface IApiPackageSaveOptions extends IJsonFileSaveOptions {
    */
   toolVersion?: string;
 
-  /** {@inheritDoc IExtractorConfig.testMode} */
+  /**
+   * Set to true only when invoking API Extractor's test harness.
+   *
+   * @remarks
+   * When `testMode` is true, the `toolVersion` field in the .api.json file is assigned an empty string
+   * to prevent spurious diffs in output files tracked for tests.
+   */
   testMode?: boolean;
 }
 

--- a/apps/api-extractor-model/src/model/Parameter.ts
+++ b/apps/api-extractor-model/src/model/Parameter.ts
@@ -30,7 +30,7 @@ export interface IParameterOptions {
  * }
  * ```
  *
- * `Parameter` objects belong to the {@link ApiParameterListMixin.parameters} collection.
+ * `Parameter` objects belong to the {@link (ApiParameterListMixin:interface).parameters} collection.
  *
  * @public
  */

--- a/apps/api-extractor/package.json
+++ b/apps/api-extractor/package.json
@@ -46,8 +46,8 @@
     "typescript": "~3.1.6"
   },
   "devDependencies": {
-    "@microsoft/node-library-build": "6.0.44",
-    "@microsoft/rush-stack-compiler-3.2": "0.2.17",
+    "@microsoft/node-library-build": "6.0.49",
+    "@microsoft/rush-stack-compiler-3.2": "0.3.1",
     "@types/jest": "23.3.11",
     "@types/lodash": "4.14.116",
     "@types/node": "8.5.8",

--- a/apps/api-extractor/src/api/IExtractorConfig.ts
+++ b/apps/api-extractor/src/api/IExtractorConfig.ts
@@ -268,7 +268,7 @@ export interface IExtractorTsdocMetadataConfig {
 }
 
 /**
- * Used with {@link IExtractorMessageRoutingConfig.logLevel}.
+ * Used with {@link IExtractorMessageReportingRuleConfig.logLevel}.
  *
  * @public
  */

--- a/common/changes/@microsoft/api-extractor-model/octogonz-bump-cyclics_2019-04-03-03-31.json
+++ b/common/changes/@microsoft/api-extractor-model/octogonz-bump-cyclics_2019-04-03-03-31.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@microsoft/api-extractor-model",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor-model",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/api-extractor/octogonz-bump-cyclics_2019-04-03-03-31.json
+++ b/common/changes/@microsoft/api-extractor/octogonz-bump-cyclics_2019-04-03-03-31.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@microsoft/api-extractor",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/gulp-core-build-mocha/octogonz-bump-cyclics_2019-04-03-03-31.json
+++ b/common/changes/@microsoft/gulp-core-build-mocha/octogonz-bump-cyclics_2019-04-03-03-31.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@microsoft/gulp-core-build-mocha",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/gulp-core-build-mocha",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/gulp-core-build-typescript/octogonz-bump-cyclics_2019-04-03-03-31.json
+++ b/common/changes/@microsoft/gulp-core-build-typescript/octogonz-bump-cyclics_2019-04-03-03-31.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@microsoft/gulp-core-build-typescript",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/gulp-core-build-typescript",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/gulp-core-build/octogonz-bump-cyclics_2019-04-03-03-31.json
+++ b/common/changes/@microsoft/gulp-core-build/octogonz-bump-cyclics_2019-04-03-03-31.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@microsoft/gulp-core-build",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/gulp-core-build",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/node-core-library/octogonz-bump-cyclics_2019-04-03-03-31.json
+++ b/common/changes/@microsoft/node-core-library/octogonz-bump-cyclics_2019-04-03-03-31.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@microsoft/node-core-library",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/node-core-library",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush-stack-compiler-2.4/octogonz-bump-cyclics_2019-04-03-03-31.json
+++ b/common/changes/@microsoft/rush-stack-compiler-2.4/octogonz-bump-cyclics_2019-04-03-03-31.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@microsoft/rush-stack-compiler-2.4",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush-stack-compiler-2.4",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush-stack-compiler-2.7/octogonz-bump-cyclics_2019-04-03-03-31.json
+++ b/common/changes/@microsoft/rush-stack-compiler-2.7/octogonz-bump-cyclics_2019-04-03-03-31.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@microsoft/rush-stack-compiler-2.7",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush-stack-compiler-2.7",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush-stack-compiler-2.9/octogonz-bump-cyclics_2019-04-03-03-31.json
+++ b/common/changes/@microsoft/rush-stack-compiler-2.9/octogonz-bump-cyclics_2019-04-03-03-31.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@microsoft/rush-stack-compiler-2.9",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush-stack-compiler-2.9",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush-stack-compiler-3.0/octogonz-bump-cyclics_2019-04-03-03-31.json
+++ b/common/changes/@microsoft/rush-stack-compiler-3.0/octogonz-bump-cyclics_2019-04-03-03-31.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@microsoft/rush-stack-compiler-3.0",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush-stack-compiler-3.0",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush-stack-compiler-3.1/octogonz-bump-cyclics_2019-04-03-03-31.json
+++ b/common/changes/@microsoft/rush-stack-compiler-3.1/octogonz-bump-cyclics_2019-04-03-03-31.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@microsoft/rush-stack-compiler-3.1",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush-stack-compiler-3.1",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush-stack-compiler-3.2/octogonz-bump-cyclics_2019-04-03-03-31.json
+++ b/common/changes/@microsoft/rush-stack-compiler-3.2/octogonz-bump-cyclics_2019-04-03-03-31.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@microsoft/rush-stack-compiler-3.2",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush-stack-compiler-3.2",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush-stack-compiler-3.3/octogonz-bump-cyclics_2019-04-03-03-31.json
+++ b/common/changes/@microsoft/rush-stack-compiler-3.3/octogonz-bump-cyclics_2019-04-03-03-31.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@microsoft/rush-stack-compiler-3.3",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush-stack-compiler-3.3",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/ts-command-line/octogonz-bump-cyclics_2019-04-03-03-31.json
+++ b/common/changes/@microsoft/ts-command-line/octogonz-bump-cyclics_2019-04-03-03-31.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@microsoft/ts-command-line",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/ts-command-line",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/config/rush/shrinkwrap.yaml
+++ b/common/config/rush/shrinkwrap.yaml
@@ -1,6 +1,6 @@
 dependencies:
-  '@microsoft/node-library-build': 6.0.44
-  '@microsoft/rush-stack-compiler-3.2': 0.2.17
+  '@microsoft/node-library-build': 6.0.49
+  '@microsoft/rush-stack-compiler-3.2': 0.3.1
   '@microsoft/teams-js': 1.3.0-beta.4
   '@microsoft/tsdoc': 0.12.8
   '@pnpm/link-bins': 1.0.3
@@ -190,7 +190,7 @@ packages:
     dev: false
     resolution:
       integrity: sha512-kZJaWwdu3z5A1DugJpOZ9dI5+DjIEhqQJwHn2/kLTpsKT7gOyqNRbGHlDGG8xSiJ6/m994+cwh3qSGYDC17dtw==
-  /@microsoft/api-extractor/7.0.32:
+  /@microsoft/api-extractor/7.0.36:
     dependencies:
       '@microsoft/api-extractor-model': 7.0.28
       '@microsoft/node-core-library': 3.13.0
@@ -204,10 +204,10 @@ packages:
     dev: false
     hasBin: true
     resolution:
-      integrity: sha512-MRXI3FVEXHrt1cjZ9tjhPF422RydWOZkD0LF8y+IRmz/QhYTQ7xFMy0afI/PBWw+607sLNTchgYx1gtHBgsn+g==
-  /@microsoft/gulp-core-build-mocha/3.5.71:
+      integrity: sha512-bA7RD7ud6TpiMiNceFwfcx9O6gv5ibC4URgMPbT35urYpUku05Eqsrliv3ShI1/Yyg+7rMC+hOFrHx8FKMR2pw==
+  /@microsoft/gulp-core-build-mocha/3.5.76:
     dependencies:
-      '@microsoft/gulp-core-build': 3.9.21
+      '@microsoft/gulp-core-build': 3.9.26
       '@types/node': 8.5.8
       glob: 7.0.6
       gulp: 3.9.1
@@ -215,12 +215,12 @@ packages:
       gulp-mocha: 6.0.0
     dev: false
     resolution:
-      integrity: sha512-V8bjEJWUKzr/u/xK4zizrXrCMDI6ipmmcz7t1XP8naa/UFh0xQlpJ1Ij9gs1e5PWZDZU5wz51BNvklApcdhpOQ==
-  /@microsoft/gulp-core-build-typescript/8.0.18:
+      integrity: sha512-EHRw/j+qsK50SbQgph2GoDwmpLUZtvEovcoU1UtKVSyGdzKJugeQpjhocOyPwkHVo3pWovmxl/PEiOL8qTcDCQ==
+  /@microsoft/gulp-core-build-typescript/8.0.23:
     dependencies:
-      '@microsoft/gulp-core-build': 3.9.21
+      '@microsoft/gulp-core-build': 3.9.26
       '@microsoft/node-core-library': 3.13.0
-      '@microsoft/rush-stack-compiler-3.2': 0.2.17
+      '@microsoft/rush-stack-compiler-3.2': 0.3.1
       '@types/node': 8.5.8
       decomment: 0.9.2
       glob: 7.0.6
@@ -228,8 +228,8 @@ packages:
       resolve: 1.8.1
     dev: false
     resolution:
-      integrity: sha512-yQF80WQ0k3Mff3zvr6PjMxn2XO9vyWXld7Z08NR7sCBW7iL/24h5f9Q4eRt+7hF1bWQwqWRW4XCq3fja3yuPUg==
-  /@microsoft/gulp-core-build/3.9.21:
+      integrity: sha512-xJ3aJqdKue0Tzsw/BRP8/dyVbYNKeFbnHIibucH7XRaPh2WtsLJLTU8ZxK3Or/jdlfgiG46A9zlc9bMWXuNfMQ==
+  /@microsoft/gulp-core-build/3.9.26:
     dependencies:
       '@microsoft/node-core-library': 3.13.0
       '@types/assertion-error': 1.0.30
@@ -271,7 +271,7 @@ packages:
       z-schema: 3.18.4
     dev: false
     resolution:
-      integrity: sha512-izzX4/uO1NLljxNu2SsdWJhOu8nQun/ZfhuYPTUqWA9i7KpgSLvbSpkLQjP0h5CiYpJ5DeNLcXJHTNbHFglZhA==
+      integrity: sha512-GdLRARlD/t6KStdmA8D6+NwSd8SgtuRDq9m3RU3zBVXrwSgaQkPls6TYBDBusluVBxPJmMIL56/7pn8ZbpPprg==
   /@microsoft/node-core-library/3.13.0:
     dependencies:
       '@types/fs-extra': 5.0.4
@@ -285,20 +285,20 @@ packages:
     dev: false
     resolution:
       integrity: sha512-mnsL/1ikVWHl8sPNssavaAgtUaIM3hkQ8zeySuApU5dNmsMPzovJPfx9m5JGiMvs1v5QNAIVeiS9jnWwe/7anw==
-  /@microsoft/node-library-build/6.0.44:
+  /@microsoft/node-library-build/6.0.49:
     dependencies:
-      '@microsoft/gulp-core-build': 3.9.21
-      '@microsoft/gulp-core-build-mocha': 3.5.71
-      '@microsoft/gulp-core-build-typescript': 8.0.18
+      '@microsoft/gulp-core-build': 3.9.26
+      '@microsoft/gulp-core-build-mocha': 3.5.76
+      '@microsoft/gulp-core-build-typescript': 8.0.23
       '@types/gulp': 3.8.32
       '@types/node': 8.5.8
       gulp: 3.9.1
     dev: false
     resolution:
-      integrity: sha512-oh5v1h7OJfvn5yF2LOU1GAlMpaLYzZStKP4m5mvPY7Det5OjNA1Qr5REXgZz6mGcVq2UW9oOd6jAk0zUpqX9jQ==
-  /@microsoft/rush-stack-compiler-3.2/0.2.17:
+      integrity: sha512-ZoHVLOUnUDXStv6RXSj4YlVVcuQF2j+tP0JDZpnZHlB8M1zSpItSpRe5RqK7ZXywNwwd4Jm6BIOGdE02OZwD5w==
+  /@microsoft/rush-stack-compiler-3.2/0.3.1:
     dependencies:
-      '@microsoft/api-extractor': 7.0.32
+      '@microsoft/api-extractor': 7.0.36
       '@microsoft/node-core-library': 3.13.0
       '@types/node': 8.5.8
       tslint: 5.12.1
@@ -307,7 +307,7 @@ packages:
     dev: false
     hasBin: true
     resolution:
-      integrity: sha512-j0Z4cBjptoDL77QroEmwF4BVheLhRsi66jk0m6qPIgLb6l4+UNFmv1rK5aRbk5XLA+IFcvUiJG09pJbjeh26Fg==
+      integrity: sha512-nYRQ2q+H6QiTOmXQ10fPwWVO1TWQ4OaKTsAvr1wMTVAgjBdu249Ppdn5jbqeVhXqoNCJDdn3vW9W3JEDPArNNw==
   /@microsoft/teams-js/1.3.0-beta.4:
     dev: false
     resolution:
@@ -1161,7 +1161,7 @@ packages:
       integrity: sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
   /autoprefixer/9.1.5:
     dependencies:
-      browserslist: 4.5.3
+      browserslist: 4.5.4
       caniuse-lite: 1.0.30000955
       normalize-range: 0.1.2
       num2fraction: 1.2.2
@@ -1583,15 +1583,15 @@ packages:
     dev: false
     resolution:
       integrity: sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==
-  /browserslist/4.5.3:
+  /browserslist/4.5.4:
     dependencies:
       caniuse-lite: 1.0.30000955
       electron-to-chromium: 1.3.122
-      node-releases: 1.1.12
+      node-releases: 1.1.13
     dev: false
     hasBin: true
     resolution:
-      integrity: sha512-Tx/Jtrmh6vFg24AelzLwCaCq1IUJiMDM1x/LPzqbmbktF8Zo7F9ONUpOWsFK6TtdON95mSMaQUWqi0ilc8xM6g==
+      integrity: sha512-rAjx494LMjqKnMPhFkuLmLp8JWEX0o8ADTGeAbOqaF+XCvYLreZrG5uVjnPBlAQ8REZK4pzXGvp0bWgrFtKaag==
   /bser/2.0.0:
     dependencies:
       node-int64: 0.4.0
@@ -1958,8 +1958,13 @@ packages:
       integrity: sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==
   /commander/2.19.0:
     dev: false
+    optional: true
     resolution:
       integrity: sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==
+  /commander/2.20.0:
+    dev: false
+    resolution:
+      integrity: sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==
   /component-emitter/1.2.1:
     dev: false
     resolution:
@@ -2161,12 +2166,6 @@ packages:
     dev: false
     resolution:
       integrity: sha512-tNvaxM5blOnxanyxI6panOsnfiyLRj3HV4qjqqS45WPNS1usdYWRUQjqTEEELK73lpeP/1KoIGYUwrBn/VcECA==
-  /cssstyle/1.2.2:
-    dependencies:
-      cssom: 0.3.6
-    dev: false
-    resolution:
-      integrity: sha512-43wY3kl1CVQSvL7wUY1qXkxVGkStjpkDmVjiIKX8R97uhajy8Bybay78uOtqvh7Q5GK75dNPfW0geWjE6qQQow==
   /currently-unhandled/0.4.1:
     dependencies:
       array-find-index: 1.0.2
@@ -3745,7 +3744,7 @@ packages:
       node: '>=0.4.7'
     hasBin: true
     optionalDependencies:
-      uglify-js: 3.5.2
+      uglify-js: 3.5.3
     resolution:
       integrity: sha512-3Zhi6C0euYZL5sM0Zcy7lInLXKQ+YLcF/olbN010mzGQ4XVm50JeyBnMqofHh696GrciGruC7kCcApPDJvVgwA==
   /har-schema/2.0.0:
@@ -5162,7 +5161,7 @@ packages:
       escodegen: 1.11.1
       html-encoding-sniffer: 1.0.2
       left-pad: 1.3.0
-      nwsapi: 2.1.2
+      nwsapi: 2.1.3
       parse5: 4.0.0
       pn: 1.1.0
       request: 2.88.0
@@ -5180,39 +5179,6 @@ packages:
     dev: false
     resolution:
       integrity: sha512-ou1VyfjwsSuWkudGxb03FotDajxAto6USAlmMZjE2lc0jCznt7sBWkhfRBRaWwbnmDqdMSTKTLT5d9sBFkkM7A==
-  /jsdom/14.0.0:
-    dependencies:
-      abab: 2.0.0
-      acorn: 6.1.1
-      acorn-globals: 4.3.0
-      array-equal: 1.0.0
-      cssom: 0.3.6
-      cssstyle: 1.2.2
-      data-urls: 1.1.0
-      domexception: 1.0.1
-      escodegen: 1.11.1
-      html-encoding-sniffer: 1.0.2
-      nwsapi: 2.1.2
-      parse5: 5.1.0
-      pn: 1.1.0
-      request: 2.88.0
-      request-promise-native: /request-promise-native/1.0.7/request@2.88.0
-      saxes: 3.1.9
-      symbol-tree: 3.2.2
-      tough-cookie: 2.5.0
-      w3c-hr-time: 1.0.1
-      w3c-xmlserializer: 1.1.2
-      webidl-conversions: 4.0.2
-      whatwg-encoding: 1.0.5
-      whatwg-mimetype: 2.3.0
-      whatwg-url: 7.0.0
-      ws: 6.2.1
-      xml-name-validator: 3.0.0
-    dev: false
-    engines:
-      node: '>=8'
-    resolution:
-      integrity: sha512-/VkyPmdtbwqpJSkwDx3YyJ3U1oawYNB/h5z8vTUZGAzjtu2OHTeFRfnJqyMHsJ5Cyes23trOmvUpM1GfHH1leA==
   /jsesc/0.5.0:
     dev: false
     hasBin: true
@@ -5971,6 +5937,7 @@ packages:
     resolution:
       integrity: sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==
   /natives/1.1.6:
+    deprecated: 'This module relies on Node.js''s internals and will break at some point. Do not use it, and update to graceful-fs@4.x.'
     dev: false
     resolution:
       integrity: sha512-6+TDFewD4yxY14ptjKaS63GVdtKiES1pTPyxn9Jb0rBqPMZ7VcCiooEhPNsr+mqHtMGxa/5c/HhcC4uPEUw/nA==
@@ -6091,12 +6058,12 @@ packages:
     dev: false
     resolution:
       integrity: sha512-SUDEb+o71XR5lXSTyivXd9J7fCloE3SyP4lSgt3lU2oSANiox+SxlNRGPjDKrwU1YN3ix2KN/VGGCg0t01rttQ==
-  /node-releases/1.1.12:
+  /node-releases/1.1.13:
     dependencies:
       semver: 5.3.0
     dev: false
     resolution:
-      integrity: sha512-Y+AQ1xdjcgaEzpL65PBEF3fnl1FNKnDh9Zm+AUQLIlyyqtSc4u93jyMN4zrjMzdwKQ10RTr3tgY1x7qpsfF/xg==
+      integrity: sha512-fKZGviSXR6YvVPyc011NHuJDSD8gFQvLPmc2d2V3BS4gr52ycyQ1Xzs7a8B+Ax3Ni/W+5h1h4SqmzeoA8WZRmA==
   /node-sass/4.9.3:
     dependencies:
       async-foreach: 0.1.3
@@ -6197,12 +6164,10 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=
-  /nwsapi/2.1.2:
-    dependencies:
-      jsdom: 14.0.0
+  /nwsapi/2.1.3:
     dev: false
     resolution:
-      integrity: sha512-TQOQNxqEdxVjwgwNZyvKDF0vALmzQKZJEZwE3fZWDb7Ns5Hw6l9PxJTGKOHZGsmf7R6grsOe8lWxI43Clz79zg==
+      integrity: sha512-RowAaJGEgYXEZfQ7tvvdtAQUKPyTR6T6wNu0fwlNsGQYr/h3yQc6oI8WnVZh3Y/Sylwc+dtAlvPqfFZjhTyk3A==
   /oauth-sign/0.8.2:
     dev: false
     resolution:
@@ -6517,10 +6482,6 @@ packages:
     dev: false
     resolution:
       integrity: sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA==
-  /parse5/5.1.0:
-    dev: false
-    resolution:
-      integrity: sha512-fxNG2sQjHvlVAYmzBZS9YlDp6PTSSDwa98vkD4QgVDDCAo84z5X1t5XyJQ62ImdLXx5NdIIfihey6xpum9/gRQ==
   /parseurl/1.3.2:
     dev: false
     engines:
@@ -7443,14 +7404,6 @@ packages:
     dev: false
     resolution:
       integrity: sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
-  /saxes/3.1.9:
-    dependencies:
-      xmlchars: 1.3.1
-    dev: false
-    engines:
-      node: '>=8'
-    resolution:
-      integrity: sha512-FZeKhJglhJHk7eWG5YM0z46VHmI3KJpMBAQm3xa9meDvd+wevB5GuBB0wc0exPInZiBBHqi00DbS8AcvCGCFMw==
   /scss-tokenizer/0.2.3:
     dependencies:
       js-base64: 2.5.1
@@ -8354,7 +8307,7 @@ packages:
       babel-code-frame: 6.26.0
       builtin-modules: 1.1.1
       chalk: 2.4.2
-      commander: 2.19.0
+      commander: 2.20.0
       diff: 3.5.0
       glob: 7.1.3
       js-yaml: 3.9.1
@@ -8500,7 +8453,7 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-0h/qGay016GG2lVav3Kz174F3T2Vjlz2v6HCt+WDQpoXfco0hWwF5gHK9yh88mUYvIC+N7Z8NT8WpjSp1yoqGA==
-  /uglify-js/3.5.2:
+  /uglify-js/3.5.3:
     dependencies:
       commander: 2.19.0
       source-map: 0.6.1
@@ -8510,7 +8463,7 @@ packages:
     hasBin: true
     optional: true
     resolution:
-      integrity: sha512-imog1WIsi9Yb56yRt5TfYVxGmnWs3WSGU73ieSOlMVFwhJCA9W8fqFFMMj4kgDqiS/80LGdsYnWL7O9UcjEBlg==
+      integrity: sha512-rIQPT2UMDnk4jRX+w4WO84/pebU2jiLsjgIyrCktYgSvx28enOE3iYQMr+BD1rHiitWnDmpu0cY/LfIEpKcjcw==
   /uglify-to-browserify/1.0.2:
     dev: false
     optional: true
@@ -8743,14 +8696,6 @@ packages:
     dev: false
     resolution:
       integrity: sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=
-  /w3c-xmlserializer/1.1.2:
-    dependencies:
-      domexception: 1.0.1
-      webidl-conversions: 4.0.2
-      xml-name-validator: 3.0.0
-    dev: false
-    resolution:
-      integrity: sha512-p10l/ayESzrBMYWRID6xbuCKh2Fp77+sA0doRuGn4tTIMrrZVeqfpKjXHY+oDh3K4nLdPgNwMTVP6Vp4pvqbNg==
   /walker/1.0.7:
     dependencies:
       makeerror: 1.0.11
@@ -8935,20 +8880,10 @@ packages:
     dev: false
     resolution:
       integrity: sha512-ZGh/8kF9rrRNffkLFV4AzhvooEclrOH0xaugmqGsIfFgOE/pIz4fMc4Ef+5HSQqTEug2S9JZIWDR47duDSLfaA==
-  /ws/6.2.1:
-    dependencies:
-      async-limiter: 1.0.0
-    dev: false
-    resolution:
-      integrity: sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==
   /xml-name-validator/3.0.0:
     dev: false
     resolution:
       integrity: sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==
-  /xmlchars/1.3.1:
-    dev: false
-    resolution:
-      integrity: sha512-tGkGJkN8XqCod7OT+EvGYK5Z4SfDQGD30zAa58OcnAa0RRWgzUEK72tkXhsX1FZd+rgnhRxFtmO+ihkp8LHSkw==
   /xtend/4.0.1:
     dev: false
     engines:
@@ -9102,7 +9037,7 @@ packages:
     dev: false
     hasBin: true
     optionalDependencies:
-      commander: 2.19.0
+      commander: 2.20.0
     resolution:
       integrity: sha512-DUOKC/IhbkdLKKiV89gw9DUauTV8U/8yJl1sjf6MtDmzevLKOF2duNJ495S3MFVjqZarr+qNGCPbkg4mu4PpLw==
   'file:projects/api-documenter-test.tgz':
@@ -9114,7 +9049,7 @@ packages:
     dev: false
     name: '@rush-temp/api-documenter-test'
     resolution:
-      integrity: sha512-5ffvSH+UMShhwzD7YvJl40zCRsXzS44ZG6JK3abn3YR/VXNgrsqXetI/A8/1BTqIHSHxI5ui8j4pYZv6uisMUw==
+      integrity: sha512-jqYh4C+uq7LdQtfZTVYyODkdJIA0RpoO9JpE7kS3pU+B8CRojSg791EndyVZzZe+M1EgSZlDPBBP2NKJRlNC5g==
       tarball: 'file:projects/api-documenter-test.tgz'
     version: 0.0.0
   'file:projects/api-documenter.tgz':
@@ -9130,7 +9065,7 @@ packages:
     dev: false
     name: '@rush-temp/api-documenter'
     resolution:
-      integrity: sha512-b3x8RYn1biwvyjkNYmVDM+tfs/Q79JKDL5WXKROHodbbJN6OoJRjc9JISZ1ViY4dlPq0xtY7MrtVFBlSi2jcLQ==
+      integrity: sha512-9bRHdFIc/Ym5wTVDiGQJaPxSLIuZdhzyk8vG7UqQTiCzv8FTYd3u6S6Fmu2/VL+JRafqDyLu8Lz7w40a6+m1iA==
       tarball: 'file:projects/api-documenter.tgz'
     version: 0.0.0
   'file:projects/api-extractor-lib1-test.tgz':
@@ -9142,7 +9077,7 @@ packages:
     dev: false
     name: '@rush-temp/api-extractor-lib1-test'
     resolution:
-      integrity: sha512-nBB4iGYVAcBPvxULNylO0aKN/RKHrn6dki5a1UfHyDLCgbF9QzdipFxs8gb+ZB5Gy7CSbcVBnmdtI0qyWXMfLA==
+      integrity: sha512-lLTHeT4YcT7+8E8VIg9RfQ/MOV+g81muOy9hFO+XZ+1L5Wh/gilp/7OAThFNhVhXKl5KOTlv2eRVYRUdIg4y/Q==
       tarball: 'file:projects/api-extractor-lib1-test.tgz'
     version: 0.0.0
   'file:projects/api-extractor-lib2-test.tgz':
@@ -9154,7 +9089,7 @@ packages:
     dev: false
     name: '@rush-temp/api-extractor-lib2-test'
     resolution:
-      integrity: sha512-nguqeKF2RPbGvnECNhtAkfDNkUsIFtPlt7HnXND1MyWu3UhlxYUW8ZNylRsF5nrSu9ICqOoV43E/k7asrgL+sw==
+      integrity: sha512-jPcEYqLPV9gWjtTZUAx4mYsyjCmb7sclAX2vMc8zbgQxp4NGcgaYS/6JJbFfBNzllECSiy8Asr449+u6Hy3LyA==
       tarball: 'file:projects/api-extractor-lib2-test.tgz'
     version: 0.0.0
   'file:projects/api-extractor-lib3-test.tgz':
@@ -9166,13 +9101,13 @@ packages:
     dev: false
     name: '@rush-temp/api-extractor-lib3-test'
     resolution:
-      integrity: sha512-1q6fDMaw50N9btJYx9a4KP8luwLTba3NOoHn9LGiD+rASc0i/L1Zjudfy83GbTvkf6Mm/nle+o+qLaMr1cTKLQ==
+      integrity: sha512-lW7XXhyUDFpFLJPB2tFoBap4DAMByw/VwK482tjxj2LaXA1NzkSp7ocI3ARXwLT6oOonGbGWoOK/OnEFPzm1eg==
       tarball: 'file:projects/api-extractor-lib3-test.tgz'
     version: 0.0.0
   'file:projects/api-extractor-model.tgz':
     dependencies:
-      '@microsoft/node-library-build': 6.0.44
-      '@microsoft/rush-stack-compiler-3.2': 0.2.17
+      '@microsoft/node-library-build': 6.0.49
+      '@microsoft/rush-stack-compiler-3.2': 0.3.1
       '@microsoft/tsdoc': 0.12.8
       '@types/jest': 23.3.11
       '@types/node': 8.5.8
@@ -9181,7 +9116,7 @@ packages:
     dev: false
     name: '@rush-temp/api-extractor-model'
     resolution:
-      integrity: sha512-dzC70EFd/a5zYcwn8VWpNmowKPIlxGMJqvka5XMdKXnhsCRzzj8p5ESIHEILSqECPciIyponRkB6p8cr/mRIeQ==
+      integrity: sha512-300RsaVeZiHTzQ1hXyI872vAE09Wzs5ZbdgOM+8MhEVT6H3nFeoUPxQYPWdmPrtwpSfxj0enoVFe0WZGlsM2Eg==
       tarball: 'file:projects/api-extractor-model.tgz'
     version: 0.0.0
   'file:projects/api-extractor-scenarios.tgz':
@@ -9195,7 +9130,7 @@ packages:
     dev: false
     name: '@rush-temp/api-extractor-scenarios'
     resolution:
-      integrity: sha512-BjAfAtYn2Xu5zwZOzJjUg/RiltnRw+qDH+DPIDkWrlvG2rdhAoeCZ7KXZaunZ/6+hO1oj1c+Oxb787Ba7mcIaQ==
+      integrity: sha512-0PxFmDpuzHaYQ7xHNwcictv3l9rW7shTJk/ZN1wiKfDGvrV+cwrqpM8uHlnpZr9giHWuatfsFp4sSqPFwBmd1g==
       tarball: 'file:projects/api-extractor-scenarios.tgz'
     version: 0.0.0
   'file:projects/api-extractor-test-01.tgz':
@@ -9207,7 +9142,7 @@ packages:
     dev: false
     name: '@rush-temp/api-extractor-test-01'
     resolution:
-      integrity: sha512-tbxfnN+T2Vc7Prs6sYhmVWBqqlhuD2Vps63p4/M8L6BANgSfxzdoVaXlJD/sZhESor2gGtefzsPzDcg2y1PolA==
+      integrity: sha512-Hx1T7d6TCPCl37EQR4vxa7uDVnG+Va6yW/bgJINfyY7DQvOSlP2rHRv7+cimq+y5qQEIxxURHbPCGq0SZI/9Ag==
       tarball: 'file:projects/api-extractor-test-01.tgz'
     version: 0.0.0
   'file:projects/api-extractor-test-02.tgz':
@@ -9220,7 +9155,7 @@ packages:
     dev: false
     name: '@rush-temp/api-extractor-test-02'
     resolution:
-      integrity: sha512-5vV+SuBHXiu+0JNjTsJkG+fXXQhFYXh1ECnxNQ+ywx9siTCS4q+n7Imprh2DnihpQM8gt4jTvT4iUyMSKFJpvw==
+      integrity: sha512-M0ASmuig3gOf+/vcTcPUXyvzy2O4x6W93Rbb8fbFwQg/OlgJPNuslVCbH8MMGPqfBIZfvpv+5BWr3f88edpYLg==
       tarball: 'file:projects/api-extractor-test-02.tgz'
     version: 0.0.0
   'file:projects/api-extractor-test-03.tgz':
@@ -9242,13 +9177,13 @@ packages:
     dev: false
     name: '@rush-temp/api-extractor-test-04'
     resolution:
-      integrity: sha512-tAz0w9mf50CPdrPa0ttETXcnYKQovJDalgqf81/1RzTZ43nn7zzo2n19nq6pgV6/Pk1AFZ8NcSjloleXjgkr7Q==
+      integrity: sha512-mafa+659CtQ0jGdRf/PJrNNmLuTryg1kFvk3GP0G7+0bHIjaz8lF+SAVf1NsaRCjEx3xKEgmM9+tE5SzdOz/eA==
       tarball: 'file:projects/api-extractor-test-04.tgz'
     version: 0.0.0
   'file:projects/api-extractor.tgz':
     dependencies:
-      '@microsoft/node-library-build': 6.0.44
-      '@microsoft/rush-stack-compiler-3.2': 0.2.17
+      '@microsoft/node-library-build': 6.0.49
+      '@microsoft/rush-stack-compiler-3.2': 0.3.1
       '@microsoft/tsdoc': 0.12.8
       '@types/jest': 23.3.11
       '@types/lodash': 4.14.116
@@ -9263,12 +9198,12 @@ packages:
     dev: false
     name: '@rush-temp/api-extractor'
     resolution:
-      integrity: sha512-w0jTvHcwL7PNoHlDp+qqPnCSZyr+A2xbe7pls+e5s+b7ZFTwpOhV0JaDt/ZtNihK9KMdcwR8Yod5VTGazJtnLA==
+      integrity: sha512-HhuN9euc4LNgnAHrdexcRC1xY2xvYkwTx+Xy0ilgH1ftNyXW7C7IyY1wV5X+Ue4paYgBm40P3mbidLT0x8e3ng==
       tarball: 'file:projects/api-extractor.tgz'
     version: 0.0.0
   'file:projects/gulp-core-build-mocha.tgz':
     dependencies:
-      '@microsoft/node-library-build': 6.0.44
+      '@microsoft/node-library-build': 6.0.49
       '@types/glob': 5.0.30
       '@types/gulp': 3.8.32
       '@types/gulp-istanbul': 0.9.30
@@ -9284,7 +9219,7 @@ packages:
     dev: false
     name: '@rush-temp/gulp-core-build-mocha'
     resolution:
-      integrity: sha512-Tl1V9Cobb/1OFQ4/uILseLu+7xNCQoxjgYriO5ZjoycvglZvsatR/MOOaUPQa1/EPaAuRvzA15KANL3lYIJeyA==
+      integrity: sha512-cjf71y4uLftLlEQ1GWkgM7/BOwjVp0LzFcdpEDJ0X9045KxVrikpdCr/u0df6aOww3de3FW2hAojTmFcE3lyAg==
       tarball: 'file:projects/gulp-core-build-mocha.tgz'
     version: 0.0.0
   'file:projects/gulp-core-build-sass.tgz':
@@ -9304,7 +9239,7 @@ packages:
     dev: false
     name: '@rush-temp/gulp-core-build-sass'
     resolution:
-      integrity: sha512-y5UqpUD6VjrjdjhfDRG+AeggcV2A7drfZNCp73aCFD3JrHoONB7jq+yD3rLzuY9HNSOsAOjkiFWlSK1ENErbGw==
+      integrity: sha512-LaP7PbGEAiKb2/Jzpdh5SzIGSgX2x6+lZe/N6I8Or0paPLXUfvEwPaqqDWl+oMnBv727hhGFX32IMzHevVF8jQ==
       tarball: 'file:projects/gulp-core-build-sass.tgz'
     version: 0.0.0
   'file:projects/gulp-core-build-serve.tgz':
@@ -9331,12 +9266,12 @@ packages:
     dev: false
     name: '@rush-temp/gulp-core-build-serve'
     resolution:
-      integrity: sha512-eT4VyYltrT4BZt6vT/ig8Ls7Yr7KHRNg1i55qUGtxF1Bl3172bxVbXvWfERVZD1RVtCVAw8/Eu7zJqSrPWcawg==
+      integrity: sha512-yJ7/BYjmL4vXA21ZEUvpQeZv8cQjuZTy+8V9LLmowBmGtFLzYxBe8CZkkUblFnSuQk51kr78OIgfkpqv6uxszg==
       tarball: 'file:projects/gulp-core-build-serve.tgz'
     version: 0.0.0
   'file:projects/gulp-core-build-typescript.tgz':
     dependencies:
-      '@microsoft/node-library-build': 6.0.44
+      '@microsoft/node-library-build': 6.0.49
       '@types/glob': 5.0.30
       '@types/node': 8.5.8
       '@types/resolve': 0.0.8
@@ -9350,7 +9285,7 @@ packages:
     dev: false
     name: '@rush-temp/gulp-core-build-typescript'
     resolution:
-      integrity: sha512-Dsax9X8aP1ytNz4K4VxpMcZlI0484belQ3wt2sQW+672TBGt0e7P6vsK7yjBMNB8WH7xjQnLK5DIbpQRy5Q1XA==
+      integrity: sha512-wbaChhFwXgqyhQM4FLJieegnn9+gLIDe26xA99hWQDIuhVWpw6lKFszUa6Ar2yYVuIFCySOKy2KAFvaIM4O4Ow==
       tarball: 'file:projects/gulp-core-build-typescript.tgz'
     version: 0.0.0
   'file:projects/gulp-core-build-webpack.tgz':
@@ -9368,12 +9303,12 @@ packages:
     dev: false
     name: '@rush-temp/gulp-core-build-webpack'
     resolution:
-      integrity: sha512-ez42FauG45YBknqGx0G1hAhbPcx6R+64rh8KfamKqmU1tgCU4cya8q4Q7NfbyoCartSAF13GDFFAONVyNvp5Ig==
+      integrity: sha512-dXzZ8U8QsBrv+sedM673+B3o7T5AGcuI7HRMJamce5B4hgpNQt/KSKhDFrtvZTcpyaU+EZob7OwbOK8d5C4iXg==
       tarball: 'file:projects/gulp-core-build-webpack.tgz'
     version: 0.0.0
   'file:projects/gulp-core-build.tgz':
     dependencies:
-      '@microsoft/node-library-build': 6.0.44
+      '@microsoft/node-library-build': 6.0.49
       '@types/assertion-error': 1.0.30
       '@types/chai': 3.4.34
       '@types/chalk': 0.4.31
@@ -9416,7 +9351,7 @@ packages:
     dev: false
     name: '@rush-temp/gulp-core-build'
     resolution:
-      integrity: sha512-4b58QZx904yPnPiz7OWKu1c5TuBejelD4DarIW9EmA4h028nZlExe6gjFXRUGCR09Oun9ftLISsPhbmEjxCkAQ==
+      integrity: sha512-ZzU6ejokJi3k8eJhgsimaOWnCpYnLPHKTXsB4G9Gx2cLolhV+iAdBL4gdoMUbTyaeckufyq/B0lRbS/KpRc0Eg==
       tarball: 'file:projects/gulp-core-build.tgz'
     version: 0.0.0
   'file:projects/load-themed-styles.tgz':
@@ -9429,7 +9364,7 @@ packages:
     dev: false
     name: '@rush-temp/load-themed-styles'
     resolution:
-      integrity: sha512-7JGgJu9jCyyzI6ki6gLh/JZneFe5SHat4szqkzgdaxhlxSQVF5Sc+/jIoerJ2Ldvd94rvb5MLxwz3A/eptP/Xg==
+      integrity: sha512-VtI4o5Qr7fwJmEzXtu4ZAScO8VORmbZYvhcvN0KZaay3M0p9JQbEdRiq1cue37koeYue40I3/irzrphKTAJFTQ==
       tarball: 'file:projects/load-themed-styles.tgz'
     version: 0.0.0
   'file:projects/loader-load-themed-styles.tgz':
@@ -9444,7 +9379,7 @@ packages:
     dev: false
     name: '@rush-temp/loader-load-themed-styles'
     resolution:
-      integrity: sha512-7R33K7wJ63zsHCsYlI1QBIaC8e3JZJ+8eGGt3oYVb+utfJ/e4TWBF8CI8MlrgnnwMwvE7XKfQo6QX7vghr8idA==
+      integrity: sha512-2uY3/29CMrythnqHCyEZbuDGKvFCB1B6NRHl0VuxxRqWFsVgdPMiyjNG+qzhibewcUXKpKm+qCiSCT0c/4zijA==
       tarball: 'file:projects/loader-load-themed-styles.tgz'
     version: 0.0.0
   'file:projects/loader-raw-script.tgz':
@@ -9458,7 +9393,7 @@ packages:
     dev: false
     name: '@rush-temp/loader-raw-script'
     resolution:
-      integrity: sha512-aObLNysKRA5upe9iOayZxccUO7+Dl6OoTZGKNVxpSJyR3sqc+MDlfF/qa0skDXKg1qtNY0MNVW8AYruJ6W66JQ==
+      integrity: sha512-OsDUisONcVTwA74VcYVpjLB8hzUNG/FB9eWFvbLXcDfH/o1BKWOyPPimqiDid+lP40khSdbJYW5P+X4xinThiA==
       tarball: 'file:projects/loader-raw-script.tgz'
     version: 0.0.0
   'file:projects/loader-set-webpack-public-path.tgz':
@@ -9474,13 +9409,13 @@ packages:
     dev: false
     name: '@rush-temp/loader-set-webpack-public-path'
     resolution:
-      integrity: sha512-yb139coYD7J0F0mtDFerBNmwW8sW0mtqutg7JP2KQhGHF436hclzZJGNoK9JwGe8em1OI92eSi/DeBPz//wiTw==
+      integrity: sha512-BsyIP85eu/9EBsP/5FBLKPLncTeMOtCRchpM39Z0NjdluvbEoq9xVNQ9V2W14f8rFiTQfGwfNJJW6Y/IEse2Kw==
       tarball: 'file:projects/loader-set-webpack-public-path.tgz'
     version: 0.0.0
   'file:projects/node-core-library.tgz':
     dependencies:
-      '@microsoft/node-library-build': 6.0.44
-      '@microsoft/rush-stack-compiler-3.2': 0.2.17
+      '@microsoft/node-library-build': 6.0.49
+      '@microsoft/rush-stack-compiler-3.2': 0.3.1
       '@types/fs-extra': 5.0.4
       '@types/jest': 23.3.11
       '@types/jju': 1.4.1
@@ -9495,7 +9430,7 @@ packages:
     dev: false
     name: '@rush-temp/node-core-library'
     resolution:
-      integrity: sha512-qE7OllTLTXOUyw5SaUWAMts9I25ONAs98eUo5e6V6g2ze/6L/e+1Mr+Q1rY0fIwiLc1/WGzYGqc118l5rID+YQ==
+      integrity: sha512-XkAENcRK8DRjVzPR5EeX9j5oPhRB/rJ1u3Uv9bRTLhjiPH28EPqLQsx3k6h8WEpC5H+Dbqi956Djf+T6ZAzjSA==
       tarball: 'file:projects/node-core-library.tgz'
     version: 0.0.0
   'file:projects/node-library-build-test.tgz':
@@ -9508,7 +9443,7 @@ packages:
     dev: false
     name: '@rush-temp/node-library-build-test'
     resolution:
-      integrity: sha512-kwKuo3hIQj2/Wb9VGiv59iQpWCP8Ky9TqFqkUhP5Jw0TG4olxEEdrW5wCLL5+2RjhgM2GgPlDwDZlz8okM+z1Q==
+      integrity: sha512-T/ccu1pPBpt6Daqq8/J1VB4YgsyhIK4+NqgB4iydVHLcdIvo7B88qMe2FUbCk2R7ov9K5Jo5czfjRHNai82pxw==
       tarball: 'file:projects/node-library-build-test.tgz'
     version: 0.0.0
   'file:projects/node-library-build.tgz':
@@ -9519,7 +9454,7 @@ packages:
     dev: false
     name: '@rush-temp/node-library-build'
     resolution:
-      integrity: sha512-iUM3OQyLjN8SIlYanf9Rn10ZIuPn0CLWMtXM11pjHiMHmK62iZ7NiIPnZAtxh6zbfHEvvAN6+jXuHsP7CTFk0g==
+      integrity: sha512-1bPPu2p5GvQubo29VUaogaq6jKig31hRIa9qVJte2pw5FdTOWz2zWfIWC0vyoGded5NqEnNXr4uB5vIJ1EnamQ==
       tarball: 'file:projects/node-library-build.tgz'
     version: 0.0.0
   'file:projects/package-deps-hash.tgz':
@@ -9532,7 +9467,7 @@ packages:
     dev: false
     name: '@rush-temp/package-deps-hash'
     resolution:
-      integrity: sha512-y9ptuJFhjWL8zPD5165OwirFv5/5/ZZbe3BynBu6DN//vf3MPloK3BHwRmQbJJimEt/Y/JbAr3iXf/ktwfTt+g==
+      integrity: sha512-QvySJsCJdg3FD+9EEFlvvoYAxRtBbTP+2lGz9VK3nYM5kNMDjxSGxPKFrJCh6PCBTt4xjcTEqj6r3N7h+MNS3Q==
       tarball: 'file:projects/package-deps-hash.tgz'
     version: 0.0.0
   'file:projects/resolve-chunk-plugin.tgz':
@@ -9545,7 +9480,7 @@ packages:
     dev: false
     name: '@rush-temp/resolve-chunk-plugin'
     resolution:
-      integrity: sha512-e8XM645h7EA7L6oTWDvtwBzLFu7rSraeHb01vHJj3YhKNAP7iIz2zlSXQBiCNZ039miAsN8zEyXICt1p1T9dFg==
+      integrity: sha512-d9AQy2AcAVlLtmiBP2I2elQGp0bWGY9tyREr9IHX2GoBgeB1AB7uu1X0KpW6Ibz9XEGWcQFQZn5JbRB6PvjJ/Q==
       tarball: 'file:projects/resolve-chunk-plugin.tgz'
     version: 0.0.0
   'file:projects/rush-lib.tgz':
@@ -9586,7 +9521,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-lib'
     resolution:
-      integrity: sha512-JqfhXt8WJeT0Q9WuEedxVyZZt+oD2AEPn+rfztQAZzjN/JbL0AbZftWZ7jhtJhMTOzpWIqf+6N8N54yozFCxkA==
+      integrity: sha512-0XLIadq9XKDVSbbvXMTviZ7e3OXERypSwscpash90GYfC8IJNXleKmd4fPp2xlWzMbWm0zgtlsekug/g5J1nBw==
       tarball: 'file:projects/rush-lib.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-2.4-library-test.tgz':
@@ -9596,13 +9531,13 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-2.4-library-test'
     resolution:
-      integrity: sha512-89qvmeQqioqgG8DtgaJAmuzTC4y+5wmbiZAD4PFwDHtFYcVF+86/lCX/x8xx8MFhCs3WyxGqdHGIq3aSlQeaKg==
+      integrity: sha512-E/LHxWoenEiXJCxEfSPKtY7qCn10fiu+b4X525ex1lGM+S6U0t7Kb7Yll1+CG6rfnKTWDMOIwf3vPTeXyZJmMw==
       tarball: 'file:projects/rush-stack-compiler-2.4-library-test.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-2.4.tgz':
     dependencies:
-      '@microsoft/node-library-build': 6.0.44
-      '@microsoft/rush-stack-compiler-3.2': 0.2.17
+      '@microsoft/node-library-build': 6.0.49
+      '@microsoft/rush-stack-compiler-3.2': 0.3.1
       '@types/node': 8.5.8
       gulp: 3.9.1
       tslint: 5.12.1
@@ -9611,7 +9546,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-2.4'
     resolution:
-      integrity: sha512-8JJjeEN/SnNeCoYlIQNIblEPoyMaaTFQ1BoybZTkHTuWzDT+IYyWubjP3f5gMJ18u/d9kLAc0WMsnY2VjJop2Q==
+      integrity: sha512-lAnBeClEOLEDWpHSkVZU//+S4nSlSh86k8iB7Gbh+LwuL86wYFTwJLPCpfANJywvPRH+HSeST0aXO246ZmNlQw==
       tarball: 'file:projects/rush-stack-compiler-2.4.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-2.7-library-test.tgz':
@@ -9621,13 +9556,13 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-2.7-library-test'
     resolution:
-      integrity: sha512-vPvP67zfgVdwOWqBFoeRspRbR3YL0AYbDlrmExRQo63Jjy5parywJTn1OSGuv97oLiCPM4UaSEk9E8SeSzjnFQ==
+      integrity: sha512-KYHnWydtac5hMiF1iLoRlFTd+u4NiY5LNqhkW5UTxaRB2k3/8hVFaZUqYn5wBXPA6DtAzaT9VgcWfczZGGySGA==
       tarball: 'file:projects/rush-stack-compiler-2.7-library-test.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-2.7.tgz':
     dependencies:
-      '@microsoft/node-library-build': 6.0.44
-      '@microsoft/rush-stack-compiler-3.2': 0.2.17
+      '@microsoft/node-library-build': 6.0.49
+      '@microsoft/rush-stack-compiler-3.2': 0.3.1
       '@types/node': 8.5.8
       gulp: 3.9.1
       tslint: 5.12.1
@@ -9636,7 +9571,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-2.7'
     resolution:
-      integrity: sha512-qFyv6A4/LEA5z/Urw11lT0V3Pvs5XZxxKi4K7dvfds5X5ip4o4KJ3IDqamvxI/nMY6hNL8sdQOYQ+AJBPmEJnw==
+      integrity: sha512-EW73ljLSigjrQp3VIqAyQa7JJuUKEIwjrYkPEMIaVTkpGOLRsQdMR5PtRN8sSoeihYZskCcufzc32Ny7YWjEWg==
       tarball: 'file:projects/rush-stack-compiler-2.7.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-2.9-library-test.tgz':
@@ -9646,13 +9581,13 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-2.9-library-test'
     resolution:
-      integrity: sha512-chDGoWSDKoQin2/fl2fPqb2nnn0TdyeMI5m34hvh31kCNYS3NKJ2lvB3z3xlRcfcsjPg0fZ1a/qAEvdtjVpMig==
+      integrity: sha512-nKVgkCeBsNsGPKf/RgBv0LzQwUkpLkPyHlHWt/m+HStxBkBT9QZDsuExrz++gArwGd767pOTbUsfaW2B9P0Afg==
       tarball: 'file:projects/rush-stack-compiler-2.9-library-test.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-2.9.tgz':
     dependencies:
-      '@microsoft/node-library-build': 6.0.44
-      '@microsoft/rush-stack-compiler-3.2': 0.2.17
+      '@microsoft/node-library-build': 6.0.49
+      '@microsoft/rush-stack-compiler-3.2': 0.3.1
       '@types/node': 8.5.8
       gulp: 3.9.1
       tslint: 5.12.1
@@ -9661,7 +9596,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-2.9'
     resolution:
-      integrity: sha512-CLA1fzfjQX0AbHRWxLu8yVwQbBdhg8xldQz78Nbu47f9fQi0/vDzu44f88S2IjnIftkWmhdMNFe3vnW6PYargw==
+      integrity: sha512-pg7XTddzg+OZmkDQr3gzUKCMwZ3F5a7jtc2bQDlyGIg4Wg52mkCXeQBjVGgsSzYAqrgL0TdZv2dU0NNwjzGhNQ==
       tarball: 'file:projects/rush-stack-compiler-2.9.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-3.0-library-test.tgz':
@@ -9671,13 +9606,13 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-3.0-library-test'
     resolution:
-      integrity: sha512-XrrOYq8KIpbMzb2TOilcm7l+lbgJAB0aBrnErZ6YzMNamZbtNyfzOH6sMPEa9cZpCwgYmaoChcBmjmgsGsDBGw==
+      integrity: sha512-eRuCJckwRmQvBa3O4fQJ1T+5XFud6hit3X/XKwM+hw386IR5pPKmHryiWXeG0ue+v+NzUVPWypSsTLBg+3Dgbw==
       tarball: 'file:projects/rush-stack-compiler-3.0-library-test.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-3.0.tgz':
     dependencies:
-      '@microsoft/node-library-build': 6.0.44
-      '@microsoft/rush-stack-compiler-3.2': 0.2.17
+      '@microsoft/node-library-build': 6.0.49
+      '@microsoft/rush-stack-compiler-3.2': 0.3.1
       '@types/node': 8.5.8
       gulp: 3.9.1
       tslint: 5.12.1
@@ -9686,7 +9621,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-3.0'
     resolution:
-      integrity: sha512-rmmUXZWoo2lLGrM+8o12WbhYZXLA+Enw94Me5Goe9hJlJ2Si+v0DmEu0/mAPvgE4QGB0pgUcEpZdjKT/wbuqcA==
+      integrity: sha512-x4mn3TwKmzpYfITJ+OE+yEaGMGnNZ8ayW7E7TQnP6I+KEub2C6V3CLcePZ+794D7VgcNU8xZjVjKnYMV1ihS3g==
       tarball: 'file:projects/rush-stack-compiler-3.0.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-3.1-library-test.tgz':
@@ -9696,13 +9631,13 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-3.1-library-test'
     resolution:
-      integrity: sha512-yzqa1KsUBLmHpsV1+Xc6Fmw2jcY55wnoASlKaxLOfzVGdnhr8IyAnf2JjMv8NmoNgyGRcSso+fjFPXj7CiGUhw==
+      integrity: sha512-cEWPq8Xox97jNZQ+Ya3D2bjdmtArnPPW1aDi2AyCYrBZnOK6eCUdmsjGpWYYonyeV8ha1t1t2vsflfckuyzrnw==
       tarball: 'file:projects/rush-stack-compiler-3.1-library-test.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-3.1.tgz':
     dependencies:
-      '@microsoft/node-library-build': 6.0.44
-      '@microsoft/rush-stack-compiler-3.2': 0.2.17
+      '@microsoft/node-library-build': 6.0.49
+      '@microsoft/rush-stack-compiler-3.2': 0.3.1
       '@types/node': 8.5.8
       gulp: 3.9.1
       tslint: 5.12.1
@@ -9711,7 +9646,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-3.1'
     resolution:
-      integrity: sha512-HiWeFPJR6KKr5XurLwphFU/re6hc9eZpkxQdfHtlup8haZok8TLQ4fGGlQM6h9ARvtBluUsMp/BiwMvr5X+dYA==
+      integrity: sha512-s+/vL+268vV4c+oTrSvEULn/2jCttM8CD3rqQrZ3z46t2qBRMjt0InEwFG+eSlIE8Yz9Jl2t2zBrT39cwio31w==
       tarball: 'file:projects/rush-stack-compiler-3.1.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-3.2-library-test.tgz':
@@ -9721,13 +9656,13 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-3.2-library-test'
     resolution:
-      integrity: sha512-PcZyeCuv79+r2Sj+15dhYEfKekNJW2yJXFG3d2pzimQF8in9Hb9jVpFfDgZIj7SOKAj5IeyltYJiUCybr0JLrw==
+      integrity: sha512-SHOGCmXggh/m2rKfduvthCDULSh04neE58LmfTYRIz3bccvHtAVra4bJeCDPnezw1UhEtCZB1LB83ttbwr/nug==
       tarball: 'file:projects/rush-stack-compiler-3.2-library-test.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-3.2.tgz':
     dependencies:
-      '@microsoft/node-library-build': 6.0.44
-      '@microsoft/rush-stack-compiler-3.2': 0.2.17
+      '@microsoft/node-library-build': 6.0.49
+      '@microsoft/rush-stack-compiler-3.2': 0.3.1
       '@types/node': 8.5.8
       gulp: 3.9.1
       tslint: 5.12.1
@@ -9736,7 +9671,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-3.2'
     resolution:
-      integrity: sha512-0SdRjekzpgCbFe7r2R0VQJGoOfBrE3UGCh8DEtB4ICA1BLMsNg84CJXQEW5vAZIYi+FvK5PZ64wfsN6/DFwy2Q==
+      integrity: sha512-ti80f+Leq3KDHWDZHqp0kEPdxO6w0m7cYttsT6O42tVK4xnsp1r5/ipPXppQWBlrzX2Fh9BLeazapxaI6T6lag==
       tarball: 'file:projects/rush-stack-compiler-3.2.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-3.3-library-test.tgz':
@@ -9746,13 +9681,13 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-3.3-library-test'
     resolution:
-      integrity: sha512-w85P0lLrmvOFKyjVJeF+MHKwJoIlEAvvibsCLagQNGmEchN2mRNCxfwU43m1GGJZ62BAr+D/uUANUHS1mW6f/A==
+      integrity: sha512-tpTe2oRgvyLVB5J2/rpj5Hai9mp7F8YgmNdim1i+sh8MLST1ST7uZ+xEv2DoM89IsIWQe+8Mm44mOT0/aChezA==
       tarball: 'file:projects/rush-stack-compiler-3.3-library-test.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-3.3.tgz':
     dependencies:
-      '@microsoft/node-library-build': 6.0.44
-      '@microsoft/rush-stack-compiler-3.2': 0.2.17
+      '@microsoft/node-library-build': 6.0.49
+      '@microsoft/rush-stack-compiler-3.2': 0.3.1
       '@types/node': 8.5.8
       gulp: 3.9.1
       tslint: 5.12.1
@@ -9761,7 +9696,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-3.3'
     resolution:
-      integrity: sha512-6xw8vWiMwuK2wT84RHCKjXuO6JEz50fz0hkoO1QEDU4GYInaaMKYccvjJMaaiWN8Tt3TrdUMAlJ2A6RpPvWNOg==
+      integrity: sha512-xMUfX1MeVsNxKV7BrSYL7dkE+D2GGzHty8XqNXoaxIy2hoMI1GjNfwjxegutdNvLcHg6asny77Z/k6pj5Ek94A==
       tarball: 'file:projects/rush-stack-compiler-3.3.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-shared.tgz':
@@ -9775,7 +9710,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-library-test'
     resolution:
-      integrity: sha512-zj65YoGZe97jQY93po7mG/V/vLmTMfnaB7WBPA11uquwK/WyhCWuajiatNah/LV3r98J8HKp271q+c5SX87Iig==
+      integrity: sha512-6K2I3USg8Ja86oomj3msxm9sCTKI/+LtuYoqSLKlgIOSFgSEhzHT7cEVyYSJL/oJpYzdXQKL3ykHLjq5BIbh6w==
       tarball: 'file:projects/rush-stack-library-test.tgz'
     version: 0.0.0
   'file:projects/rush-stack.tgz':
@@ -9786,7 +9721,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack'
     resolution:
-      integrity: sha512-b3F1ooNMKcZwHKRlPzndRw0Yee/6NEC97vWGTfFgMcpx3RImbK5fOFr6QccLeBcPaGW+EoXG2qDE28WUrwwKJQ==
+      integrity: sha512-wKXonJHOEWNP5oTgSoUC5SJLCpsy1VCJYaPwqgKpE7W0afuZt7tUIkDeZ/+QEkv9eZFmKDxgcP3j9ZB8tJdYIQ==
       tarball: 'file:projects/rush-stack.tgz'
     version: 0.0.0
   'file:projects/rush.tgz':
@@ -9804,7 +9739,7 @@ packages:
     dev: false
     name: '@rush-temp/rush'
     resolution:
-      integrity: sha512-GQRPhRpvzWXQkrc6z0ZAVrCi+3oKTcDqLowXW++9EoPli3OSGyr0tiALp+WKjDIfxCZr5fd91o4Gfh6HrYbCMg==
+      integrity: sha512-RSCexMxOZu21OJRB0ga9DZQD5oF1lFlgdXh4c4daEenCs+NGSj3PRHpld/6gtQW5VtOGNqCyvekY5xtp2FVUlw==
       tarball: 'file:projects/rush.tgz'
     version: 0.0.0
   'file:projects/rushell.tgz':
@@ -9817,7 +9752,7 @@ packages:
     dev: false
     name: '@rush-temp/rushell'
     resolution:
-      integrity: sha512-+cf+ez0iU6FzP/eXBRzAMsTR6hfVncHFkIJWPTK7gXRUHlSQhuIGE0OcD1CrBxntHRUf9uL/XEM88ePbDrTVPQ==
+      integrity: sha512-oFTsTwfAWJ8NHpir5j/f5080c6LlQBcMU9SqzEhSnZm02eQtJ/jrKL0OY6ihOLrHEOaY6c5c4m3wl0/VOsn8wg==
       tarball: 'file:projects/rushell.tgz'
     version: 0.0.0
   'file:projects/set-webpack-public-path-plugin.tgz':
@@ -9836,7 +9771,7 @@ packages:
     dev: false
     name: '@rush-temp/set-webpack-public-path-plugin'
     resolution:
-      integrity: sha512-cfcNB6kQPpeHWdJ7tdYqo8+NBJVpJUT5dRM+mo3TcOl7cAFy+Vl6kMCPhnUCp426D5hIQX4iWZwAo15KHmOJCg==
+      integrity: sha512-4YYivpgIbgkIqyGh4/Z2j1LCtzMS6nBQREMVDi2DhPvUx1Pig8eezUpXPKyP4dZhUpA65SPZocOpFJo+Q0DABA==
       tarball: 'file:projects/set-webpack-public-path-plugin.tgz'
     version: 0.0.0
   'file:projects/stream-collator.tgz':
@@ -9851,13 +9786,13 @@ packages:
     dev: false
     name: '@rush-temp/stream-collator'
     resolution:
-      integrity: sha512-b+FY0OUn6Pz8kkg8Uvti8UgrP7EHBTB30VoWFIPhFYQzKr5YTd/R3oJb+0MXvfsavYmi2Vvw/Oiji7kNx7D/6Q==
+      integrity: sha512-OBBCU/lwuzEqeG46FpcYLVR9aWh2Joo6NljFlrhU40cw8uDVNieQJ51557bPoklyzTotVoa2w2ahV/KgP0tAPA==
       tarball: 'file:projects/stream-collator.tgz'
     version: 0.0.0
   'file:projects/ts-command-line.tgz':
     dependencies:
-      '@microsoft/node-library-build': 6.0.44
-      '@microsoft/rush-stack-compiler-3.2': 0.2.17
+      '@microsoft/node-library-build': 6.0.49
+      '@microsoft/rush-stack-compiler-3.2': 0.3.1
       '@types/argparse': 1.0.33
       '@types/jest': 23.3.11
       '@types/node': 8.5.8
@@ -9868,7 +9803,7 @@ packages:
     dev: false
     name: '@rush-temp/ts-command-line'
     resolution:
-      integrity: sha512-GofnpG4y9Dgk35CkwWRqzHFEt6xHhyqZT5pvbz6xJQ/lbqfWGLAerqoPl/Z5n6LiBnygfuMqu2Yfm6On2rMWIg==
+      integrity: sha512-R40ozm6AVp2RkNZU6kI0Qk6PRST0uwgj9ps7Uqhm6t4XHnpBgnLuDSVNGWC0ICXAF0oF2z/R6SL+8UXm8RCcpw==
       tarball: 'file:projects/ts-command-line.tgz'
     version: 0.0.0
   'file:projects/web-library-build-test.tgz':
@@ -9879,7 +9814,7 @@ packages:
     dev: false
     name: '@rush-temp/web-library-build-test'
     resolution:
-      integrity: sha512-pZx3x8vDOF9W7C8w5FmKUcUiXsRrSkEdtYaewQxXf/emp/yKiuk4M+qLXLEBIVGiXlIlr9/kGf1ibwPG3K4VLA==
+      integrity: sha512-Is7j4V5TH3206dT6RMSUcP6yqtTB71Dnh94hbJgYmWyC4B6rIesenfw1kvIBBP0hvQ4NG5IyHCtgOrUXrFyydg==
       tarball: 'file:projects/web-library-build-test.tgz'
     version: 0.0.0
   'file:projects/web-library-build.tgz':
@@ -9891,15 +9826,15 @@ packages:
     dev: false
     name: '@rush-temp/web-library-build'
     resolution:
-      integrity: sha512-SzI9n7ZlJXyQQxtrkVyNtDgECZi9YYJ6gvJjhktVBnvWyx6RRCn3IKZ0WWKG3P9XQZHChTyITnIqo2uLTzCuqQ==
+      integrity: sha512-hCHdTSVqRfJnh12xsPjBGBywhO7Tf1AuhSQIuS5o8A0xOoUND6xAyZmFnU+y1vM8NoZlwRHC0jlB1MoSfOAWMw==
       tarball: 'file:projects/web-library-build.tgz'
     version: 0.0.0
 registry: 'https://registry.npmjs.org/'
 shrinkwrapMinorVersion: 9
 shrinkwrapVersion: 3
 specifiers:
-  '@microsoft/node-library-build': 6.0.44
-  '@microsoft/rush-stack-compiler-3.2': 0.2.17
+  '@microsoft/node-library-build': 6.0.49
+  '@microsoft/rush-stack-compiler-3.2': 0.3.1
   '@microsoft/teams-js': 1.3.0-beta.4
   '@microsoft/tsdoc': 0.12.8
   '@pnpm/link-bins': ~1.0.1

--- a/common/reviews/api/api-extractor-model.api.md
+++ b/common/reviews/api/api-extractor-model.api.md
@@ -28,7 +28,6 @@ export class AedocDefinitions {
 // 
 // @public
 export class ApiCallSignature extends ApiCallSignature_base {
-    // (undocumented)
     constructor(options: IApiCallSignatureOptions);
     // @override (undocumented)
     readonly canonicalReference: string;
@@ -42,7 +41,6 @@ export class ApiCallSignature extends ApiCallSignature_base {
 // 
 // @public
 export class ApiClass extends ApiClass_base {
-    // (undocumented)
     constructor(options: IApiClassOptions);
     // @override (undocumented)
     readonly canonicalReference: string;
@@ -64,7 +62,6 @@ export class ApiClass extends ApiClass_base {
 // 
 // @public
 export class ApiConstructor extends ApiConstructor_base {
-    // (undocumented)
     constructor(options: IApiConstructorOptions);
     // @override (undocumented)
     readonly canonicalReference: string;
@@ -78,7 +75,6 @@ export class ApiConstructor extends ApiConstructor_base {
 // 
 // @public
 export class ApiConstructSignature extends ApiConstructSignature_base {
-    // (undocumented)
     constructor(options: IApiConstructSignatureOptions);
     // @override (undocumented)
     readonly canonicalReference: string;
@@ -90,7 +86,6 @@ export class ApiConstructSignature extends ApiConstructSignature_base {
 
 // @public
 export class ApiDeclaredItem extends ApiDocumentedItem {
-    // (undocumented)
     constructor(options: IApiDeclaredItemOptions);
     buildExcerpt(tokenRange: IExcerptTokenRange): Excerpt;
     readonly excerpt: Excerpt;
@@ -106,7 +101,6 @@ export class ApiDeclaredItem extends ApiDocumentedItem {
 
 // @public
 export class ApiDocumentedItem extends ApiItem {
-    // (undocumented)
     constructor(options: IApiDocumentedItemOptions);
     // Warning: (ae-forgotten-export) The symbol "IApiItemJson" needs to be exported by the entry point index.d.ts
     // 
@@ -124,7 +118,6 @@ export class ApiDocumentedItem extends ApiItem {
 // 
 // @public
 export class ApiEntryPoint extends ApiEntryPoint_base {
-    // (undocumented)
     constructor(options: IApiEntryPointOptions);
     // @override (undocumented)
     readonly canonicalReference: string;
@@ -136,7 +129,6 @@ export class ApiEntryPoint extends ApiEntryPoint_base {
 // 
 // @public
 export class ApiEnum extends ApiEnum_base {
-    // (undocumented)
     constructor(options: IApiEnumOptions);
     // @override (undocumented)
     addMember(member: ApiEnumMember): void;
@@ -154,7 +146,6 @@ export class ApiEnum extends ApiEnum_base {
 // 
 // @public
 export class ApiEnumMember extends ApiEnumMember_base {
-    // (undocumented)
     constructor(options: IApiEnumMemberOptions);
     // @override (undocumented)
     readonly canonicalReference: string;
@@ -175,7 +166,6 @@ export class ApiEnumMember extends ApiEnumMember_base {
 // 
 // @public
 export class ApiFunction extends ApiFunction_base {
-    // (undocumented)
     constructor(options: IApiFunctionOptions);
     // @override (undocumented)
     readonly canonicalReference: string;
@@ -189,7 +179,6 @@ export class ApiFunction extends ApiFunction_base {
 // 
 // @public
 export class ApiIndexSignature extends ApiIndexSignature_base {
-    // (undocumented)
     constructor(options: IApiIndexSignatureOptions);
     // @override (undocumented)
     readonly canonicalReference: string;
@@ -203,7 +192,6 @@ export class ApiIndexSignature extends ApiIndexSignature_base {
 // 
 // @public
 export class ApiInterface extends ApiInterface_base {
-    // (undocumented)
     constructor(options: IApiInterfaceOptions);
     // @override (undocumented)
     readonly canonicalReference: string;
@@ -224,7 +212,6 @@ export class ApiInterface extends ApiInterface_base {
 export class ApiItem {
     // (undocumented)
     [ApiItem_parent]: ApiItem | undefined;
-    // (undocumented)
     constructor(options: IApiItemOptions);
     // @virtual (undocumented)
     readonly canonicalReference: string;
@@ -315,7 +302,6 @@ export const enum ApiItemKind {
 // 
 // @public
 export class ApiMethod extends ApiMethod_base {
-    // (undocumented)
     constructor(options: IApiMethodOptions);
     // @override (undocumented)
     readonly canonicalReference: string;
@@ -329,7 +315,6 @@ export class ApiMethod extends ApiMethod_base {
 // 
 // @public
 export class ApiMethodSignature extends ApiMethodSignature_base {
-    // (undocumented)
     constructor(options: IApiMethodSignatureOptions);
     // @override (undocumented)
     readonly canonicalReference: string;
@@ -343,7 +328,6 @@ export class ApiMethodSignature extends ApiMethodSignature_base {
 // 
 // @public
 export class ApiModel extends ApiModel_base {
-    // (undocumented)
     constructor();
     // @override (undocumented)
     addMember(member: ApiPackage): void;
@@ -364,7 +348,6 @@ export class ApiModel extends ApiModel_base {
 // 
 // @public
 export class ApiNamespace extends ApiNamespace_base {
-    // (undocumented)
     constructor(options: IApiNamespaceOptions);
     // @override (undocumented)
     readonly canonicalReference: string;
@@ -378,7 +361,6 @@ export class ApiNamespace extends ApiNamespace_base {
 // 
 // @public
 export class ApiPackage extends ApiPackage_base {
-    // (undocumented)
     constructor(options: IApiPackageOptions);
     // @override (undocumented)
     addMember(member: ApiEntryPoint): void;
@@ -416,7 +398,6 @@ export namespace ApiParameterListMixin {
 // 
 // @public
 export class ApiProperty extends ApiProperty_base {
-    // (undocumented)
     constructor(options: IApiPropertyOptions);
     // @override (undocumented)
     readonly canonicalReference: string;
@@ -430,7 +411,6 @@ export class ApiProperty extends ApiProperty_base {
 // 
 // @public
 export class ApiPropertyItem extends ApiPropertyItem_base {
-    // (undocumented)
     constructor(options: IApiPropertyItemOptions);
     readonly isEventProperty: boolean;
     // Warning: (ae-forgotten-export) The symbol "IApiPropertyItemJson" needs to be exported by the entry point index.d.ts
@@ -444,7 +424,6 @@ export class ApiPropertyItem extends ApiPropertyItem_base {
 
 // @public
 export class ApiPropertySignature extends ApiPropertyItem {
-    // (undocumented)
     constructor(options: IApiPropertySignatureOptions);
     // @override (undocumented)
     readonly canonicalReference: string;
@@ -505,7 +484,6 @@ export namespace ApiStaticMixin {
 // 
 // @public
 export class ApiTypeAlias extends ApiTypeAlias_base {
-    // (undocumented)
     constructor(options: IApiTypeAliasOptions);
     // @override (undocumented)
     readonly canonicalReference: string;
@@ -519,7 +497,6 @@ export class ApiTypeAlias extends ApiTypeAlias_base {
 // 
 // @public
 export class ApiVariable extends ApiVariable_base {
-    // (undocumented)
     constructor(options: IApiVariableOptions);
     // @override (undocumented)
     readonly canonicalReference: string;
@@ -541,7 +518,6 @@ export type Constructor<T = {}> = new (...args: any[]) => T;
 
 // @public
 export class Excerpt {
-    // (undocumented)
     constructor(tokens: ReadonlyArray<ExcerptToken>, tokenRange: IExcerptTokenRange);
     // (undocumented)
     readonly text: string;
@@ -553,7 +529,6 @@ export class Excerpt {
 
 // @public (undocumented)
 export class ExcerptToken {
-    // (undocumented)
     constructor(kind: ExcerptTokenKind, text: string);
     // (undocumented)
     readonly kind: ExcerptTokenKind;
@@ -571,7 +546,6 @@ export const enum ExcerptTokenKind {
 
 // @public
 export class HeritageType {
-    // (undocumented)
     constructor(excerpt: Excerpt);
     readonly excerpt: Excerpt;
 }
@@ -670,7 +644,6 @@ export interface IApiPackageOptions extends IApiItemContainerMixinOptions, IApiN
 
 // @public
 export interface IApiPackageSaveOptions extends IJsonFileSaveOptions {
-    // (undocumented)
     testMode?: boolean;
     toolPackage?: string;
     toolVersion?: string;
@@ -768,7 +741,6 @@ export interface IResolveDeclarationReferenceResult {
 
 // @public
 export class Parameter {
-    // (undocumented)
     constructor(options: IParameterOptions);
     name: string;
     readonly parameterTypeExcerpt: Excerpt;

--- a/common/reviews/api/api-extractor.api.md
+++ b/common/reviews/api/api-extractor.api.md
@@ -10,7 +10,6 @@ import * as tsdoc from '@microsoft/tsdoc';
 
 // @public
 export class Extractor {
-    // (undocumented)
     constructor(config: IExtractorConfig, options?: IExtractorOptions);
     readonly actualConfig: IExtractorConfig;
     // @deprecated
@@ -99,25 +98,19 @@ export interface IExtractorApiReviewFileConfig {
 
 // @public
 export interface IExtractorConfig {
-    // (undocumented)
     apiJsonFile?: IExtractorApiJsonFileConfig;
-    // (undocumented)
     apiReviewFile?: IExtractorApiReviewFileConfig;
     compiler: IExtractorTsconfigCompilerConfig | IExtractorRuntimeCompilerConfig;
-    // @beta (undocumented)
+    // @beta
     dtsRollup?: IExtractorDtsRollupConfig;
     extends?: string;
-    // (undocumented)
     messages?: IExtractorMessagesConfig;
-    // (undocumented)
     policies?: IExtractorPoliciesConfig;
-    // (undocumented)
     project: IExtractorProjectConfig;
     skipLibCheck?: boolean;
     testMode?: boolean;
-    // @beta (undocumented)
+    // @beta
     tsdocMetadata?: IExtractorTsdocMetadataConfig;
-    // (undocumented)
     validationRules?: IExtractorValidationRulesConfig;
 }
 

--- a/common/reviews/api/node-core-library.api.md
+++ b/common/reviews/api/node-core-library.api.md
@@ -88,14 +88,10 @@ export enum ColorValue {
 
 // @beta
 export class ConsoleTerminalProvider implements ITerminalProvider {
-    // (undocumented)
     constructor(options?: Partial<IConsoleTerminalProviderOptions>);
-    // (undocumented)
     readonly eolCharacter: string;
-    // (undocumented)
     readonly supportsColor: boolean;
     verboseEnabled: boolean;
-    // (undocumented)
     write(data: string, severity: TerminalProviderSeverity): void;
 }
 
@@ -423,7 +419,6 @@ export const enum NewlineKind {
 
 // @public
 export class PackageJsonLookup {
-    // (undocumented)
     constructor(parameters?: IPackageJsonLookupParameters);
     clearCache(): void;
     loadNodePackageJson(jsonFilename: string): INodePackageJson;
@@ -438,9 +433,7 @@ export class PackageJsonLookup {
 // @public
 export class PackageName {
     static combineParts(scope: string, unscopedName: string): string;
-    // (undocumented)
     static getScope(packageName: string): string;
-    // (undocumented)
     static getUnscopedName(packageName: string): string;
     static isValidName(packageName: string): boolean;
     static parse(packageName: string): IParsedPackageName;
@@ -473,7 +466,6 @@ export const enum PosixModeBits {
 
 // @public
 export class ProtectableMap<K, V> {
-    // (undocumented)
     constructor(parameters: IProtectableMapParameters<K, V>);
     clear(): void;
     delete(key: K): boolean;
@@ -498,33 +490,25 @@ export class Sort {
 
 // @beta
 export class StringBufferTerminalProvider implements ITerminalProvider {
-    // (undocumented)
     constructor(supportsColor?: boolean);
-    // (undocumented)
     readonly eolCharacter: string;
     getErrorOutput(): string;
     getOutput(): string;
     getVerbose(): string;
     getWarningOutput(): string;
-    // (undocumented)
     readonly supportsColor: boolean;
-    // (undocumented)
     write(data: string, severity: TerminalProviderSeverity): void;
 }
 
 // @public
 export class StringBuilder implements IStringBuilder {
-    // (undocumented)
     constructor();
-    // (undocumented)
     append(text: string): void;
-    // (undocumented)
     toString(): string;
 }
 
 // @beta
 export class Terminal {
-    // (undocumented)
     constructor(provider: ITerminalProvider);
     registerProvider(provider: ITerminalProvider): void;
     unregisterProvider(provider: ITerminalProvider): void;

--- a/common/reviews/api/node-core-library.api.md
+++ b/common/reviews/api/node-core-library.api.md
@@ -309,7 +309,6 @@ export class InternalError extends Error {
 
 // @public
 export interface IPackageJson extends INodePackageJson {
-    // (undocumented)
     version: string;
 }
 

--- a/common/reviews/api/rush-stack-compiler-2.4.api.md
+++ b/common/reviews/api/rush-stack-compiler-2.4.api.md
@@ -15,7 +15,6 @@ import * as Typescript from 'typescript';
 
 // @beta
 export class ApiExtractorRunner extends RushStackCompilerBase {
-    // (undocumented)
     constructor(extractorConfig: IExtractorConfig, extractorOptions: IExtractorOptions, rootPath: string, terminalProvider: ITerminalProvider);
     // (undocumented)
     static apiExtractor: typeof ApiExtractor;
@@ -39,7 +38,6 @@ export interface ITypescriptCompilerOptions {
 
 // @beta (undocumented)
 export abstract class RushStackCompilerBase<TOptions = {}> {
-    // (undocumented)
     constructor(taskOptions: TOptions, rootPath: string, terminalProvider: ITerminalProvider);
     // (undocumented)
     protected _standardBuildFolders: StandardBuildFolders;
@@ -51,7 +49,6 @@ export abstract class RushStackCompilerBase<TOptions = {}> {
 
 // @beta (undocumented)
 export class StandardBuildFolders {
-    // (undocumented)
     constructor(projectFolderPath: string);
     // (undocumented)
     readonly distFolderPath: string;
@@ -89,7 +86,6 @@ export class ToolPaths {
 
 // @beta (undocumented)
 export class TslintRunner extends RushStackCompilerBase<ITslintRunnerConfig> {
-    // (undocumented)
     constructor(taskOptions: ITslintRunnerConfig, rootPath: string, terminalProvider: ITerminalProvider);
     // (undocumented)
     invoke(): Promise<void>;
@@ -97,9 +93,7 @@ export class TslintRunner extends RushStackCompilerBase<ITslintRunnerConfig> {
 
 // @beta (undocumented)
 export class TypescriptCompiler extends RushStackCompilerBase<ITypescriptCompilerOptions> {
-    // (undocumented)
     constructor(rootPath: string, terminalProvider: ITerminalProvider);
-    // (undocumented)
     constructor(taskOptions: ITypescriptCompilerOptions, rootPath: string, terminalProvider: ITerminalProvider);
     // (undocumented)
     invoke(): Promise<void>;

--- a/common/reviews/api/rush-stack-compiler-2.7.api.md
+++ b/common/reviews/api/rush-stack-compiler-2.7.api.md
@@ -15,7 +15,6 @@ import * as Typescript from 'typescript';
 
 // @beta
 export class ApiExtractorRunner extends RushStackCompilerBase {
-    // (undocumented)
     constructor(extractorConfig: IExtractorConfig, extractorOptions: IExtractorOptions, rootPath: string, terminalProvider: ITerminalProvider);
     // (undocumented)
     static apiExtractor: typeof ApiExtractor;
@@ -39,7 +38,6 @@ export interface ITypescriptCompilerOptions {
 
 // @beta (undocumented)
 export abstract class RushStackCompilerBase<TOptions = {}> {
-    // (undocumented)
     constructor(taskOptions: TOptions, rootPath: string, terminalProvider: ITerminalProvider);
     // (undocumented)
     protected _standardBuildFolders: StandardBuildFolders;
@@ -51,7 +49,6 @@ export abstract class RushStackCompilerBase<TOptions = {}> {
 
 // @beta (undocumented)
 export class StandardBuildFolders {
-    // (undocumented)
     constructor(projectFolderPath: string);
     // (undocumented)
     readonly distFolderPath: string;
@@ -89,7 +86,6 @@ export class ToolPaths {
 
 // @beta (undocumented)
 export class TslintRunner extends RushStackCompilerBase<ITslintRunnerConfig> {
-    // (undocumented)
     constructor(taskOptions: ITslintRunnerConfig, rootPath: string, terminalProvider: ITerminalProvider);
     // (undocumented)
     invoke(): Promise<void>;
@@ -97,9 +93,7 @@ export class TslintRunner extends RushStackCompilerBase<ITslintRunnerConfig> {
 
 // @beta (undocumented)
 export class TypescriptCompiler extends RushStackCompilerBase<ITypescriptCompilerOptions> {
-    // (undocumented)
     constructor(rootPath: string, terminalProvider: ITerminalProvider);
-    // (undocumented)
     constructor(taskOptions: ITypescriptCompilerOptions, rootPath: string, terminalProvider: ITerminalProvider);
     // (undocumented)
     invoke(): Promise<void>;

--- a/common/reviews/api/rush-stack-compiler-2.9.api.md
+++ b/common/reviews/api/rush-stack-compiler-2.9.api.md
@@ -15,7 +15,6 @@ import * as Typescript from 'typescript';
 
 // @beta
 export class ApiExtractorRunner extends RushStackCompilerBase {
-    // (undocumented)
     constructor(extractorConfig: IExtractorConfig, extractorOptions: IExtractorOptions, rootPath: string, terminalProvider: ITerminalProvider);
     // (undocumented)
     static apiExtractor: typeof ApiExtractor;
@@ -39,7 +38,6 @@ export interface ITypescriptCompilerOptions {
 
 // @beta (undocumented)
 export abstract class RushStackCompilerBase<TOptions = {}> {
-    // (undocumented)
     constructor(taskOptions: TOptions, rootPath: string, terminalProvider: ITerminalProvider);
     // (undocumented)
     protected _standardBuildFolders: StandardBuildFolders;
@@ -51,7 +49,6 @@ export abstract class RushStackCompilerBase<TOptions = {}> {
 
 // @beta (undocumented)
 export class StandardBuildFolders {
-    // (undocumented)
     constructor(projectFolderPath: string);
     // (undocumented)
     readonly distFolderPath: string;
@@ -89,7 +86,6 @@ export class ToolPaths {
 
 // @beta (undocumented)
 export class TslintRunner extends RushStackCompilerBase<ITslintRunnerConfig> {
-    // (undocumented)
     constructor(taskOptions: ITslintRunnerConfig, rootPath: string, terminalProvider: ITerminalProvider);
     // (undocumented)
     invoke(): Promise<void>;
@@ -97,9 +93,7 @@ export class TslintRunner extends RushStackCompilerBase<ITslintRunnerConfig> {
 
 // @beta (undocumented)
 export class TypescriptCompiler extends RushStackCompilerBase<ITypescriptCompilerOptions> {
-    // (undocumented)
     constructor(rootPath: string, terminalProvider: ITerminalProvider);
-    // (undocumented)
     constructor(taskOptions: ITypescriptCompilerOptions, rootPath: string, terminalProvider: ITerminalProvider);
     // (undocumented)
     invoke(): Promise<void>;

--- a/common/reviews/api/rush-stack-compiler-3.0.api.md
+++ b/common/reviews/api/rush-stack-compiler-3.0.api.md
@@ -15,7 +15,6 @@ import * as Typescript from 'typescript';
 
 // @beta
 export class ApiExtractorRunner extends RushStackCompilerBase {
-    // (undocumented)
     constructor(extractorConfig: IExtractorConfig, extractorOptions: IExtractorOptions, rootPath: string, terminalProvider: ITerminalProvider);
     // (undocumented)
     static apiExtractor: typeof ApiExtractor;
@@ -39,7 +38,6 @@ export interface ITypescriptCompilerOptions {
 
 // @beta (undocumented)
 export abstract class RushStackCompilerBase<TOptions = {}> {
-    // (undocumented)
     constructor(taskOptions: TOptions, rootPath: string, terminalProvider: ITerminalProvider);
     // (undocumented)
     protected _standardBuildFolders: StandardBuildFolders;
@@ -51,7 +49,6 @@ export abstract class RushStackCompilerBase<TOptions = {}> {
 
 // @beta (undocumented)
 export class StandardBuildFolders {
-    // (undocumented)
     constructor(projectFolderPath: string);
     // (undocumented)
     readonly distFolderPath: string;
@@ -89,7 +86,6 @@ export class ToolPaths {
 
 // @beta (undocumented)
 export class TslintRunner extends RushStackCompilerBase<ITslintRunnerConfig> {
-    // (undocumented)
     constructor(taskOptions: ITslintRunnerConfig, rootPath: string, terminalProvider: ITerminalProvider);
     // (undocumented)
     invoke(): Promise<void>;
@@ -97,9 +93,7 @@ export class TslintRunner extends RushStackCompilerBase<ITslintRunnerConfig> {
 
 // @beta (undocumented)
 export class TypescriptCompiler extends RushStackCompilerBase<ITypescriptCompilerOptions> {
-    // (undocumented)
     constructor(rootPath: string, terminalProvider: ITerminalProvider);
-    // (undocumented)
     constructor(taskOptions: ITypescriptCompilerOptions, rootPath: string, terminalProvider: ITerminalProvider);
     // (undocumented)
     invoke(): Promise<void>;

--- a/common/reviews/api/rush-stack-compiler-3.1.api.md
+++ b/common/reviews/api/rush-stack-compiler-3.1.api.md
@@ -15,7 +15,6 @@ import * as Typescript from 'typescript';
 
 // @beta
 export class ApiExtractorRunner extends RushStackCompilerBase {
-    // (undocumented)
     constructor(extractorConfig: IExtractorConfig, extractorOptions: IExtractorOptions, rootPath: string, terminalProvider: ITerminalProvider);
     // (undocumented)
     static apiExtractor: typeof ApiExtractor;
@@ -39,7 +38,6 @@ export interface ITypescriptCompilerOptions {
 
 // @beta (undocumented)
 export abstract class RushStackCompilerBase<TOptions = {}> {
-    // (undocumented)
     constructor(taskOptions: TOptions, rootPath: string, terminalProvider: ITerminalProvider);
     // (undocumented)
     protected _standardBuildFolders: StandardBuildFolders;
@@ -51,7 +49,6 @@ export abstract class RushStackCompilerBase<TOptions = {}> {
 
 // @beta (undocumented)
 export class StandardBuildFolders {
-    // (undocumented)
     constructor(projectFolderPath: string);
     // (undocumented)
     readonly distFolderPath: string;
@@ -89,7 +86,6 @@ export class ToolPaths {
 
 // @beta (undocumented)
 export class TslintRunner extends RushStackCompilerBase<ITslintRunnerConfig> {
-    // (undocumented)
     constructor(taskOptions: ITslintRunnerConfig, rootPath: string, terminalProvider: ITerminalProvider);
     // (undocumented)
     invoke(): Promise<void>;
@@ -97,9 +93,7 @@ export class TslintRunner extends RushStackCompilerBase<ITslintRunnerConfig> {
 
 // @beta (undocumented)
 export class TypescriptCompiler extends RushStackCompilerBase<ITypescriptCompilerOptions> {
-    // (undocumented)
     constructor(rootPath: string, terminalProvider: ITerminalProvider);
-    // (undocumented)
     constructor(taskOptions: ITypescriptCompilerOptions, rootPath: string, terminalProvider: ITerminalProvider);
     // (undocumented)
     invoke(): Promise<void>;

--- a/common/reviews/api/rush-stack-compiler-3.2.api.md
+++ b/common/reviews/api/rush-stack-compiler-3.2.api.md
@@ -15,7 +15,6 @@ import * as Typescript from 'typescript';
 
 // @beta
 export class ApiExtractorRunner extends RushStackCompilerBase {
-    // (undocumented)
     constructor(extractorConfig: IExtractorConfig, extractorOptions: IExtractorOptions, rootPath: string, terminalProvider: ITerminalProvider);
     // (undocumented)
     static apiExtractor: typeof ApiExtractor;
@@ -39,7 +38,6 @@ export interface ITypescriptCompilerOptions {
 
 // @beta (undocumented)
 export abstract class RushStackCompilerBase<TOptions = {}> {
-    // (undocumented)
     constructor(taskOptions: TOptions, rootPath: string, terminalProvider: ITerminalProvider);
     // (undocumented)
     protected _standardBuildFolders: StandardBuildFolders;
@@ -51,7 +49,6 @@ export abstract class RushStackCompilerBase<TOptions = {}> {
 
 // @beta (undocumented)
 export class StandardBuildFolders {
-    // (undocumented)
     constructor(projectFolderPath: string);
     // (undocumented)
     readonly distFolderPath: string;
@@ -89,7 +86,6 @@ export class ToolPaths {
 
 // @beta (undocumented)
 export class TslintRunner extends RushStackCompilerBase<ITslintRunnerConfig> {
-    // (undocumented)
     constructor(taskOptions: ITslintRunnerConfig, rootPath: string, terminalProvider: ITerminalProvider);
     // (undocumented)
     invoke(): Promise<void>;
@@ -97,9 +93,7 @@ export class TslintRunner extends RushStackCompilerBase<ITslintRunnerConfig> {
 
 // @beta (undocumented)
 export class TypescriptCompiler extends RushStackCompilerBase<ITypescriptCompilerOptions> {
-    // (undocumented)
     constructor(rootPath: string, terminalProvider: ITerminalProvider);
-    // (undocumented)
     constructor(taskOptions: ITypescriptCompilerOptions, rootPath: string, terminalProvider: ITerminalProvider);
     // (undocumented)
     invoke(): Promise<void>;

--- a/common/reviews/api/rush-stack-compiler-3.3.api.md
+++ b/common/reviews/api/rush-stack-compiler-3.3.api.md
@@ -15,7 +15,6 @@ import * as Typescript from 'typescript';
 
 // @beta
 export class ApiExtractorRunner extends RushStackCompilerBase {
-    // (undocumented)
     constructor(extractorConfig: IExtractorConfig, extractorOptions: IExtractorOptions, rootPath: string, terminalProvider: ITerminalProvider);
     // (undocumented)
     static apiExtractor: typeof ApiExtractor;
@@ -39,7 +38,6 @@ export interface ITypescriptCompilerOptions {
 
 // @beta (undocumented)
 export abstract class RushStackCompilerBase<TOptions = {}> {
-    // (undocumented)
     constructor(taskOptions: TOptions, rootPath: string, terminalProvider: ITerminalProvider);
     // (undocumented)
     protected _standardBuildFolders: StandardBuildFolders;
@@ -51,7 +49,6 @@ export abstract class RushStackCompilerBase<TOptions = {}> {
 
 // @beta (undocumented)
 export class StandardBuildFolders {
-    // (undocumented)
     constructor(projectFolderPath: string);
     // (undocumented)
     readonly distFolderPath: string;
@@ -89,7 +86,6 @@ export class ToolPaths {
 
 // @beta (undocumented)
 export class TslintRunner extends RushStackCompilerBase<ITslintRunnerConfig> {
-    // (undocumented)
     constructor(taskOptions: ITslintRunnerConfig, rootPath: string, terminalProvider: ITerminalProvider);
     // (undocumented)
     invoke(): Promise<void>;
@@ -97,9 +93,7 @@ export class TslintRunner extends RushStackCompilerBase<ITslintRunnerConfig> {
 
 // @beta (undocumented)
 export class TypescriptCompiler extends RushStackCompilerBase<ITypescriptCompilerOptions> {
-    // (undocumented)
     constructor(rootPath: string, terminalProvider: ITerminalProvider);
-    // (undocumented)
     constructor(taskOptions: ITypescriptCompilerOptions, rootPath: string, terminalProvider: ITerminalProvider);
     // (undocumented)
     invoke(): Promise<void>;

--- a/common/reviews/api/ts-command-line.api.md
+++ b/common/reviews/api/ts-command-line.api.md
@@ -8,24 +8,19 @@ import * as argparse from 'argparse';
 
 // @public
 export abstract class CommandLineAction extends CommandLineParameterProvider {
-    // (undocumented)
     constructor(options: ICommandLineActionOptions);
-    // (undocumented)
     readonly actionName: string;
     // @internal
     _buildParser(actionsSubParser: argparse.SubParser): void;
-    // (undocumented)
     readonly documentation: string;
     // @internal
     _execute(): Promise<void>;
-    // @internal (undocumented)
+    // @internal
     protected _getArgumentParser(): argparse.ArgumentParser;
-    // (undocumented)
     protected abstract onDefineParameters(): void;
     protected abstract onExecute(): Promise<void>;
     // @internal
     _processParsedData(data: _ICommandLineParserData): void;
-    // (undocumented)
     readonly summary: string;
 }
 
@@ -33,17 +28,14 @@ export abstract class CommandLineAction extends CommandLineParameterProvider {
 export class CommandLineChoiceParameter extends CommandLineParameter {
     // @internal
     constructor(definition: ICommandLineChoiceDefinition);
-    // (undocumented)
     readonly alternatives: ReadonlyArray<string>;
-    // @override (undocumented)
+    // @override
     appendToArgList(argList: string[]): void;
-    // (undocumented)
     readonly defaultValue: string | undefined;
-    // @internal (undocumented)
+    // @internal
     _getSupplementaryNotes(supplementaryNotes: string[]): void;
-    // (undocumented)
     readonly kind: CommandLineParameterKind;
-    // @internal (undocumented)
+    // @internal
     _setValue(data: any): void;
     readonly value: string | undefined;
     }
@@ -52,11 +44,10 @@ export class CommandLineChoiceParameter extends CommandLineParameter {
 export class CommandLineFlagParameter extends CommandLineParameter {
     // @internal
     constructor(definition: ICommandLineFlagDefinition);
-    // @override (undocumented)
+    // @override
     appendToArgList(argList: string[]): void;
-    // (undocumented)
     readonly kind: CommandLineParameterKind;
-    // @internal (undocumented)
+    // @internal
     _setValue(data: any): void;
     readonly value: boolean;
     }
@@ -65,15 +56,13 @@ export class CommandLineFlagParameter extends CommandLineParameter {
 export class CommandLineIntegerParameter extends CommandLineParameterWithArgument {
     // @internal
     constructor(definition: ICommandLineIntegerDefinition);
-    // @override (undocumented)
+    // @override
     appendToArgList(argList: string[]): void;
-    // (undocumented)
     readonly defaultValue: number | undefined;
-    // @internal (undocumented)
+    // @internal
     _getSupplementaryNotes(supplementaryNotes: string[]): void;
-    // (undocumented)
     readonly kind: CommandLineParameterKind;
-    // @internal (undocumented)
+    // @internal
     _setValue(data: any): void;
     readonly value: number | undefined;
     }
@@ -83,23 +72,18 @@ export abstract class CommandLineParameter {
     // @internal
     constructor(definition: IBaseCommandLineDefinition);
     abstract appendToArgList(argList: string[]): void;
-    // (undocumented)
     readonly description: string;
-    // (undocumented)
     readonly environmentVariable: string | undefined;
     // @internal
     _getSupplementaryNotes(supplementaryNotes: string[]): void;
     abstract readonly kind: CommandLineParameterKind;
-    // (undocumented)
     readonly longName: string;
     // @internal
     _parserKey: string;
     protected reportInvalidData(data: any): never;
-    // (undocumented)
     readonly required: boolean;
     // @internal
     abstract _setValue(data: any): void;
-    // (undocumented)
     readonly shortName: string | undefined;
     // (undocumented)
     protected validateDefaultValue(hasDefaultValue: boolean): void;
@@ -141,26 +125,22 @@ export abstract class CommandLineParameterProvider {
 export abstract class CommandLineParameterWithArgument extends CommandLineParameter {
     // @internal
     constructor(definition: IBaseCommandLineDefinitionWithArgument);
-    // (undocumented)
     readonly argumentName: string;
     }
 
 // @public
 export abstract class CommandLineParser extends CommandLineParameterProvider {
-    // (undocumented)
     constructor(options: ICommandLineParserOptions);
     readonly actions: ReadonlyArray<CommandLineAction>;
     addAction(action: CommandLineAction): void;
     execute(args?: string[]): Promise<boolean>;
     executeWithoutErrorHandling(args?: string[]): Promise<void>;
     getAction(actionName: string): CommandLineAction;
-    // @internal (undocumented)
+    // @internal
     protected _getArgumentParser(): argparse.ArgumentParser;
     protected onExecute(): Promise<void>;
     selectedAction: CommandLineAction | undefined;
-    // (undocumented)
     readonly toolDescription: string;
-    // (undocumented)
     readonly toolFilename: string;
     tryGetAction(actionName: string): CommandLineAction | undefined;
 }
@@ -169,11 +149,10 @@ export abstract class CommandLineParser extends CommandLineParameterProvider {
 export class CommandLineStringListParameter extends CommandLineParameterWithArgument {
     // @internal
     constructor(definition: ICommandLineStringListDefinition);
-    // @override (undocumented)
+    // @override
     appendToArgList(argList: string[]): void;
-    // (undocumented)
     readonly kind: CommandLineParameterKind;
-    // @internal (undocumented)
+    // @internal
     _setValue(data: any): void;
     readonly values: ReadonlyArray<string>;
     }
@@ -182,15 +161,13 @@ export class CommandLineStringListParameter extends CommandLineParameterWithArgu
 export class CommandLineStringParameter extends CommandLineParameterWithArgument {
     // @internal
     constructor(definition: ICommandLineStringDefinition);
-    // @override (undocumented)
+    // @override
     appendToArgList(argList: string[]): void;
-    // (undocumented)
     readonly defaultValue: string | undefined;
-    // @internal (undocumented)
+    // @internal
     _getSupplementaryNotes(supplementaryNotes: string[]): void;
-    // (undocumented)
     readonly kind: CommandLineParameterKind;
-    // @internal (undocumented)
+    // @internal
     _setValue(data: any): void;
     readonly value: string | undefined;
     }
@@ -233,7 +210,6 @@ export interface ICommandLineActionOptions {
 // @public
 export interface ICommandLineChoiceDefinition extends IBaseCommandLineDefinition {
     alternatives: string[];
-    // (undocumented)
     defaultValue?: string;
 }
 
@@ -243,7 +219,6 @@ export interface ICommandLineFlagDefinition extends IBaseCommandLineDefinition {
 
 // @public
 export interface ICommandLineIntegerDefinition extends IBaseCommandLineDefinitionWithArgument {
-    // (undocumented)
     defaultValue?: number;
 }
 

--- a/core-build/gulp-core-build-mocha/package.json
+++ b/core-build/gulp-core-build-mocha/package.json
@@ -25,7 +25,7 @@
   },
   "devDependencies": {
     "@microsoft/rush-stack-compiler-3.2": "0.3.1",
-    "@microsoft/node-library-build": "6.0.44",
+    "@microsoft/node-library-build": "6.0.49",
     "@types/glob": "5.0.30",
     "@types/gulp": "3.8.32",
     "@types/gulp-istanbul": "0.9.30",

--- a/core-build/gulp-core-build-typescript/package.json
+++ b/core-build/gulp-core-build-typescript/package.json
@@ -28,7 +28,7 @@
   "devDependencies": {
     "tslint-microsoft-contrib": "~5.2.1",
     "@microsoft/api-extractor": "7.0.36",
-    "@microsoft/node-library-build": "6.0.44",
+    "@microsoft/node-library-build": "6.0.49",
     "@types/glob": "5.0.30",
     "gulp": "~3.9.1",
     "typescript": "~3.2.4",

--- a/core-build/gulp-core-build/package.json
+++ b/core-build/gulp-core-build/package.json
@@ -58,7 +58,7 @@
   "devDependencies": {
     "@microsoft/rush-stack-compiler-3.2": "0.3.1",
     "@types/z-schema": "3.16.31",
-    "@microsoft/node-library-build": "6.0.44",
+    "@microsoft/node-library-build": "6.0.49",
     "chai": "~3.5.0"
   }
 }

--- a/libraries/node-core-library/package.json
+++ b/libraries/node-core-library/package.json
@@ -28,7 +28,7 @@
     "tslint-microsoft-contrib": "~5.2.1",
     "@types/jest": "23.3.11",
     "gulp": "~3.9.1",
-    "@microsoft/node-library-build": "6.0.44",
-    "@microsoft/rush-stack-compiler-3.2": "0.2.17"
+    "@microsoft/node-library-build": "6.0.49",
+    "@microsoft/rush-stack-compiler-3.2": "0.3.1"
   }
 }

--- a/libraries/node-core-library/src/IPackageJson.ts
+++ b/libraries/node-core-library/src/IPackageJson.ts
@@ -175,6 +175,6 @@ export interface IPackageJsonTsdocConfiguration {
  */
 export interface IPackageJson extends INodePackageJson {
   // Make the "version" field non-optional.
-  /** {@inheritDoc IPackageJson.version} */
+  /** {@inheritDoc INodePackageJson.version} */
   version: string;
 }

--- a/libraries/node-core-library/src/PackageJsonLookup.ts
+++ b/libraries/node-core-library/src/PackageJsonLookup.ts
@@ -178,8 +178,8 @@ export class PackageJsonLookup {
   }
 
   /**
-   * This function is similar to {@link tryLoadPackageJsonFor}, except that it does not report an error if the
-   * `version` field is missing from the package.json file.
+   * This function is similar to {@link PackageJsonLookup.tryLoadPackageJsonFor}, except that it does not report
+   * an error if the `version` field is missing from the package.json file.
    */
   public tryLoadNodePackageJsonFor(fileOrFolderPath: string): INodePackageJson | undefined {
     const packageJsonFilePath: string | undefined = this.tryGetPackageJsonFilePathFor(fileOrFolderPath);
@@ -212,8 +212,8 @@ export class PackageJsonLookup {
   }
 
   /**
-   * This function is similar to {@link loadPackageJson}, except that it does not report an error if the
-   * `version` field is missing from the package.json file.
+   * This function is similar to {@link PackageJsonLookup.loadPackageJson}, except that it does not report an error
+   * if the `version` field is missing from the package.json file.
    */
   public loadNodePackageJson(jsonFilename: string): INodePackageJson {
     if (!FileSystem.exists(jsonFilename)) {

--- a/libraries/ts-command-line/package.json
+++ b/libraries/ts-command-line/package.json
@@ -25,7 +25,7 @@
     "tslint-microsoft-contrib": "~5.2.1",
     "@types/jest": "23.3.11",
     "gulp": "~3.9.1",
-    "@microsoft/node-library-build": "6.0.44",
-    "@microsoft/rush-stack-compiler-3.2": "0.2.17"
+    "@microsoft/node-library-build": "6.0.49",
+    "@microsoft/rush-stack-compiler-3.2": "0.3.1"
   }
 }

--- a/stack/rush-stack-compiler-2.4/package.json
+++ b/stack/rush-stack-compiler-2.4/package.json
@@ -26,8 +26,8 @@
     "typescript": "~2.4.2"
   },
   "devDependencies": {
-    "@microsoft/node-library-build": "6.0.44",
-    "@microsoft/rush-stack-compiler-3.2": "0.2.17",
+    "@microsoft/node-library-build": "6.0.49",
+    "@microsoft/rush-stack-compiler-3.2": "0.3.1",
     "@microsoft/rush-stack-compiler-shared": "0.0.0",
     "gulp": "~3.9.1"
   }

--- a/stack/rush-stack-compiler-2.7/package.json
+++ b/stack/rush-stack-compiler-2.7/package.json
@@ -26,8 +26,8 @@
     "typescript": "~2.7.2"
   },
   "devDependencies": {
-    "@microsoft/node-library-build": "6.0.44",
-    "@microsoft/rush-stack-compiler-3.2": "0.2.17",
+    "@microsoft/node-library-build": "6.0.49",
+    "@microsoft/rush-stack-compiler-3.2": "0.3.1",
     "@microsoft/rush-stack-compiler-shared": "0.0.0",
     "gulp": "~3.9.1"
   }

--- a/stack/rush-stack-compiler-2.9/package.json
+++ b/stack/rush-stack-compiler-2.9/package.json
@@ -26,8 +26,8 @@
     "typescript": "~2.9.2"
   },
   "devDependencies": {
-    "@microsoft/node-library-build": "6.0.44",
-    "@microsoft/rush-stack-compiler-3.2": "0.2.17",
+    "@microsoft/node-library-build": "6.0.49",
+    "@microsoft/rush-stack-compiler-3.2": "0.3.1",
     "@microsoft/rush-stack-compiler-shared": "0.0.0",
     "gulp": "~3.9.1"
   }

--- a/stack/rush-stack-compiler-3.0/package.json
+++ b/stack/rush-stack-compiler-3.0/package.json
@@ -26,8 +26,8 @@
     "typescript": "~3.0.3"
   },
   "devDependencies": {
-    "@microsoft/node-library-build": "6.0.44",
-    "@microsoft/rush-stack-compiler-3.2": "0.2.17",
+    "@microsoft/node-library-build": "6.0.49",
+    "@microsoft/rush-stack-compiler-3.2": "0.3.1",
     "@microsoft/rush-stack-compiler-shared": "0.0.0",
     "gulp": "~3.9.1"
   }

--- a/stack/rush-stack-compiler-3.1/package.json
+++ b/stack/rush-stack-compiler-3.1/package.json
@@ -26,8 +26,8 @@
     "typescript": "~3.1.6"
   },
   "devDependencies": {
-    "@microsoft/node-library-build": "6.0.44",
-    "@microsoft/rush-stack-compiler-3.2": "0.2.17",
+    "@microsoft/node-library-build": "6.0.49",
+    "@microsoft/rush-stack-compiler-3.2": "0.3.1",
     "@microsoft/rush-stack-compiler-shared": "0.0.0",
     "gulp": "~3.9.1"
   }

--- a/stack/rush-stack-compiler-3.2/package.json
+++ b/stack/rush-stack-compiler-3.2/package.json
@@ -26,8 +26,8 @@
     "typescript": "~3.2.4"
   },
   "devDependencies": {
-    "@microsoft/node-library-build": "6.0.44",
-    "@microsoft/rush-stack-compiler-3.2": "0.2.17",
+    "@microsoft/node-library-build": "6.0.49",
+    "@microsoft/rush-stack-compiler-3.2": "0.3.1",
     "@microsoft/rush-stack-compiler-shared": "0.0.0",
     "gulp": "~3.9.1"
   }

--- a/stack/rush-stack-compiler-3.3/package.json
+++ b/stack/rush-stack-compiler-3.3/package.json
@@ -26,8 +26,8 @@
     "typescript": "~3.3.3"
   },
   "devDependencies": {
-    "@microsoft/node-library-build": "6.0.44",
-    "@microsoft/rush-stack-compiler-3.2": "0.2.17",
+    "@microsoft/node-library-build": "6.0.49",
+    "@microsoft/rush-stack-compiler-3.2": "0.3.1",
     "@microsoft/rush-stack-compiler-shared": "0.0.0",
     "gulp": "~3.9.1"
   }


### PR DESCRIPTION
This upgrades us to API Extractor 7.0.36 which enables more validation checks.