### PR TITLE
[api-documenter] Fix the "Home" link in the breadcrumb when viewed with GitHub

### DIFF
--- a/apps/api-documenter/src/documenters/MarkdownDocumenter.ts
+++ b/apps/api-documenter/src/documenters/MarkdownDocumenter.ts
@@ -696,7 +696,7 @@ export class MarkdownDocumenter {
       configuration: this._tsdocConfiguration,
       tagName: '@link',
       linkText: 'Home',
-      urlDestination: './index'
+      urlDestination: './index.md'
     }));
 
     for (const hierarchyItem of apiItem.getHierarchy()) {

--- a/common/changes/@microsoft/api-documenter/octogonz-ad-fix-home_2019-04-27-22-20.json
+++ b/common/changes/@microsoft/api-documenter/octogonz-ad-fix-home_2019-04-27-22-20.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-documenter",
+      "comment": "Fix the \"Home\" link in the breadcrumb when viewing docs using GitHub's markdown renderer",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/api-documenter",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}


### PR DESCRIPTION
Fix the "Home" link in the breadcrumb when viewing docs using GitHub's markdown renderer