### PR TITLE
[rush] Add suppressedWarnings option

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -17,5 +17,9 @@
     "temp": true,
     "**/test/**/temp": false,
     "coverage": true
+  },
+  "files.associations": {
+    "rush.json": "jsonc",
+    "**/common/config/rush/*.json": "jsonc"
   }
 }

--- a/apps/rush-lib/assets/rush-init/rush.json
+++ b/apps/rush-lib/assets/rush-init/rush.json
@@ -271,14 +271,10 @@
   /*[LINE "HYPOTHETICAL"]*/ "hotfixChangeEnabled": false,
 
   /**
-   * If a warning message includes any substrings listed here, it should be treated as a standard
-   * log message rather than a warning. This prevents inconsequential warning messages caused by
-   * external packages from breaking incremental builds (packages marked as "success with warnings"
-   * will be rebuilt on each rush build).
-   *
-   * For example, certain npm packages with C++ bindings intermittently cause Node to display a warning
-   * starting with "Using a domain property in MakeCallback is deprecated." The source of this warning
-   * has been hard to track down, so it can be added to this list to make incremental builds work.
+   * If a warning message matches any of the regular expressions listed here, it should be treated
+   * as a standard log message rather than a warning. This prevents inconsequential warning messages
+   * caused by external packages from breaking incremental builds (packages marked as "success with
+   * warnings" will be rebuilt on each rush build).
    */
   /*[LINE "HYPOTHETICAL"]*/ "suppressedWarnings": [],
 

--- a/apps/rush-lib/assets/rush-init/rush.json
+++ b/apps/rush-lib/assets/rush-init/rush.json
@@ -271,6 +271,18 @@
   /*[LINE "HYPOTHETICAL"]*/ "hotfixChangeEnabled": false,
 
   /**
+   * If a warning message includes any substrings listed here, it should be treated as a standard
+   * log message rather than a warning. This prevents inconsequential warning messages caused by
+   * external packages from breaking incremental builds (packages marked as "success with warnings"
+   * will be rebuilt on each rush build).
+   *
+   * For example, certain npm packages with C++ bindings intermittently cause Node to display a warning
+   * starting with "Using a domain property in MakeCallback is deprecated." The source of this warning
+   * has been hard to track down, so it can be added to this list to make incremental builds work.
+   */
+  /*[LINE "HYPOTHETICAL"]*/ "suppressedWarnings": [],
+
+  /**
    * (Required) This is the inventory of projects to be managed by Rush.
    *
    * Rush does not automatically scan for projects using wildcards, for a few reasons:

--- a/apps/rush-lib/src/api/RushConfiguration.ts
+++ b/apps/rush-lib/src/api/RushConfiguration.ts
@@ -247,7 +247,7 @@ export class RushConfiguration {
   private _variants: {
     [variantName: string]: boolean;
   };
-  private _suppressedWarnings: string[];
+  private _suppressedWarnings: RegExp[];
 
   // "approvedPackagesPolicy" feature
   private _approvedPackagesPolicy: ApprovedPackagesPolicy;
@@ -737,10 +737,10 @@ export class RushConfiguration {
   }
 
   /**
-   * Gets the list of warning message substrings which should be suppressed (treated as standard
-   * log messages rather than warnings).
+   * Gets a list of regular expressions for suppressing warnings. If a warning message
+   * matches any of these, it should be treated as a standard message rather than an error.
    */
-  public get suppressedWarnings(): string[] {
+  public get suppressedWarnings(): RegExp[] {
     return this._suppressedWarnings;
   }
 
@@ -984,7 +984,8 @@ export class RushConfiguration {
 
     this._ensureConsistentVersions = !!rushConfigurationJson.ensureConsistentVersions;
 
-    this._suppressedWarnings = rushConfigurationJson.suppressedWarnings || [];
+    const suppressedWarnings: string[] = rushConfigurationJson.suppressedWarnings || [];
+    this._suppressedWarnings = suppressedWarnings.map((value: string) => new RegExp(value));
 
     this._pnpmOptions = new PnpmOptionsConfiguration(rushConfigurationJson.pnpmOptions || {});
     this._yarnOptions = new YarnOptionsConfiguration(rushConfigurationJson.yarnOptions || { });

--- a/apps/rush-lib/src/api/RushConfiguration.ts
+++ b/apps/rush-lib/src/api/RushConfiguration.ts
@@ -122,6 +122,7 @@ export interface IRushConfigurationJson {
   yarnOptions?: IYarnOptionsJson;
   ensureConsistentVersions?: boolean;
   variants?: IRushVariantOptionsJson[];
+  suppressedWarnings?: string[];
 }
 
 /**
@@ -246,6 +247,7 @@ export class RushConfiguration {
   private _variants: {
     [variantName: string]: boolean;
   };
+  private _suppressedWarnings: string[];
 
   // "approvedPackagesPolicy" feature
   private _approvedPackagesPolicy: ApprovedPackagesPolicy;
@@ -735,6 +737,14 @@ export class RushConfiguration {
   }
 
   /**
+   * Gets the list of warning message substrings which should be suppressed (treated as standard
+   * log messages rather than warnings).
+   */
+  public get suppressedWarnings(): string[] {
+    return this._suppressedWarnings;
+  }
+
+  /**
    * Indicates whether telemetry collection is enabled for Rush runs.
    * @beta
    */
@@ -973,6 +983,8 @@ export class RushConfiguration {
     this._currentVariantJsonFilename = path.join(this._commonTempFolder, 'current-variant.json');
 
     this._ensureConsistentVersions = !!rushConfigurationJson.ensureConsistentVersions;
+
+    this._suppressedWarnings = rushConfigurationJson.suppressedWarnings || [];
 
     this._pnpmOptions = new PnpmOptionsConfiguration(rushConfigurationJson.pnpmOptions || {});
     this._yarnOptions = new YarnOptionsConfiguration(rushConfigurationJson.yarnOptions || { });

--- a/apps/rush-lib/src/logic/taskRunner/ProjectTask.ts
+++ b/apps/rush-lib/src/logic/taskRunner/ProjectTask.ts
@@ -162,7 +162,7 @@ export class ProjectTask implements ITaskDefinition {
         task.stderr.on('data', (data: string) => {
           // If this error matches any of the suppressed warnings from the config, write it to
           // stdout instead of stderr and don't treat the task as having a warning/error.
-          if (this._rushConfiguration.suppressedWarnings.some((warning: string) => data.indexOf(warning) !== -1)) {
+          if (this._rushConfiguration.suppressedWarnings.some((warning: RegExp) => warning.test(data))) {
             writer.write(data);
           } else {
             writer.writeError(data);

--- a/apps/rush-lib/src/logic/taskRunner/ProjectTask.ts
+++ b/apps/rush-lib/src/logic/taskRunner/ProjectTask.ts
@@ -160,8 +160,14 @@ export class ProjectTask implements ITaskDefinition {
         });
 
         task.stderr.on('data', (data: string) => {
-          writer.writeError(data);
-          this._hasWarningOrError = true;
+          // If this error matches any of the suppressed warnings from the config, write it to
+          // stdout instead of stderr and don't treat the task as having a warning/error.
+          if (this._rushConfiguration.suppressedWarnings.some((warning: string) => data.indexOf(warning) !== -1)) {
+            writer.write(data);
+          } else {
+            writer.writeError(data);
+            this._hasWarningOrError = true;
+          }
         });
 
         return new Promise((resolve: (status: TaskStatus) => void, reject: (error: TaskError) => void) => {

--- a/apps/rush-lib/src/schemas/rush.schema.json
+++ b/apps/rush-lib/src/schemas/rush.schema.json
@@ -234,7 +234,14 @@
         }
       },
       "additionalProperties": false
-    }
+    },
+    "suppressedWarnings": {
+      "description": "A list of warning messages which should be treated as standard log messages instead of warnings.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+}
   },
   "additionalProperties": false,
   "required": [

--- a/common/changes/@microsoft/rush/ignore-warnings_2019-04-10-19-30.json
+++ b/common/changes/@microsoft/rush/ignore-warnings_2019-04-10-19-30.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Add suppressedWarnings option",
+      "packageName": "@microsoft/rush",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "ecraig12345@users.noreply.github.com"
+}

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -259,6 +259,7 @@ export class RushConfiguration {
     readonly rushJsonFolder: string;
     readonly rushLinkJsonFilename: string;
     readonly shrinkwrapFilePhrase: string;
+    readonly suppressedWarnings: string[];
     // @beta
     readonly telemetryEnabled: boolean;
     readonly tempShrinkwrapFilename: string;

--- a/rush.json
+++ b/rush.json
@@ -224,6 +224,18 @@
   // "hotfixChangeEnabled": false,
 
   /**
+   * If a warning message includes any substrings listed here, it should be treated as a standard
+   * log message rather than a warning. This prevents inconsequential warning messages caused by
+   * external packages from breaking incremental builds (packages marked as "success with warnings"
+   * will be rebuilt on each rush build).
+   *
+   * For example, certain npm packages with C++ bindings intermittently cause Node to display a warning
+   * starting with "Using a domain property in MakeCallback is deprecated." The source of this warning
+   * has been hard to track down, so it can be added to this list to make incremental builds work.
+   */
+  // "suppressedWarnings": [],
+
+  /**
    * (Required) This is the inventory of projects to be managed by Rush.
    *
    * Rush does not automatically scan for projects using wildcards, for a few reasons:

--- a/rush.json
+++ b/rush.json
@@ -224,14 +224,10 @@
   // "hotfixChangeEnabled": false,
 
   /**
-   * If a warning message includes any substrings listed here, it should be treated as a standard
-   * log message rather than a warning. This prevents inconsequential warning messages caused by
-   * external packages from breaking incremental builds (packages marked as "success with warnings"
-   * will be rebuilt on each rush build).
-   *
-   * For example, certain npm packages with C++ bindings intermittently cause Node to display a warning
-   * starting with "Using a domain property in MakeCallback is deprecated." The source of this warning
-   * has been hard to track down, so it can be added to this list to make incremental builds work.
+   * If a warning message matches any of the regular expressions listed here, it should be treated
+   * as a standard log message rather than a warning. This prevents inconsequential warning messages
+   * caused by external packages from breaking incremental builds (packages marked as "success with
+   * warnings" will be rebuilt on each rush build).
    */
   // "suppressedWarnings": [],
 


### PR DESCRIPTION
Add an option `suppressedWarnings` (naming negotiable) to treat certain warning substrings as standard log messages rather than errors. This is so that if those warnings show up for reasons outside a project's control, they won't break incremental builds.

Background: In Fabric, we've increasingly been having problems with an intermittent warning `[DEP0097] DeprecationWarning: Using a domain property in MakeCallback is deprecated. Use the async_context variant of MakeCallback or the AsyncResource class instead.` breaking incremental builds ([fabric issue](https://github.com/OfficeDev/office-ui-fabric-react/issues/8622)). I did some investigation and figured out that this warning comes is due to the way certain packages are calling into Node's C++ layer, but I had no luck tracking down the actual problem packages. And even if I'd been able to track down the issue, it would likely have been a nightmare of getting dependencies of dependencies to upgrade before it could really be fixed.