### PR TITLE
[API Documenter]  Add extra newline character to example header

### DIFF
--- a/apps/api-documenter/src/documenters/OfficeYamlDocumenter.ts
+++ b/apps/api-documenter/src/documenters/OfficeYamlDocumenter.ts
@@ -133,7 +133,7 @@ export class OfficeYamlDocumenter extends YamlDocumenter {
   }
 
   private _generateExampleSnippetText(snippets: string[]): string {
-    const text: string[] = ['\n#### Examples\n'];
+    const text: string[] = ['\n\n#### Examples\n'];
     for (const snippet of snippets) {
       if (snippet.search(/await/) === -1) {
         text.push('```javascript');

--- a/common/changes/@microsoft/api-documenter/AlexJ-Example_2019-04-16-00-12.json
+++ b/common/changes/@microsoft/api-documenter/AlexJ-Example_2019-04-16-00-12.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-documenter",
+      "comment": "Adding an extra newline to the OfficeYamlDocumenter Examples header insertion",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/api-documenter",
+  "email": "AlexJerabek@users.noreply.github.com"
+}


### PR DESCRIPTION
This extra line prevents the example header from being caught up in any preceding markdown (such as bulleted lists).