### PR TITLE
[api-extractor] Add a new setting "tsconfigFilePath"

### DIFF
--- a/apps/api-extractor/src/api/CompilerState.ts
+++ b/apps/api-extractor/src/api/CompilerState.ts
@@ -52,7 +52,7 @@ export class CompilerState {
     let tsconfig: {} | undefined = extractorConfig.overrideTsconfig;
     if (!tsconfig) {
       // If it wasn't overridden, then load it from disk
-      tsconfig = JsonFile.load(path.join(extractorConfig.projectFolder, 'tsconfig.json'));
+      tsconfig = JsonFile.load(extractorConfig.tsconfigFilePath);
     }
 
     const commandLine: ts.ParsedCommandLine = ts.parseJsonConfigFileContent(

--- a/apps/api-extractor/src/api/ExtractorConfig.ts
+++ b/apps/api-extractor/src/api/ExtractorConfig.ts
@@ -533,7 +533,7 @@ export class ExtractorConfig {
           throw new Error('Either the "tsconfigFilePath" or "overrideTsconfig" setting must be specified');
         }
         if (!FileSystem.exists(tsconfigFilePath)) {
-          throw new Error('The "tsconfigFilePath" path does not exist: ' + tsconfigFilePath);
+          throw new Error('The file referenced by "tsconfigFilePath" does not exist: ' + tsconfigFilePath);
         }
       }
 

--- a/apps/api-extractor/src/api/IConfigFile.ts
+++ b/apps/api-extractor/src/api/IConfigFile.ts
@@ -12,6 +12,16 @@ import { ExtractorLogLevel } from './ExtractorLogLevel';
  * @public
  */
 export interface IConfigCompiler {
+  /**
+   * Specifies the path to the tsconfig.json file to be used by API Extractor when analyzing the project.
+   *
+   * @remarks
+   * The path is resolved relative to the folder of the config file that contains the setting; to change this,
+   * prepend a folder token such as `<projectFolder>`.
+   *
+   * Note: This setting will be ignored if `overrideTsconfig` is used.
+   */
+  tsconfigFilePath?: string;
 
   /**
    * Provides already parsed tsconfig.json contents.

--- a/apps/api-extractor/src/collector/Collector.ts
+++ b/apps/api-extractor/src/collector/Collector.ts
@@ -95,14 +95,14 @@ export class Collector {
       throw new Error('Unable to load file: ' + extractorConfig.mainEntryPointFile);
     }
 
-    if (!extractorConfig.packageJsonFullPath || !extractorConfig.packageJson) {
+    if (!extractorConfig.packageFolder || !extractorConfig.packageJson) {
       // TODO: We should be able to analyze projects that don't have any package.json.
       // The ExtractorConfig class is already designed to allow this.
       throw new Error('Unable to find a package.json file for the project being analyzed');
     }
 
     this.workingPackage = new WorkingPackage({
-      packageFolder: extractorConfig.packageJsonFullPath,
+      packageFolder: extractorConfig.packageFolder,
       packageJson: extractorConfig.packageJson,
       entryPointSourceFile
     });

--- a/apps/api-extractor/src/schemas/api-extractor-defaults.json
+++ b/apps/api-extractor/src/schemas/api-extractor-defaults.json
@@ -4,6 +4,7 @@
   "projectFolder": "<lookup>",
 
   "compiler": {
+    "tsconfigFilePath": "<projectFolder>/tsconfig.json",
     "skipLibCheck": false
   },
 

--- a/apps/api-extractor/src/schemas/api-extractor-template.json
+++ b/apps/api-extractor/src/schemas/api-extractor-template.json
@@ -52,6 +52,19 @@
    */
   "compiler": {
     /**
+     * Specifies the path to the tsconfig.json file to be used by API Extractor when analyzing the project.
+     *
+     * The path is resolved relative to the folder of the config file that contains the setting; to change this,
+     * prepend a folder token such as "<projectFolder>".
+     *
+     * Note: This setting will be ignored if "overrideTsconfig" is used.
+     *
+     * SUPPORTED TOKENS: <projectFolder>, <packageName>, <unscopedPackageName>
+     * DEFAULT VALUE: "<projectFolder>/tsconfig.json"
+     */
+    // "tsconfigFilePath": "<projectFolder>/tsconfig.json",
+
+    /**
      * Provides compiler configuration that will be used instead of reading the tsconfig.json file from disk.
      * The object must conform to the TypeScript tsconfig schema:
      *

--- a/apps/api-extractor/src/schemas/api-extractor.schema.json
+++ b/apps/api-extractor/src/schemas/api-extractor.schema.json
@@ -27,6 +27,10 @@
       "description": "Determines how the TypeScript compiler engine will be invoked by API Extractor.",
       "type": "object",
       "properties": {
+        "tsconfigFilePath": {
+          "description": " Specifies the path to the tsconfig.json file to be used by API Extractor when analyzing the project.  The path is resolved relative to the folder of the config file that contains the setting; to change this, prepend a folder token such as \"<projectFolder>\".  Note: This setting will be ignored if \"overrideTsconfig\" is used.",
+          "type": "string"
+        },
         "overrideTsconfig": {
           "description": "Provides already parsed tsconfig.json contents conforming to the TypeScript tsconfig schema: http://json.schemastore.org/tsconfig If omitted, then the tsconfig.json file will be read from the \"projectFolder\".",
           "type": "object"

--- a/common/changes/@microsoft/api-extractor/octogonz-ae-tsconfigfilepath_2019-04-11-05-11.json
+++ b/common/changes/@microsoft/api-extractor/octogonz-ae-tsconfigfilepath_2019-04-11-05-11.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor",
+      "comment": "Add a new api-extractor.json setting \"tsconfigFilePath\" for customizing the tsconfig.json path",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/api-extractor/octogonz-ae-tsconfigfilepath_2019-04-11-05-22.json
+++ b/common/changes/@microsoft/api-extractor/octogonz-ae-tsconfigfilepath_2019-04-11-05-22.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor",
+      "comment": "Replace ExtractorConfig.packageJsonFullPath with ExtractorConfig.packageFolder",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/reviews/api/api-extractor.api.md
+++ b/common/reviews/api/api-extractor.api.md
@@ -51,8 +51,8 @@ export class ExtractorConfig {
     readonly mainEntryPointFile: string;
     readonly messages: IExtractorMessagesConfig;
     readonly overrideTsconfig: {} | undefined;
+    readonly packageFolder: string | undefined;
     readonly packageJson: INodePackageJson | undefined;
-    readonly packageJsonFullPath: string | undefined;
     static prepare(options: IExtractorConfigPrepareOptions): ExtractorConfig;
     readonly projectFolder: string;
     readonly publicTrimmedFilePath: string;

--- a/common/reviews/api/api-extractor.api.md
+++ b/common/reviews/api/api-extractor.api.md
@@ -61,6 +61,7 @@ export class ExtractorConfig {
     readonly rollupEnabled: boolean;
     readonly skipLibCheck: boolean;
     readonly testMode: boolean;
+    readonly tsconfigFilePath: string;
     readonly tsdocMetadataEnabled: boolean;
     readonly tsdocMetadataFilePath: string;
     readonly untrimmedFilePath: string;
@@ -150,6 +151,7 @@ export interface IConfigApiReport {
 export interface IConfigCompiler {
     overrideTsconfig?: {};
     skipLibCheck?: boolean;
+    tsconfigFilePath?: string;
 }
 
 // @public


### PR DESCRIPTION
Fixes issue https://github.com/Microsoft/web-build-tools/issues/1222

This PR adds a new config file setting `tsconfigFilePath` for customizing the path for `tsconfig.json`.

It also improves some config file related error messages.