### PR TITLE
[rush] Fix git process in rush version action

### DIFF
--- a/apps/rush-lib/src/cli/actions/VersionAction.ts
+++ b/apps/rush-lib/src/cli/actions/VersionAction.ts
@@ -236,6 +236,7 @@ export class VersionAction extends BaseRushAction {
       git.push(tempBranch);
 
       // Now merge to target branch.
+      git.fetch();
       git.checkout(this._targetBranch.value);
       git.pull();
       git.merge(tempBranch);
@@ -243,6 +244,7 @@ export class VersionAction extends BaseRushAction {
       git.deleteBranch(tempBranch);
     } else {
       // skip commits
+      git.fetch();
       git.checkout(this._targetBranch.value);
       git.deleteBranch(tempBranch, false);
     }

--- a/apps/rush-lib/src/logic/PublishGit.ts
+++ b/apps/rush-lib/src/logic/PublishGit.ts
@@ -32,6 +32,10 @@ export class PublishGit {
     PublishUtilities.execCommand(!!this._targetBranch, 'git', `pull origin ${this._targetBranch}`.split(' '));
   }
 
+  public fetch(): void {
+    PublishUtilities.execCommand(!!this._targetBranch, 'git', ['fetch', 'origin']);
+  }
+
   public addChanges(pathspec?: string, workingDirectory?: string): void {
     const files: string = pathspec ? pathspec : '.';
     PublishUtilities.execCommand(!!this._targetBranch, 'git', ['add', files],

--- a/common/changes/@microsoft/rush/master_2019-06-06-23-07.json
+++ b/common/changes/@microsoft/rush/master_2019-06-06-23-07.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Fix git process in rush version",
+      "packageName": "@microsoft/rush",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "dahajek@microsoft.com"
+}

--- a/common/changes/@microsoft/rush/master_2019-06-06-23-07.json
+++ b/common/changes/@microsoft/rush/master_2019-06-06-23-07.json
@@ -1,11 +1,11 @@
 {
   "changes": [
     {
-      "comment": "Fix git process in rush version",
+      "comment": "Improve 'rush version' to fetch before checkout, which avoids an error in cases where the branch wasn't fetched.",
       "packageName": "@microsoft/rush",
       "type": "none"
     }
   ],
   "packageName": "@microsoft/rush",
-  "email": "dahajek@microsoft.com"
+  "email": "dalimil@users.noreply.github.com"
 }


### PR DESCRIPTION
When running `rush version --bump -b master` the ending git commands may fail if master changed in the meantime. 
![image](https://user-images.githubusercontent.com/4202539/59072096-1e74cb80-8876-11e9-8ce2-b65c344261a6.png)
It should instead `git fetch` before running the `git checkout master` to update refs.

This fixes #1318