### PR TITLE
[api-extractor] Remove ApiConstructor.isStatic, since TypeScript constructors cannot be static

### DIFF
--- a/apps/api-extractor-model/src/model/ApiConstructor.ts
+++ b/apps/api-extractor-model/src/model/ApiConstructor.ts
@@ -2,7 +2,6 @@
 // See LICENSE in the project root for license information.
 
 import { ApiItemKind } from '../items/ApiItem';
-import { ApiStaticMixin, IApiStaticMixinOptions } from '../mixins/ApiStaticMixin';
 import { IApiDeclaredItemOptions, ApiDeclaredItem } from '../items/ApiDeclaredItem';
 import { IApiParameterListMixinOptions, ApiParameterListMixin } from '../mixins/ApiParameterListMixin';
 import { IApiReleaseTagMixinOptions, ApiReleaseTagMixin } from '../mixins/ApiReleaseTagMixin';
@@ -14,7 +13,6 @@ import { IApiReleaseTagMixinOptions, ApiReleaseTagMixin } from '../mixins/ApiRel
 export interface IApiConstructorOptions extends
   IApiParameterListMixinOptions,
   IApiReleaseTagMixinOptions,
-  IApiStaticMixinOptions,
   IApiDeclaredItemOptions {
 }
 
@@ -45,14 +43,10 @@ export interface IApiConstructorOptions extends
  *
  * @public
  */
-export class ApiConstructor extends ApiParameterListMixin(ApiReleaseTagMixin(ApiStaticMixin(ApiDeclaredItem))) {
+export class ApiConstructor extends ApiParameterListMixin(ApiReleaseTagMixin(ApiDeclaredItem)) {
 
-  public static getCanonicalReference(isStatic: boolean, overloadIndex: number): string {
-    if (isStatic) {
-      return `(:constructor,static,${overloadIndex})`;
-    } else {
-      return `(:constructor,instance,${overloadIndex})`;
-    }
+  public static getCanonicalReference(overloadIndex: number): string {
+    return `(:constructor,${overloadIndex})`;
   }
 
   public constructor(options: IApiConstructorOptions) {
@@ -66,6 +60,6 @@ export class ApiConstructor extends ApiParameterListMixin(ApiReleaseTagMixin(Api
 
   /** @override */
   public get canonicalReference(): string {
-    return ApiConstructor.getCanonicalReference(this.isStatic, this.overloadIndex);
+    return ApiConstructor.getCanonicalReference(this.overloadIndex);
   }
 }

--- a/apps/api-extractor/src/generators/ApiModelGenerator.ts
+++ b/apps/api-extractor/src/generators/ApiModelGenerator.ts
@@ -207,9 +207,8 @@ export class ApiModelGenerator {
   private _processApiConstructor(astDeclaration: AstDeclaration, exportedName: string | undefined,
     parentApiItem: ApiItemContainerMixin): void {
 
-    const isStatic: boolean = (astDeclaration.modifierFlags & ts.ModifierFlags.Static) !== 0;
     const overloadIndex: number = this._getOverloadIndex(astDeclaration);
-    const canonicalReference: string = ApiConstructor.getCanonicalReference(isStatic, overloadIndex);
+    const canonicalReference: string = ApiConstructor.getCanonicalReference(overloadIndex);
 
     let apiConstructor: ApiConstructor | undefined = parentApiItem.tryGetMember(canonicalReference) as ApiConstructor;
 
@@ -229,7 +228,7 @@ export class ApiModelGenerator {
       const docComment: tsdoc.DocComment | undefined = this._collector.fetchMetadata(astDeclaration).tsdocComment;
       const releaseTag: ReleaseTag = this._collector.fetchMetadata(astDeclaration.astSymbol).releaseTag;
 
-      apiConstructor = new ApiConstructor({ docComment, releaseTag, isStatic, parameters, overloadIndex,
+      apiConstructor = new ApiConstructor({ docComment, releaseTag, parameters, overloadIndex,
         excerptTokens });
 
       parentApiItem.addMember(apiConstructor);

--- a/build-tests/api-documenter-test/etc/api-documenter-test.api.json
+++ b/build-tests/api-documenter-test/etc/api-documenter-test.api.json
@@ -37,7 +37,7 @@
           "members": [
             {
               "kind": "Constructor",
-              "canonicalReference": "(:constructor,instance,0)",
+              "canonicalReference": "(:constructor,0)",
               "docComment": "/**\n * The simple constructor for `DocBaseClass`\n */\n",
               "excerptTokens": [
                 {
@@ -45,14 +45,13 @@
                   "text": "constructor();"
                 }
               ],
-              "isStatic": false,
               "releaseTag": "Public",
               "overloadIndex": 0,
               "parameters": []
             },
             {
               "kind": "Constructor",
-              "canonicalReference": "(:constructor,instance,1)",
+              "canonicalReference": "(:constructor,1)",
               "docComment": "/**\n * The overloaded constructor for `DocBaseClass`\n */\n",
               "excerptTokens": [
                 {
@@ -76,7 +75,6 @@
                   "text": ");"
                 }
               ],
-              "isStatic": false,
               "releaseTag": "Public",
               "overloadIndex": 1,
               "parameters": [

--- a/common/changes/@microsoft/api-extractor-model/octogonz-ae-ctor-cannot-be-static_2019-06-02-21-52.json
+++ b/common/changes/@microsoft/api-extractor-model/octogonz-ae-ctor-cannot-be-static_2019-06-02-21-52.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor-model",
+      "comment": "Fix an issue where ApiConstructor inherited from ApiStaticMixin, but TypeScript constructors cannot be static",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor-model",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/api-extractor/octogonz-ae-ctor-cannot-be-static_2019-06-02-21-52.json
+++ b/common/changes/@microsoft/api-extractor/octogonz-ae-ctor-cannot-be-static_2019-06-02-21-52.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor",
+      "comment": "Upgrade api-extractor-model to remove ApiConstructor.isStatic, since TypeScript constructors cannot be static",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/reviews/api/api-extractor-model.api.md
+++ b/common/reviews/api/api-extractor-model.api.md
@@ -66,7 +66,7 @@ export class ApiConstructor extends ApiConstructor_base {
     // @override (undocumented)
     readonly canonicalReference: string;
     // (undocumented)
-    static getCanonicalReference(isStatic: boolean, overloadIndex: number): string;
+    static getCanonicalReference(overloadIndex: number): string;
     // @override (undocumented)
     readonly kind: ApiItemKind;
 }
@@ -565,7 +565,7 @@ export interface IApiClassOptions extends IApiItemContainerMixinOptions, IApiNam
 }
 
 // @public
-export interface IApiConstructorOptions extends IApiParameterListMixinOptions, IApiReleaseTagMixinOptions, IApiStaticMixinOptions, IApiDeclaredItemOptions {
+export interface IApiConstructorOptions extends IApiParameterListMixinOptions, IApiReleaseTagMixinOptions, IApiDeclaredItemOptions {
 }
 
 // @public


### PR DESCRIPTION
This PR fixes a minor oversight where API Extractor modeled class constructors as being possibly static, even though this [can never occur](https://basarat.gitbooks.io/typescript/docs/tips/staticConstructor.html) in the TypeScript language.

Although this is technically a breaking API change, the change itself is somewhat trivial, and the affected API is very unlikely to be used by any tool other than API Extractor itself.  The .api.json file format also is changed, but the affected JSON field is mostly informational and not used during deserialization.  Thus, I'm marking this as a SemVer PATCH change.

@iclanton 