### PR TITLE
[rush] Fix an issue where "rush add" erroneously believes ensureConsistentVersions is unset.

### DIFF
--- a/apps/rush-lib/src/logic/PackageJsonUpdater.ts
+++ b/apps/rush-lib/src/logic/PackageJsonUpdater.ts
@@ -118,72 +118,12 @@ export class PackageJsonUpdater {
       variant
     } = options;
 
-    const implicitlyPinned: Map<string, string>
-      = InstallManager.collectImplicitlyPreferredVersions(this._rushConfiguration, {
+    const implicitlyPinned: Map<string, string> = InstallManager.collectImplicitlyPreferredVersions(
+      this._rushConfiguration,
+      {
         variant
-      });
-
-    const version: string = this._getNormalizedVersionSpec(
-      packageName, initialVersion, implicitlyPinned.get(packageName), rangeStyle);
-
-    console.log();
-    console.log(colors.green(`Updating projects to use `)
-      + packageName + '@' + colors.cyan(version));
-    console.log();
-
-    const currentProjectUpdate: IUpdateProjectOptions = {
-      project: currentProject,
-      packageName,
-      newVersion: version,
-      dependencyType: devDependency ? DependencyType.Dev : undefined
-    };
-    this.updateProject(currentProjectUpdate);
-
-    const otherPackageUpdates: Array<IUpdateProjectOptions> = [];
-
-    if (this._rushConfiguration.ensureConsistentVersions || updateOtherPackages) {
-      // we need to do a mismatch check
-      const mismatchFinder: VersionMismatchFinder = VersionMismatchFinder.getMismatches(this._rushConfiguration, {
-        variant: variant
-      });
-
-      const mismatches: Array<string> = mismatchFinder.getMismatches();
-      if (mismatches.length) {
-        if (!updateOtherPackages) {
-          return Promise.reject(new Error(`Adding '${packageName}@${version}' to ${currentProject.packageName}`
-            + ` causes mismatched dependencies. Use the "--make-consistent" flag to update other packages to use this`
-            + ` version, or do not specify a SemVer range.`));
-        }
-
-        // otherwise we need to go update a bunch of other projects
-        const mismatchedVersions: Array<string> | undefined = mismatchFinder.getVersionsOfMismatch(packageName);
-        if (mismatchedVersions) {
-          for (const mismatchedVersion of mismatchedVersions) {
-            for (const consumer of mismatchFinder.getConsumersOfMismatch(packageName, mismatchedVersion)!) {
-              if (consumer !== currentProject.packageName) {
-                otherPackageUpdates.push({
-                  project: this._rushConfiguration.getProjectByName(consumer)!,
-                  packageName: packageName,
-                  newVersion: version
-                });
-              }
-            }
-          }
-        }
       }
-    }
-
-    this.updateProjects(otherPackageUpdates);
-
-    for (const project of this._rushConfiguration.projects) {
-      if (project.packageJsonEditor.saveIfModified()) {
-        console.log(colors.green('Wrote ') + project.packageJsonEditor.filePath);
-      }
-    }
-
-    if (skipUpdate) {
-      return Promise.resolve();
-    }
+    );
 
     const purgeManager: PurgeManager = new PurgeManager(this._rushConfiguration, this._rushGlobalFolder);
     const installManagerOptions: IInstallManagerOptions = {
@@ -204,16 +144,82 @@ export class PackageJsonUpdater {
       installManagerOptions
     );
 
-    console.log();
-    console.log(colors.green('Running "rush update"'));
-    console.log();
-    return installManager.doInstall()
-      .then(() => {
-        purgeManager.deleteAll();
-      })
-      .catch((error) => {
-        purgeManager.deleteAll();
-        throw error;
+    return  this._getNormalizedVersionSpec(
+      installManager,
+      packageName,
+      initialVersion,
+      implicitlyPinned.get(packageName),
+      rangeStyle
+    ).then((version) => {
+      console.log();
+      console.log(colors.green(`Updating projects to use `) + packageName + '@' + colors.cyan(version));
+      console.log();
+
+      const currentProjectUpdate: IUpdateProjectOptions = {
+        project: currentProject,
+        packageName,
+        newVersion: version,
+        dependencyType: devDependency ? DependencyType.Dev : undefined
+      };
+      this.updateProject(currentProjectUpdate);
+
+      const otherPackageUpdates: Array<IUpdateProjectOptions> = [];
+
+      if (this._rushConfiguration.ensureConsistentVersions || updateOtherPackages) {
+        // we need to do a mismatch check
+        const mismatchFinder: VersionMismatchFinder = VersionMismatchFinder.getMismatches(this._rushConfiguration, {
+          variant: variant
+        });
+
+        const mismatches: Array<string> = mismatchFinder.getMismatches();
+        if (mismatches.length) {
+          if (!updateOtherPackages) {
+            return Promise.reject(new Error(`Adding '${packageName}@${version}' to ${currentProject.packageName}`
+              + ` causes mismatched dependencies. Use the "--make-consistent" flag to update other packages to use this`
+              + ` version, or do not specify a SemVer range.`));
+          }
+
+          // otherwise we need to go update a bunch of other projects
+          const mismatchedVersions: Array<string> | undefined = mismatchFinder.getVersionsOfMismatch(packageName);
+          if (mismatchedVersions) {
+            for (const mismatchedVersion of mismatchedVersions) {
+              for (const consumer of mismatchFinder.getConsumersOfMismatch(packageName, mismatchedVersion)!) {
+                if (consumer !== currentProject.packageName) {
+                  otherPackageUpdates.push({
+                    project: this._rushConfiguration.getProjectByName(consumer)!,
+                    packageName: packageName,
+                    newVersion: version
+                  });
+                }
+              }
+            }
+          }
+        }
+      }
+
+      this.updateProjects(otherPackageUpdates);
+
+      for (const project of this._rushConfiguration.projects) {
+        if (project.packageJsonEditor.saveIfModified()) {
+          console.log(colors.green('Wrote ') + project.packageJsonEditor.filePath);
+        }
+      }
+
+      if (skipUpdate) {
+        return Promise.resolve();
+      }
+
+      console.log();
+      console.log(colors.green('Running "rush update"'));
+      console.log();
+      return installManager.doInstall()
+        .then(() => {
+          purgeManager.deleteAll();
+        })
+        .catch((error) => {
+          purgeManager.deleteAll();
+          throw error;
+        });
       });
   }
 
@@ -261,10 +267,12 @@ export class PackageJsonUpdater {
    *   the selected version.
    */
   private _getNormalizedVersionSpec(
+    installManager: InstallManager,
     packageName: string,
     initialSpec: string | undefined,
     implicitlyPinnedVersion: string | undefined,
-    rangeStyle: SemVerStyle): string {
+    rangeStyle: SemVerStyle
+  ): Promise<string> {
 
     console.log(colors.gray(`Determining new version for dependency: ${packageName}`));
     if (initialSpec) {
@@ -280,76 +288,82 @@ export class PackageJsonUpdater {
       console.log(colors.green('Assigning "')
         + colors.cyan(initialSpec)
         + colors.green(`" for "${packageName}" because it matches what other projects are using in this repo.`));
-      return initialSpec;
+      return Promise.resolve(initialSpec);
     }
 
     if (this._rushConfiguration.ensureConsistentVersions && !initialSpec && implicitlyPinnedVersion) {
       console.log(`Assigning the version range "${colors.cyan(implicitlyPinnedVersion)}" for "${packageName}" because`
         + ` it is already used by other projects in this repo.`);
-      return implicitlyPinnedVersion;
+      return Promise.resolve(implicitlyPinnedVersion);
     }
-
-    let selectedVersion: string | undefined;
 
     if (this._rushConfiguration.packageManager === 'yarn') {
       throw new Error('The Yarn package manager is not currently supported by the "rush add" command.');
     }
 
-    if (initialSpec && initialSpec !== 'latest') {
-      console.log(colors.gray('Finding newest version that satisfies the selector: ') + initialSpec);
-      console.log();
-      console.log(`Querying registry for all versions of "${packageName}"...`);
+    return installManager.ensureLocalPackageManager().then(() => {
+      let selectedVersion: string | undefined;
 
-      const allVersions: string =
-        Utilities.executeCommandAndCaptureOutput(this._rushConfiguration.packageManagerToolFilename,
-          ['view', packageName, 'versions', '--json'],
-          this._rushConfiguration.commonTempFolder);
-
-      let versionList: Array<string> = JSON.parse(allVersions);
-      versionList = versionList.sort((a: string, b: string) => { return semver.gt(a, b) ? -1 : 1; });
-
-      console.log(colors.gray(`Found ${versionList.length} available versions.`));
-
-      for (const version of versionList) {
-        if (semver.satisfies(version, initialSpec)) {
-          selectedVersion = version;
-          console.log(`Found latest version: ${colors.cyan(selectedVersion)}`);
-          break;
-        }
-      }
-      if (!selectedVersion) {
-        throw new Error(`Unable to find a version of "${packageName}" that satisfies`
-          + ` the version range "${initialSpec}"`);
-      }
-    } else {
-      if (!this._rushConfiguration.ensureConsistentVersions) {
-        console.log(colors.gray(`The "ensureConsistentVersions" policy is NOT active,`
-          + ` so we will assign the latest version.`));
+      if (initialSpec && initialSpec !== 'latest') {
+        console.log(colors.gray('Finding newest version that satisfies the selector: ') + initialSpec);
         console.log();
-      }
-      console.log(`Querying NPM registry for latest version of "${packageName}"...`);
+        console.log(`Querying registry for all versions of "${packageName}"...`);
 
-      selectedVersion = Utilities.executeCommandAndCaptureOutput(this._rushConfiguration.packageManagerToolFilename,
-        ['view', `${packageName}@latest`, 'version'],
-        this._rushConfiguration.commonTempFolder).trim();
+        const allVersions: string =
+          Utilities.executeCommandAndCaptureOutput(this._rushConfiguration.packageManagerToolFilename,
+            ['view', packageName, 'versions', '--json'],
+            this._rushConfiguration.commonTempFolder);
+
+        let versionList: Array<string> = JSON.parse(allVersions);
+        versionList = versionList.sort((a: string, b: string) => { return semver.gt(a, b) ? -1 : 1; });
+
+        console.log(colors.gray(`Found ${versionList.length} available versions.`));
+
+        for (const version of versionList) {
+          if (semver.satisfies(version, initialSpec)) {
+            selectedVersion = version;
+            console.log(`Found latest version: ${colors.cyan(selectedVersion)}`);
+            break;
+          }
+        }
+
+        if (!selectedVersion) {
+          throw new Error(`Unable to find a version of "${packageName}" that satisfies`
+            + ` the version range "${initialSpec}"`);
+        }
+      } else {
+        if (!this._rushConfiguration.ensureConsistentVersions) {
+          console.log(colors.gray(`The "ensureConsistentVersions" policy is NOT active,`
+            + ` so we will assign the latest version.`));
+          console.log();
+        }
+        console.log(`Querying NPM registry for latest version of "${packageName}"...`);
+
+        selectedVersion = Utilities.executeCommandAndCaptureOutput(
+          this._rushConfiguration.packageManagerToolFilename,
+          ['view', `${packageName}@latest`, 'version'],
+          this._rushConfiguration.commonTempFolder
+        ).trim();
+
+        console.log();
+
+        console.log(`Found latest version: ${colors.cyan(selectedVersion)}`);
+      }
+
       console.log();
 
-      console.log(`Found latest version: ${colors.cyan(selectedVersion)}`);
-    }
-
-    console.log();
-
-    if (rangeStyle === SemVerStyle.Caret) {
-      console.log(colors.grey(`Assigning version "^${selectedVersion}" for "${packageName}" because the "--caret"`
-        + ` flag was specified.`));
-      return '^' + selectedVersion;
-    } else if (rangeStyle === SemVerStyle.Exact) {
-      console.log(colors.grey(`Assigning version "${selectedVersion}" for "${packageName}" because the "--exact"`
-        + ` flag was specified.`));
-      return selectedVersion;
-    } else {
-      console.log(colors.gray(`Assigning version "~${selectedVersion}" for "${packageName}".`));
-      return '~' + selectedVersion!;
-    }
+      if (rangeStyle === SemVerStyle.Caret) {
+        console.log(colors.grey(`Assigning version "^${selectedVersion}" for "${packageName}" because the "--caret"`
+          + ` flag was specified.`));
+        return '^' + selectedVersion;
+      } else if (rangeStyle === SemVerStyle.Exact) {
+        console.log(colors.grey(`Assigning version "${selectedVersion}" for "${packageName}" because the "--exact"`
+          + ` flag was specified.`));
+        return selectedVersion;
+      } else {
+        console.log(colors.gray(`Assigning version "~${selectedVersion}" for "${packageName}".`));
+        return '~' + selectedVersion!;
+      }
+    });
   }
 }

--- a/apps/rush-lib/src/logic/PackageJsonUpdater.ts
+++ b/apps/rush-lib/src/logic/PackageJsonUpdater.ts
@@ -322,7 +322,7 @@ export class PackageJsonUpdater {
           + ` the version range "${initialSpec}"`);
       }
     } else {
-      if (initialSpec !== 'latest') {
+      if (!this._rushConfiguration.ensureConsistentVersions) {
         console.log(colors.gray(`The "ensureConsistentVersions" policy is NOT active,`
           + ` so we will assign the latest version.`));
         console.log();

--- a/common/changes/@microsoft/rush/ianc-fix-rush-add_2019-07-03-03-03.json
+++ b/common/changes/@microsoft/rush/ianc-fix-rush-add_2019-07-03-03-03.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Fix an issue where \"rush add\" erroneously believes ensureConsistentVersions is unset.",
+      "packageName": "@microsoft/rush",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush/ianc-fix-rush-add_2019-07-03-03-07.json
+++ b/common/changes/@microsoft/rush/ianc-fix-rush-add_2019-07-03-03-07.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Fix an issue that arises when \"rush add\" is run and the package manager isn't installed.",
+      "packageName": "@microsoft/rush",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "iclanton@users.noreply.github.com"
+}


### PR DESCRIPTION
This also fixes an issue where the package manager may not be installed when `rush add` is invoked.

This fixes https://github.com/microsoft/web-build-tools/issues/1138.