### PR TITLE
[api-extractor] Fix an issue where ExtractorResult.warningCount was sometimes not incremented

### DIFF
--- a/common/changes/@microsoft/api-extractor/octogonz-ae-issue1258_2019-05-05-18-43.json
+++ b/common/changes/@microsoft/api-extractor/octogonz-ae-issue1258_2019-05-05-18-43.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor",
+      "comment": "Fix an issue where ExtractorResult.warningCount was not incremented for messages handled by IExtractorInvokeOptions.messageCallback (GitHub #1258)",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}


### PR DESCRIPTION
Fixes #1258

Fix an issue where `ExtractorResult.warningCount` was not incremented for messages handled by `IExtractorInvokeOptions.messageCallback`. 