### PR TITLE
[api-extractor] Improve the .api.json deserializer to support backwards compatibility

### DIFF
--- a/apps/api-extractor-model/src/items/ApiDeclaredItem.ts
+++ b/apps/api-extractor-model/src/items/ApiDeclaredItem.ts
@@ -3,6 +3,7 @@
 
 import { ApiDocumentedItem, IApiDocumentedItemJson, IApiDocumentedItemOptions } from './ApiDocumentedItem';
 import { Excerpt, ExcerptToken, IExcerptTokenRange, IExcerptToken } from '../mixins/Excerpt';
+import { DeserializerContext } from '../model/DeserializerContext';
 
 /**
  * Constructor options for {@link ApiDeclaredItem}.
@@ -35,10 +36,10 @@ export class ApiDeclaredItem extends ApiDocumentedItem {
   private _excerpt: Excerpt;
 
   /** @override */
-  public static onDeserializeInto(options: Partial<IApiDeclaredItemOptions>,
+  public static onDeserializeInto(options: Partial<IApiDeclaredItemOptions>, context: DeserializerContext,
     jsonObject: IApiDeclaredItemJson): void {
 
-    super.onDeserializeInto(options, jsonObject);
+    super.onDeserializeInto(options, context, jsonObject);
 
     options.excerptTokens = jsonObject.excerptTokens;
   }

--- a/apps/api-extractor-model/src/items/ApiDocumentedItem.ts
+++ b/apps/api-extractor-model/src/items/ApiDocumentedItem.ts
@@ -4,6 +4,7 @@
 import * as tsdoc from '@microsoft/tsdoc';
 import { ApiItem, IApiItemOptions, IApiItemJson } from './ApiItem';
 import { AedocDefinitions } from '../aedoc/AedocDefinitions';
+import { DeserializerContext } from '../model/DeserializerContext';
 
 /**
  * Constructor options for {@link ApiDocumentedItem}.
@@ -31,10 +32,10 @@ export class ApiDocumentedItem extends ApiItem {
   private _tsdocComment: tsdoc.DocComment | undefined;
 
   /** @override */
-  public static onDeserializeInto(options: Partial<IApiDocumentedItemOptions>,
+  public static onDeserializeInto(options: Partial<IApiDocumentedItemOptions>, context: DeserializerContext,
     jsonObject: IApiItemJson): void {
 
-    super.onDeserializeInto(options, jsonObject);
+    super.onDeserializeInto(options,  context, jsonObject);
 
     const documentedJson: IApiDocumentedItemJson = jsonObject as IApiDocumentedItemJson;
 

--- a/apps/api-extractor-model/src/items/ApiItem.ts
+++ b/apps/api-extractor-model/src/items/ApiItem.ts
@@ -4,6 +4,7 @@
 import { Constructor, PropertiesOf } from '../mixins/Mixin';
 import { ApiPackage } from '../model/ApiPackage';
 import { ApiParameterListMixin } from '../mixins/ApiParameterListMixin';
+import { DeserializerContext } from '../model/DeserializerContext';
 
 /**
  * The type returned by the {@link ApiItem.kind} property, which can be used to easily distinguish subclasses of
@@ -64,15 +65,16 @@ export const ApiItem_parent: unique symbol = Symbol('ApiItem._parent');
 export class ApiItem {
   public [ApiItem_parent]: ApiItem | undefined;
 
-  public static deserialize(jsonObject: IApiItemJson): ApiItem {
+  public static deserialize(jsonObject: IApiItemJson, context: DeserializerContext): ApiItem {
     // The Deserializer class is coupled with a ton of other classes, so  we delay loading it
     // to avoid ES5 circular imports.
     const deserializerModule: typeof import('../model/Deserializer') = require('../model/Deserializer');
-    return deserializerModule.Deserializer.deserialize(jsonObject);
+    return deserializerModule.Deserializer.deserialize(context, jsonObject);
   }
 
   /** @virtual */
-  public static onDeserializeInto(options: Partial<IApiItemOptions>, jsonObject: IApiItemJson): void {
+  public static onDeserializeInto(options: Partial<IApiItemOptions>,  context: DeserializerContext,
+    jsonObject: IApiItemJson): void {
     // (implemented by subclasses)
   }
 

--- a/apps/api-extractor-model/src/items/ApiPropertyItem.ts
+++ b/apps/api-extractor-model/src/items/ApiPropertyItem.ts
@@ -5,6 +5,7 @@ import { Excerpt, IExcerptTokenRange } from '../mixins/Excerpt';
 import { IApiDeclaredItemOptions, ApiDeclaredItem, IApiDeclaredItemJson } from '../items/ApiDeclaredItem';
 import { ApiReleaseTagMixin, IApiReleaseTagMixinOptions } from '../mixins/ApiReleaseTagMixin';
 import { IApiNameMixinOptions, ApiNameMixin } from '../mixins/ApiNameMixin';
+import { DeserializerContext } from '../model/DeserializerContext';
 
 /**
  * Constructor options for {@link ApiPropertyItem}.
@@ -34,8 +35,10 @@ export class ApiPropertyItem extends ApiNameMixin(ApiReleaseTagMixin(ApiDeclared
   public readonly propertyTypeExcerpt: Excerpt;
 
   /** @override */
-  public static onDeserializeInto(options: Partial<IApiPropertyItemOptions>, jsonObject: IApiPropertyItemJson): void {
-    super.onDeserializeInto(options, jsonObject);
+  public static onDeserializeInto(options: Partial<IApiPropertyItemOptions>, context: DeserializerContext,
+    jsonObject: IApiPropertyItemJson): void {
+
+    super.onDeserializeInto(options, context, jsonObject);
 
     options.propertyTypeTokenRange = jsonObject.propertyTypeTokenRange;
   }

--- a/apps/api-extractor-model/src/mixins/ApiItemContainerMixin.ts
+++ b/apps/api-extractor-model/src/mixins/ApiItemContainerMixin.ts
@@ -3,6 +3,7 @@
 
 import { ApiItem, ApiItem_parent, IApiItemJson, IApiItemOptions, IApiItemConstructor } from '../items/ApiItem';
 import { ApiNameMixin } from './ApiNameMixin';
+import { DeserializerContext } from '../model/DeserializerContext';
 
 /**
  * Constructor options for {@link (ApiItemContainerMixin:interface)}.
@@ -89,13 +90,13 @@ export function ApiItemContainerMixin<TBaseClass extends IApiItemConstructor>(ba
 
     /** @override */
     public static onDeserializeInto(options: Partial<IApiItemContainerMixinOptions>,
-      jsonObject: IApiItemContainerJson): void {
+      context: DeserializerContext, jsonObject: IApiItemContainerJson): void {
 
-      baseClass.onDeserializeInto(options, jsonObject);
+      baseClass.onDeserializeInto(options, context, jsonObject);
 
       options.members = [];
       for (const memberObject of jsonObject.members) {
-        options.members.push(ApiItem.deserialize(memberObject));
+        options.members.push(ApiItem.deserialize(memberObject, context));
       }
     }
 

--- a/apps/api-extractor-model/src/mixins/ApiNameMixin.ts
+++ b/apps/api-extractor-model/src/mixins/ApiNameMixin.ts
@@ -2,6 +2,7 @@
 // See LICENSE in the project root for license information.s
 
 import { ApiItem, IApiItemJson, IApiItemConstructor, IApiItemOptions } from '../items/ApiItem';
+import { DeserializerContext } from '../model/DeserializerContext';
 
 /**
  * Constructor options for {@link (IApiNameMixinOptions:interface)}.
@@ -62,8 +63,10 @@ export function ApiNameMixin<TBaseClass extends IApiItemConstructor>(baseClass: 
     public readonly [_name]: string;
 
     /** @override */
-    public static onDeserializeInto(options: Partial<IApiNameMixinOptions>, jsonObject: IApiNameMixinJson): void {
-      baseClass.onDeserializeInto(options, jsonObject);
+    public static onDeserializeInto(options: Partial<IApiNameMixinOptions>, context: DeserializerContext,
+      jsonObject: IApiNameMixinJson): void {
+
+      baseClass.onDeserializeInto(options, context, jsonObject);
 
       options.name = jsonObject.name;
     }

--- a/apps/api-extractor-model/src/mixins/ApiParameterListMixin.ts
+++ b/apps/api-extractor-model/src/mixins/ApiParameterListMixin.ts
@@ -6,6 +6,7 @@ import { Parameter } from '../model/Parameter';
 import { ApiDeclaredItem } from '../items/ApiDeclaredItem';
 import { IExcerptTokenRange } from './Excerpt';
 import { InternalError } from '@microsoft/node-core-library';
+import { DeserializerContext } from '../model/DeserializerContext';
 
 /**
  * Represents parameter information that is part of {@link IApiParameterListMixinOptions}
@@ -103,10 +104,10 @@ export function ApiParameterListMixin<TBaseClass extends IApiItemConstructor>(ba
     public readonly [_parameters]: Parameter[];
 
     /** @override */
-    public static onDeserializeInto(options: Partial<IApiParameterListMixinOptions>,
+    public static onDeserializeInto(options: Partial<IApiParameterListMixinOptions>, context: DeserializerContext,
       jsonObject: IApiParameterListJson): void {
 
-      baseClass.onDeserializeInto(options, jsonObject);
+      baseClass.onDeserializeInto(options, context, jsonObject);
 
       options.overloadIndex = jsonObject.overloadIndex;
       options.parameters = jsonObject.parameters || [];

--- a/apps/api-extractor-model/src/mixins/ApiReleaseTagMixin.ts
+++ b/apps/api-extractor-model/src/mixins/ApiReleaseTagMixin.ts
@@ -3,6 +3,7 @@
 
 import { ApiItem, IApiItemJson, IApiItemConstructor, IApiItemOptions } from '../items/ApiItem';
 import { ReleaseTag } from '../aedoc/ReleaseTag';
+import { DeserializerContext } from '../model/DeserializerContext';
 
 /**
  * Constructor options for {@link (ApiReleaseTagMixin:interface)}.
@@ -64,10 +65,10 @@ export function ApiReleaseTagMixin<TBaseClass extends IApiItemConstructor>(baseC
     public [_releaseTag]: ReleaseTag;
 
     /** @override */
-    public static onDeserializeInto(options: Partial<IApiReleaseTagMixinOptions>,
+    public static onDeserializeInto(options: Partial<IApiReleaseTagMixinOptions>, context: DeserializerContext,
       jsonObject: IApiReleaseTagMixinJson): void {
 
-      baseClass.onDeserializeInto(options, jsonObject);
+      baseClass.onDeserializeInto(options, context, jsonObject);
 
       const deserializedReleaseTag: ReleaseTag | undefined = ReleaseTag[jsonObject.releaseTag];
       if (deserializedReleaseTag === undefined) {

--- a/apps/api-extractor-model/src/mixins/ApiReturnTypeMixin.ts
+++ b/apps/api-extractor-model/src/mixins/ApiReturnTypeMixin.ts
@@ -5,6 +5,7 @@ import { ApiItem, IApiItemJson, IApiItemConstructor, IApiItemOptions } from '../
 import { IExcerptTokenRange, Excerpt } from './Excerpt';
 import { ApiDeclaredItem } from '../items/ApiDeclaredItem';
 import { InternalError } from '@microsoft/node-core-library';
+import { DeserializerContext } from '../model/DeserializerContext';
 
 /**
  * Constructor options for {@link (ApiReturnTypeMixin:interface)}.
@@ -61,10 +62,10 @@ export function ApiReturnTypeMixin<TBaseClass extends IApiItemConstructor>(baseC
     public [_returnTypeExcerpt]: Excerpt;
 
     /** @override */
-    public static onDeserializeInto(options: Partial<IApiReturnTypeMixinOptions>,
+    public static onDeserializeInto(options: Partial<IApiReturnTypeMixinOptions>, context: DeserializerContext,
       jsonObject: IApiReturnTypeMixinJson): void {
 
-      baseClass.onDeserializeInto(options, jsonObject);
+      baseClass.onDeserializeInto(options, context, jsonObject);
 
       options.returnTypeTokenRange = jsonObject.returnTypeTokenRange;
     }

--- a/apps/api-extractor-model/src/mixins/ApiStaticMixin.ts
+++ b/apps/api-extractor-model/src/mixins/ApiStaticMixin.ts
@@ -2,6 +2,7 @@
 // See LICENSE in the project root for license information.s
 
 import { ApiItem, IApiItemJson, IApiItemConstructor, IApiItemOptions } from '../items/ApiItem';
+import { DeserializerContext } from '../model/DeserializerContext';
 
 /**
  * Constructor options for {@link (IApiStaticMixinOptions:interface)}.
@@ -58,8 +59,10 @@ export function ApiStaticMixin<TBaseClass extends IApiItemConstructor>(baseClass
     public [_isStatic]: boolean;
 
     /** @override */
-    public static onDeserializeInto(options: Partial<IApiStaticMixinOptions>, jsonObject: IApiStaticMixinJson): void {
-      baseClass.onDeserializeInto(options, jsonObject);
+    public static onDeserializeInto(options: Partial<IApiStaticMixinOptions>, context: DeserializerContext,
+      jsonObject: IApiStaticMixinJson): void {
+
+      baseClass.onDeserializeInto(options, context, jsonObject);
 
       options.isStatic = jsonObject.isStatic;
     }

--- a/apps/api-extractor-model/src/mixins/ApiTypeParameterListMixin.ts
+++ b/apps/api-extractor-model/src/mixins/ApiTypeParameterListMixin.ts
@@ -6,6 +6,7 @@ import { IExcerptTokenRange } from './Excerpt';
 import { TypeParameter } from '../model/TypeParameter';
 import { InternalError } from '@microsoft/node-core-library';
 import { ApiDeclaredItem } from '../items/ApiDeclaredItem';
+import { DeserializerContext } from '../model/DeserializerContext';
 
 /**
  * Represents parameter information that is part of {@link IApiTypeParameterListMixinOptions}
@@ -72,10 +73,10 @@ export function ApiTypeParameterListMixin<TBaseClass extends IApiItemConstructor
     public readonly [_typeParameters]: TypeParameter[];
 
     /** @override */
-    public static onDeserializeInto(options: Partial<IApiTypeParameterListMixinOptions>,
+    public static onDeserializeInto(options: Partial<IApiTypeParameterListMixinOptions>, context: DeserializerContext,
       jsonObject: IApiTypeParameterListMixinJson): void {
 
-      baseClass.onDeserializeInto(options, jsonObject);
+      baseClass.onDeserializeInto(options, context, jsonObject);
 
       options.typeParameters = jsonObject.typeParameters || [];
     }

--- a/apps/api-extractor-model/src/model/ApiClass.ts
+++ b/apps/api-extractor-model/src/model/ApiClass.ts
@@ -10,6 +10,7 @@ import { HeritageType } from './HeritageType';
 import { IApiNameMixinOptions, ApiNameMixin } from '../mixins/ApiNameMixin';
 import { ApiTypeParameterListMixin, IApiTypeParameterListMixinOptions, IApiTypeParameterListMixinJson
   } from '../mixins/ApiTypeParameterListMixin';
+import { DeserializerContext } from './DeserializerContext';
 
 /**
  * Constructor options for {@link ApiClass}.
@@ -64,8 +65,10 @@ export class ApiClass extends ApiItemContainerMixin(ApiNameMixin(ApiTypeParamete
   }
 
   /** @override */
-  public static onDeserializeInto(options: Partial<IApiClassOptions>, jsonObject: IApiClassJson): void {
-    super.onDeserializeInto(options, jsonObject);
+  public static onDeserializeInto(options: Partial<IApiClassOptions>, context: DeserializerContext,
+    jsonObject: IApiClassJson): void {
+
+    super.onDeserializeInto(options, context, jsonObject);
 
     options.extendsTokenRange = jsonObject.extendsTokenRange;
     options.implementsTokenRanges = jsonObject.implementsTokenRanges;

--- a/apps/api-extractor-model/src/model/ApiEnumMember.ts
+++ b/apps/api-extractor-model/src/model/ApiEnumMember.ts
@@ -6,6 +6,7 @@ import { ApiDeclaredItem, IApiDeclaredItemOptions, IApiDeclaredItemJson } from '
 import { ApiReleaseTagMixin, IApiReleaseTagMixinOptions } from '../mixins/ApiReleaseTagMixin';
 import { Excerpt, IExcerptTokenRange } from '../mixins/Excerpt';
 import { IApiNameMixinOptions, ApiNameMixin } from '../mixins/ApiNameMixin';
+import { DeserializerContext } from './DeserializerContext';
 
 /**
  * Constructor options for {@link ApiEnumMember}.
@@ -54,8 +55,10 @@ export class ApiEnumMember extends ApiNameMixin(ApiReleaseTagMixin(ApiDeclaredIt
   }
 
   /** @override */
-  public static onDeserializeInto(options: Partial<IApiEnumMemberOptions>, jsonObject: IApiEnumMemberJson): void {
-    super.onDeserializeInto(options, jsonObject);
+  public static onDeserializeInto(options: Partial<IApiEnumMemberOptions>, context: DeserializerContext,
+    jsonObject: IApiEnumMemberJson): void {
+
+    super.onDeserializeInto(options, context, jsonObject);
 
     options.initializerTokenRange = jsonObject.initializerTokenRange;
   }

--- a/apps/api-extractor-model/src/model/ApiInterface.ts
+++ b/apps/api-extractor-model/src/model/ApiInterface.ts
@@ -11,6 +11,7 @@ import { HeritageType } from './HeritageType';
 import { IApiNameMixinOptions, ApiNameMixin, IApiNameMixinJson } from '../mixins/ApiNameMixin';
 import { IApiTypeParameterListMixinOptions, IApiTypeParameterListMixinJson, ApiTypeParameterListMixin
   } from '../mixins/ApiTypeParameterListMixin';
+import { DeserializerContext } from './DeserializerContext';
 
 /**
  * Constructor options for {@link ApiInterface}.
@@ -63,8 +64,10 @@ export class ApiInterface extends ApiItemContainerMixin(ApiNameMixin(ApiTypePara
   }
 
   /** @override */
-  public static onDeserializeInto(options: Partial<IApiInterfaceOptions>, jsonObject: IApiInterfaceJson): void {
-    super.onDeserializeInto(options, jsonObject);
+  public static onDeserializeInto(options: Partial<IApiInterfaceOptions>, context: DeserializerContext,
+    jsonObject: IApiInterfaceJson): void {
+
+    super.onDeserializeInto(options, context, jsonObject);
 
     options.extendsTokenRanges = jsonObject.extendsTokenRanges;
   }

--- a/apps/api-extractor-model/src/model/ApiPackage.ts
+++ b/apps/api-extractor-model/src/model/ApiPackage.ts
@@ -25,6 +25,7 @@ export interface IApiPackageMetadataJson {
    * For informational purposes only.
    */
   toolPackage: string;
+
   /**
    * The NPM package version for the tool that wrote the *.api.json file.
    * For informational purposes only.
@@ -32,10 +33,26 @@ export interface IApiPackageMetadataJson {
   toolVersion: string;
 
   /**
-   * The *.api.json schema version.  Used for determining whether the file format is
+   * The schema version for the .api.json file format.  Used for determining whether the file format is
    * supported, and for backwards compatibility.
    */
   schemaVersion: ApiJsonSchemaVersion;
+
+  /**
+   * To support forwards compatibility, the `oldestForwardsCompatibleVersion` field tracks the oldest schema version
+   * whose corresponding deserializer could safely load this file.
+   *
+   * @remarks
+   * Normally api-extractor-model should refuse to load a schema version that is newer than the latest version
+   * that its deserializer understands.  However, sometimes a schema change may merely introduce some new fields
+   * without modifying or removing any existing fields.  In this case, an older api-extractor-model library can
+   * safely deserialize the newer version (by ignoring the extra fields that it doesn't recognize).  The newer
+   * serializer can use this field to communicate that.
+   *
+   * If present, the `oldestForwardsCompatibleVersion` must be less than or equal to
+   * `IApiPackageMetadataJson.schemaVersion`.
+   */
+  oldestForwardsCompatibleVersion?: ApiJsonSchemaVersion;
 }
 
 export interface IApiPackageJson extends IApiItemJson {
@@ -93,24 +110,44 @@ export class ApiPackage extends ApiItemContainerMixin(ApiNameMixin(ApiDocumented
         + `\nThe file format is not recognized; the "metadata.schemaVersion" field is missing or invalid`);
     }
 
+    const schemaVersion: number = jsonObject.metadata.schemaVersion;
+
+    if (schemaVersion < ApiJsonSchemaVersion.OLDEST_SUPPORTED) {
+      throw new Error(`Error loading ${apiJsonFilename}:`
+        + `\nThe file format is version ${schemaVersion},`
+        + ` whereas ${ApiJsonSchemaVersion.OLDEST_SUPPORTED} is the oldest version supported by this tool`);
+    }
+
+    let oldestForwardsCompatibleVersion: number = schemaVersion;
+    if (jsonObject.metadata.oldestForwardsCompatibleVersion) {
+      // Sanity check
+      if (jsonObject.metadata.oldestForwardsCompatibleVersion > schemaVersion) {
+        throw new Error(`Error loading ${apiJsonFilename}:`
+        + `\nInvalid file format; "oldestForwardsCompatibleVersion" cannot be newer than "schemaVersion"`);
+      }
+      oldestForwardsCompatibleVersion = jsonObject.metadata.oldestForwardsCompatibleVersion;
+    }
+
+    let versionToDeserialize: number = schemaVersion;
+    if (versionToDeserialize > ApiJsonSchemaVersion.LATEST) {
+      // If the file format is too new, can we treat it as some earlier compatible version
+      // as indicated by oldestForwardsCompatibleVersion?
+      versionToDeserialize = Math.max(oldestForwardsCompatibleVersion, ApiJsonSchemaVersion.LATEST);
+
+      if (versionToDeserialize > ApiJsonSchemaVersion.LATEST) {
+        // Nope, still too new
+        throw new Error(`Error loading ${apiJsonFilename}:`
+        + `\nThe file format version ${schemaVersion} was written by a newer release of`
+        + ` the api-extractor-model library; you may need to upgrade your software`);
+      }
+    }
+
     const context: DeserializerContext = new DeserializerContext({
       apiJsonFilename,
       toolPackage: jsonObject.metadata.toolPackage,
       toolVersion: jsonObject.metadata.toolVersion,
-      versionToDeserialize: jsonObject.metadata.schemaVersion
+      versionToDeserialize: versionToDeserialize
     });
-
-    if (context.versionToDeserialize < ApiJsonSchemaVersion.OLDEST_SUPPORTED) {
-      throw new Error(`Error loading ${apiJsonFilename}:`
-        + `\nThe file format is version ${context.versionToDeserialize},`
-        + ` whereas ${ApiJsonSchemaVersion.OLDEST_SUPPORTED} is the oldest version supported by this tool`);
-    }
-
-    if (context.versionToDeserialize > ApiJsonSchemaVersion.LATEST) {
-      throw new Error(`Error loading ${apiJsonFilename}:`
-        + `\nThe file format version ${context.versionToDeserialize} was written by a newer release of`
-        + ` the api-extractor-model library; you may need to upgrade your software`);
-    }
 
     return ApiItem.deserialize(jsonObject, context) as ApiPackage;
   }
@@ -158,7 +195,8 @@ export class ApiPackage extends ApiItemContainerMixin(ApiNameMixin(ApiDocumented
         // In test mode, we don't write the real version, since that would cause spurious diffs whenever
         // the version is bumped.  Instead we write a placeholder string.
         toolVersion: options.testMode ? '[test mode]' : options.toolVersion || packageJson.version,
-        schemaVersion: ApiJsonSchemaVersion.LATEST
+        schemaVersion: ApiJsonSchemaVersion.LATEST,
+        oldestForwardsCompatibleVersion: ApiJsonSchemaVersion.OLDEST_FORWARDS_COMPATIBLE
       }
     } as IApiPackageJson;
     this.serializeInto(jsonObject);

--- a/apps/api-extractor-model/src/model/ApiTypeAlias.ts
+++ b/apps/api-extractor-model/src/model/ApiTypeAlias.ts
@@ -59,7 +59,7 @@ export class ApiTypeAlias extends ApiTypeParameterListMixin(ApiNameMixin(ApiRele
    * An {@link Excerpt} that describes the type of the alias.
    *
    * @remarks
-   * In the example below, the `aliasTypeExcerpt` would correspond to the subexpression
+   * In the example below, the `typeExcerpt` would correspond to the subexpression
    * `T extends any[] ? BoxedArray<T[number]> : BoxedValue<T>;`:
    *
    * ```ts

--- a/apps/api-extractor-model/src/model/ApiTypeAlias.ts
+++ b/apps/api-extractor-model/src/model/ApiTypeAlias.ts
@@ -74,9 +74,7 @@ export class ApiTypeAlias extends ApiTypeParameterListMixin(ApiNameMixin(ApiRele
 
     super.onDeserializeInto(options, context, jsonObject);
 
-    // NOTE: This did not exist in the initial release, so we apply a default
-    //       in the event it doesn't exist in 'jsonObject'.
-    options.typeTokenRange = jsonObject.typeTokenRange || { startIndex: 0, endIndex: 0 };
+    options.typeTokenRange = jsonObject.typeTokenRange;
   }
 
   public static getCanonicalReference(name: string): string {

--- a/apps/api-extractor-model/src/model/ApiTypeAlias.ts
+++ b/apps/api-extractor-model/src/model/ApiTypeAlias.ts
@@ -8,6 +8,7 @@ import { ApiReleaseTagMixin, IApiReleaseTagMixinOptions } from '../mixins/ApiRel
 import { IApiNameMixinOptions, ApiNameMixin } from '../mixins/ApiNameMixin';
 import { ApiTypeParameterListMixin, IApiTypeParameterListMixinOptions, IApiTypeParameterListMixinJson
   } from '../mixins/ApiTypeParameterListMixin';
+import { DeserializerContext } from './DeserializerContext';
 
 /**
  * Constructor options for {@link ApiTypeAlias}.
@@ -68,8 +69,10 @@ export class ApiTypeAlias extends ApiTypeParameterListMixin(ApiNameMixin(ApiRele
   public readonly typeExcerpt: Excerpt;
 
   /** @override */
-  public static onDeserializeInto(options: Partial<IApiTypeAliasOptions>, jsonObject: IApiTypeAliasJson): void {
-    super.onDeserializeInto(options, jsonObject);
+  public static onDeserializeInto(options: Partial<IApiTypeAliasOptions>, context: DeserializerContext,
+    jsonObject: IApiTypeAliasJson): void {
+
+    super.onDeserializeInto(options, context, jsonObject);
 
     // NOTE: This did not exist in the initial release, so we apply a default
     //       in the event it doesn't exist in 'jsonObject'.

--- a/apps/api-extractor-model/src/model/ApiVariable.ts
+++ b/apps/api-extractor-model/src/model/ApiVariable.ts
@@ -6,6 +6,7 @@ import { ApiDeclaredItem, IApiDeclaredItemOptions, IApiDeclaredItemJson } from '
 import { ApiReleaseTagMixin, IApiReleaseTagMixinOptions } from '../mixins/ApiReleaseTagMixin';
 import { IApiNameMixinOptions, ApiNameMixin } from '../mixins/ApiNameMixin';
 import { IExcerptTokenRange, Excerpt } from '../mixins/Excerpt';
+import { DeserializerContext } from './DeserializerContext';
 
 /**
  * Constructor options for {@link ApiVariable}.
@@ -50,10 +51,10 @@ export class ApiVariable extends ApiNameMixin(ApiReleaseTagMixin(ApiDeclaredItem
   public readonly variableTypeExcerpt: Excerpt;
 
   /** @override */
-  public static onDeserializeInto(options: Partial<IApiVariableOptions>,
+  public static onDeserializeInto(options: Partial<IApiVariableOptions>, context: DeserializerContext,
     jsonObject: IApiVariableJson): void {
 
-    super.onDeserializeInto(options, jsonObject);
+    super.onDeserializeInto(options, context, jsonObject);
 
     options.variableTypeTokenRange = jsonObject.variableTypeTokenRange;
   }

--- a/apps/api-extractor-model/src/model/Deserializer.ts
+++ b/apps/api-extractor-model/src/model/Deserializer.ts
@@ -23,67 +23,68 @@ import { ApiIndexSignature, IApiIndexSignatureOptions } from './ApiIndexSignatur
 import { ApiTypeAlias, IApiTypeAliasOptions, IApiTypeAliasJson } from './ApiTypeAlias';
 import { ApiVariable, IApiVariableOptions, IApiVariableJson } from './ApiVariable';
 import { IApiDeclaredItemJson } from '../items/ApiDeclaredItem';
+import { DeserializerContext } from './DeserializerContext';
 
 export class Deserializer {
-  public static deserialize(jsonObject: IApiItemJson): ApiItem {
+  public static deserialize(context: DeserializerContext, jsonObject: IApiItemJson): ApiItem {
     const options: Partial<IApiItemOptions> = { };
 
     switch (jsonObject.kind) {
       case ApiItemKind.Class:
-        ApiClass.onDeserializeInto(options, jsonObject as IApiClassJson);
+        ApiClass.onDeserializeInto(options, context, jsonObject as IApiClassJson);
         return new ApiClass(options as IApiClassOptions);
       case ApiItemKind.CallSignature:
-        ApiCallSignature.onDeserializeInto(options, jsonObject as IApiDeclaredItemJson);
+        ApiCallSignature.onDeserializeInto(options, context, jsonObject as IApiDeclaredItemJson);
         return new ApiCallSignature(options as IApiCallSignatureOptions);
       case ApiItemKind.Constructor:
-        ApiConstructor.onDeserializeInto(options, jsonObject as IApiDeclaredItemJson);
+        ApiConstructor.onDeserializeInto(options, context, jsonObject as IApiDeclaredItemJson);
         return new ApiConstructor(options as IApiConstructorOptions);
       case ApiItemKind.ConstructSignature:
-        ApiConstructSignature.onDeserializeInto(options, jsonObject as IApiDeclaredItemJson);
+        ApiConstructSignature.onDeserializeInto(options, context, jsonObject as IApiDeclaredItemJson);
         return new ApiConstructSignature(options as IApiConstructSignatureOptions);
       case ApiItemKind.EntryPoint:
-        ApiEntryPoint.onDeserializeInto(options, jsonObject);
+        ApiEntryPoint.onDeserializeInto(options, context, jsonObject);
         return new ApiEntryPoint(options as IApiEntryPointOptions);
       case ApiItemKind.Enum:
-        ApiEnum.onDeserializeInto(options, jsonObject as IApiDeclaredItemJson);
+        ApiEnum.onDeserializeInto(options, context, jsonObject as IApiDeclaredItemJson);
         return new ApiEnum(options as IApiEnumOptions);
       case ApiItemKind.EnumMember:
-        ApiEnumMember.onDeserializeInto(options, jsonObject as IApiEnumMemberJson);
+        ApiEnumMember.onDeserializeInto(options, context, jsonObject as IApiEnumMemberJson);
         return new ApiEnumMember(options as IApiEnumMemberOptions);
       case ApiItemKind.Function:
-        ApiFunction.onDeserializeInto(options, jsonObject as IApiDeclaredItemJson);
+        ApiFunction.onDeserializeInto(options, context, jsonObject as IApiDeclaredItemJson);
         return new ApiFunction(options as IApiFunctionOptions);
       case ApiItemKind.IndexSignature:
-        ApiIndexSignature.onDeserializeInto(options, jsonObject as IApiDeclaredItemJson);
+        ApiIndexSignature.onDeserializeInto(options, context, jsonObject as IApiDeclaredItemJson);
         return new ApiIndexSignature(options as IApiIndexSignatureOptions);
       case ApiItemKind.Interface:
-        ApiInterface.onDeserializeInto(options, jsonObject as IApiInterfaceJson);
+        ApiInterface.onDeserializeInto(options, context, jsonObject as IApiInterfaceJson);
         return new ApiInterface(options as IApiInterfaceOptions);
       case ApiItemKind.Method:
-        ApiMethod.onDeserializeInto(options, jsonObject as IApiDeclaredItemJson);
+        ApiMethod.onDeserializeInto(options, context, jsonObject as IApiDeclaredItemJson);
         return new ApiMethod(options as IApiMethodOptions);
       case ApiItemKind.MethodSignature:
-        ApiMethodSignature.onDeserializeInto(options, jsonObject as IApiDeclaredItemJson);
+        ApiMethodSignature.onDeserializeInto(options, context, jsonObject as IApiDeclaredItemJson);
         return new ApiMethodSignature(options as IApiMethodSignatureOptions);
       case ApiItemKind.Model:
         return new ApiModel();
       case ApiItemKind.Namespace:
-        ApiNamespace.onDeserializeInto(options, jsonObject as IApiDeclaredItemJson);
+        ApiNamespace.onDeserializeInto(options, context, jsonObject as IApiDeclaredItemJson);
         return new ApiNamespace(options as IApiNamespaceOptions);
       case ApiItemKind.Package:
-        ApiPackage.onDeserializeInto(options, jsonObject);
+        ApiPackage.onDeserializeInto(options, context, jsonObject);
         return new ApiPackage(options as IApiPackageOptions);
       case ApiItemKind.Property:
-        ApiProperty.onDeserializeInto(options, jsonObject as IApiPropertyItemJson);
+        ApiProperty.onDeserializeInto(options, context, jsonObject as IApiPropertyItemJson);
         return new ApiProperty(options as IApiPropertyOptions);
       case ApiItemKind.PropertySignature:
-        ApiPropertySignature.onDeserializeInto(options, jsonObject as IApiPropertyItemJson);
+        ApiPropertySignature.onDeserializeInto(options, context, jsonObject as IApiPropertyItemJson);
         return new ApiPropertySignature(options as IApiPropertySignatureOptions);
       case ApiItemKind.TypeAlias:
-        ApiTypeAlias.onDeserializeInto(options, jsonObject as IApiTypeAliasJson);
+        ApiTypeAlias.onDeserializeInto(options, context, jsonObject as IApiTypeAliasJson);
         return new ApiTypeAlias(options as IApiTypeAliasOptions);
       case ApiItemKind.Variable:
-        ApiVariable.onDeserializeInto(options, jsonObject as IApiVariableJson);
+        ApiVariable.onDeserializeInto(options, context, jsonObject as IApiVariableJson);
         return new ApiVariable(options as IApiVariableOptions);
       default:
         throw new Error(`Failed to deserialize unsupported API item type ${JSON.stringify(jsonObject.kind)}`);

--- a/apps/api-extractor-model/src/model/DeserializerContext.ts
+++ b/apps/api-extractor-model/src/model/DeserializerContext.ts
@@ -1,0 +1,53 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+export enum ApiJsonSchemaVersion {
+  /**
+   * The initial release.
+   */
+  V_1000 = 1000,
+
+  /**
+   * Add support for type parameters and type alias types.
+   */
+  V_1001 = 1001,
+
+  /**
+   * The current latest .api.json schema version
+   */
+  LATEST = V_1001,
+
+  /**
+   * The oldest .api.json schema version that is still supported for backwards compatibility
+   */
+  OLDEST_SUPPORTED = V_1000
+}
+
+export class DeserializerContext {
+  /**
+   * The path of the file being deserialized, which may be useful for diagnostic purposes.
+   */
+  public readonly apiJsonFilename: string;
+
+  /**
+   * Metadata from `IApiPackageMetadataJson.toolPackage`.
+   */
+  public readonly toolPackage: string;
+
+  /**
+   * Metadata from `IApiPackageMetadataJson.toolVersion`.
+   */
+  public readonly toolVersion: string;
+
+  /**
+   * The version of the schema being deserialized, as obtained from `IApiPackageMetadataJson.schemaVersion`.
+   */
+  public readonly versionToDeserialize: ApiJsonSchemaVersion;
+
+  public constructor(options: DeserializerContext) {
+    this.apiJsonFilename = options.apiJsonFilename;
+    this.toolPackage = options.toolPackage;
+    this.toolVersion = options.toolVersion;
+    this.versionToDeserialize = options.versionToDeserialize;
+  }
+}

--- a/apps/api-extractor-model/src/model/DeserializerContext.ts
+++ b/apps/api-extractor-model/src/model/DeserializerContext.ts
@@ -13,14 +13,29 @@ export enum ApiJsonSchemaVersion {
   V_1001 = 1001,
 
   /**
-   * The current latest .api.json schema version
+   * The current latest .api.json schema version.
+   *
+   * IMPORTANT: When incrementing this number, consider whether `OLDEST_SUPPORTED` or `OLDEST_FORWARDS_COMPATIBLE`
+   * should be updated.
    */
   LATEST = V_1001,
 
   /**
-   * The oldest .api.json schema version that is still supported for backwards compatibility
+   * The oldest .api.json schema version that is still supported for backwards compatibility.
+   *
+   * This must be updated if you change to the file format and do not implement compatibility logic for
+   * deserializing the older representation.
    */
-  OLDEST_SUPPORTED = V_1000
+  OLDEST_SUPPORTED = V_1001,
+
+  /**
+   * Used to assign `IApiPackageMetadataJson.oldestForwardsCompatibleVersion`.
+   *
+   * This value must be <= `ApiJsonSchemaVersion.LATEST`.  It must be reset to the `LATEST` value
+   * if the older library would not be able to deserialize your new file format.  Adding a nonessential field
+   * is generally okay.  Removing, modifying, or reinterpreting existing fields is NOT safe.
+   */
+  OLDEST_FORWARDS_COMPATIBLE = V_1001
 }
 
 export class DeserializerContext {

--- a/build-tests/api-documenter-test/etc/api-documenter-test.api.json
+++ b/build-tests/api-documenter-test/etc/api-documenter-test.api.json
@@ -2,7 +2,8 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1000
+    "schemaVersion": 1001,
+    "oldestForwardsCompatibleVersion": 1001
   },
   "kind": "Package",
   "canonicalReference": "api-documenter-test",

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/ambientNameConflict/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/ambientNameConflict/api-extractor-scenarios.api.json
@@ -2,7 +2,8 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1000
+    "schemaVersion": 1001,
+    "oldestForwardsCompatibleVersion": 1001
   },
   "kind": "Package",
   "canonicalReference": "api-extractor-scenarios",

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/apiItemKinds/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/apiItemKinds/api-extractor-scenarios.api.json
@@ -2,7 +2,8 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1000
+    "schemaVersion": 1001,
+    "oldestForwardsCompatibleVersion": 1001
   },
   "kind": "Package",
   "canonicalReference": "api-extractor-scenarios",

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/circularImport/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/circularImport/api-extractor-scenarios.api.json
@@ -2,7 +2,8 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1000
+    "schemaVersion": 1001,
+    "oldestForwardsCompatibleVersion": 1001
   },
   "kind": "Package",
   "canonicalReference": "api-extractor-scenarios",

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/circularImport2/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/circularImport2/api-extractor-scenarios.api.json
@@ -2,7 +2,8 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1000
+    "schemaVersion": 1001,
+    "oldestForwardsCompatibleVersion": 1001
   },
   "kind": "Package",
   "canonicalReference": "api-extractor-scenarios",

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/defaultExportOfEntryPoint/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/defaultExportOfEntryPoint/api-extractor-scenarios.api.json
@@ -2,7 +2,8 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1000
+    "schemaVersion": 1001,
+    "oldestForwardsCompatibleVersion": 1001
   },
   "kind": "Package",
   "canonicalReference": "api-extractor-scenarios",

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/defaultExportOfEntryPoint2/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/defaultExportOfEntryPoint2/api-extractor-scenarios.api.json
@@ -2,7 +2,8 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1000
+    "schemaVersion": 1001,
+    "oldestForwardsCompatibleVersion": 1001
   },
   "kind": "Package",
   "canonicalReference": "api-extractor-scenarios",

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/defaultExportOfEntryPoint3/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/defaultExportOfEntryPoint3/api-extractor-scenarios.api.json
@@ -2,7 +2,8 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1000
+    "schemaVersion": 1001,
+    "oldestForwardsCompatibleVersion": 1001
   },
   "kind": "Package",
   "canonicalReference": "api-extractor-scenarios",

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/defaultExportOfEntryPoint4/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/defaultExportOfEntryPoint4/api-extractor-scenarios.api.json
@@ -2,7 +2,8 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1000
+    "schemaVersion": 1001,
+    "oldestForwardsCompatibleVersion": 1001
   },
   "kind": "Package",
   "canonicalReference": "api-extractor-scenarios",

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/docReferences/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/docReferences/api-extractor-scenarios.api.json
@@ -2,7 +2,8 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1000
+    "schemaVersion": 1001,
+    "oldestForwardsCompatibleVersion": 1001
   },
   "kind": "Package",
   "canonicalReference": "api-extractor-scenarios",

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/docReferences2/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/docReferences2/api-extractor-scenarios.api.json
@@ -2,7 +2,8 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1000
+    "schemaVersion": 1001,
+    "oldestForwardsCompatibleVersion": 1001
   },
   "kind": "Package",
   "canonicalReference": "api-extractor-scenarios",

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/docReferences3/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/docReferences3/api-extractor-scenarios.api.json
@@ -2,7 +2,8 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1000
+    "schemaVersion": 1001,
+    "oldestForwardsCompatibleVersion": 1001
   },
   "kind": "Package",
   "canonicalReference": "api-extractor-scenarios",

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/exportDuplicate/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/exportDuplicate/api-extractor-scenarios.api.json
@@ -2,7 +2,8 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1000
+    "schemaVersion": 1001,
+    "oldestForwardsCompatibleVersion": 1001
   },
   "kind": "Package",
   "canonicalReference": "api-extractor-scenarios",

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/exportEquals/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/exportEquals/api-extractor-scenarios.api.json
@@ -2,7 +2,8 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1000
+    "schemaVersion": 1001,
+    "oldestForwardsCompatibleVersion": 1001
   },
   "kind": "Package",
   "canonicalReference": "api-extractor-scenarios",

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/exportImportedExternal/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/exportImportedExternal/api-extractor-scenarios.api.json
@@ -2,7 +2,8 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1000
+    "schemaVersion": 1001,
+    "oldestForwardsCompatibleVersion": 1001
   },
   "kind": "Package",
   "canonicalReference": "api-extractor-scenarios",

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/exportImportedExternal2/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/exportImportedExternal2/api-extractor-scenarios.api.json
@@ -2,7 +2,8 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1000
+    "schemaVersion": 1001,
+    "oldestForwardsCompatibleVersion": 1001
   },
   "kind": "Package",
   "canonicalReference": "api-extractor-scenarios",

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/exportStar/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/exportStar/api-extractor-scenarios.api.json
@@ -2,7 +2,8 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1000
+    "schemaVersion": 1001,
+    "oldestForwardsCompatibleVersion": 1001
   },
   "kind": "Package",
   "canonicalReference": "api-extractor-scenarios",

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/exportStar2/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/exportStar2/api-extractor-scenarios.api.json
@@ -2,7 +2,8 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1000
+    "schemaVersion": 1001,
+    "oldestForwardsCompatibleVersion": 1001
   },
   "kind": "Package",
   "canonicalReference": "api-extractor-scenarios",

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/exportStar3/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/exportStar3/api-extractor-scenarios.api.json
@@ -2,7 +2,8 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1000
+    "schemaVersion": 1001,
+    "oldestForwardsCompatibleVersion": 1001
   },
   "kind": "Package",
   "canonicalReference": "api-extractor-scenarios",

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/importEquals/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/importEquals/api-extractor-scenarios.api.json
@@ -2,7 +2,8 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1000
+    "schemaVersion": 1001,
+    "oldestForwardsCompatibleVersion": 1001
   },
   "kind": "Package",
   "canonicalReference": "api-extractor-scenarios",

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/inconsistentReleaseTags/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/inconsistentReleaseTags/api-extractor-scenarios.api.json
@@ -2,7 +2,8 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1000
+    "schemaVersion": 1001,
+    "oldestForwardsCompatibleVersion": 1001
   },
   "kind": "Package",
   "canonicalReference": "api-extractor-scenarios",

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/preapproved/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/preapproved/api-extractor-scenarios.api.json
@@ -2,7 +2,8 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1000
+    "schemaVersion": 1001,
+    "oldestForwardsCompatibleVersion": 1001
   },
   "kind": "Package",
   "canonicalReference": "api-extractor-scenarios",

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/typeOf/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/typeOf/api-extractor-scenarios.api.json
@@ -2,7 +2,8 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1000
+    "schemaVersion": 1001,
+    "oldestForwardsCompatibleVersion": 1001
   },
   "kind": "Package",
   "canonicalReference": "api-extractor-scenarios",

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/typeParameters/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/typeParameters/api-extractor-scenarios.api.json
@@ -2,7 +2,8 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1000
+    "schemaVersion": 1001,
+    "oldestForwardsCompatibleVersion": 1001
   },
   "kind": "Package",
   "canonicalReference": "api-extractor-scenarios",
@@ -530,7 +531,7 @@
               }
             }
           ],
-          "aliasTypeTokenRange": {
+          "typeTokenRange": {
             "startIndex": 5,
             "endIndex": 6
           }

--- a/common/changes/@microsoft/api-extractor-model/octogonz-ae-model-versioning_2019-06-10-17-19.json
+++ b/common/changes/@microsoft/api-extractor-model/octogonz-ae-model-versioning_2019-06-10-17-19.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor-model",
+      "comment": "Improve the .api.json deserializer to validate the schema version and support backwards compatibility",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor-model",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/reviews/api/api-extractor-model.api.md
+++ b/common/reviews/api/api-extractor-model.api.md
@@ -50,10 +50,11 @@ export class ApiClass extends ApiClass_base {
     readonly implementsTypes: ReadonlyArray<HeritageType>;
     // @override (undocumented)
     readonly kind: ApiItemKind;
+    // Warning: (ae-forgotten-export) The symbol "DeserializerContext" needs to be exported by the entry point index.d.ts
     // Warning: (ae-forgotten-export) The symbol "IApiClassJson" needs to be exported by the entry point index.d.ts
     // 
     // @override (undocumented)
-    static onDeserializeInto(options: Partial<IApiClassOptions>, jsonObject: IApiClassJson): void;
+    static onDeserializeInto(options: Partial<IApiClassOptions>, context: DeserializerContext, jsonObject: IApiClassJson): void;
     // @override (undocumented)
     serializeInto(jsonObject: Partial<IApiClassJson>): void;
 }
@@ -94,7 +95,7 @@ export class ApiDeclaredItem extends ApiDocumentedItem {
     // Warning: (ae-forgotten-export) The symbol "IApiDeclaredItemJson" needs to be exported by the entry point index.d.ts
     // 
     // @override (undocumented)
-    static onDeserializeInto(options: Partial<IApiDeclaredItemOptions>, jsonObject: IApiDeclaredItemJson): void;
+    static onDeserializeInto(options: Partial<IApiDeclaredItemOptions>, context: DeserializerContext, jsonObject: IApiDeclaredItemJson): void;
     // @override (undocumented)
     serializeInto(jsonObject: Partial<IApiDeclaredItemJson>): void;
 }
@@ -105,7 +106,7 @@ export class ApiDocumentedItem extends ApiItem {
     // Warning: (ae-forgotten-export) The symbol "IApiItemJson" needs to be exported by the entry point index.d.ts
     // 
     // @override (undocumented)
-    static onDeserializeInto(options: Partial<IApiDocumentedItemOptions>, jsonObject: IApiItemJson): void;
+    static onDeserializeInto(options: Partial<IApiDocumentedItemOptions>, context: DeserializerContext, jsonObject: IApiItemJson): void;
     // Warning: (ae-forgotten-export) The symbol "IApiDocumentedItemJson" needs to be exported by the entry point index.d.ts
     // 
     // @override (undocumented)
@@ -157,7 +158,7 @@ export class ApiEnumMember extends ApiEnumMember_base {
     // Warning: (ae-forgotten-export) The symbol "IApiEnumMemberJson" needs to be exported by the entry point index.d.ts
     // 
     // @override (undocumented)
-    static onDeserializeInto(options: Partial<IApiEnumMemberOptions>, jsonObject: IApiEnumMemberJson): void;
+    static onDeserializeInto(options: Partial<IApiEnumMemberOptions>, context: DeserializerContext, jsonObject: IApiEnumMemberJson): void;
     // @override (undocumented)
     serializeInto(jsonObject: Partial<IApiEnumMemberJson>): void;
 }
@@ -203,7 +204,7 @@ export class ApiInterface extends ApiInterface_base {
     // Warning: (ae-forgotten-export) The symbol "IApiInterfaceJson" needs to be exported by the entry point index.d.ts
     // 
     // @override (undocumented)
-    static onDeserializeInto(options: Partial<IApiInterfaceOptions>, jsonObject: IApiInterfaceJson): void;
+    static onDeserializeInto(options: Partial<IApiInterfaceOptions>, context: DeserializerContext, jsonObject: IApiInterfaceJson): void;
     // @override (undocumented)
     serializeInto(jsonObject: Partial<IApiInterfaceJson>): void;
 }
@@ -216,7 +217,7 @@ export class ApiItem {
     // @virtual (undocumented)
     readonly canonicalReference: string;
     // (undocumented)
-    static deserialize(jsonObject: IApiItemJson): ApiItem;
+    static deserialize(jsonObject: IApiItemJson, context: DeserializerContext): ApiItem;
     // @virtual
     readonly displayName: string;
     getAssociatedPackage(): ApiPackage | undefined;
@@ -229,7 +230,7 @@ export class ApiItem {
     // @virtual
     readonly members: ReadonlyArray<ApiItem>;
     // @virtual (undocumented)
-    static onDeserializeInto(options: Partial<IApiItemOptions>, jsonObject: IApiItemJson): void;
+    static onDeserializeInto(options: Partial<IApiItemOptions>, context: DeserializerContext, jsonObject: IApiItemJson): void;
     // @virtual
     readonly parent: ApiItem | undefined;
     // @virtual (undocumented)
@@ -431,7 +432,7 @@ export class ApiPropertyItem extends ApiPropertyItem_base {
     // Warning: (ae-forgotten-export) The symbol "IApiPropertyItemJson" needs to be exported by the entry point index.d.ts
     // 
     // @override (undocumented)
-    static onDeserializeInto(options: Partial<IApiPropertyItemOptions>, jsonObject: IApiPropertyItemJson): void;
+    static onDeserializeInto(options: Partial<IApiPropertyItemOptions>, context: DeserializerContext, jsonObject: IApiPropertyItemJson): void;
     readonly propertyTypeExcerpt: Excerpt;
     // @override (undocumented)
     serializeInto(jsonObject: Partial<IApiPropertyItemJson>): void;
@@ -509,7 +510,7 @@ export class ApiTypeAlias extends ApiTypeAlias_base {
     // Warning: (ae-forgotten-export) The symbol "IApiTypeAliasJson" needs to be exported by the entry point index.d.ts
     // 
     // @override (undocumented)
-    static onDeserializeInto(options: Partial<IApiTypeAliasOptions>, jsonObject: IApiTypeAliasJson): void;
+    static onDeserializeInto(options: Partial<IApiTypeAliasOptions>, context: DeserializerContext, jsonObject: IApiTypeAliasJson): void;
     // @override (undocumented)
     serializeInto(jsonObject: Partial<IApiTypeAliasJson>): void;
     readonly typeExcerpt: Excerpt;
@@ -544,7 +545,7 @@ export class ApiVariable extends ApiVariable_base {
     // Warning: (ae-forgotten-export) The symbol "IApiVariableJson" needs to be exported by the entry point index.d.ts
     // 
     // @override (undocumented)
-    static onDeserializeInto(options: Partial<IApiVariableOptions>, jsonObject: IApiVariableJson): void;
+    static onDeserializeInto(options: Partial<IApiVariableOptions>, context: DeserializerContext, jsonObject: IApiVariableJson): void;
     // @override (undocumented)
     serializeInto(jsonObject: Partial<IApiVariableJson>): void;
     readonly variableTypeExcerpt: Excerpt;


### PR DESCRIPTION
- Introduce `DeserializerContext` that can be consulted by deserializer functions to determine the schema version being loaded
- Add version checking and validation logic during loading
- Introduce an `oldestForwardsCompatibleVersion` concept
- Bump the version to capture the changes introduced by PR #1317

@iclanton @rbuckton 