### PR TITLE
[api-extractor] Rename "mainEntryPointFile" setting to "mainEntryPointFilePath"

### DIFF
--- a/apps/api-extractor/src/api/CompilerState.ts
+++ b/apps/api-extractor/src/api/CompilerState.ts
@@ -71,7 +71,7 @@ export class CompilerState {
 
     CompilerState._updateCommandLineForTypescriptPackage(commandLine, options);
 
-    const inputFilePaths: string[] = commandLine.fileNames.concat(extractorConfig.mainEntryPointFile);
+    const inputFilePaths: string[] = commandLine.fileNames.concat(extractorConfig.mainEntryPointFilePath);
     if (options && options.additionalEntryPoints) {
       inputFilePaths.push(...options.additionalEntryPoints);
     }

--- a/apps/api-extractor/src/api/ExtractorConfig.ts
+++ b/apps/api-extractor/src/api/ExtractorConfig.ts
@@ -93,7 +93,7 @@ interface IExtractorConfigParameters {
   projectFolder: string;
   packageJson: INodePackageJson | undefined;
   packageFolder: string | undefined;
-  mainEntryPointFile: string;
+  mainEntryPointFilePath: string;
   tsconfigFilePath: string;
   overrideTsconfig: { } | undefined;
   skipLibCheck: boolean;
@@ -148,8 +148,8 @@ export class ExtractorConfig {
    */
   public readonly packageFolder: string | undefined;
 
-  /** {@inheritDoc IConfigFile.mainEntryPointFile} */
-  public readonly mainEntryPointFile: string;
+  /** {@inheritDoc IConfigFile.mainEntryPointFilePath} */
+  public readonly mainEntryPointFilePath: string;
 
   /** {@inheritDoc IConfigCompiler.tsconfigFilePath} */
   public readonly tsconfigFilePath: string;
@@ -197,7 +197,7 @@ export class ExtractorConfig {
     this.projectFolder = parameters.projectFolder;
     this.packageJson = parameters.packageJson;
     this.packageFolder = parameters.packageFolder;
-    this.mainEntryPointFile = parameters.mainEntryPointFile;
+    this.mainEntryPointFilePath = parameters.mainEntryPointFilePath;
     this.tsconfigFilePath = parameters.tsconfigFilePath;
     this.overrideTsconfig = parameters.overrideTsconfig;
     this.skipLibCheck = parameters.skipLibCheck;
@@ -342,9 +342,9 @@ export class ExtractorConfig {
         'projectFolder', configFile.projectFolder, currentConfigFolderPath);
     }
 
-    if (configFile.mainEntryPointFile) {
-      configFile.mainEntryPointFile = ExtractorConfig._resolveConfigFileRelativePath(
-        'mainEntryPointFile', configFile.mainEntryPointFile, currentConfigFolderPath);
+    if (configFile.mainEntryPointFilePath) {
+      configFile.mainEntryPointFilePath = ExtractorConfig._resolveConfigFileRelativePath(
+        'mainEntryPointFilePath', configFile.mainEntryPointFilePath, currentConfigFolderPath);
     }
 
     if (configFile.compiler) {
@@ -510,19 +510,19 @@ export class ExtractorConfig {
         tokenContext.unscopedPackageName = PackageName.getUnscopedName(packageJson.name);
       }
 
-      if (!configObject.mainEntryPointFile) {
+      if (!configObject.mainEntryPointFilePath) {
         // A merged configuration should have this
-        throw new Error('The "mainEntryPointFile" setting is missing');
+        throw new Error('The "mainEntryPointFilePath" setting is missing');
       }
-      const mainEntryPointFile: string = ExtractorConfig._resolvePathWithTokens('mainEntryPointFile',
-        configObject.mainEntryPointFile, tokenContext);
+      const mainEntryPointFilePath: string = ExtractorConfig._resolvePathWithTokens('mainEntryPointFilePath',
+        configObject.mainEntryPointFilePath, tokenContext);
 
-      if (!ExtractorConfig.hasDtsFileExtension(mainEntryPointFile)) {
-        throw new Error('The "mainEntryPointFile" value is not a declaration file: ' + mainEntryPointFile);
+      if (!ExtractorConfig.hasDtsFileExtension(mainEntryPointFilePath)) {
+        throw new Error('The "mainEntryPointFilePath" value is not a declaration file: ' + mainEntryPointFilePath);
       }
 
-      if (!FileSystem.exists(mainEntryPointFile)) {
-        throw new Error('The "mainEntryPointFile" path does not exist: ' + mainEntryPointFile);
+      if (!FileSystem.exists(mainEntryPointFilePath)) {
+        throw new Error('The "mainEntryPointFilePath" path does not exist: ' + mainEntryPointFilePath);
       }
 
       const tsconfigFilePath: string = ExtractorConfig._resolvePathWithTokens('tsconfigFilePath',
@@ -624,7 +624,7 @@ export class ExtractorConfig {
         projectFolder: projectFolder,
         packageJson,
         packageFolder,
-        mainEntryPointFile,
+        mainEntryPointFilePath,
         tsconfigFilePath,
         overrideTsconfig: configObject.compiler.overrideTsconfig,
         skipLibCheck: !!configObject.compiler.skipLibCheck,

--- a/apps/api-extractor/src/api/IConfigFile.ts
+++ b/apps/api-extractor/src/api/IConfigFile.ts
@@ -312,7 +312,7 @@ export interface IConfigFile {
    * The file extension must be ".d.ts" and not ".ts".
    * The path is resolved relative to the "projectFolder" location.
    */
-  mainEntryPointFile: string;
+  mainEntryPointFilePath: string;
 
   /**
    * {@inheritDoc IConfigCompiler}

--- a/apps/api-extractor/src/collector/Collector.ts
+++ b/apps/api-extractor/src/collector/Collector.ts
@@ -89,10 +89,10 @@ export class Collector {
     const extractorConfig: ExtractorConfig = options.extractorConfig;
 
     const entryPointSourceFile: ts.SourceFile | undefined = options.program.getSourceFile(
-      extractorConfig.mainEntryPointFile);
+      extractorConfig.mainEntryPointFilePath);
 
     if (!entryPointSourceFile) {
-      throw new Error('Unable to load file: ' + extractorConfig.mainEntryPointFile);
+      throw new Error('Unable to load file: ' + extractorConfig.mainEntryPointFilePath);
     }
 
     if (!extractorConfig.packageFolder || !extractorConfig.packageJson) {

--- a/apps/api-extractor/src/schemas/api-extractor-defaults.json
+++ b/apps/api-extractor/src/schemas/api-extractor-defaults.json
@@ -1,5 +1,5 @@
 {
-  // ("mainEntryPointFile" is required)
+  // ("mainEntryPointFilePath" is required)
 
   "projectFolder": "<lookup>",
 

--- a/apps/api-extractor/src/schemas/api-extractor-template.json
+++ b/apps/api-extractor/src/schemas/api-extractor-template.json
@@ -45,7 +45,7 @@
    *
    * SUPPORTED TOKENS: <projectFolder>, <packageName>, <unscopedPackageName>
    */
-  "mainEntryPointFile": "<projectFolder>/lib/index.d.ts",
+  "mainEntryPointFilePath": "<projectFolder>/lib/index.d.ts",
 
   /**
    * Determines how the TypeScript compiler engine will be invoked by API Extractor.

--- a/apps/api-extractor/src/schemas/api-extractor.schema.json
+++ b/apps/api-extractor/src/schemas/api-extractor.schema.json
@@ -18,7 +18,7 @@
       "type": "string"
     },
 
-    "mainEntryPointFile": {
+    "mainEntryPointFilePath": {
       "description": "Specifies the .d.ts file to be used as the starting point for analysis.  API Extractor analyzes the symbols exported by this module. The file extension must be \".d.ts\" and not \".ts\". The path is resolved relative to the folder of the config file that contains the setting; to change this, prepend a folder token such as \"<projectFolder>\".",
       "type": "string"
     },
@@ -155,7 +155,7 @@
       "type": "boolean"
     }
   },
-  "required": [ "mainEntryPointFile" ],
+  "required": [ "mainEntryPointFilePath" ],
   "additionalProperties": false,
 
   "definitions": {

--- a/apps/rush-lib/config/api-extractor.json
+++ b/apps/rush-lib/config/api-extractor.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
 
-  "mainEntryPointFile": "<projectFolder>/lib/index.d.ts",
+  "mainEntryPointFilePath": "<projectFolder>/lib/index.d.ts",
 
   "apiReport": {
     "enabled": true,

--- a/build-tests/api-documenter-test/config/api-extractor.json
+++ b/build-tests/api-documenter-test/config/api-extractor.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
 
-  "mainEntryPointFile": "<projectFolder>/lib/index.d.ts",
+  "mainEntryPointFilePath": "<projectFolder>/lib/index.d.ts",
 
   "apiReport": {
     "enabled": true,

--- a/build-tests/api-extractor-lib1-test/config/api-extractor.json
+++ b/build-tests/api-extractor-lib1-test/config/api-extractor.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
 
-  "mainEntryPointFile": "<projectFolder>/lib/index.d.ts",
+  "mainEntryPointFilePath": "<projectFolder>/lib/index.d.ts",
 
   "apiReport": {
     "enabled": true,

--- a/build-tests/api-extractor-lib2-test/config/api-extractor.json
+++ b/build-tests/api-extractor-lib2-test/config/api-extractor.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
 
-  "mainEntryPointFile": "<projectFolder>/lib/index.d.ts",
+  "mainEntryPointFilePath": "<projectFolder>/lib/index.d.ts",
 
   "apiReport": {
     "enabled": true,

--- a/build-tests/api-extractor-lib3-test/config/api-extractor.json
+++ b/build-tests/api-extractor-lib3-test/config/api-extractor.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
 
-  "mainEntryPointFile": "<projectFolder>/lib/index.d.ts",
+  "mainEntryPointFilePath": "<projectFolder>/lib/index.d.ts",
 
   "apiReport": {
     "enabled": true,

--- a/build-tests/api-extractor-scenarios/src/runScenarios.ts
+++ b/build-tests/api-extractor-scenarios/src/runScenarios.ts
@@ -27,7 +27,7 @@ export function runScenarios(buildConfigPath: string): void {
     const apiExtractorJson = {
       '$schema': 'https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json',
 
-      'mainEntryPointFile': entryPoint,
+      'mainEntryPointFilePath': entryPoint,
 
       'apiReport': {
         'enabled': true,

--- a/build-tests/api-extractor-test-01/config/api-extractor.json
+++ b/build-tests/api-extractor-test-01/config/api-extractor.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
 
-  "mainEntryPointFile": "<projectFolder>/lib/index.d.ts",
+  "mainEntryPointFilePath": "<projectFolder>/lib/index.d.ts",
 
   "apiReport": {
     "enabled": true,

--- a/build-tests/api-extractor-test-02/config/api-extractor.json
+++ b/build-tests/api-extractor-test-02/config/api-extractor.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
 
-  "mainEntryPointFile": "<projectFolder>/lib/index.d.ts",
+  "mainEntryPointFilePath": "<projectFolder>/lib/index.d.ts",
 
   "apiReport": {
     "enabled": true,

--- a/build-tests/api-extractor-test-04/config/api-extractor.json
+++ b/build-tests/api-extractor-test-04/config/api-extractor.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
 
-  "mainEntryPointFile": "<projectFolder>/lib/index.d.ts",
+  "mainEntryPointFilePath": "<projectFolder>/lib/index.d.ts",
 
   "apiReport": {
     "enabled": true,

--- a/build-tests/web-library-build-test/config/api-extractor.json
+++ b/build-tests/web-library-build-test/config/api-extractor.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
 
-  "mainEntryPointFile": "<projectFolder>/lib/test.d.ts",
+  "mainEntryPointFilePath": "<projectFolder>/lib/test.d.ts",
 
   "apiReport": {
     "enabled": true,

--- a/common/changes/@microsoft/api-extractor/octogonz-ae-mainentrypointfilepath_2019-04-11-06-55.json
+++ b/common/changes/@microsoft/api-extractor/octogonz-ae-mainentrypointfilepath_2019-04-11-06-55.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor",
+      "comment": "(Breaking change) Rename \"mainEntryPointFile\" to \"mainEntryPointFilePath\" so all settings use a consistent naming convention",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/gulp-core-build-sass/octogonz-ae-mainentrypointfilepath_2019-04-11-06-55.json
+++ b/common/changes/@microsoft/gulp-core-build-sass/octogonz-ae-mainentrypointfilepath_2019-04-11-06-55.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@microsoft/gulp-core-build-sass",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/gulp-core-build-sass",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/gulp-core-build-serve/octogonz-ae-mainentrypointfilepath_2019-04-11-06-55.json
+++ b/common/changes/@microsoft/gulp-core-build-serve/octogonz-ae-mainentrypointfilepath_2019-04-11-06-55.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@microsoft/gulp-core-build-serve",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/gulp-core-build-serve",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/gulp-core-build-webpack/octogonz-ae-mainentrypointfilepath_2019-04-11-06-55.json
+++ b/common/changes/@microsoft/gulp-core-build-webpack/octogonz-ae-mainentrypointfilepath_2019-04-11-06-55.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@microsoft/gulp-core-build-webpack",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/gulp-core-build-webpack",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/loader-load-themed-styles/octogonz-ae-mainentrypointfilepath_2019-04-11-06-55.json
+++ b/common/changes/@microsoft/loader-load-themed-styles/octogonz-ae-mainentrypointfilepath_2019-04-11-06-55.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@microsoft/loader-load-themed-styles",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/loader-load-themed-styles",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/node-library-build/octogonz-ae-mainentrypointfilepath_2019-04-11-06-55.json
+++ b/common/changes/@microsoft/node-library-build/octogonz-ae-mainentrypointfilepath_2019-04-11-06-55.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@microsoft/node-library-build",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/node-library-build",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/package-deps-hash/octogonz-ae-mainentrypointfilepath_2019-04-11-06-55.json
+++ b/common/changes/@microsoft/package-deps-hash/octogonz-ae-mainentrypointfilepath_2019-04-11-06-55.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@microsoft/package-deps-hash",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/package-deps-hash",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/resolve-chunk-plugin/octogonz-ae-mainentrypointfilepath_2019-04-11-06-55.json
+++ b/common/changes/@microsoft/resolve-chunk-plugin/octogonz-ae-mainentrypointfilepath_2019-04-11-06-55.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@microsoft/resolve-chunk-plugin",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/resolve-chunk-plugin",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush/octogonz-ae-mainentrypointfilepath_2019-04-11-06-55.json
+++ b/common/changes/@microsoft/rush/octogonz-ae-mainentrypointfilepath_2019-04-11-06-55.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@microsoft/rush",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/set-webpack-public-path-plugin/octogonz-ae-mainentrypointfilepath_2019-04-11-06-55.json
+++ b/common/changes/@microsoft/set-webpack-public-path-plugin/octogonz-ae-mainentrypointfilepath_2019-04-11-06-55.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@microsoft/set-webpack-public-path-plugin",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/set-webpack-public-path-plugin",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/stream-collator/octogonz-ae-mainentrypointfilepath_2019-04-11-06-55.json
+++ b/common/changes/@microsoft/stream-collator/octogonz-ae-mainentrypointfilepath_2019-04-11-06-55.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@microsoft/stream-collator",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/stream-collator",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/web-library-build/octogonz-ae-mainentrypointfilepath_2019-04-11-06-55.json
+++ b/common/changes/@microsoft/web-library-build/octogonz-ae-mainentrypointfilepath_2019-04-11-06-55.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@microsoft/web-library-build",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/web-library-build",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/reviews/api/api-extractor.api.md
+++ b/common/reviews/api/api-extractor.api.md
@@ -48,7 +48,7 @@ export class ExtractorConfig {
     static readonly jsonSchema: JsonSchema;
     static loadFile(jsonFilePath: string): IConfigFile;
     static loadFileAndPrepare(configJsonFilePath: string): ExtractorConfig;
-    readonly mainEntryPointFile: string;
+    readonly mainEntryPointFilePath: string;
     readonly messages: IExtractorMessagesConfig;
     readonly overrideTsconfig: {} | undefined;
     readonly packageFolder: string | undefined;
@@ -176,7 +176,7 @@ export interface IConfigFile {
     // @beta
     dtsRollup?: IConfigDtsRollup;
     extends?: string;
-    mainEntryPointFile: string;
+    mainEntryPointFilePath: string;
     messages?: IExtractorMessagesConfig;
     projectFolder?: string;
     testMode?: boolean;

--- a/core-build/gulp-core-build-sass/config/api-extractor.json
+++ b/core-build/gulp-core-build-sass/config/api-extractor.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
 
-  "mainEntryPointFile": "<projectFolder>/lib/index.d.ts",
+  "mainEntryPointFilePath": "<projectFolder>/lib/index.d.ts",
 
   "apiReport": {
     "enabled": true,

--- a/core-build/gulp-core-build-serve/config/api-extractor.json
+++ b/core-build/gulp-core-build-serve/config/api-extractor.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
 
-  "mainEntryPointFile": "<projectFolder>/lib/index.d.ts",
+  "mainEntryPointFilePath": "<projectFolder>/lib/index.d.ts",
 
   "apiReport": {
     "enabled": true,

--- a/core-build/gulp-core-build-webpack/config/api-extractor.json
+++ b/core-build/gulp-core-build-webpack/config/api-extractor.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
 
-  "mainEntryPointFile": "<projectFolder>/lib/index.d.ts",
+  "mainEntryPointFilePath": "<projectFolder>/lib/index.d.ts",
 
   "apiReport": {
     "enabled": true,

--- a/core-build/node-library-build/config/api-extractor.json
+++ b/core-build/node-library-build/config/api-extractor.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
 
-  "mainEntryPointFile": "<projectFolder>/lib/index.d.ts",
+  "mainEntryPointFilePath": "<projectFolder>/lib/index.d.ts",
 
   "apiReport": {
     "enabled": true,

--- a/core-build/web-library-build/config/api-extractor.json
+++ b/core-build/web-library-build/config/api-extractor.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
 
-  "mainEntryPointFile": "<projectFolder>/lib/index.d.ts",
+  "mainEntryPointFilePath": "<projectFolder>/lib/index.d.ts",
 
   "apiReport": {
     "enabled": true,

--- a/libraries/package-deps-hash/config/api-extractor.json
+++ b/libraries/package-deps-hash/config/api-extractor.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
 
-  "mainEntryPointFile": "<projectFolder>/lib/index.d.ts",
+  "mainEntryPointFilePath": "<projectFolder>/lib/index.d.ts",
 
   "apiReport": {
     "enabled": true,

--- a/libraries/rushell/config/api-extractor.json
+++ b/libraries/rushell/config/api-extractor.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
 
-  "mainEntryPointFile": "<projectFolder>/lib/index.d.ts",
+  "mainEntryPointFilePath": "<projectFolder>/lib/index.d.ts",
 
   "apiReport": {
     "enabled": true,

--- a/libraries/stream-collator/config/api-extractor.json
+++ b/libraries/stream-collator/config/api-extractor.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
 
-  "mainEntryPointFile": "<projectFolder>/lib/index.d.ts",
+  "mainEntryPointFilePath": "<projectFolder>/lib/index.d.ts",
 
   "apiReport": {
     "enabled": true,

--- a/webpack/loader-load-themed-styles/config/api-extractor.json
+++ b/webpack/loader-load-themed-styles/config/api-extractor.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
 
-  "mainEntryPointFile": "<projectFolder>/lib/index.d.ts",
+  "mainEntryPointFilePath": "<projectFolder>/lib/index.d.ts",
 
   "apiReport": {
     "enabled": true,

--- a/webpack/resolve-chunk-plugin/config/api-extractor.json
+++ b/webpack/resolve-chunk-plugin/config/api-extractor.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
 
-  "mainEntryPointFile": "<projectFolder>/lib/index.d.ts",
+  "mainEntryPointFilePath": "<projectFolder>/lib/index.d.ts",
 
   "apiReport": {
     "enabled": true,

--- a/webpack/set-webpack-public-path-plugin/config/api-extractor.json
+++ b/webpack/set-webpack-public-path-plugin/config/api-extractor.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
 
-  "mainEntryPointFile": "<projectFolder>/lib/index.d.ts",
+  "mainEntryPointFilePath": "<projectFolder>/lib/index.d.ts",
 
   "apiReport": {
     "enabled": true,


### PR DESCRIPTION
This PR updates mainEntryPointFile to follow the naming convention of the other path settings.  Here's the full list:

- `projectFolder`
- `mainEntryPointFile`  <-- is a path
- `tsconfigFilePath`
- `reportFileName`  <-- not a path
- `reportFolder`
- `reportTempFolder`
- `apiJsonFilePath`
- `untrimmedFilePath`
- `betaTrimmedFilePath`
- `publicTrimmedFilePath`
- `tsdocMetadataFilePath`

The `Path` suffix is used because these settings become variables in code, and in some contexts it's ambiguous whether they refer to a path or the contents of the loaded file (or possibly a base filename without the path).  

Although it would seem most consistent for `projectFolder` to be called `projectFolderPath`, this ambiguity never arises with folders.  And adding the suffix would annoyingly increase the length of the heavily used `<projectFolder>` token.