### PR TITLE
[api-extractor]  Fix issue where "typescriptCompilerFolder" did not work with TypeScript 3.4

### DIFF
--- a/common/changes/@microsoft/api-extractor/octogonz-fix-issue-1304_2019-06-26-15-32.json
+++ b/common/changes/@microsoft/api-extractor/octogonz-fix-issue-1304_2019-06-26-15-32.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor",
+      "comment": "Fix GitHub issue #1304 where \"IExtractorInvokeOptions.typescriptCompilerFolder\" did not work with TypeScript 3.4",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}


### PR DESCRIPTION
Fixes GitHub issue #1304.