### PR TITLE
[rush] For "rush publish" and "rush version", change the path spec for 'git add' to include everything from the root directory. This addresses #669.

### DIFF
--- a/apps/rush-lib/src/cli/actions/PublishAction.ts
+++ b/apps/rush-lib/src/cli/actions/PublishAction.ts
@@ -253,7 +253,7 @@ export class PublishAction extends BaseRushAction {
 
       if (VersionControl.hasUncommittedChanges()) {
         // Stage, commit, and push the changes to remote temp branch.
-        git.addChanges();
+        git.addChanges(':/*');
         git.commit(this.rushConfiguration.gitVersionBumpCommitMessage || DEFAULT_PACKAGE_UPDATE_MESSAGE);
         git.push(tempBranch);
 

--- a/apps/rush-lib/src/cli/actions/VersionAction.ts
+++ b/apps/rush-lib/src/cli/actions/VersionAction.ts
@@ -210,8 +210,8 @@ export class VersionAction extends BaseRushAction {
 
     if (changeLogUpdated) {
       git.addChanges('.', this.rushConfiguration.changesFolder);
-      git.addChanges('**/CHANGELOG.json');
-      git.addChanges('**/CHANGELOG.md');
+      git.addChanges(':/**/CHANGELOG.json');
+      git.addChanges(':/**/CHANGELOG.md');
       git.commit('Deleting change files and updating change logs for package updates.');
     }
 
@@ -221,7 +221,7 @@ export class VersionAction extends BaseRushAction {
     });
 
     if (packageJsonUpdated) {
-      git.addChanges();
+      git.addChanges(':/*');
       git.commit(this.rushConfiguration.gitVersionBumpCommitMessage || DEFAULT_PACKAGE_UPDATE_MESSAGE);
     }
 

--- a/common/changes/@microsoft/rush/sachinjoseph-fix669_2019-07-12-19-04.json
+++ b/common/changes/@microsoft/rush/sachinjoseph-fix669_2019-07-12-19-04.json
@@ -1,7 +1,7 @@
 {
   "changes": [
     {
-      "comment": "For rush publish and rush version, change the path spec for git add to include everything from the root directory. This addresses https://github.com/microsoft/web-build-tools/issues/669.",
+      "comment": "For rush publish and rush version, change the path spec for git add to include everything from the repo root directory. This addresses https://github.com/microsoft/web-build-tools/issues/669.",
       "packageName": "@microsoft/rush",
       "type": "none"
     }

--- a/common/changes/@microsoft/rush/sachinjoseph-fix669_2019-07-12-19-04.json
+++ b/common/changes/@microsoft/rush/sachinjoseph-fix669_2019-07-12-19-04.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "For rush publish and rush version, change the path spec for git add to include everything from the root directory. This addresses https://github.com/microsoft/web-build-tools/issues/669.",
+      "packageName": "@microsoft/rush",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "sachinjoseph@users.noreply.github.com"
+}


### PR DESCRIPTION
For "rush publish" and "rush version", change the path spec for git add to include everything from the root directory. This addresses https://github.com/microsoft/web-build-tools/issues/669.