### PR TITLE
[rush] Fix #1392  "rush install not working on pnpm 3.5" by getting the  temporary project dependency key from the shrinkwrap

### DIFF
--- a/apps/rush-lib/src/logic/pnpm/PnpmLinkManager.ts
+++ b/apps/rush-lib/src/logic/pnpm/PnpmLinkManager.ts
@@ -155,19 +155,13 @@ export class PnpmLinkManager extends BaseLinkManager {
     //   file:projects/bentleyjs-core.tgz
     //   file:projects/build-tools.tgz_dc21d88642e18a947127a751e00b020a
     //   file:projects/imodel-from-geojson.tgz_request@2.88.0
-    const topLevelDependencyVersion: string | undefined =
-      pnpmShrinkwrapFile.getTopLevelDependencyVersion(project.tempProjectName);
-
-    if (!topLevelDependencyVersion) {
-      throw new InternalError(`Cannot find top level dependency for "${project.tempProjectName}"` +
-        ` in shrinkwrap.`);
-    }
+    const tempProjectDependencyKey: string = pnpmShrinkwrapFile.getTempProjectKey(project.tempProjectName);
 
     // e.g.: file:projects/project-name.tgz
-    const tarballEntry: string | undefined = pnpmShrinkwrapFile.getTarballPath(topLevelDependencyVersion);
+    const tarballEntry: string | undefined = pnpmShrinkwrapFile.getTarballPath(tempProjectDependencyKey);
 
     if (!tarballEntry) {
-      throw new InternalError(`Cannot find tarball path for "${topLevelDependencyVersion}"` +
+      throw new InternalError(`Cannot find tarball path for "${project.tempProjectName}"` +
         ` in shrinkwrap.`);
     }
 
@@ -191,8 +185,8 @@ export class PnpmLinkManager extends BaseLinkManager {
     //   '' [empty string]
     //   _jsdom@11.12.0
     //   _2a665c89609864b4e75bc5365d7f8f56
-    const folderNameSuffix: string = (tarballEntry && tarballEntry.length < topLevelDependencyVersion.length ?
-      topLevelDependencyVersion.slice(tarballEntry.length) : '');
+    const folderNameSuffix: string = (tarballEntry && tarballEntry.length < tempProjectDependencyKey.length ?
+      tempProjectDependencyKey.slice(tarballEntry.length) : '');
 
     // e.g.:
     //   C%3A%2Fwbt%2Fcommon%2Ftemp%2Fprojects%2Fapi-documenter.tgz

--- a/apps/rush-lib/src/logic/pnpm/PnpmLinkManager.ts
+++ b/apps/rush-lib/src/logic/pnpm/PnpmLinkManager.ts
@@ -155,8 +155,13 @@ export class PnpmLinkManager extends BaseLinkManager {
     //   file:projects/bentleyjs-core.tgz
     //   file:projects/build-tools.tgz_dc21d88642e18a947127a751e00b020a
     //   file:projects/imodel-from-geojson.tgz_request@2.88.0
-    const tempProjectDependencyKey: string = pnpmShrinkwrapFile.getTempProjectKey(project.tempProjectName);
+    const tempProjectDependencyKey: string | undefined =
+      pnpmShrinkwrapFile.getTopLevelDependencyVersion(project.tempProjectName);
 
+    if (!tempProjectDependencyKey) {
+      throw new Error(`Cannot get dependency key for temp project: `
+      + `${project.tempProjectName}`);
+    }
     // e.g.: file:projects/project-name.tgz
     const tarballEntry: string | undefined = pnpmShrinkwrapFile.getTarballPath(tempProjectDependencyKey);
 

--- a/apps/rush-lib/src/logic/pnpm/PnpmShrinkwrapFile.ts
+++ b/apps/rush-lib/src/logic/pnpm/PnpmShrinkwrapFile.ts
@@ -161,28 +161,17 @@ export class PnpmShrinkwrapFile extends BaseShrinkwrapFile {
   }
 
   /**
-   * Gets the dependency key name of the given temporary project
-   * Examples of the return value:
-   *   file:projects/empty-webpart-project.tgz
-   *   file:projects/article-site-demo.tgz_jest@22.4.4+typescript@2.9.2
-   *   file:projects/i18n-utilities.tgz_462eaf34881863298955eb323c130fc7
-   */
-  public getTempProjectKey(tempProjectName: string): string {
-    const tempProjectDependencyKey: string | undefined = this.getTopLevelDependencyVersion(tempProjectName);
-
-    if (!tempProjectDependencyKey) {
-      throw new Error(`Cannot get dependency key for temp project: `
-      + `${tempProjectName}`);
-    }
-
-    return tempProjectDependencyKey;
-  }
-
-  /**
    * Gets the version number from the list of top-level dependencies in the "dependencies" section
-   * of the shrinkwrap file
+   * of the shrinkwrap file. Sample return values:
+   *   '2.1.113'
+   *   '1.9.0-dev.27_typescript@2.9.2'
+   *   '5.0.0_25c559a5921686293a001a397be4dce0'
+   *   'file:projects/empty-webpart-project.tgz'
+   *   'file:projects/article-site-demo.tgz_jest@22.4.4+typescript@2.9.2'
+   *   'file:projects/i18n-utilities.tgz_462eaf34881863298955eb323c130fc7'
+   *   undefined
    */
-  protected getTopLevelDependencyVersion(dependencyName: string): string | undefined {
+  public getTopLevelDependencyVersion(dependencyName: string): string | undefined {
     return BaseShrinkwrapFile.tryGetValue(this._shrinkwrapJson.dependencies, dependencyName);
   }
 
@@ -209,7 +198,12 @@ export class PnpmShrinkwrapFile extends BaseShrinkwrapFile {
     // Because of this, we actually need to check for a version that this package is directly
     // linked to.
 
-    const tempProjectDependencyKey: string = this.getTempProjectKey(tempProjectName);
+    const tempProjectDependencyKey: string | undefined = this.getTopLevelDependencyVersion(tempProjectName);
+
+    if (!tempProjectDependencyKey) {
+      throw new Error(`Cannot get dependency key for temp project: `
+      + `${tempProjectName}`);
+    }
 
     const packageDescription: IPnpmShrinkwrapDependencyYaml | undefined =
       this._getPackageDescription(tempProjectDependencyKey);
@@ -278,7 +272,13 @@ export class PnpmShrinkwrapFile extends BaseShrinkwrapFile {
    * Returns the version of a dependency being used by a given project
    */
   private _getDependencyVersion(dependencyName: string, tempProjectName: string): string | undefined {
-    const tempProjectDependencyKey: string = this.getTempProjectKey(tempProjectName);
+    const tempProjectDependencyKey: string | undefined = this.getTopLevelDependencyVersion(tempProjectName);
+
+    if (!tempProjectDependencyKey) {
+      throw new Error(`Cannot get dependency key for temp project: `
+      + `${tempProjectName}`);
+    }
+
     const packageDescription: IPnpmShrinkwrapDependencyYaml | undefined =
       this._getPackageDescription(tempProjectDependencyKey);
     if (!packageDescription) {

--- a/apps/rush-lib/src/logic/pnpm/PnpmShrinkwrapFile.ts
+++ b/apps/rush-lib/src/logic/pnpm/PnpmShrinkwrapFile.ts
@@ -1,7 +1,7 @@
 import * as yaml from 'js-yaml';
 import * as os from 'os';
 import * as semver from 'semver';
-import { PackageName, FileSystem } from '@microsoft/node-core-library';
+import { FileSystem } from '@microsoft/node-core-library';
 
 import { BaseShrinkwrapFile } from '../base/BaseShrinkwrapFile';
 
@@ -161,10 +161,28 @@ export class PnpmShrinkwrapFile extends BaseShrinkwrapFile {
   }
 
   /**
+   * Gets the dependency key name of the given temporary project
+   * Examples of the return value:
+   *   file:projects/empty-webpart-project.tgz
+   *   file:projects/article-site-demo.tgz_jest@22.4.4+typescript@2.9.2
+   *   file:projects/i18n-utilities.tgz_462eaf34881863298955eb323c130fc7
+   */
+  public getTempProjectKey(tempProjectName: string): string {
+    const tempProjectDependencyKey: string | undefined = this.getTopLevelDependencyVersion(tempProjectName);
+
+    if (!tempProjectDependencyKey) {
+      throw new Error(`Cannot get dependency key for temp project: `
+      + `${tempProjectName}`);
+    }
+
+    return tempProjectDependencyKey;
+  }
+
+  /**
    * Gets the version number from the list of top-level dependencies in the "dependencies" section
    * of the shrinkwrap file
    */
-  public getTopLevelDependencyVersion(dependencyName: string): string | undefined {
+  protected getTopLevelDependencyVersion(dependencyName: string): string | undefined {
     return BaseShrinkwrapFile.tryGetValue(this._shrinkwrapJson.dependencies, dependencyName);
   }
 
@@ -191,7 +209,8 @@ export class PnpmShrinkwrapFile extends BaseShrinkwrapFile {
     // Because of this, we actually need to check for a version that this package is directly
     // linked to.
 
-    const tempProjectDependencyKey: string = this._getTempProjectKey(tempProjectName);
+    const tempProjectDependencyKey: string = this.getTempProjectKey(tempProjectName);
+
     const packageDescription: IPnpmShrinkwrapDependencyYaml | undefined =
       this._getPackageDescription(tempProjectDependencyKey);
     if (!packageDescription) {
@@ -259,7 +278,7 @@ export class PnpmShrinkwrapFile extends BaseShrinkwrapFile {
    * Returns the version of a dependency being used by a given project
    */
   private _getDependencyVersion(dependencyName: string, tempProjectName: string): string | undefined {
-    const tempProjectDependencyKey: string = this._getTempProjectKey(tempProjectName);
+    const tempProjectDependencyKey: string = this.getTempProjectKey(tempProjectName);
     const packageDescription: IPnpmShrinkwrapDependencyYaml | undefined =
       this._getPackageDescription(tempProjectDependencyKey);
     if (!packageDescription) {
@@ -290,12 +309,6 @@ export class PnpmShrinkwrapFile extends BaseShrinkwrapFile {
   private _getValidDependencyVersion(dependencyVersion: string): string {
     const validDependencyVersion: string = dependencyVersion.split('/').pop()!;
     return semver.valid(validDependencyVersion) ? validDependencyVersion : dependencyVersion.split('_')[0]!;
-  }
-
-  private _getTempProjectKey(tempProjectName: string): string {
-    // Example: "project1"
-    const unscopedTempProjectName: string = PackageName.getUnscopedName(tempProjectName);
-    return `file:projects/${unscopedTempProjectName}.tgz`;
   }
 
   private _normalizeDependencyVersion(dependencyName: string, version: string): string | undefined {

--- a/apps/rush-lib/src/logic/test/shrinkwrapFile/pnpm-lock.yaml
+++ b/apps/rush-lib/src/logic/test/shrinkwrapFile/pnpm-lock.yaml
@@ -1,7 +1,7 @@
 dependencies:
-  '@rush-temp/project1': 'file:./projects/project1.tgz'
-  '@rush-temp/project2': 'file:./projects/project2.tgz'
-  '@rush-temp/project3': 'file:./projects/project3.tgz'
+  '@rush-temp/project1': 'file:projects/project1.tgz'
+  '@rush-temp/project2': 'file:projects/project2.tgz'
+  '@rush-temp/project3': 'file:projects/project3.tgz'
 packages:
   /jquery/1.0.0:
     resolution:

--- a/common/changes/@microsoft/rush/sachinjoseph-fix1392_2019-07-17-04-50.json
+++ b/common/changes/@microsoft/rush/sachinjoseph-fix1392_2019-07-17-04-50.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Fix 1392 \"rush install not working on pnpm 3.5\" by getting the temporary project dependency key from the shrinkwrap file. See  https://github.com/microsoft/web-build-tools/issues/1392.",
+      "packageName": "@microsoft/rush",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "sachinjoseph@users.noreply.github.com"
+}


### PR DESCRIPTION
Fix #1392 "rush install not working on pnpm 3.5" by getting the temporary project dependency key from the shrinkwrap.