### PR TITLE
Print out tag name for unknown block tags

### DIFF
--- a/apps/api-documenter/src/markdown/MarkdownEmitter.ts
+++ b/apps/api-documenter/src/markdown/MarkdownEmitter.ts
@@ -15,7 +15,8 @@ import {
   DocSection,
   DocNodeTransforms,
   DocEscapedText,
-  DocErrorText
+  DocErrorText,
+  DocBlockTag
 } from '@microsoft/tsdoc';
 import { InternalError } from '@microsoft/node-core-library';
 
@@ -189,6 +190,11 @@ export class MarkdownEmitter {
         break;
       }
       case DocNodeKind.InlineTag: {
+        break;
+      }
+      case DocNodeKind.BlockTag: {
+        const tagNode: DocBlockTag = docNode as DocBlockTag;
+        console.warn('Unsupported block tag: ' + tagNode.tagName);
         break;
       }
       default:

--- a/apps/api-documenter/src/markdown/test/CustomMarkdownEmitter.test.ts
+++ b/apps/api-documenter/src/markdown/test/CustomMarkdownEmitter.test.ts
@@ -10,7 +10,8 @@ import {
   DocSoftBreak,
   DocLinkTag,
   DocHtmlStartTag,
-  DocHtmlEndTag
+  DocHtmlEndTag,
+  DocBlockTag
 } from '@microsoft/tsdoc';
 
 import { CustomDocNodes } from '../../nodes/CustomDocNodeKind';
@@ -121,6 +122,23 @@ test('render Markdown from TSDoc', () => {
           tagName: '@link',
           linkText: 'a link',
           urlDestination: './index.md'
+        }),
+        new DocEmphasisSpan({ configuration, bold: true },
+          [ new DocPlainText({ configuration, text: 'bold' }) ]
+        ),
+        new DocPlainText({ configuration, text: 'non-bold' }),
+        new DocPlainText({ configuration, text: 'more-non-bold' })
+      ]
+    )
+  ]);
+
+  output.appendNodes([
+    new DocHeading({ configuration, title: 'Unknown block tag' }),
+    new DocParagraph({ configuration },
+      [
+        new DocBlockTag({
+          configuration,
+          tagName: '@unknown'
         }),
         new DocEmphasisSpan({ configuration, bold: true },
           [ new DocPlainText({ configuration, text: 'bold' }) ]

--- a/apps/api-documenter/src/markdown/test/__snapshots__/CustomMarkdownEmitter.test.ts.snap
+++ b/apps/api-documenter/src/markdown/test/__snapshots__/CustomMarkdownEmitter.test.ts.snap
@@ -28,6 +28,10 @@ This is a <b>bold</b> word.
 
 [a link](./index.md)<!-- --><b>bold</b>non-boldmore-non-bold
 
+## Unknown block tag
+
+<b>bold</b>non-boldmore-non-bold
+
 ## Bad characters
 
 <b>\\\\*one\\\\*two\\\\*</b><b>three\\\\*four</b>


### PR DESCRIPTION
We ran into various cases that tsdoc comments have unknown block tags, such as:

```ts
/**
 * @decorator A new tag
 * @return A bad tag
 */
```

Without this PR, api-documenter just aborts with `Unsupported element kind: BlockTag`. The error message is meaningless and it does not help fix the underlying issue.

I would also like to know what source TS file (line/column) has the invalid tag. Please let me know how to access such metadata so that I can improve this PR.