### PR TITLE
[api-extractor] Improved support for symbolic properties and methods

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -17,5 +17,8 @@
     "temp": true,
     "**/test/**/temp": false,
     "coverage": true
+  },
+  "files.associations": {
+    "rush.json": "jsonc",
   }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -17,8 +17,5 @@
     "temp": true,
     "**/test/**/temp": false,
     "coverage": true
-  },
-  "files.associations": {
-    "rush.json": "jsonc",
   }
 }

--- a/apps/api-extractor/src/analyzer/AstSymbolTable.ts
+++ b/apps/api-extractor/src/analyzer/AstSymbolTable.ts
@@ -433,6 +433,8 @@ export class AstSymbolTable {
         // but the declaration name is "X".
         localName = followedSymbol.name;
         if (TypeScriptHelpers.isWellKnownSymbolName(localName)) {
+          // TypeScript binds well-known ECMAScript symbols like "Symbol.iterator" as "__@iterator".
+          // This converts a string like "__@iterator" into the property name "[Symbol.iterator]".
           localName = `[Symbol.${localName.slice(3)}]`;
         } else {
           const isUniqueSymbol: boolean = TypeScriptHelpers.isUniqueSymbolName(localName);

--- a/apps/api-extractor/src/analyzer/AstSymbolTable.ts
+++ b/apps/api-extractor/src/analyzer/AstSymbolTable.ts
@@ -12,6 +12,7 @@ import { PackageMetadataManager } from './PackageMetadataManager';
 import { ExportAnalyzer } from './ExportAnalyzer';
 import { AstImport } from './AstImport';
 import { MessageRouter } from '../collector/MessageRouter';
+import { TypeScriptInternals } from './TypeScriptInternals';
 
 export type AstEntity = AstSymbol | AstImport;
 
@@ -302,7 +303,8 @@ export class AstSymbolTable {
       return undefined;
     }
 
-    const symbol: ts.Symbol | undefined = TypeScriptHelpers.getSymbolForDeclaration(node as ts.Declaration);
+    const symbol: ts.Symbol | undefined = TypeScriptHelpers.getSymbolForDeclaration(node as ts.Declaration,
+      this._typeChecker);
     if (!symbol) {
       throw new InternalError('Unable to find symbol for node');
     }
@@ -338,7 +340,8 @@ export class AstSymbolTable {
     const arbitraryDeclaration: ts.Declaration = followedSymbol.declarations[0];
 
     // tslint:disable-next-line:no-bitwise
-    if (followedSymbol.flags & (ts.SymbolFlags.TypeParameter | ts.SymbolFlags.TypeLiteral | ts.SymbolFlags.Transient)) {
+    if (followedSymbol.flags & (ts.SymbolFlags.TypeParameter | ts.SymbolFlags.TypeLiteral | ts.SymbolFlags.Transient)
+      && !TypeScriptInternals.isLateBoundSymbol(followedSymbol)) {
       return undefined;
     }
 
@@ -406,7 +409,8 @@ export class AstSymbolTable {
 
         if (arbitraryParentDeclaration) {
           const parentSymbol: ts.Symbol = TypeScriptHelpers.getSymbolForDeclaration(
-            arbitraryParentDeclaration as ts.Declaration);
+            arbitraryParentDeclaration as ts.Declaration,
+            this._typeChecker);
 
           parentAstSymbol = this._fetchAstSymbol({
             followedSymbol: parentSymbol,
@@ -428,11 +432,23 @@ export class AstSymbolTable {
         // This handles cases such as "export default class X { }" where the symbol name is "default"
         // but the declaration name is "X".
         localName = followedSymbol.name;
-        for (const declaration of followedSymbol.declarations || []) {
-          const declarationNameIdentifier: ts.DeclarationName | undefined = ts.getNameOfDeclaration(declaration);
-          if (declarationNameIdentifier && ts.isIdentifier(declarationNameIdentifier)) {
-            localName = declarationNameIdentifier.getText().trim();
-            break;
+        if (TypeScriptHelpers.isWellKnownSymbolName(localName)) {
+          localName = `[Symbol.${localName.slice(3)}]`;
+        } else {
+          const isUniqueSymbol: boolean = TypeScriptHelpers.isUniqueSymbolName(localName);
+          for (const declaration of followedSymbol.declarations || []) {
+            const declarationName: ts.DeclarationName | undefined = ts.getNameOfDeclaration(declaration);
+            if (declarationName && ts.isIdentifier(declarationName)) {
+              localName = declarationName.getText().trim();
+              break;
+            }
+            if (isUniqueSymbol && declarationName && ts.isComputedPropertyName(declarationName)) {
+              const lateBoundName: string | undefined = TypeScriptHelpers.tryGetLateBoundName(declarationName);
+              if (lateBoundName) {
+                localName = lateBoundName;
+                break;
+              }
+            }
           }
         }
       }

--- a/apps/api-extractor/src/analyzer/ExportAnalyzer.ts
+++ b/apps/api-extractor/src/analyzer/ExportAnalyzer.ts
@@ -171,7 +171,8 @@ export class ExportAnalyzer {
   private _getModuleSymbolFromSourceFile(sourceFile: ts.SourceFile,
     moduleReference: IAstModuleReference | undefined): ts.Symbol {
 
-    const moduleSymbol: ts.Symbol | undefined = TypeScriptInternals.tryGetSymbolForDeclaration(sourceFile);
+    const moduleSymbol: ts.Symbol | undefined = TypeScriptInternals.tryGetSymbolForDeclaration(sourceFile,
+      this._typeChecker);
     if (moduleSymbol !== undefined) {
       // This is the normal case.  The SourceFile acts is a module and has a symbol.
       return moduleSymbol;

--- a/apps/api-extractor/src/analyzer/TypeScriptInternals.ts
+++ b/apps/api-extractor/src/analyzer/TypeScriptInternals.ts
@@ -24,13 +24,17 @@ export class TypeScriptInternals {
   public static tryGetSymbolForDeclaration(declaration: ts.Declaration, checker: ts.TypeChecker): ts.Symbol
     | undefined {
     let symbol: ts.Symbol | undefined = (declaration as any).symbol;
-    if (symbol && symbol.escapedName === '__computed') {
+    if (symbol && symbol.escapedName === ts.InternalSymbolName.Computed) {
       const name: ts.DeclarationName | undefined = ts.getNameOfDeclaration(declaration);
       symbol = name && checker.getSymbolAtLocation(name) || symbol;
     }
     return symbol;
   }
 
+  /**
+   * Returns whether the provided Symbol is a TypeScript "late-bound" Symbol (i.e. was created by the Checker
+   * for a computed property based on its type, rather than by the Binder).
+   */
   public static isLateBoundSymbol(symbol: ts.Symbol): boolean {
     // tslint:disable-next-line:no-bitwise
     if (symbol.flags & ts.SymbolFlags.Transient &&

--- a/apps/api-extractor/src/analyzer/TypeScriptInternals.ts
+++ b/apps/api-extractor/src/analyzer/TypeScriptInternals.ts
@@ -21,9 +21,23 @@ export class TypeScriptInternals {
    * @returns The associated Symbol.  If there is no semantic information (e.g. if the
    * declaration is an extra semicolon somewhere), then "undefined" is returned.
    */
-  public static tryGetSymbolForDeclaration(declaration: ts.Declaration): ts.Symbol | undefined {
-    const symbol: ts.Symbol = (declaration as any).symbol;
+  public static tryGetSymbolForDeclaration(declaration: ts.Declaration, checker: ts.TypeChecker): ts.Symbol
+    | undefined {
+    let symbol: ts.Symbol | undefined = (declaration as any).symbol;
+    if (symbol && symbol.escapedName === '__computed') {
+      const name: ts.DeclarationName | undefined = ts.getNameOfDeclaration(declaration);
+      symbol = name && checker.getSymbolAtLocation(name) || symbol;
+    }
     return symbol;
+  }
+
+  public static isLateBoundSymbol(symbol: ts.Symbol): boolean {
+    // tslint:disable-next-line:no-bitwise
+    if (symbol.flags & ts.SymbolFlags.Transient &&
+        (symbol as any).checkFlags === (ts as any).CheckFlags.Late) {
+      return true;
+    }
+    return false;
   }
 
   /**

--- a/build-tests/api-extractor-test-01/dist/api-extractor-test-01-beta.d.ts
+++ b/build-tests/api-extractor-test-01/dist/api-extractor-test-01-beta.d.ts
@@ -10,6 +10,7 @@
  */
 
 /// <reference types="jest" />
+/// <reference lib="es2015.symbol.wellknown" />
 /// <reference lib="es2018.intl" />
 import Long from 'long';
 import { MAX_UNSIGNED_VALUE } from 'long';
@@ -67,6 +68,13 @@ export declare class AmbientConsumer {
     localTypings(): IAmbientInterfaceExample;
 }
 
+/** @public */
+declare namespace ANamespace {
+    const locallyExportedCustomSymbol: unique symbol;
+    /** @public */
+    const fullyExportedCustomSymbol: unique symbol;
+}
+
 /**
  * Referenced by DefaultExportEdgeCaseReferencer.
  * @public
@@ -110,6 +118,9 @@ export declare class ClassWithSymbols {
     readonly [unexportedCustomSymbol]: number;
     readonly [locallyExportedCustomSymbol]: string;
     [fullyExportedCustomSymbol](): void;
+    readonly [ANamespace.locallyExportedCustomSymbol]: string;
+    [ANamespace.fullyExportedCustomSymbol](): void;
+    readonly [Symbol.toStringTag]: string;
 }
 
 /**

--- a/build-tests/api-extractor-test-01/dist/api-extractor-test-01-public.d.ts
+++ b/build-tests/api-extractor-test-01/dist/api-extractor-test-01-public.d.ts
@@ -10,6 +10,7 @@
  */
 
 /// <reference types="jest" />
+/// <reference lib="es2015.symbol.wellknown" />
 /// <reference lib="es2018.intl" />
 import Long from 'long';
 import { MAX_UNSIGNED_VALUE } from 'long';
@@ -67,6 +68,13 @@ export declare class AmbientConsumer {
     localTypings(): IAmbientInterfaceExample;
 }
 
+/** @public */
+declare namespace ANamespace {
+    const locallyExportedCustomSymbol: unique symbol;
+    /** @public */
+    const fullyExportedCustomSymbol: unique symbol;
+}
+
 /**
  * Referenced by DefaultExportEdgeCaseReferencer.
  * @public
@@ -110,6 +118,9 @@ export declare class ClassWithSymbols {
     readonly [unexportedCustomSymbol]: number;
     readonly [locallyExportedCustomSymbol]: string;
     [fullyExportedCustomSymbol](): void;
+    readonly [ANamespace.locallyExportedCustomSymbol]: string;
+    [ANamespace.fullyExportedCustomSymbol](): void;
+    readonly [Symbol.toStringTag]: string;
 }
 
 /**

--- a/build-tests/api-extractor-test-01/dist/api-extractor-test-01.d.ts
+++ b/build-tests/api-extractor-test-01/dist/api-extractor-test-01.d.ts
@@ -10,6 +10,7 @@
  */
 
 /// <reference types="jest" />
+/// <reference lib="es2015.symbol.wellknown" />
 /// <reference lib="es2018.intl" />
 import Long from 'long';
 import { MAX_UNSIGNED_VALUE } from 'long';
@@ -67,6 +68,13 @@ export declare class AmbientConsumer {
     localTypings(): IAmbientInterfaceExample;
 }
 
+/** @public */
+declare namespace ANamespace {
+    const locallyExportedCustomSymbol: unique symbol;
+    /** @public */
+    const fullyExportedCustomSymbol: unique symbol;
+}
+
 /**
  * Referenced by DefaultExportEdgeCaseReferencer.
  * @public
@@ -110,6 +118,9 @@ export declare class ClassWithSymbols {
     readonly [unexportedCustomSymbol]: number;
     readonly [locallyExportedCustomSymbol]: string;
     [fullyExportedCustomSymbol](): void;
+    readonly [ANamespace.locallyExportedCustomSymbol]: string;
+    [ANamespace.fullyExportedCustomSymbol](): void;
+    readonly [Symbol.toStringTag]: string;
 }
 
 /**

--- a/build-tests/api-extractor-test-01/etc/api-extractor-test-01.api.md
+++ b/build-tests/api-extractor-test-01/etc/api-extractor-test-01.api.md
@@ -49,11 +49,11 @@ export class ClassWithAccessModifiers {
 // @public (undocumented)
 export class ClassWithSymbols {
     // (undocumented)
-    readonly [unexportedCustomSymbol]: number;
+    [fullyExportedCustomSymbol](): void;
     // (undocumented)
     readonly [locallyExportedCustomSymbol]: string;
     // (undocumented)
-    [fullyExportedCustomSymbol](): void;
+    readonly [unexportedCustomSymbol]: number;
 }
 
 // @public

--- a/build-tests/api-extractor-test-01/etc/api-extractor-test-01.api.md
+++ b/build-tests/api-extractor-test-01/etc/api-extractor-test-01.api.md
@@ -49,9 +49,17 @@ export class ClassWithAccessModifiers {
 // @public (undocumented)
 export class ClassWithSymbols {
     // (undocumented)
+    [ANamespace.fullyExportedCustomSymbol](): void;
+    // Warning: (ae-forgotten-export) The symbol "ANamespace" needs to be exported by the entry point index.d.ts
+    // 
+    // (undocumented)
+    readonly [ANamespace.locallyExportedCustomSymbol]: string;
+    // (undocumented)
     [fullyExportedCustomSymbol](): void;
     // (undocumented)
     readonly [locallyExportedCustomSymbol]: string;
+    // (undocumented)
+    readonly [Symbol.toStringTag]: string;
     // (undocumented)
     readonly [unexportedCustomSymbol]: number;
 }

--- a/build-tests/api-extractor-test-01/src/EcmaScriptSymbols.ts
+++ b/build-tests/api-extractor-test-01/src/EcmaScriptSymbols.ts
@@ -1,11 +1,23 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
+/// <reference lib="es2015.symbol.wellknown" />
+
 const unexportedCustomSymbol: unique symbol = Symbol('unexportedCustomSymbol');
 export const locallyExportedCustomSymbol: unique symbol = Symbol('locallyExportedCustomSymbol');
 
 /** @public */
 export const fullyExportedCustomSymbol: unique symbol = Symbol('fullyExportedCustomSymbol');
+
+// NOTE: named 'ANamespace' so that it appears earlier in the rollup .d.ts file, due to
+// https://github.com/microsoft/TypeScript/issues/31746
+/** @public */
+export namespace ANamespace {
+  export const locallyExportedCustomSymbol: unique symbol = Symbol('locallyExportedCustomSymbol');
+
+  /** @public */
+  export const fullyExportedCustomSymbol: unique symbol = Symbol('fullyExportedCustomSymbol');
+}
 
 /**
  * @public
@@ -18,5 +30,16 @@ export class ClassWithSymbols {
   }
 
   public [fullyExportedCustomSymbol](): void {
+  }
+
+  public get [ANamespace.locallyExportedCustomSymbol](): string {
+    return 'hello';
+  }
+
+  public [ANamespace.fullyExportedCustomSymbol](): void {
+  }
+
+  public get [Symbol.toStringTag](): string {
+    return "ClassWithSymbols";
   }
 }

--- a/common/changes/@microsoft/api-extractor/supportSymbolMembers_2019-05-29-22-28.json
+++ b/common/changes/@microsoft/api-extractor/supportSymbolMembers_2019-05-29-22-28.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor",
+      "comment": "Improved handling of symbolic property and method names.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor",
+  "email": "ron.buckton@microsoft.com"
+}

--- a/common/changes/@microsoft/api-extractor/supportSymbolMembers_2019-05-29-22-28.json
+++ b/common/changes/@microsoft/api-extractor/supportSymbolMembers_2019-05-29-22-28.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/api-extractor",
-      "comment": "Improved handling of symbolic property and method names.",
+      "comment": "Improve handling of symbolic property and method names.",
       "type": "patch"
     }
   ],


### PR DESCRIPTION
This changes how we determine the `localName` of an `AstSymbol` in the following cases:

1. When the underlying TypeScript `Symbol` is a well-known ECMAScript symbol (i.e. it's `name` property is something like `__@iterator`).
2. When the underlying TypeScript `Symbol` is a late-bound name for a TypeScript `unique symbol`. In this case, `api-extractor` incorrectly reports these as `"__computed"`.

For case (1), we now extract the well-known symbol name (i.e. `iterator`) and report the name as something like `[Symbol.iterator]`.

For case (2), we will resolve the late-bound symbol (via `ts.TypeChecker.getSymbolAtLocation`), allow these late-bound symbols to pass through the checks in `AstSymbolTable._fetchAstSymbol`, and compute the name from the expression of the computed property.

Fixes #1301