### PR TITLE
[api-extractor] Rename ApiItem.canonicalReference to ApiItem.containerKey

### DIFF
--- a/apps/api-documenter/package.json
+++ b/apps/api-documenter/package.json
@@ -18,7 +18,7 @@
     "@microsoft/api-extractor-model": "7.2.0",
     "@microsoft/node-core-library": "3.13.0",
     "@microsoft/ts-command-line": "4.2.6",
-    "@microsoft/tsdoc": "0.12.9",
+    "@microsoft/tsdoc": "0.12.10",
     "colors": "~1.2.1",
     "js-yaml": "~3.13.1"
   },

--- a/apps/api-extractor-model/package.json
+++ b/apps/api-extractor-model/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@microsoft/node-core-library": "3.13.0",
-    "@microsoft/tsdoc": "0.12.9",
+    "@microsoft/tsdoc": "0.12.10",
     "@types/node": "8.5.8"
   },
   "devDependencies": {

--- a/apps/api-extractor-model/src/items/ApiItem.ts
+++ b/apps/api-extractor-model/src/items/ApiItem.ts
@@ -44,7 +44,6 @@ export interface IApiItemOptions {
 
 export interface IApiItemJson {
   kind: ApiItemKind;
-  containerKey: string;
 }
 
 /**
@@ -85,7 +84,6 @@ export class ApiItem {
   /** @virtual */
   public serializeInto(jsonObject: Partial<IApiItemJson>): void {
     jsonObject.kind = this.kind;
-    jsonObject.containerKey = this.containerKey;
   }
 
   /**

--- a/apps/api-extractor-model/src/items/ApiItem.ts
+++ b/apps/api-extractor-model/src/items/ApiItem.ts
@@ -44,7 +44,7 @@ export interface IApiItemOptions {
 
 export interface IApiItemJson {
   kind: ApiItemKind;
-  canonicalReference: string;
+  containerKey: string;
 }
 
 /**
@@ -85,17 +85,29 @@ export class ApiItem {
   /** @virtual */
   public serializeInto(jsonObject: Partial<IApiItemJson>): void {
     jsonObject.kind = this.kind;
-    jsonObject.canonicalReference = this.canonicalReference;
+    jsonObject.containerKey = this.containerKey;
   }
 
-  /** @virtual */
+  /**
+   * Identifies the subclass of the `ApiItem` base class.
+   * @virtual
+   */
   public get kind(): ApiItemKind {
     throw new Error('ApiItem.kind was not implemented by the child class');
   }
 
-  /** @virtual */
-  public get canonicalReference(): string {
-    throw new Error('ApiItem.canonicalReference was not implemented by the child class');
+  /**
+   * Returns a string key that can be used to efficiently retrieve an `ApiItem` from an `ApiItemContainerMixin`.
+   * The key is unique within the container.  Its format is undocumented and may change at any time.
+   *
+   * @remarks
+   * Use the `getContainerKey()` static member to construct the key.  Each subclass has a different implementation
+   * of this function, according to the aspects that are important for identifying it.
+   *
+   * @virtual
+   */
+  public get containerKey(): string {
+    throw new Error('ApiItem.containerKey was not implemented by the child class');
   }
 
   /**
@@ -203,7 +215,7 @@ export class ApiItem {
 
   /** @virtual */
   public getSortKey(): string {
-    return this.canonicalReference;
+    return this.containerKey;
   }
 }
 

--- a/apps/api-extractor-model/src/mixins/ApiItemContainerMixin.ts
+++ b/apps/api-extractor-model/src/mixins/ApiItemContainerMixin.ts
@@ -19,7 +19,7 @@ export interface IApiItemContainerJson extends IApiItemJson {
 
 const _members: unique symbol = Symbol('ApiItemContainerMixin._members');
 const _membersSorted: unique symbol = Symbol('ApiItemContainerMixin._membersSorted');
-const _membersByCanonicalReference: unique symbol = Symbol('ApiItemContainerMixin._membersByCanonicalReference');
+const _membersByContainerKey: unique symbol = Symbol('ApiItemContainerMixin._membersByContainerKey');
 const _membersByName: unique symbol = Symbol('ApiItemContainerMixin._membersByName');
 
 /**
@@ -58,9 +58,15 @@ export interface ApiItemContainerMixin extends ApiItem {
   addMember(member: ApiItem): void;
 
   /**
-   * Attempts to retrieve a member using its canonicalReference, or returns undefined if no matching member was found.
+   * Attempts to retrieve a member using its containerKey, or returns `undefined` if no matching member was found.
+   *
+   * @remarks
+   * Use the `getContainerKey()` static member to construct the key.  Each subclass has a different implementation
+   * of this function, according to the aspects that are important for identifying it.
+   *
+   * See {@link ApiItem.containerKey} for more information.
    */
-  tryGetMember(canonicalReference: string): ApiItem | undefined;
+  tryGetMemberByKey(containerKey: string): ApiItem | undefined;
 
   /**
    * Returns a list of members with the specified name.
@@ -85,7 +91,7 @@ export function ApiItemContainerMixin<TBaseClass extends IApiItemConstructor>(ba
   abstract class MixedClass extends baseClass implements ApiItemContainerMixin {
     public readonly [_members]: ApiItem[];
     public [_membersSorted]: boolean;
-    public [_membersByCanonicalReference]: Map<string, ApiItem>;
+    public [_membersByContainerKey]: Map<string, ApiItem>;
     public [_membersByName]: Map<string, ApiItem[]> | undefined;
 
     /** @override */
@@ -106,7 +112,7 @@ export function ApiItemContainerMixin<TBaseClass extends IApiItemConstructor>(ba
       const options: IApiItemContainerMixinOptions = args[0] as IApiItemContainerMixinOptions;
 
       this[_members] = [];
-      this[_membersByCanonicalReference] = new Map<string, ApiItem>();
+      this[_membersByContainerKey] = new Map<string, ApiItem>();
 
       if (options.members) {
         for (const member of options.members) {
@@ -125,8 +131,8 @@ export function ApiItemContainerMixin<TBaseClass extends IApiItemConstructor>(ba
     }
 
     public addMember(member: ApiItem): void {
-      if (this[_membersByCanonicalReference].has(member.canonicalReference)) {
-        throw new Error('Another member has already been added with the same name and canonicalReference');
+      if (this[_membersByContainerKey].has(member.containerKey)) {
+        throw new Error('Another member has already been added with the same name and containerKey');
       }
 
       const existingParent: ApiItem | undefined = member[ApiItem_parent];
@@ -137,13 +143,13 @@ export function ApiItemContainerMixin<TBaseClass extends IApiItemConstructor>(ba
       this[_members].push(member);
       this[_membersByName] = undefined; // invalidate the lookup
       this[_membersSorted] = false;
-      this[_membersByCanonicalReference].set(member.canonicalReference, member);
+      this[_membersByContainerKey].set(member.containerKey, member);
 
       member[ApiItem_parent] = this;
     }
 
-    public tryGetMember(canonicalReference: string): ApiItem | undefined {
-      return this[_membersByCanonicalReference].get(canonicalReference);
+    public tryGetMemberByKey(containerKey: string): ApiItem | undefined {
+      return this[_membersByContainerKey].get(containerKey);
     }
 
     public findMembersByName(name: string): ReadonlyArray<ApiItem> {

--- a/apps/api-extractor-model/src/model/ApiCallSignature.ts
+++ b/apps/api-extractor-model/src/model/ApiCallSignature.ts
@@ -52,8 +52,8 @@ export interface IApiCallSignatureOptions extends
 export class ApiCallSignature extends ApiTypeParameterListMixin(ApiParameterListMixin(ApiReleaseTagMixin(
   ApiReturnTypeMixin(ApiDeclaredItem)))) {
 
-  public static getCanonicalReference(overloadIndex: number): string {
-    return `(:call,${overloadIndex})`;
+  public static getContainerKey(overloadIndex: number): string {
+    return `|${ApiItemKind.CallSignature}|${overloadIndex}`;
   }
 
   public constructor(options: IApiCallSignatureOptions) {
@@ -66,7 +66,7 @@ export class ApiCallSignature extends ApiTypeParameterListMixin(ApiParameterList
   }
 
   /** @override */
-  public get canonicalReference(): string {
-    return ApiCallSignature.getCanonicalReference(this.overloadIndex);
+  public get containerKey(): string {
+    return ApiCallSignature.getContainerKey(this.overloadIndex);
   }
 }

--- a/apps/api-extractor-model/src/model/ApiClass.ts
+++ b/apps/api-extractor-model/src/model/ApiClass.ts
@@ -60,8 +60,8 @@ export class ApiClass extends ApiItemContainerMixin(ApiNameMixin(ApiTypeParamete
 
   private readonly _implementsTypes: HeritageType[] = [];
 
-  public static getCanonicalReference(name: string): string {
-    return `(${name}:class)`;
+  public static getContainerKey(name: string): string {
+    return `${name}|${ApiItemKind.Class}`;
   }
 
   /** @override */
@@ -94,8 +94,8 @@ export class ApiClass extends ApiItemContainerMixin(ApiNameMixin(ApiTypeParamete
   }
 
   /** @override */
-  public get canonicalReference(): string {
-    return ApiClass.getCanonicalReference(this.name);
+  public get containerKey(): string {
+    return ApiClass.getContainerKey(this.name);
   }
 
   /**

--- a/apps/api-extractor-model/src/model/ApiConstructSignature.ts
+++ b/apps/api-extractor-model/src/model/ApiConstructSignature.ts
@@ -65,8 +65,8 @@ export interface IApiConstructSignatureOptions extends
 export class ApiConstructSignature extends ApiTypeParameterListMixin(ApiParameterListMixin(ApiReleaseTagMixin(
   ApiReturnTypeMixin(ApiDeclaredItem)))) {
 
-  public static getCanonicalReference(overloadIndex: number): string {
-    return `(:new,${overloadIndex})`;
+  public static getContainerKey(overloadIndex: number): string {
+    return `|${ApiItemKind.ConstructSignature}|${overloadIndex}`;
   }
 
   public constructor(options: IApiConstructSignatureOptions) {
@@ -79,7 +79,7 @@ export class ApiConstructSignature extends ApiTypeParameterListMixin(ApiParamete
   }
 
   /** @override */
-  public get canonicalReference(): string {
-    return ApiConstructSignature.getCanonicalReference(this.overloadIndex);
+  public get containerKey(): string {
+    return ApiConstructSignature.getContainerKey(this.overloadIndex);
   }
 }

--- a/apps/api-extractor-model/src/model/ApiConstructor.ts
+++ b/apps/api-extractor-model/src/model/ApiConstructor.ts
@@ -45,8 +45,8 @@ export interface IApiConstructorOptions extends
  */
 export class ApiConstructor extends ApiParameterListMixin(ApiReleaseTagMixin(ApiDeclaredItem)) {
 
-  public static getCanonicalReference(overloadIndex: number): string {
-    return `(:constructor,${overloadIndex})`;
+  public static getContainerKey(overloadIndex: number): string {
+    return `|${ApiItemKind.Constructor}|${overloadIndex}`;
   }
 
   public constructor(options: IApiConstructorOptions) {
@@ -59,7 +59,7 @@ export class ApiConstructor extends ApiParameterListMixin(ApiReleaseTagMixin(Api
   }
 
   /** @override */
-  public get canonicalReference(): string {
-    return ApiConstructor.getCanonicalReference(this.overloadIndex);
+  public get containerKey(): string {
+    return ApiConstructor.getContainerKey(this.overloadIndex);
   }
 }

--- a/apps/api-extractor-model/src/model/ApiEntryPoint.ts
+++ b/apps/api-extractor-model/src/model/ApiEntryPoint.ts
@@ -47,7 +47,8 @@ export class ApiEntryPoint extends ApiItemContainerMixin(ApiNameMixin(ApiItem)) 
   }
 
   /** @override */
-  public get canonicalReference(): string {
+  public get containerKey(): string {
+    // No prefix needed, because ApiEntryPoint is the only possible member of an ApiPackage
     return this.name;
   }
 }

--- a/apps/api-extractor-model/src/model/ApiEnum.ts
+++ b/apps/api-extractor-model/src/model/ApiEnum.ts
@@ -41,8 +41,8 @@ export interface IApiEnumOptions extends
  */
 export class ApiEnum extends ApiItemContainerMixin(ApiNameMixin(ApiReleaseTagMixin(ApiDeclaredItem))) {
 
-  public static getCanonicalReference(name: string): string {
-    return `(${name}:enum)`;
+  public static getContainerKey(name: string): string {
+    return `${name}|${ApiItemKind.Enum}`;
   }
 
   public constructor(options: IApiEnumOptions) {
@@ -60,8 +60,8 @@ export class ApiEnum extends ApiItemContainerMixin(ApiNameMixin(ApiReleaseTagMix
   }
 
   /** @override */
-  public get canonicalReference(): string {
-    return ApiEnum.getCanonicalReference(this.name);
+  public get containerKey(): string {
+    return ApiEnum.getContainerKey(this.name);
   }
 
   /** @override */

--- a/apps/api-extractor-model/src/model/ApiEnumMember.ts
+++ b/apps/api-extractor-model/src/model/ApiEnumMember.ts
@@ -50,7 +50,8 @@ export class ApiEnumMember extends ApiNameMixin(ApiReleaseTagMixin(ApiDeclaredIt
    */
   public readonly initializerExcerpt: Excerpt;
 
-  public static getCanonicalReference(name: string): string {
+  public static getContainerKey(name: string): string {
+    // No prefix needed, because ApiEnumMember is the only possible member of an ApiEnum
     return name;
   }
 
@@ -75,8 +76,8 @@ export class ApiEnumMember extends ApiNameMixin(ApiReleaseTagMixin(ApiDeclaredIt
   }
 
   /** @override */
-  public get canonicalReference(): string {
-    return ApiEnumMember.getCanonicalReference(this.name);
+  public get containerKey(): string {
+    return ApiEnumMember.getContainerKey(this.name);
   }
 
   /** @override */

--- a/apps/api-extractor-model/src/model/ApiFunction.ts
+++ b/apps/api-extractor-model/src/model/ApiFunction.ts
@@ -46,8 +46,8 @@ export interface IApiFunctionOptions extends
 export class ApiFunction extends ApiNameMixin(ApiTypeParameterListMixin(ApiParameterListMixin(ApiReleaseTagMixin(
   ApiReturnTypeMixin(ApiDeclaredItem))))) {
 
-  public static getCanonicalReference(name: string, overloadIndex: number): string {
-    return `(${name}:${overloadIndex})`;
+  public static getContainerKey(name: string, overloadIndex: number): string {
+    return `${name}|${ApiItemKind.Function}|${overloadIndex}`;
   }
 
   public constructor(options: IApiFunctionOptions) {
@@ -60,7 +60,7 @@ export class ApiFunction extends ApiNameMixin(ApiTypeParameterListMixin(ApiParam
   }
 
   /** @override */
-  public get canonicalReference(): string {
-    return ApiFunction.getCanonicalReference(this.name, this.overloadIndex);
+  public get containerKey(): string {
+    return ApiFunction.getContainerKey(this.name, this.overloadIndex);
   }
 }

--- a/apps/api-extractor-model/src/model/ApiIndexSignature.ts
+++ b/apps/api-extractor-model/src/model/ApiIndexSignature.ts
@@ -42,8 +42,8 @@ export interface IApiIndexSignatureOptions extends
  */
 export class ApiIndexSignature extends ApiParameterListMixin(ApiReleaseTagMixin(ApiReturnTypeMixin(ApiDeclaredItem))) {
 
-  public static getCanonicalReference(overloadIndex: number): string {
-    return `(:index,${overloadIndex})`;
+  public static getContainerKey(overloadIndex: number): string {
+    return `|${ApiItemKind.IndexSignature}|${overloadIndex}`;
   }
 
   public constructor(options: IApiIndexSignatureOptions) {
@@ -56,7 +56,7 @@ export class ApiIndexSignature extends ApiParameterListMixin(ApiReleaseTagMixin(
   }
 
   /** @override */
-  public get canonicalReference(): string {
-    return ApiIndexSignature.getCanonicalReference(this.overloadIndex);
+  public get containerKey(): string {
+    return ApiIndexSignature.getContainerKey(this.overloadIndex);
   }
 }

--- a/apps/api-extractor-model/src/model/ApiInterface.ts
+++ b/apps/api-extractor-model/src/model/ApiInterface.ts
@@ -59,8 +59,8 @@ export class ApiInterface extends ApiItemContainerMixin(ApiNameMixin(ApiTypePara
 
   private readonly _extendsTypes: HeritageType[] = [];
 
-  public static getCanonicalReference(name: string): string {
-    return `(${name}:interface)`;
+  public static getContainerKey(name: string): string {
+    return `${name}|${ApiItemKind.Interface}`;
   }
 
   /** @override */
@@ -86,8 +86,8 @@ export class ApiInterface extends ApiItemContainerMixin(ApiNameMixin(ApiTypePara
   }
 
   /** @override */
-  public get canonicalReference(): string {
-    return ApiInterface.getCanonicalReference(this.name);
+  public get containerKey(): string {
+    return ApiInterface.getContainerKey(this.name);
   }
 
   /**

--- a/apps/api-extractor-model/src/model/ApiMethod.ts
+++ b/apps/api-extractor-model/src/model/ApiMethod.ts
@@ -48,11 +48,11 @@ export interface IApiMethodOptions extends
 export class ApiMethod extends ApiNameMixin(ApiTypeParameterListMixin(ApiParameterListMixin(
   ApiReleaseTagMixin(ApiReturnTypeMixin(ApiStaticMixin(ApiDeclaredItem)))))) {
 
-  public static getCanonicalReference(name: string, isStatic: boolean, overloadIndex: number): string {
+  public static getContainerKey(name: string, isStatic: boolean, overloadIndex: number): string {
     if (isStatic) {
-      return `(${name}:static,${overloadIndex})`;
+      return `${name}|${ApiItemKind.Method}|static|${overloadIndex}`;
     } else {
-      return `(${name}:instance,${overloadIndex})`;
+      return `${name}|${ApiItemKind.Method}|instance|${overloadIndex}`;
     }
   }
 
@@ -66,7 +66,7 @@ export class ApiMethod extends ApiNameMixin(ApiTypeParameterListMixin(ApiParamet
   }
 
   /** @override */
-  public get canonicalReference(): string {
-    return ApiMethod.getCanonicalReference(this.name, this.isStatic, this.overloadIndex);
+  public get containerKey(): string {
+    return ApiMethod.getContainerKey(this.name, this.isStatic, this.overloadIndex);
   }
 }

--- a/apps/api-extractor-model/src/model/ApiMethodSignature.ts
+++ b/apps/api-extractor-model/src/model/ApiMethodSignature.ts
@@ -43,8 +43,8 @@ export interface IApiMethodSignatureOptions extends
 export class ApiMethodSignature extends ApiNameMixin(ApiTypeParameterListMixin(ApiParameterListMixin(
   ApiReleaseTagMixin(ApiReturnTypeMixin(ApiDeclaredItem))))) {
 
-  public static getCanonicalReference(name: string, overloadIndex: number): string {
-    return `(${name}:${overloadIndex})`;
+  public static getContainerKey(name: string, overloadIndex: number): string {
+    return `${name}|${ApiItemKind.MethodSignature}|${overloadIndex}`;
   }
 
   public constructor(options: IApiMethodSignatureOptions) {
@@ -57,7 +57,7 @@ export class ApiMethodSignature extends ApiNameMixin(ApiTypeParameterListMixin(A
   }
 
   /** @override */
-  public get canonicalReference(): string {
-    return ApiMethodSignature.getCanonicalReference(this.name, this.overloadIndex);
+  public get containerKey(): string {
+    return ApiMethodSignature.getContainerKey(this.name, this.overloadIndex);
   }
 }

--- a/apps/api-extractor-model/src/model/ApiModel.ts
+++ b/apps/api-extractor-model/src/model/ApiModel.ts
@@ -71,7 +71,7 @@ export class ApiModel extends ApiItemContainerMixin(ApiItem) {
   }
 
   /** @override */
-  public get canonicalReference(): string {
+  public get containerKey(): string {
     return '';
   }
 

--- a/apps/api-extractor-model/src/model/ApiNamespace.ts
+++ b/apps/api-extractor-model/src/model/ApiNamespace.ts
@@ -42,8 +42,8 @@ export interface IApiNamespaceOptions extends
  */
 export class ApiNamespace extends ApiItemContainerMixin(ApiNameMixin(ApiReleaseTagMixin(ApiDeclaredItem))) {
 
-    public static getCanonicalReference(name: string): string {
-    return `(${name}:namespace)`;
+  public static getContainerKey(name: string): string {
+    return `${name}|${ApiItemKind.Namespace}`;
   }
 
   public constructor(options: IApiNamespaceOptions) {
@@ -56,7 +56,7 @@ export class ApiNamespace extends ApiItemContainerMixin(ApiNameMixin(ApiReleaseT
   }
 
   /** @override */
-  public get canonicalReference(): string {
-    return ApiNamespace.getCanonicalReference(this.name);
+  public get containerKey(): string {
+    return ApiNamespace.getContainerKey(this.name);
   }
 }

--- a/apps/api-extractor-model/src/model/ApiPackage.ts
+++ b/apps/api-extractor-model/src/model/ApiPackage.ts
@@ -162,7 +162,8 @@ export class ApiPackage extends ApiItemContainerMixin(ApiNameMixin(ApiDocumented
   }
 
   /** @override */
-  public get canonicalReference(): string {
+  public get containerKey(): string {
+    // No prefix needed, because ApiPackage is the only possible member of an ApiModel
     return this.name;
   }
 

--- a/apps/api-extractor-model/src/model/ApiProperty.ts
+++ b/apps/api-extractor-model/src/model/ApiProperty.ts
@@ -49,11 +49,11 @@ export interface IApiPropertyOptions extends IApiPropertyItemOptions,
  */
 export class ApiProperty extends ApiStaticMixin(ApiPropertyItem) {
 
-  public static getCanonicalReference(name: string, isStatic: boolean): string {
+  public static getContainerKey(name: string, isStatic: boolean): string {
     if (isStatic) {
-      return `(${name}:static)`;
+      return `${name}|${ApiItemKind.Property}|static`;
     } else {
-      return `(${name}:instance)`;
+      return `${name}|${ApiItemKind.Property}|instance`;
     }
   }
 
@@ -67,7 +67,7 @@ export class ApiProperty extends ApiStaticMixin(ApiPropertyItem) {
   }
 
   /** @override */
-  public get canonicalReference(): string {
-    return ApiProperty.getCanonicalReference(this.name, this.isStatic);
+  public get containerKey(): string {
+    return ApiProperty.getContainerKey(this.name, this.isStatic);
   }
 }

--- a/apps/api-extractor-model/src/model/ApiPropertySignature.ts
+++ b/apps/api-extractor-model/src/model/ApiPropertySignature.ts
@@ -35,8 +35,8 @@ export interface IApiPropertySignatureOptions extends IApiPropertyItemOptions {
  */
 export class ApiPropertySignature extends ApiPropertyItem {
 
-  public static getCanonicalReference(name: string): string {
-    return name;
+  public static getContainerKey(name: string): string {
+    return `${name}|${ApiItemKind.PropertySignature}`;
   }
 
   public constructor(options: IApiPropertySignatureOptions) {
@@ -49,7 +49,7 @@ export class ApiPropertySignature extends ApiPropertyItem {
   }
 
   /** @override */
-  public get canonicalReference(): string {
-    return ApiPropertySignature.getCanonicalReference(this.name);
+  public get containerKey(): string {
+    return ApiPropertySignature.getContainerKey(this.name);
   }
 }

--- a/apps/api-extractor-model/src/model/ApiTypeAlias.ts
+++ b/apps/api-extractor-model/src/model/ApiTypeAlias.ts
@@ -77,8 +77,8 @@ export class ApiTypeAlias extends ApiTypeParameterListMixin(ApiNameMixin(ApiRele
     options.typeTokenRange = jsonObject.typeTokenRange;
   }
 
-  public static getCanonicalReference(name: string): string {
-    return name;
+  public static getContainerKey(name: string): string {
+    return `${name}|${ApiItemKind.TypeAlias}`;
   }
 
   public constructor(options: IApiTypeAliasOptions) {
@@ -93,8 +93,8 @@ export class ApiTypeAlias extends ApiTypeParameterListMixin(ApiNameMixin(ApiRele
   }
 
   /** @override */
-  public get canonicalReference(): string {
-    return ApiTypeAlias.getCanonicalReference(this.name);
+  public get containerKey(): string {
+    return ApiTypeAlias.getContainerKey(this.name);
   }
 
   /** @override */

--- a/apps/api-extractor-model/src/model/ApiVariable.ts
+++ b/apps/api-extractor-model/src/model/ApiVariable.ts
@@ -59,8 +59,8 @@ export class ApiVariable extends ApiNameMixin(ApiReleaseTagMixin(ApiDeclaredItem
     options.variableTypeTokenRange = jsonObject.variableTypeTokenRange;
   }
 
-  public static getCanonicalReference(name: string): string {
-    return name;
+  public static getContainerKey(name: string): string {
+    return `${name}|${ApiItemKind.Variable}`;
   }
 
   public constructor(options: IApiVariableOptions) {
@@ -75,8 +75,8 @@ export class ApiVariable extends ApiNameMixin(ApiReleaseTagMixin(ApiDeclaredItem
   }
 
   /** @override */
-  public get canonicalReference(): string {
-    return ApiVariable.getCanonicalReference(this.name);
+  public get containerKey(): string {
+    return ApiVariable.getContainerKey(this.name);
   }
 
   /** @override */

--- a/apps/api-extractor-model/src/model/DeserializerContext.ts
+++ b/apps/api-extractor-model/src/model/DeserializerContext.ts
@@ -13,12 +13,17 @@ export enum ApiJsonSchemaVersion {
   V_1001 = 1001,
 
   /**
+   * Remove "canonicalReference" field.  This field was for diagnostic purposes only and was never deserialized.
+   */
+  V_1002 = 1002,
+
+  /**
    * The current latest .api.json schema version.
    *
    * IMPORTANT: When incrementing this number, consider whether `OLDEST_SUPPORTED` or `OLDEST_FORWARDS_COMPATIBLE`
    * should be updated.
    */
-  LATEST = V_1001,
+  LATEST = V_1002,
 
   /**
    * The oldest .api.json schema version that is still supported for backwards compatibility.

--- a/apps/api-extractor/package.json
+++ b/apps/api-extractor/package.json
@@ -38,7 +38,7 @@
     "@microsoft/api-extractor-model": "7.2.0",
     "@microsoft/node-core-library": "3.13.0",
     "@microsoft/ts-command-line": "4.2.6",
-    "@microsoft/tsdoc": "0.12.9",
+    "@microsoft/tsdoc": "0.12.10",
     "colors": "~1.2.1",
     "lodash": "~4.17.5",
     "resolve": "1.8.1",

--- a/apps/api-extractor/src/generators/ApiModelGenerator.ts
+++ b/apps/api-extractor/src/generators/ApiModelGenerator.ts
@@ -176,10 +176,10 @@ export class ApiModelGenerator {
     parentApiItem: ApiItemContainerMixin): void {
 
     const overloadIndex: number = this._getOverloadIndex(astDeclaration);
-    const canonicalReference: string = ApiCallSignature.getCanonicalReference(overloadIndex);
+    const containerKey: string = ApiCallSignature.getContainerKey(overloadIndex);
 
-    let apiCallSignature: ApiCallSignature | undefined = parentApiItem.tryGetMember(canonicalReference) as
-    ApiCallSignature;
+    let apiCallSignature: ApiCallSignature | undefined = parentApiItem.tryGetMemberByKey(containerKey) as
+      ApiCallSignature;
 
     if (apiCallSignature === undefined) {
       const callSignature: ts.CallSignatureDeclaration = astDeclaration.declaration as ts.CallSignatureDeclaration;
@@ -212,9 +212,9 @@ export class ApiModelGenerator {
     parentApiItem: ApiItemContainerMixin): void {
 
     const overloadIndex: number = this._getOverloadIndex(astDeclaration);
-    const canonicalReference: string = ApiConstructor.getCanonicalReference(overloadIndex);
+    const containerKey: string = ApiConstructor.getContainerKey(overloadIndex);
 
-    let apiConstructor: ApiConstructor | undefined = parentApiItem.tryGetMember(canonicalReference) as ApiConstructor;
+    let apiConstructor: ApiConstructor | undefined = parentApiItem.tryGetMemberByKey(containerKey) as ApiConstructor;
 
     if (apiConstructor === undefined) {
       const constructorDeclaration: ts.ConstructorDeclaration = astDeclaration.declaration as ts.ConstructorDeclaration;
@@ -243,9 +243,9 @@ export class ApiModelGenerator {
     parentApiItem: ApiItemContainerMixin): void {
 
     const name: string = !!exportedName ? exportedName : astDeclaration.astSymbol.localName;
-    const canonicalReference: string = ApiClass.getCanonicalReference(name);
+    const containerKey: string = ApiClass.getContainerKey(name);
 
-    let apiClass: ApiClass | undefined = parentApiItem.tryGetMember(canonicalReference) as ApiClass;
+    let apiClass: ApiClass | undefined = parentApiItem.tryGetMemberByKey(containerKey) as ApiClass;
 
     if (apiClass === undefined) {
       const classDeclaration: ts.ClassDeclaration = astDeclaration.declaration as ts.ClassDeclaration;
@@ -294,9 +294,9 @@ export class ApiModelGenerator {
     parentApiItem: ApiItemContainerMixin): void {
 
     const overloadIndex: number = this._getOverloadIndex(astDeclaration);
-    const canonicalReference: string = ApiConstructSignature.getCanonicalReference(overloadIndex);
+    const containerKey: string = ApiConstructSignature.getContainerKey(overloadIndex);
 
-    let apiConstructSignature: ApiConstructSignature | undefined = parentApiItem.tryGetMember(canonicalReference) as
+    let apiConstructSignature: ApiConstructSignature | undefined = parentApiItem.tryGetMemberByKey(containerKey) as
       ApiConstructSignature;
 
     if (apiConstructSignature === undefined) {
@@ -331,9 +331,9 @@ export class ApiModelGenerator {
     parentApiItem: ApiItemContainerMixin): void {
 
     const name: string = !!exportedName ? exportedName : astDeclaration.astSymbol.localName;
-    const canonicalReference: string = ApiEnum.getCanonicalReference(name);
+    const containerKey: string = ApiEnum.getContainerKey(name);
 
-    let apiEnum: ApiEnum | undefined = parentApiItem.tryGetMember(canonicalReference) as ApiEnum;
+    let apiEnum: ApiEnum | undefined = parentApiItem.tryGetMemberByKey(containerKey) as ApiEnum;
 
     if (apiEnum === undefined) {
       const excerptTokens: IExcerptToken[] = ExcerptBuilder.build({
@@ -355,9 +355,9 @@ export class ApiModelGenerator {
     parentApiItem: ApiItemContainerMixin): void {
 
     const name: string = !!exportedName ? exportedName : astDeclaration.astSymbol.localName;
-    const canonicalReference: string = ApiEnumMember.getCanonicalReference(name);
+    const containerKey: string = ApiEnumMember.getContainerKey(name);
 
-    let apiEnumMember: ApiEnumMember | undefined = parentApiItem.tryGetMember(canonicalReference) as ApiEnumMember;
+    let apiEnumMember: ApiEnumMember | undefined = parentApiItem.tryGetMemberByKey(containerKey) as ApiEnumMember;
 
     if (apiEnumMember === undefined) {
       const enumMember: ts.EnumMember = astDeclaration.declaration as ts.EnumMember;
@@ -388,9 +388,9 @@ export class ApiModelGenerator {
     const name: string = !!exportedName ? exportedName : astDeclaration.astSymbol.localName;
 
     const overloadIndex: number = this._getOverloadIndex(astDeclaration);
-    const canonicalReference: string = ApiFunction.getCanonicalReference(name, overloadIndex);
+    const containerKey: string = ApiFunction.getContainerKey(name, overloadIndex);
 
-    let apiFunction: ApiFunction | undefined = parentApiItem.tryGetMember(canonicalReference) as
+    let apiFunction: ApiFunction | undefined = parentApiItem.tryGetMemberByKey(containerKey) as
       ApiFunction;
 
     if (apiFunction === undefined) {
@@ -425,9 +425,9 @@ export class ApiModelGenerator {
     parentApiItem: ApiItemContainerMixin): void {
 
     const overloadIndex: number = this._getOverloadIndex(astDeclaration);
-    const canonicalReference: string = ApiIndexSignature.getCanonicalReference(overloadIndex);
+    const containerKey: string = ApiIndexSignature.getContainerKey(overloadIndex);
 
-    let apiIndexSignature: ApiIndexSignature | undefined = parentApiItem.tryGetMember(canonicalReference) as
+    let apiIndexSignature: ApiIndexSignature | undefined = parentApiItem.tryGetMemberByKey(containerKey) as
     ApiIndexSignature;
 
     if (apiIndexSignature === undefined) {
@@ -458,9 +458,9 @@ export class ApiModelGenerator {
     parentApiItem: ApiItemContainerMixin): void {
 
     const name: string = !!exportedName ? exportedName : astDeclaration.astSymbol.localName;
-    const canonicalReference: string = ApiInterface.getCanonicalReference(name);
+    const containerKey: string = ApiInterface.getContainerKey(name);
 
-    let apiInterface: ApiInterface | undefined = parentApiItem.tryGetMember(canonicalReference) as ApiInterface;
+    let apiInterface: ApiInterface | undefined = parentApiItem.tryGetMemberByKey(containerKey) as ApiInterface;
 
     if (apiInterface === undefined) {
       const interfaceDeclaration: ts.InterfaceDeclaration = astDeclaration.declaration as ts.InterfaceDeclaration;
@@ -507,9 +507,9 @@ export class ApiModelGenerator {
 
     const isStatic: boolean = (astDeclaration.modifierFlags & ts.ModifierFlags.Static) !== 0;
     const overloadIndex: number = this._getOverloadIndex(astDeclaration);
-    const canonicalReference: string = ApiMethod.getCanonicalReference(name, isStatic, overloadIndex);
+    const containerKey: string = ApiMethod.getContainerKey(name, isStatic, overloadIndex);
 
-    let apiMethod: ApiMethod | undefined = parentApiItem.tryGetMember(canonicalReference) as ApiMethod;
+    let apiMethod: ApiMethod | undefined = parentApiItem.tryGetMemberByKey(containerKey) as ApiMethod;
 
     if (apiMethod === undefined) {
       const methodDeclaration: ts.MethodDeclaration = astDeclaration.declaration as ts.MethodDeclaration;
@@ -545,9 +545,9 @@ export class ApiModelGenerator {
     const name: string = !!exportedName ? exportedName : astDeclaration.astSymbol.localName;
 
     const overloadIndex: number = this._getOverloadIndex(astDeclaration);
-    const canonicalReference: string = ApiMethodSignature.getCanonicalReference(name, overloadIndex);
+    const containerKey: string = ApiMethodSignature.getContainerKey(name, overloadIndex);
 
-    let apiMethodSignature: ApiMethodSignature | undefined = parentApiItem.tryGetMember(canonicalReference) as
+    let apiMethodSignature: ApiMethodSignature | undefined = parentApiItem.tryGetMemberByKey(containerKey) as
       ApiMethodSignature;
 
     if (apiMethodSignature === undefined) {
@@ -581,9 +581,9 @@ export class ApiModelGenerator {
     parentApiItem: ApiItemContainerMixin): void {
 
     const name: string = !!exportedName ? exportedName : astDeclaration.astSymbol.localName;
-    const canonicalReference: string = ApiNamespace.getCanonicalReference(name);
+    const containerKey: string = ApiNamespace.getContainerKey(name);
 
-    let apiNamespace: ApiNamespace | undefined = parentApiItem.tryGetMember(canonicalReference) as ApiNamespace;
+    let apiNamespace: ApiNamespace | undefined = parentApiItem.tryGetMemberByKey(containerKey) as ApiNamespace;
 
     if (apiNamespace === undefined) {
       const excerptTokens: IExcerptToken[] = ExcerptBuilder.build({
@@ -608,10 +608,10 @@ export class ApiModelGenerator {
 
     const isStatic: boolean = (astDeclaration.modifierFlags & ts.ModifierFlags.Static) !== 0;
 
-    const canonicalReference: string = ApiProperty.getCanonicalReference(name, isStatic);
+    const containerKey: string = ApiProperty.getContainerKey(name, isStatic);
 
     let apiProperty: ApiProperty | undefined
-      = parentApiItem.tryGetMember(canonicalReference) as ApiProperty;
+      = parentApiItem.tryGetMemberByKey(containerKey) as ApiProperty;
 
     if (apiProperty === undefined) {
       const propertyDeclaration: ts.PropertyDeclaration = astDeclaration.declaration as ts.PropertyDeclaration;
@@ -640,10 +640,10 @@ export class ApiModelGenerator {
     parentApiItem: ApiItemContainerMixin): void {
 
     const name: string = !!exportedName ? exportedName : astDeclaration.astSymbol.localName;
-    const canonicalReference: string = ApiPropertySignature.getCanonicalReference(name);
+    const containerKey: string = ApiPropertySignature.getContainerKey(name);
 
     let apiPropertySignature: ApiPropertySignature | undefined
-      = parentApiItem.tryGetMember(canonicalReference) as ApiPropertySignature;
+      = parentApiItem.tryGetMemberByKey(containerKey) as ApiPropertySignature;
 
     if (apiPropertySignature === undefined) {
       const propertySignature: ts.PropertySignature = astDeclaration.declaration as ts.PropertySignature;
@@ -674,9 +674,9 @@ export class ApiModelGenerator {
 
     const name: string = !!exportedName ? exportedName : astDeclaration.astSymbol.localName;
 
-    const canonicalReference: string = ApiTypeAlias.getCanonicalReference(name);
+    const containerKey: string = ApiTypeAlias.getContainerKey(name);
 
-    let apiTypeAlias: ApiTypeAlias | undefined = parentApiItem.tryGetMember(canonicalReference) as
+    let apiTypeAlias: ApiTypeAlias | undefined = parentApiItem.tryGetMemberByKey(containerKey) as
       ApiTypeAlias;
 
     if (apiTypeAlias === undefined) {
@@ -709,9 +709,9 @@ export class ApiModelGenerator {
 
     const name: string = !!exportedName ? exportedName : astDeclaration.astSymbol.localName;
 
-    const canonicalReference: string = ApiVariable.getCanonicalReference(name);
+    const containerKey: string = ApiVariable.getContainerKey(name);
 
-    let apiVariable: ApiVariable | undefined = parentApiItem.tryGetMember(canonicalReference) as
+    let apiVariable: ApiVariable | undefined = parentApiItem.tryGetMemberByKey(containerKey) as
       ApiVariable;
 
     if (apiVariable === undefined) {

--- a/build-tests/api-documenter-test/etc/api-documenter-test.api.json
+++ b/build-tests/api-documenter-test/etc/api-documenter-test.api.json
@@ -2,22 +2,19 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1001,
+    "schemaVersion": 1002,
     "oldestForwardsCompatibleVersion": 1001
   },
   "kind": "Package",
-  "containerKey": "api-documenter-test",
   "docComment": "/**\n * api-extractor-test-05\n *\n * This project tests various documentation generation scenarios and doc comment syntaxes.\n *\n * @packageDocumentation\n */\n",
   "name": "api-documenter-test",
   "members": [
     {
       "kind": "EntryPoint",
-      "containerKey": "",
       "name": "",
       "members": [
         {
           "kind": "Variable",
-          "containerKey": "constVariable|Variable",
           "docComment": "/**\n * An exported variable declaration.\n *\n * @public\n */\n",
           "excerptTokens": [
             {
@@ -42,7 +39,6 @@
         },
         {
           "kind": "Class",
-          "containerKey": "DocBaseClass|Class",
           "docComment": "/**\n * Example base class\n *\n * {@docCategory DocBaseClass}\n *\n * @public\n */\n",
           "excerptTokens": [
             {
@@ -63,7 +59,6 @@
           "members": [
             {
               "kind": "Constructor",
-              "containerKey": "|Constructor|1",
               "docComment": "/**\n * The simple constructor for `DocBaseClass`\n */\n",
               "excerptTokens": [
                 {
@@ -77,7 +72,6 @@
             },
             {
               "kind": "Constructor",
-              "containerKey": "|Constructor|2",
               "docComment": "/**\n * The overloaded constructor for `DocBaseClass`\n */\n",
               "excerptTokens": [
                 {
@@ -118,7 +112,6 @@
         },
         {
           "kind": "Class",
-          "containerKey": "DocClass1|Class",
           "docComment": "/**\n * This is an example class.\n *\n * @remarks\n *\n * These are some remarks.\n *\n * The constructor for this class is marked as internal. Third-party code should not call the constructor directly or create subclasses that extend the `DocClass1` class.\n *\n * @defaultValue\n *\n * a default value for this function\n *\n * {@docCategory DocClass1}\n *\n * @public\n */\n",
           "excerptTokens": [
             {
@@ -167,7 +160,6 @@
           "members": [
             {
               "kind": "Method",
-              "containerKey": "deprecatedExample|Method|instance|0",
               "docComment": "/**\n * @deprecated\n *\n * Use `otherThing()` instead.\n */\n",
               "excerptTokens": [
                 {
@@ -199,7 +191,6 @@
             },
             {
               "kind": "Method",
-              "containerKey": "exampleFunction|Method|instance|1",
               "docComment": "/**\n * This is an overloaded function.\n *\n * @param a - the first string\n *\n * @param b - the second string\n */\n",
               "excerptTokens": [
                 {
@@ -278,7 +269,6 @@
             },
             {
               "kind": "Method",
-              "containerKey": "exampleFunction|Method|instance|2",
               "docComment": "/**\n * This is also an overloaded function.\n *\n * @param x - the number\n */\n",
               "excerptTokens": [
                 {
@@ -334,7 +324,6 @@
             },
             {
               "kind": "Method",
-              "containerKey": "interestingEdgeCases|Method|instance|0",
               "docComment": "/**\n * Example: \"\\{ \\\\\"maxItemsToShow\\\\\": 123 \\}\"\n *\n * The regular expression used to validate the constraints is /^[a-zA-Z0-9\\\\-_]+$/\n */\n",
               "excerptTokens": [
                 {
@@ -366,7 +355,6 @@
             },
             {
               "kind": "Property",
-              "containerKey": "malformedEvent|Property|instance",
               "docComment": "/**\n * This event should have been marked as readonly.\n *\n * @eventProperty\n */\n",
               "excerptTokens": [
                 {
@@ -396,7 +384,6 @@
             },
             {
               "kind": "Property",
-              "containerKey": "modifiedEvent|Property|instance",
               "docComment": "/**\n * This event is fired whenever the object is modified.\n *\n * @eventProperty\n */\n",
               "excerptTokens": [
                 {
@@ -430,7 +417,6 @@
             },
             {
               "kind": "Property",
-              "containerKey": "regularProperty|Property|instance",
               "docComment": "/**\n * This is a regular property that happens to use the SystemEvent type.\n */\n",
               "excerptTokens": [
                 {
@@ -460,7 +446,6 @@
             },
             {
               "kind": "Method",
-              "containerKey": "sumWithExample|Method|static|0",
               "docComment": "/**\n * Returns the sum of two numbers.\n *\n * @remarks\n *\n * This illustrates usage of the `@example` block tag.\n *\n * @param x - the first number to add\n *\n * @param y - the second number to add\n *\n * @returns the sum of the two numbers\n *\n * @example\n *\n * Here's a simple example:\n * ```\n * // Prints \"2\":\n * console.log(DocClass1.sumWithExample(1,1));\n * ```\n *\n * @example\n *\n * Here's an example with negative numbers:\n * ```\n * // Prints \"0\":\n * console.log(DocClass1.sumWithExample(1,-1));\n * ```\n *\n */\n",
               "excerptTokens": [
                 {
@@ -543,7 +528,6 @@
             },
             {
               "kind": "Method",
-              "containerKey": "tableExample|Method|instance|0",
               "docComment": "/**\n * An example with tables:\n *\n * @remarks\n *\n * <table> <tr> <td>John</td> <td>Doe</td> </tr> </table>\n */\n",
               "excerptTokens": [
                 {
@@ -591,7 +575,6 @@
         },
         {
           "kind": "Enum",
-          "containerKey": "DocEnum|Enum",
           "docComment": "/**\n * Docs for DocEnum\n *\n * {@docCategory SystemEvent}\n *\n * @public\n */\n",
           "excerptTokens": [
             {
@@ -612,7 +595,6 @@
           "members": [
             {
               "kind": "EnumMember",
-              "containerKey": "One",
               "docComment": "/**\n * These are some docs for One\n */\n",
               "excerptTokens": [
                 {
@@ -637,7 +619,6 @@
             },
             {
               "kind": "EnumMember",
-              "containerKey": "Two",
               "docComment": "/**\n * These are some docs for Two\n */\n",
               "excerptTokens": [
                 {
@@ -662,7 +643,6 @@
             },
             {
               "kind": "EnumMember",
-              "containerKey": "Zero",
               "docComment": "/**\n * These are some docs for Zero\n */\n",
               "excerptTokens": [
                 {
@@ -689,7 +669,6 @@
         },
         {
           "kind": "TypeAlias",
-          "containerKey": "ExampleTypeAlias|TypeAlias",
           "docComment": "/**\n * A type alias\n *\n * @public\n */\n",
           "excerptTokens": [
             {
@@ -726,7 +705,6 @@
         },
         {
           "kind": "Class",
-          "containerKey": "Generic|Class",
           "docComment": "/**\n * Generic class.\n *\n * @public\n */\n",
           "excerptTokens": [
             {
@@ -770,7 +748,6 @@
         },
         {
           "kind": "Function",
-          "containerKey": "globalFunction|Function|0",
           "docComment": "/**\n * An exported function\n *\n * @public\n */\n",
           "excerptTokens": [
             {
@@ -829,7 +806,6 @@
         },
         {
           "kind": "Interface",
-          "containerKey": "IDocInterface1|Interface",
           "docComment": "/**\n * {@docCategory DocBaseClass}\n *\n * @public\n */\n",
           "excerptTokens": [
             {
@@ -850,7 +826,6 @@
           "members": [
             {
               "kind": "PropertySignature",
-              "containerKey": "regularProperty|PropertySignature",
               "docComment": "/**\n * Does something\n */\n",
               "excerptTokens": [
                 {
@@ -882,7 +857,6 @@
         },
         {
           "kind": "Interface",
-          "containerKey": "IDocInterface2|Interface",
           "docComment": "/**\n * {@docCategory DocBaseClass}\n *\n * @public\n */\n",
           "excerptTokens": [
             {
@@ -911,7 +885,6 @@
           "members": [
             {
               "kind": "MethodSignature",
-              "containerKey": "deprecatedExample|MethodSignature|0",
               "docComment": "/**\n * @deprecated\n *\n * Use `otherThing()` instead.\n */\n",
               "excerptTokens": [
                 {
@@ -950,7 +923,6 @@
         },
         {
           "kind": "Interface",
-          "containerKey": "IDocInterface3|Interface",
           "docComment": "/**\n * Some less common TypeScript declaration kinds.\n *\n * {@docCategory DocClass1}\n *\n * @public\n */\n",
           "excerptTokens": [
             {
@@ -971,7 +943,6 @@
           "members": [
             {
               "kind": "CallSignature",
-              "containerKey": "|CallSignature|0",
               "docComment": "/**\n * Call signature\n *\n * @param x - the parameter\n */\n",
               "excerptTokens": [
                 {
@@ -1021,7 +992,6 @@
             },
             {
               "kind": "ConstructSignature",
-              "containerKey": "|ConstructSignature|0",
               "docComment": "/**\n * Construct signature\n */\n",
               "excerptTokens": [
                 {
@@ -1047,7 +1017,6 @@
             },
             {
               "kind": "IndexSignature",
-              "containerKey": "|IndexSignature|0",
               "docComment": "/**\n * Indexer\n *\n * @param x - the parameter\n */\n",
               "excerptTokens": [
                 {
@@ -1100,7 +1069,6 @@
         },
         {
           "kind": "Interface",
-          "containerKey": "IDocInterface4|Interface",
           "docComment": "/**\n * Type union in an interface.\n *\n * {@docCategory DocClass1}\n *\n * @public\n */\n",
           "excerptTokens": [
             {
@@ -1121,7 +1089,6 @@
           "members": [
             {
               "kind": "PropertySignature",
-              "containerKey": "Context|PropertySignature",
               "docComment": "/**\n * Test newline rendering when code blocks are used in tables\n */\n",
               "excerptTokens": [
                 {
@@ -1166,7 +1133,6 @@
             },
             {
               "kind": "PropertySignature",
-              "containerKey": "generic|PropertySignature",
               "docComment": "/**\n * make sure html entities are escaped in tables.\n */\n",
               "excerptTokens": [
                 {
@@ -1199,7 +1165,6 @@
             },
             {
               "kind": "PropertySignature",
-              "containerKey": "numberOrFunction|PropertySignature",
               "docComment": "/**\n * a union type with a function\n */\n",
               "excerptTokens": [
                 {
@@ -1228,7 +1193,6 @@
             },
             {
               "kind": "PropertySignature",
-              "containerKey": "stringOrNumber|PropertySignature",
               "docComment": "/**\n * a union type\n */\n",
               "excerptTokens": [
                 {
@@ -1260,7 +1224,6 @@
         },
         {
           "kind": "Interface",
-          "containerKey": "IDocInterface5|Interface",
           "docComment": "/**\n * Interface without inline tag to test custom TOC\n *\n * @public\n */\n",
           "excerptTokens": [
             {
@@ -1281,7 +1244,6 @@
           "members": [
             {
               "kind": "PropertySignature",
-              "containerKey": "regularProperty|PropertySignature",
               "docComment": "/**\n * Property of type string that does something\n */\n",
               "excerptTokens": [
                 {
@@ -1313,7 +1275,6 @@
         },
         {
           "kind": "Interface",
-          "containerKey": "IDocInterface6|Interface",
           "docComment": "/**\n * Interface without inline tag to test custom TOC with injection\n *\n * @public\n */\n",
           "excerptTokens": [
             {
@@ -1334,7 +1295,6 @@
           "members": [
             {
               "kind": "PropertySignature",
-              "containerKey": "regularProperty|PropertySignature",
               "docComment": "/**\n * Property of type number that does something\n */\n",
               "excerptTokens": [
                 {
@@ -1366,7 +1326,6 @@
         },
         {
           "kind": "Namespace",
-          "containerKey": "OuterNamespace|Namespace",
           "docComment": "/**\n * A top-level namespace\n *\n * @public\n */\n",
           "excerptTokens": [
             {
@@ -1387,7 +1346,6 @@
           "members": [
             {
               "kind": "Namespace",
-              "containerKey": "InnerNamespace|Namespace",
               "docComment": "/**\n * A nested namespace\n */\n",
               "excerptTokens": [
                 {
@@ -1408,7 +1366,6 @@
               "members": [
                 {
                   "kind": "Function",
-                  "containerKey": "nestedFunction|Function|0",
                   "docComment": "/**\n * A function inside a namespace\n */\n",
                   "excerptTokens": [
                     {
@@ -1469,7 +1426,6 @@
             },
             {
               "kind": "Variable",
-              "containerKey": "nestedVariable|Variable",
               "docComment": "/**\n * A variable exported from within a namespace.\n */\n",
               "excerptTokens": [
                 {
@@ -1496,7 +1452,6 @@
         },
         {
           "kind": "Class",
-          "containerKey": "SystemEvent|Class",
           "docComment": "/**\n * A class used to exposed events.\n *\n * {@docCategory SystemEvent}\n *\n * @public\n */\n",
           "excerptTokens": [
             {
@@ -1517,7 +1472,6 @@
           "members": [
             {
               "kind": "Method",
-              "containerKey": "addHandler|Method|instance|0",
               "docComment": "/**\n * Adds an handler for the event.\n */\n",
               "excerptTokens": [
                 {

--- a/build-tests/api-documenter-test/etc/api-documenter-test.api.json
+++ b/build-tests/api-documenter-test/etc/api-documenter-test.api.json
@@ -6,18 +6,43 @@
     "oldestForwardsCompatibleVersion": 1001
   },
   "kind": "Package",
-  "canonicalReference": "api-documenter-test",
+  "containerKey": "api-documenter-test",
   "docComment": "/**\n * api-extractor-test-05\n *\n * This project tests various documentation generation scenarios and doc comment syntaxes.\n *\n * @packageDocumentation\n */\n",
   "name": "api-documenter-test",
   "members": [
     {
       "kind": "EntryPoint",
-      "canonicalReference": "",
+      "containerKey": "",
       "name": "",
       "members": [
         {
+          "kind": "Variable",
+          "containerKey": "constVariable|Variable",
+          "docComment": "/**\n * An exported variable declaration.\n *\n * @public\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Reference",
+              "text": "constVariable"
+            },
+            {
+              "kind": "Content",
+              "text": ": "
+            },
+            {
+              "kind": "Content",
+              "text": "number"
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "constVariable",
+          "variableTypeTokenRange": {
+            "startIndex": 2,
+            "endIndex": 3
+          }
+        },
+        {
           "kind": "Class",
-          "canonicalReference": "(DocBaseClass:class)",
+          "containerKey": "DocBaseClass|Class",
           "docComment": "/**\n * Example base class\n *\n * {@docCategory DocBaseClass}\n *\n * @public\n */\n",
           "excerptTokens": [
             {
@@ -38,7 +63,7 @@
           "members": [
             {
               "kind": "Constructor",
-              "canonicalReference": "(:constructor,1)",
+              "containerKey": "|Constructor|1",
               "docComment": "/**\n * The simple constructor for `DocBaseClass`\n */\n",
               "excerptTokens": [
                 {
@@ -52,7 +77,7 @@
             },
             {
               "kind": "Constructor",
-              "canonicalReference": "(:constructor,2)",
+              "containerKey": "|Constructor|2",
               "docComment": "/**\n * The overloaded constructor for `DocBaseClass`\n */\n",
               "excerptTokens": [
                 {
@@ -93,7 +118,7 @@
         },
         {
           "kind": "Class",
-          "canonicalReference": "(DocClass1:class)",
+          "containerKey": "DocClass1|Class",
           "docComment": "/**\n * This is an example class.\n *\n * @remarks\n *\n * These are some remarks.\n *\n * The constructor for this class is marked as internal. Third-party code should not call the constructor directly or create subclasses that extend the `DocClass1` class.\n *\n * @defaultValue\n *\n * a default value for this function\n *\n * {@docCategory DocClass1}\n *\n * @public\n */\n",
           "excerptTokens": [
             {
@@ -142,7 +167,7 @@
           "members": [
             {
               "kind": "Method",
-              "canonicalReference": "(deprecatedExample:instance,0)",
+              "containerKey": "deprecatedExample|Method|instance|0",
               "docComment": "/**\n * @deprecated\n *\n * Use `otherThing()` instead.\n */\n",
               "excerptTokens": [
                 {
@@ -174,7 +199,7 @@
             },
             {
               "kind": "Method",
-              "canonicalReference": "(exampleFunction:instance,1)",
+              "containerKey": "exampleFunction|Method|instance|1",
               "docComment": "/**\n * This is an overloaded function.\n *\n * @param a - the first string\n *\n * @param b - the second string\n */\n",
               "excerptTokens": [
                 {
@@ -253,7 +278,7 @@
             },
             {
               "kind": "Method",
-              "canonicalReference": "(exampleFunction:instance,2)",
+              "containerKey": "exampleFunction|Method|instance|2",
               "docComment": "/**\n * This is also an overloaded function.\n *\n * @param x - the number\n */\n",
               "excerptTokens": [
                 {
@@ -309,7 +334,7 @@
             },
             {
               "kind": "Method",
-              "canonicalReference": "(interestingEdgeCases:instance,0)",
+              "containerKey": "interestingEdgeCases|Method|instance|0",
               "docComment": "/**\n * Example: \"\\{ \\\\\"maxItemsToShow\\\\\": 123 \\}\"\n *\n * The regular expression used to validate the constraints is /^[a-zA-Z0-9\\\\-_]+$/\n */\n",
               "excerptTokens": [
                 {
@@ -341,7 +366,7 @@
             },
             {
               "kind": "Property",
-              "canonicalReference": "(malformedEvent:instance)",
+              "containerKey": "malformedEvent|Property|instance",
               "docComment": "/**\n * This event should have been marked as readonly.\n *\n * @eventProperty\n */\n",
               "excerptTokens": [
                 {
@@ -371,7 +396,7 @@
             },
             {
               "kind": "Property",
-              "canonicalReference": "(modifiedEvent:instance)",
+              "containerKey": "modifiedEvent|Property|instance",
               "docComment": "/**\n * This event is fired whenever the object is modified.\n *\n * @eventProperty\n */\n",
               "excerptTokens": [
                 {
@@ -405,7 +430,7 @@
             },
             {
               "kind": "Property",
-              "canonicalReference": "(regularProperty:instance)",
+              "containerKey": "regularProperty|Property|instance",
               "docComment": "/**\n * This is a regular property that happens to use the SystemEvent type.\n */\n",
               "excerptTokens": [
                 {
@@ -435,7 +460,7 @@
             },
             {
               "kind": "Method",
-              "canonicalReference": "(sumWithExample:static,0)",
+              "containerKey": "sumWithExample|Method|static|0",
               "docComment": "/**\n * Returns the sum of two numbers.\n *\n * @remarks\n *\n * This illustrates usage of the `@example` block tag.\n *\n * @param x - the first number to add\n *\n * @param y - the second number to add\n *\n * @returns the sum of the two numbers\n *\n * @example\n *\n * Here's a simple example:\n * ```\n * // Prints \"2\":\n * console.log(DocClass1.sumWithExample(1,1));\n * ```\n *\n * @example\n *\n * Here's an example with negative numbers:\n * ```\n * // Prints \"0\":\n * console.log(DocClass1.sumWithExample(1,-1));\n * ```\n *\n */\n",
               "excerptTokens": [
                 {
@@ -518,7 +543,7 @@
             },
             {
               "kind": "Method",
-              "canonicalReference": "(tableExample:instance,0)",
+              "containerKey": "tableExample|Method|instance|0",
               "docComment": "/**\n * An example with tables:\n *\n * @remarks\n *\n * <table> <tr> <td>John</td> <td>Doe</td> </tr> </table>\n */\n",
               "excerptTokens": [
                 {
@@ -566,7 +591,7 @@
         },
         {
           "kind": "Enum",
-          "canonicalReference": "(DocEnum:enum)",
+          "containerKey": "DocEnum|Enum",
           "docComment": "/**\n * Docs for DocEnum\n *\n * {@docCategory SystemEvent}\n *\n * @public\n */\n",
           "excerptTokens": [
             {
@@ -587,7 +612,7 @@
           "members": [
             {
               "kind": "EnumMember",
-              "canonicalReference": "One",
+              "containerKey": "One",
               "docComment": "/**\n * These are some docs for One\n */\n",
               "excerptTokens": [
                 {
@@ -612,7 +637,7 @@
             },
             {
               "kind": "EnumMember",
-              "canonicalReference": "Two",
+              "containerKey": "Two",
               "docComment": "/**\n * These are some docs for Two\n */\n",
               "excerptTokens": [
                 {
@@ -637,7 +662,7 @@
             },
             {
               "kind": "EnumMember",
-              "canonicalReference": "Zero",
+              "containerKey": "Zero",
               "docComment": "/**\n * These are some docs for Zero\n */\n",
               "excerptTokens": [
                 {
@@ -663,8 +688,45 @@
           ]
         },
         {
+          "kind": "TypeAlias",
+          "containerKey": "ExampleTypeAlias|TypeAlias",
+          "docComment": "/**\n * A type alias\n *\n * @public\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare type "
+            },
+            {
+              "kind": "Reference",
+              "text": "ExampleTypeAlias"
+            },
+            {
+              "kind": "Content",
+              "text": " = "
+            },
+            {
+              "kind": "Reference",
+              "text": "Promise"
+            },
+            {
+              "kind": "Content",
+              "text": "<boolean>"
+            },
+            {
+              "kind": "Content",
+              "text": ";"
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "ExampleTypeAlias",
+          "typeTokenRange": {
+            "startIndex": 3,
+            "endIndex": 5
+          }
+        },
+        {
           "kind": "Class",
-          "canonicalReference": "(Generic:class)",
+          "containerKey": "Generic|Class",
           "docComment": "/**\n * Generic class.\n *\n * @public\n */\n",
           "excerptTokens": [
             {
@@ -708,7 +770,7 @@
         },
         {
           "kind": "Function",
-          "canonicalReference": "(globalFunction:0)",
+          "containerKey": "globalFunction|Function|0",
           "docComment": "/**\n * An exported function\n *\n * @public\n */\n",
           "excerptTokens": [
             {
@@ -767,7 +829,7 @@
         },
         {
           "kind": "Interface",
-          "canonicalReference": "(IDocInterface1:interface)",
+          "containerKey": "IDocInterface1|Interface",
           "docComment": "/**\n * {@docCategory DocBaseClass}\n *\n * @public\n */\n",
           "excerptTokens": [
             {
@@ -788,7 +850,7 @@
           "members": [
             {
               "kind": "PropertySignature",
-              "canonicalReference": "regularProperty",
+              "containerKey": "regularProperty|PropertySignature",
               "docComment": "/**\n * Does something\n */\n",
               "excerptTokens": [
                 {
@@ -820,7 +882,7 @@
         },
         {
           "kind": "Interface",
-          "canonicalReference": "(IDocInterface2:interface)",
+          "containerKey": "IDocInterface2|Interface",
           "docComment": "/**\n * {@docCategory DocBaseClass}\n *\n * @public\n */\n",
           "excerptTokens": [
             {
@@ -849,7 +911,7 @@
           "members": [
             {
               "kind": "MethodSignature",
-              "canonicalReference": "(deprecatedExample:0)",
+              "containerKey": "deprecatedExample|MethodSignature|0",
               "docComment": "/**\n * @deprecated\n *\n * Use `otherThing()` instead.\n */\n",
               "excerptTokens": [
                 {
@@ -888,7 +950,7 @@
         },
         {
           "kind": "Interface",
-          "canonicalReference": "(IDocInterface3:interface)",
+          "containerKey": "IDocInterface3|Interface",
           "docComment": "/**\n * Some less common TypeScript declaration kinds.\n *\n * {@docCategory DocClass1}\n *\n * @public\n */\n",
           "excerptTokens": [
             {
@@ -909,7 +971,7 @@
           "members": [
             {
               "kind": "CallSignature",
-              "canonicalReference": "(:call,0)",
+              "containerKey": "|CallSignature|0",
               "docComment": "/**\n * Call signature\n *\n * @param x - the parameter\n */\n",
               "excerptTokens": [
                 {
@@ -958,8 +1020,34 @@
               ]
             },
             {
+              "kind": "ConstructSignature",
+              "containerKey": "|ConstructSignature|0",
+              "docComment": "/**\n * Construct signature\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "new (): "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "IDocInterface1"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "returnTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              },
+              "releaseTag": "Public",
+              "overloadIndex": 0,
+              "parameters": []
+            },
+            {
               "kind": "IndexSignature",
-              "canonicalReference": "(:index,0)",
+              "containerKey": "|IndexSignature|0",
               "docComment": "/**\n * Indexer\n *\n * @param x - the parameter\n */\n",
               "excerptTokens": [
                 {
@@ -1006,39 +1094,13 @@
                   }
                 }
               ]
-            },
-            {
-              "kind": "ConstructSignature",
-              "canonicalReference": "(:new,0)",
-              "docComment": "/**\n * Construct signature\n */\n",
-              "excerptTokens": [
-                {
-                  "kind": "Content",
-                  "text": "new (): "
-                },
-                {
-                  "kind": "Reference",
-                  "text": "IDocInterface1"
-                },
-                {
-                  "kind": "Content",
-                  "text": ";"
-                }
-              ],
-              "returnTypeTokenRange": {
-                "startIndex": 1,
-                "endIndex": 2
-              },
-              "releaseTag": "Public",
-              "overloadIndex": 0,
-              "parameters": []
             }
           ],
           "extendsTokenRanges": []
         },
         {
           "kind": "Interface",
-          "canonicalReference": "(IDocInterface4:interface)",
+          "containerKey": "IDocInterface4|Interface",
           "docComment": "/**\n * Type union in an interface.\n *\n * {@docCategory DocClass1}\n *\n * @public\n */\n",
           "excerptTokens": [
             {
@@ -1059,7 +1121,7 @@
           "members": [
             {
               "kind": "PropertySignature",
-              "canonicalReference": "Context",
+              "containerKey": "Context|PropertySignature",
               "docComment": "/**\n * Test newline rendering when code blocks are used in tables\n */\n",
               "excerptTokens": [
                 {
@@ -1104,7 +1166,7 @@
             },
             {
               "kind": "PropertySignature",
-              "canonicalReference": "generic",
+              "containerKey": "generic|PropertySignature",
               "docComment": "/**\n * make sure html entities are escaped in tables.\n */\n",
               "excerptTokens": [
                 {
@@ -1137,7 +1199,7 @@
             },
             {
               "kind": "PropertySignature",
-              "canonicalReference": "numberOrFunction",
+              "containerKey": "numberOrFunction|PropertySignature",
               "docComment": "/**\n * a union type with a function\n */\n",
               "excerptTokens": [
                 {
@@ -1166,7 +1228,7 @@
             },
             {
               "kind": "PropertySignature",
-              "canonicalReference": "stringOrNumber",
+              "containerKey": "stringOrNumber|PropertySignature",
               "docComment": "/**\n * a union type\n */\n",
               "excerptTokens": [
                 {
@@ -1198,7 +1260,7 @@
         },
         {
           "kind": "Interface",
-          "canonicalReference": "(IDocInterface5:interface)",
+          "containerKey": "IDocInterface5|Interface",
           "docComment": "/**\n * Interface without inline tag to test custom TOC\n *\n * @public\n */\n",
           "excerptTokens": [
             {
@@ -1219,7 +1281,7 @@
           "members": [
             {
               "kind": "PropertySignature",
-              "canonicalReference": "regularProperty",
+              "containerKey": "regularProperty|PropertySignature",
               "docComment": "/**\n * Property of type string that does something\n */\n",
               "excerptTokens": [
                 {
@@ -1251,7 +1313,7 @@
         },
         {
           "kind": "Interface",
-          "canonicalReference": "(IDocInterface6:interface)",
+          "containerKey": "IDocInterface6|Interface",
           "docComment": "/**\n * Interface without inline tag to test custom TOC with injection\n *\n * @public\n */\n",
           "excerptTokens": [
             {
@@ -1272,7 +1334,7 @@
           "members": [
             {
               "kind": "PropertySignature",
-              "canonicalReference": "regularProperty",
+              "containerKey": "regularProperty|PropertySignature",
               "docComment": "/**\n * Property of type number that does something\n */\n",
               "excerptTokens": [
                 {
@@ -1304,7 +1366,7 @@
         },
         {
           "kind": "Namespace",
-          "canonicalReference": "(OuterNamespace:namespace)",
+          "containerKey": "OuterNamespace|Namespace",
           "docComment": "/**\n * A top-level namespace\n *\n * @public\n */\n",
           "excerptTokens": [
             {
@@ -1325,7 +1387,7 @@
           "members": [
             {
               "kind": "Namespace",
-              "canonicalReference": "(InnerNamespace:namespace)",
+              "containerKey": "InnerNamespace|Namespace",
               "docComment": "/**\n * A nested namespace\n */\n",
               "excerptTokens": [
                 {
@@ -1346,7 +1408,7 @@
               "members": [
                 {
                   "kind": "Function",
-                  "canonicalReference": "(nestedFunction:0)",
+                  "containerKey": "nestedFunction|Function|0",
                   "docComment": "/**\n * A function inside a namespace\n */\n",
                   "excerptTokens": [
                     {
@@ -1407,7 +1469,7 @@
             },
             {
               "kind": "Variable",
-              "canonicalReference": "nestedVariable",
+              "containerKey": "nestedVariable|Variable",
               "docComment": "/**\n * A variable exported from within a namespace.\n */\n",
               "excerptTokens": [
                 {
@@ -1434,7 +1496,7 @@
         },
         {
           "kind": "Class",
-          "canonicalReference": "(SystemEvent:class)",
+          "containerKey": "SystemEvent|Class",
           "docComment": "/**\n * A class used to exposed events.\n *\n * {@docCategory SystemEvent}\n *\n * @public\n */\n",
           "excerptTokens": [
             {
@@ -1455,7 +1517,7 @@
           "members": [
             {
               "kind": "Method",
-              "canonicalReference": "(addHandler:instance,0)",
+              "containerKey": "addHandler|Method|instance|0",
               "docComment": "/**\n * Adds an handler for the event.\n */\n",
               "excerptTokens": [
                 {
@@ -1511,68 +1573,6 @@
             }
           ],
           "implementsTokenRanges": []
-        },
-        {
-          "kind": "Variable",
-          "canonicalReference": "constVariable",
-          "docComment": "/**\n * An exported variable declaration.\n *\n * @public\n */\n",
-          "excerptTokens": [
-            {
-              "kind": "Reference",
-              "text": "constVariable"
-            },
-            {
-              "kind": "Content",
-              "text": ": "
-            },
-            {
-              "kind": "Content",
-              "text": "number"
-            }
-          ],
-          "releaseTag": "Public",
-          "name": "constVariable",
-          "variableTypeTokenRange": {
-            "startIndex": 2,
-            "endIndex": 3
-          }
-        },
-        {
-          "kind": "TypeAlias",
-          "canonicalReference": "ExampleTypeAlias",
-          "docComment": "/**\n * A type alias\n *\n * @public\n */\n",
-          "excerptTokens": [
-            {
-              "kind": "Content",
-              "text": "export declare type "
-            },
-            {
-              "kind": "Reference",
-              "text": "ExampleTypeAlias"
-            },
-            {
-              "kind": "Content",
-              "text": " = "
-            },
-            {
-              "kind": "Reference",
-              "text": "Promise"
-            },
-            {
-              "kind": "Content",
-              "text": "<boolean>"
-            },
-            {
-              "kind": "Content",
-              "text": ";"
-            }
-          ],
-          "releaseTag": "Public",
-          "name": "ExampleTypeAlias",
-          "typeTokenRange": {
-            "startIndex": 3,
-            "endIndex": 5
-          }
         }
       ]
     }

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/ambientNameConflict/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/ambientNameConflict/api-extractor-scenarios.api.json
@@ -2,22 +2,19 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1001,
+    "schemaVersion": 1002,
     "oldestForwardsCompatibleVersion": 1001
   },
   "kind": "Package",
-  "containerKey": "api-extractor-scenarios",
   "docComment": "",
   "name": "api-extractor-scenarios",
   "members": [
     {
       "kind": "EntryPoint",
-      "containerKey": "",
       "name": "",
       "members": [
         {
           "kind": "Function",
-          "containerKey": "ambientNameConflict|Function|0",
           "docComment": "/**\n * @public\n */\n",
           "excerptTokens": [
             {

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/ambientNameConflict/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/ambientNameConflict/api-extractor-scenarios.api.json
@@ -6,18 +6,18 @@
     "oldestForwardsCompatibleVersion": 1001
   },
   "kind": "Package",
-  "canonicalReference": "api-extractor-scenarios",
+  "containerKey": "api-extractor-scenarios",
   "docComment": "",
   "name": "api-extractor-scenarios",
   "members": [
     {
       "kind": "EntryPoint",
-      "canonicalReference": "",
+      "containerKey": "",
       "name": "",
       "members": [
         {
           "kind": "Function",
-          "canonicalReference": "(ambientNameConflict:0)",
+          "containerKey": "ambientNameConflict|Function|0",
           "docComment": "/**\n * @public\n */\n",
           "excerptTokens": [
             {

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/apiItemKinds/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/apiItemKinds/api-extractor-scenarios.api.json
@@ -2,22 +2,19 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1001,
+    "schemaVersion": 1002,
     "oldestForwardsCompatibleVersion": 1001
   },
   "kind": "Package",
-  "containerKey": "api-extractor-scenarios",
   "docComment": "",
   "name": "api-extractor-scenarios",
   "members": [
     {
       "kind": "EntryPoint",
-      "containerKey": "",
       "name": "",
       "members": [
         {
           "kind": "Class",
-          "containerKey": "AbstractClass|Class",
           "docComment": "/**\n * @public\n */\n",
           "excerptTokens": [
             {
@@ -38,7 +35,6 @@
           "members": [
             {
               "kind": "Method",
-              "containerKey": "member|Method|instance|0",
               "docComment": "",
               "excerptTokens": [
                 {
@@ -77,7 +73,6 @@
         },
         {
           "kind": "Class",
-          "containerKey": "ClassWithTypeLiterals|Class",
           "docComment": "/**\n * @public\n */\n",
           "excerptTokens": [
             {
@@ -98,7 +93,6 @@
           "members": [
             {
               "kind": "Method",
-              "containerKey": "method1|Method|instance|0",
               "docComment": "/**\n * type literal in\n */\n",
               "excerptTokens": [
                 {
@@ -170,7 +164,6 @@
             },
             {
               "kind": "Method",
-              "containerKey": "method2|Method|instance|0",
               "docComment": "/**\n * type literal output\n */\n",
               "excerptTokens": [
                 {
@@ -229,7 +222,6 @@
         },
         {
           "kind": "Enum",
-          "containerKey": "ConstEnum|Enum",
           "docComment": "/**\n * @public\n */\n",
           "excerptTokens": [
             {
@@ -250,7 +242,6 @@
           "members": [
             {
               "kind": "EnumMember",
-              "containerKey": "One",
               "docComment": "",
               "excerptTokens": [
                 {
@@ -275,7 +266,6 @@
             },
             {
               "kind": "EnumMember",
-              "containerKey": "Two",
               "docComment": "",
               "excerptTokens": [
                 {
@@ -300,7 +290,6 @@
             },
             {
               "kind": "EnumMember",
-              "containerKey": "Zero",
               "docComment": "",
               "excerptTokens": [
                 {
@@ -327,7 +316,6 @@
         },
         {
           "kind": "Interface",
-          "containerKey": "IInterface|Interface",
           "docComment": "/**\n * @public\n */\n",
           "excerptTokens": [
             {
@@ -348,7 +336,6 @@
           "members": [
             {
               "kind": "PropertySignature",
-              "containerKey": "member|PropertySignature",
               "docComment": "",
               "excerptTokens": [
                 {
@@ -380,7 +367,6 @@
         },
         {
           "kind": "Namespace",
-          "containerKey": "NamespaceContainingVariable|Namespace",
           "docComment": "/**\n * @public\n */\n",
           "excerptTokens": [
             {
@@ -401,7 +387,6 @@
           "members": [
             {
               "kind": "Variable",
-              "containerKey": "constVariable|Variable",
               "docComment": "",
               "excerptTokens": [
                 {
@@ -426,7 +411,6 @@
             },
             {
               "kind": "Variable",
-              "containerKey": "variable|Variable",
               "docComment": "",
               "excerptTokens": [
                 {
@@ -453,7 +437,6 @@
         },
         {
           "kind": "Enum",
-          "containerKey": "RegularEnum|Enum",
           "docComment": "/**\n * @public\n */\n",
           "excerptTokens": [
             {
@@ -474,7 +457,6 @@
           "members": [
             {
               "kind": "EnumMember",
-              "containerKey": "One",
               "docComment": "/**\n * These are some docs for One\n */\n",
               "excerptTokens": [
                 {
@@ -499,7 +481,6 @@
             },
             {
               "kind": "EnumMember",
-              "containerKey": "Two",
               "docComment": "/**\n * These are some docs for Two\n */\n",
               "excerptTokens": [
                 {
@@ -524,7 +505,6 @@
             },
             {
               "kind": "EnumMember",
-              "containerKey": "Zero",
               "docComment": "/**\n * These are some docs for Zero\n */\n",
               "excerptTokens": [
                 {
@@ -551,7 +531,6 @@
         },
         {
           "kind": "Class",
-          "containerKey": "SimpleClass|Class",
           "docComment": "/**\n * @public\n */\n",
           "excerptTokens": [
             {
@@ -572,7 +551,6 @@
           "members": [
             {
               "kind": "Method",
-              "containerKey": "member|Method|instance|0",
               "docComment": "",
               "excerptTokens": [
                 {
@@ -607,7 +585,6 @@
         },
         {
           "kind": "Variable",
-          "containerKey": "VARIABLE|Variable",
           "docComment": "/**\n * @public\n */\n",
           "excerptTokens": [
             {

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/apiItemKinds/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/apiItemKinds/api-extractor-scenarios.api.json
@@ -6,18 +6,18 @@
     "oldestForwardsCompatibleVersion": 1001
   },
   "kind": "Package",
-  "canonicalReference": "api-extractor-scenarios",
+  "containerKey": "api-extractor-scenarios",
   "docComment": "",
   "name": "api-extractor-scenarios",
   "members": [
     {
       "kind": "EntryPoint",
-      "canonicalReference": "",
+      "containerKey": "",
       "name": "",
       "members": [
         {
           "kind": "Class",
-          "canonicalReference": "(AbstractClass:class)",
+          "containerKey": "AbstractClass|Class",
           "docComment": "/**\n * @public\n */\n",
           "excerptTokens": [
             {
@@ -38,7 +38,7 @@
           "members": [
             {
               "kind": "Method",
-              "canonicalReference": "(member:instance,0)",
+              "containerKey": "member|Method|instance|0",
               "docComment": "",
               "excerptTokens": [
                 {
@@ -77,7 +77,7 @@
         },
         {
           "kind": "Class",
-          "canonicalReference": "(ClassWithTypeLiterals:class)",
+          "containerKey": "ClassWithTypeLiterals|Class",
           "docComment": "/**\n * @public\n */\n",
           "excerptTokens": [
             {
@@ -98,7 +98,7 @@
           "members": [
             {
               "kind": "Method",
-              "canonicalReference": "(method1:instance,0)",
+              "containerKey": "method1|Method|instance|0",
               "docComment": "/**\n * type literal in\n */\n",
               "excerptTokens": [
                 {
@@ -170,7 +170,7 @@
             },
             {
               "kind": "Method",
-              "canonicalReference": "(method2:instance,0)",
+              "containerKey": "method2|Method|instance|0",
               "docComment": "/**\n * type literal output\n */\n",
               "excerptTokens": [
                 {
@@ -229,7 +229,7 @@
         },
         {
           "kind": "Enum",
-          "canonicalReference": "(ConstEnum:enum)",
+          "containerKey": "ConstEnum|Enum",
           "docComment": "/**\n * @public\n */\n",
           "excerptTokens": [
             {
@@ -250,7 +250,7 @@
           "members": [
             {
               "kind": "EnumMember",
-              "canonicalReference": "One",
+              "containerKey": "One",
               "docComment": "",
               "excerptTokens": [
                 {
@@ -275,7 +275,7 @@
             },
             {
               "kind": "EnumMember",
-              "canonicalReference": "Two",
+              "containerKey": "Two",
               "docComment": "",
               "excerptTokens": [
                 {
@@ -300,7 +300,7 @@
             },
             {
               "kind": "EnumMember",
-              "canonicalReference": "Zero",
+              "containerKey": "Zero",
               "docComment": "",
               "excerptTokens": [
                 {
@@ -327,7 +327,7 @@
         },
         {
           "kind": "Interface",
-          "canonicalReference": "(IInterface:interface)",
+          "containerKey": "IInterface|Interface",
           "docComment": "/**\n * @public\n */\n",
           "excerptTokens": [
             {
@@ -348,7 +348,7 @@
           "members": [
             {
               "kind": "PropertySignature",
-              "canonicalReference": "member",
+              "containerKey": "member|PropertySignature",
               "docComment": "",
               "excerptTokens": [
                 {
@@ -380,7 +380,7 @@
         },
         {
           "kind": "Namespace",
-          "canonicalReference": "(NamespaceContainingVariable:namespace)",
+          "containerKey": "NamespaceContainingVariable|Namespace",
           "docComment": "/**\n * @public\n */\n",
           "excerptTokens": [
             {
@@ -401,7 +401,7 @@
           "members": [
             {
               "kind": "Variable",
-              "canonicalReference": "constVariable",
+              "containerKey": "constVariable|Variable",
               "docComment": "",
               "excerptTokens": [
                 {
@@ -426,7 +426,7 @@
             },
             {
               "kind": "Variable",
-              "canonicalReference": "variable",
+              "containerKey": "variable|Variable",
               "docComment": "",
               "excerptTokens": [
                 {
@@ -453,7 +453,7 @@
         },
         {
           "kind": "Enum",
-          "canonicalReference": "(RegularEnum:enum)",
+          "containerKey": "RegularEnum|Enum",
           "docComment": "/**\n * @public\n */\n",
           "excerptTokens": [
             {
@@ -474,7 +474,7 @@
           "members": [
             {
               "kind": "EnumMember",
-              "canonicalReference": "One",
+              "containerKey": "One",
               "docComment": "/**\n * These are some docs for One\n */\n",
               "excerptTokens": [
                 {
@@ -499,7 +499,7 @@
             },
             {
               "kind": "EnumMember",
-              "canonicalReference": "Two",
+              "containerKey": "Two",
               "docComment": "/**\n * These are some docs for Two\n */\n",
               "excerptTokens": [
                 {
@@ -524,7 +524,7 @@
             },
             {
               "kind": "EnumMember",
-              "canonicalReference": "Zero",
+              "containerKey": "Zero",
               "docComment": "/**\n * These are some docs for Zero\n */\n",
               "excerptTokens": [
                 {
@@ -551,7 +551,7 @@
         },
         {
           "kind": "Class",
-          "canonicalReference": "(SimpleClass:class)",
+          "containerKey": "SimpleClass|Class",
           "docComment": "/**\n * @public\n */\n",
           "excerptTokens": [
             {
@@ -572,7 +572,7 @@
           "members": [
             {
               "kind": "Method",
-              "canonicalReference": "(member:instance,0)",
+              "containerKey": "member|Method|instance|0",
               "docComment": "",
               "excerptTokens": [
                 {
@@ -607,7 +607,7 @@
         },
         {
           "kind": "Variable",
-          "canonicalReference": "VARIABLE",
+          "containerKey": "VARIABLE|Variable",
           "docComment": "/**\n * @public\n */\n",
           "excerptTokens": [
             {

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/circularImport/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/circularImport/api-extractor-scenarios.api.json
@@ -6,18 +6,18 @@
     "oldestForwardsCompatibleVersion": 1001
   },
   "kind": "Package",
-  "canonicalReference": "api-extractor-scenarios",
+  "containerKey": "api-extractor-scenarios",
   "docComment": "",
   "name": "api-extractor-scenarios",
   "members": [
     {
       "kind": "EntryPoint",
-      "canonicalReference": "",
+      "containerKey": "",
       "name": "",
       "members": [
         {
           "kind": "Class",
-          "canonicalReference": "(IFile:class)",
+          "containerKey": "IFile|Class",
           "docComment": "/**\n * @public\n */\n",
           "excerptTokens": [
             {
@@ -38,7 +38,7 @@
           "members": [
             {
               "kind": "Property",
-              "canonicalReference": "(containingFolder:instance)",
+              "containerKey": "containingFolder|Property|instance",
               "docComment": "",
               "excerptTokens": [
                 {
@@ -71,7 +71,7 @@
         },
         {
           "kind": "Class",
-          "canonicalReference": "(IFolder:class)",
+          "containerKey": "IFolder|Class",
           "docComment": "/**\n * @public\n */\n",
           "excerptTokens": [
             {
@@ -92,7 +92,7 @@
           "members": [
             {
               "kind": "Property",
-              "canonicalReference": "(containingFolder:instance)",
+              "containerKey": "containingFolder|Property|instance",
               "docComment": "",
               "excerptTokens": [
                 {
@@ -126,7 +126,7 @@
             },
             {
               "kind": "Property",
-              "canonicalReference": "(files:instance)",
+              "containerKey": "files|Property|instance",
               "docComment": "",
               "excerptTokens": [
                 {

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/circularImport/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/circularImport/api-extractor-scenarios.api.json
@@ -2,22 +2,19 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1001,
+    "schemaVersion": 1002,
     "oldestForwardsCompatibleVersion": 1001
   },
   "kind": "Package",
-  "containerKey": "api-extractor-scenarios",
   "docComment": "",
   "name": "api-extractor-scenarios",
   "members": [
     {
       "kind": "EntryPoint",
-      "containerKey": "",
       "name": "",
       "members": [
         {
           "kind": "Class",
-          "containerKey": "IFile|Class",
           "docComment": "/**\n * @public\n */\n",
           "excerptTokens": [
             {
@@ -38,7 +35,6 @@
           "members": [
             {
               "kind": "Property",
-              "containerKey": "containingFolder|Property|instance",
               "docComment": "",
               "excerptTokens": [
                 {
@@ -71,7 +67,6 @@
         },
         {
           "kind": "Class",
-          "containerKey": "IFolder|Class",
           "docComment": "/**\n * @public\n */\n",
           "excerptTokens": [
             {
@@ -92,7 +87,6 @@
           "members": [
             {
               "kind": "Property",
-              "containerKey": "containingFolder|Property|instance",
               "docComment": "",
               "excerptTokens": [
                 {
@@ -126,7 +120,6 @@
             },
             {
               "kind": "Property",
-              "containerKey": "files|Property|instance",
               "docComment": "",
               "excerptTokens": [
                 {

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/circularImport2/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/circularImport2/api-extractor-scenarios.api.json
@@ -2,22 +2,19 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1001,
+    "schemaVersion": 1002,
     "oldestForwardsCompatibleVersion": 1001
   },
   "kind": "Package",
-  "containerKey": "api-extractor-scenarios",
   "docComment": "",
   "name": "api-extractor-scenarios",
   "members": [
     {
       "kind": "EntryPoint",
-      "containerKey": "",
       "name": "",
       "members": [
         {
           "kind": "Class",
-          "containerKey": "A|Class",
           "docComment": "/**\n * @public\n */\n",
           "excerptTokens": [
             {
@@ -40,7 +37,6 @@
         },
         {
           "kind": "Class",
-          "containerKey": "B|Class",
           "docComment": "/**\n * @public\n */\n",
           "excerptTokens": [
             {
@@ -63,7 +59,6 @@
         },
         {
           "kind": "Class",
-          "containerKey": "IFile|Class",
           "docComment": "/**\n * @public\n */\n",
           "excerptTokens": [
             {
@@ -84,7 +79,6 @@
           "members": [
             {
               "kind": "Property",
-              "containerKey": "containingFolder|Property|instance",
               "docComment": "",
               "excerptTokens": [
                 {
@@ -117,7 +111,6 @@
         },
         {
           "kind": "Class",
-          "containerKey": "IFolder|Class",
           "docComment": "/**\n * @public\n */\n",
           "excerptTokens": [
             {
@@ -138,7 +131,6 @@
           "members": [
             {
               "kind": "Property",
-              "containerKey": "containingFolder|Property|instance",
               "docComment": "",
               "excerptTokens": [
                 {
@@ -172,7 +164,6 @@
             },
             {
               "kind": "Property",
-              "containerKey": "files|Property|instance",
               "docComment": "",
               "excerptTokens": [
                 {

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/circularImport2/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/circularImport2/api-extractor-scenarios.api.json
@@ -6,18 +6,18 @@
     "oldestForwardsCompatibleVersion": 1001
   },
   "kind": "Package",
-  "canonicalReference": "api-extractor-scenarios",
+  "containerKey": "api-extractor-scenarios",
   "docComment": "",
   "name": "api-extractor-scenarios",
   "members": [
     {
       "kind": "EntryPoint",
-      "canonicalReference": "",
+      "containerKey": "",
       "name": "",
       "members": [
         {
           "kind": "Class",
-          "canonicalReference": "(A:class)",
+          "containerKey": "A|Class",
           "docComment": "/**\n * @public\n */\n",
           "excerptTokens": [
             {
@@ -40,7 +40,7 @@
         },
         {
           "kind": "Class",
-          "canonicalReference": "(B:class)",
+          "containerKey": "B|Class",
           "docComment": "/**\n * @public\n */\n",
           "excerptTokens": [
             {
@@ -63,7 +63,7 @@
         },
         {
           "kind": "Class",
-          "canonicalReference": "(IFile:class)",
+          "containerKey": "IFile|Class",
           "docComment": "/**\n * @public\n */\n",
           "excerptTokens": [
             {
@@ -84,7 +84,7 @@
           "members": [
             {
               "kind": "Property",
-              "canonicalReference": "(containingFolder:instance)",
+              "containerKey": "containingFolder|Property|instance",
               "docComment": "",
               "excerptTokens": [
                 {
@@ -117,7 +117,7 @@
         },
         {
           "kind": "Class",
-          "canonicalReference": "(IFolder:class)",
+          "containerKey": "IFolder|Class",
           "docComment": "/**\n * @public\n */\n",
           "excerptTokens": [
             {
@@ -138,7 +138,7 @@
           "members": [
             {
               "kind": "Property",
-              "canonicalReference": "(containingFolder:instance)",
+              "containerKey": "containingFolder|Property|instance",
               "docComment": "",
               "excerptTokens": [
                 {
@@ -172,7 +172,7 @@
             },
             {
               "kind": "Property",
-              "canonicalReference": "(files:instance)",
+              "containerKey": "files|Property|instance",
               "docComment": "",
               "excerptTokens": [
                 {

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/defaultExportOfEntryPoint/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/defaultExportOfEntryPoint/api-extractor-scenarios.api.json
@@ -6,18 +6,18 @@
     "oldestForwardsCompatibleVersion": 1001
   },
   "kind": "Package",
-  "canonicalReference": "api-extractor-scenarios",
+  "containerKey": "api-extractor-scenarios",
   "docComment": "",
   "name": "api-extractor-scenarios",
   "members": [
     {
       "kind": "EntryPoint",
-      "canonicalReference": "",
+      "containerKey": "",
       "name": "",
       "members": [
         {
           "kind": "Class",
-          "canonicalReference": "(DefaultClass:class)",
+          "containerKey": "DefaultClass|Class",
           "docComment": "/**\n * @public\n */\n",
           "excerptTokens": [
             {

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/defaultExportOfEntryPoint/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/defaultExportOfEntryPoint/api-extractor-scenarios.api.json
@@ -2,22 +2,19 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1001,
+    "schemaVersion": 1002,
     "oldestForwardsCompatibleVersion": 1001
   },
   "kind": "Package",
-  "containerKey": "api-extractor-scenarios",
   "docComment": "",
   "name": "api-extractor-scenarios",
   "members": [
     {
       "kind": "EntryPoint",
-      "containerKey": "",
       "name": "",
       "members": [
         {
           "kind": "Class",
-          "containerKey": "DefaultClass|Class",
           "docComment": "/**\n * @public\n */\n",
           "excerptTokens": [
             {

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/defaultExportOfEntryPoint2/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/defaultExportOfEntryPoint2/api-extractor-scenarios.api.json
@@ -6,18 +6,18 @@
     "oldestForwardsCompatibleVersion": 1001
   },
   "kind": "Package",
-  "canonicalReference": "api-extractor-scenarios",
+  "containerKey": "api-extractor-scenarios",
   "docComment": "",
   "name": "api-extractor-scenarios",
   "members": [
     {
       "kind": "EntryPoint",
-      "canonicalReference": "",
+      "containerKey": "",
       "name": "",
       "members": [
         {
           "kind": "Variable",
-          "canonicalReference": "defaultFunctionStatement",
+          "containerKey": "defaultFunctionStatement|Variable",
           "docComment": "/**\n * @public\n */\n",
           "excerptTokens": [
             {

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/defaultExportOfEntryPoint2/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/defaultExportOfEntryPoint2/api-extractor-scenarios.api.json
@@ -2,22 +2,19 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1001,
+    "schemaVersion": 1002,
     "oldestForwardsCompatibleVersion": 1001
   },
   "kind": "Package",
-  "containerKey": "api-extractor-scenarios",
   "docComment": "",
   "name": "api-extractor-scenarios",
   "members": [
     {
       "kind": "EntryPoint",
-      "containerKey": "",
       "name": "",
       "members": [
         {
           "kind": "Variable",
-          "containerKey": "defaultFunctionStatement|Variable",
           "docComment": "/**\n * @public\n */\n",
           "excerptTokens": [
             {

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/defaultExportOfEntryPoint3/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/defaultExportOfEntryPoint3/api-extractor-scenarios.api.json
@@ -6,18 +6,18 @@
     "oldestForwardsCompatibleVersion": 1001
   },
   "kind": "Package",
-  "canonicalReference": "api-extractor-scenarios",
+  "containerKey": "api-extractor-scenarios",
   "docComment": "",
   "name": "api-extractor-scenarios",
   "members": [
     {
       "kind": "EntryPoint",
-      "canonicalReference": "",
+      "containerKey": "",
       "name": "",
       "members": [
         {
           "kind": "Function",
-          "canonicalReference": "(defaultFunctionDeclaration:0)",
+          "containerKey": "defaultFunctionDeclaration|Function|0",
           "docComment": "/**\n * @public\n */\n",
           "excerptTokens": [
             {

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/defaultExportOfEntryPoint3/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/defaultExportOfEntryPoint3/api-extractor-scenarios.api.json
@@ -2,22 +2,19 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1001,
+    "schemaVersion": 1002,
     "oldestForwardsCompatibleVersion": 1001
   },
   "kind": "Package",
-  "containerKey": "api-extractor-scenarios",
   "docComment": "",
   "name": "api-extractor-scenarios",
   "members": [
     {
       "kind": "EntryPoint",
-      "containerKey": "",
       "name": "",
       "members": [
         {
           "kind": "Function",
-          "containerKey": "defaultFunctionDeclaration|Function|0",
           "docComment": "/**\n * @public\n */\n",
           "excerptTokens": [
             {

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/defaultExportOfEntryPoint4/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/defaultExportOfEntryPoint4/api-extractor-scenarios.api.json
@@ -6,18 +6,18 @@
     "oldestForwardsCompatibleVersion": 1001
   },
   "kind": "Package",
-  "canonicalReference": "api-extractor-scenarios",
+  "containerKey": "api-extractor-scenarios",
   "docComment": "",
   "name": "api-extractor-scenarios",
   "members": [
     {
       "kind": "EntryPoint",
-      "canonicalReference": "",
+      "containerKey": "",
       "name": "",
       "members": [
         {
           "kind": "Variable",
-          "canonicalReference": "_default",
+          "containerKey": "_default|Variable",
           "docComment": "",
           "excerptTokens": [
             {

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/defaultExportOfEntryPoint4/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/defaultExportOfEntryPoint4/api-extractor-scenarios.api.json
@@ -2,22 +2,19 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1001,
+    "schemaVersion": 1002,
     "oldestForwardsCompatibleVersion": 1001
   },
   "kind": "Package",
-  "containerKey": "api-extractor-scenarios",
   "docComment": "",
   "name": "api-extractor-scenarios",
   "members": [
     {
       "kind": "EntryPoint",
-      "containerKey": "",
       "name": "",
       "members": [
         {
           "kind": "Variable",
-          "containerKey": "_default|Variable",
           "docComment": "",
           "excerptTokens": [
             {

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/docReferences/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/docReferences/api-extractor-scenarios.api.json
@@ -6,18 +6,18 @@
     "oldestForwardsCompatibleVersion": 1001
   },
   "kind": "Package",
-  "canonicalReference": "api-extractor-scenarios",
+  "containerKey": "api-extractor-scenarios",
   "docComment": "",
   "name": "api-extractor-scenarios",
   "members": [
     {
       "kind": "EntryPoint",
-      "canonicalReference": "",
+      "containerKey": "",
       "name": "",
       "members": [
         {
           "kind": "Function",
-          "canonicalReference": "(failWithBrokenLink:0)",
+          "containerKey": "failWithBrokenLink|Function|0",
           "docComment": "/**\n * {@inheritDoc MyNamespace.MyClass.nonExistentMethod}\n *\n * @public\n */\n",
           "excerptTokens": [
             {
@@ -52,7 +52,7 @@
         },
         {
           "kind": "Function",
-          "canonicalReference": "(failWithMissingReference:0)",
+          "containerKey": "failWithMissingReference|Function|0",
           "docComment": "/**\n * {@inheritDoc}\n *\n * @public\n */\n",
           "excerptTokens": [
             {
@@ -87,7 +87,7 @@
         },
         {
           "kind": "Namespace",
-          "canonicalReference": "(MyNamespace:namespace)",
+          "containerKey": "MyNamespace|Namespace",
           "docComment": "/**\n * @public\n */\n",
           "excerptTokens": [
             {
@@ -108,7 +108,7 @@
           "members": [
             {
               "kind": "Class",
-              "canonicalReference": "(MyClass:class)",
+              "containerKey": "MyClass|Class",
               "docComment": "",
               "excerptTokens": [
                 {
@@ -129,7 +129,7 @@
               "members": [
                 {
                   "kind": "Method",
-                  "canonicalReference": "(myMethod:instance,0)",
+                  "containerKey": "myMethod|Method|instance|0",
                   "docComment": "/**\n * Summary for myMethod\n *\n * @remarks\n *\n * Remarks for myMethod\n *\n * @param x - the parameter\n *\n * @returns a number\n *\n * @beta\n */\n",
                   "excerptTokens": [
                     {
@@ -190,7 +190,7 @@
         },
         {
           "kind": "Function",
-          "canonicalReference": "(succeedForNow:0)",
+          "containerKey": "succeedForNow|Function|0",
           "docComment": "/**\n * {@inheritDoc nonexistent-package#MyNamespace.MyClass.nonExistentMethod}\n *\n * @public\n */\n",
           "excerptTokens": [
             {
@@ -225,7 +225,7 @@
         },
         {
           "kind": "Function",
-          "canonicalReference": "(testSimple:0)",
+          "containerKey": "testSimple|Function|0",
           "docComment": "/**\n * Summary for myMethod\n *\n * @remarks\n *\n * Remarks for myMethod\n *\n * @param x - the parameter\n *\n * @returns a number\n *\n * @public\n */\n",
           "excerptTokens": [
             {

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/docReferences/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/docReferences/api-extractor-scenarios.api.json
@@ -2,22 +2,19 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1001,
+    "schemaVersion": 1002,
     "oldestForwardsCompatibleVersion": 1001
   },
   "kind": "Package",
-  "containerKey": "api-extractor-scenarios",
   "docComment": "",
   "name": "api-extractor-scenarios",
   "members": [
     {
       "kind": "EntryPoint",
-      "containerKey": "",
       "name": "",
       "members": [
         {
           "kind": "Function",
-          "containerKey": "failWithBrokenLink|Function|0",
           "docComment": "/**\n * {@inheritDoc MyNamespace.MyClass.nonExistentMethod}\n *\n * @public\n */\n",
           "excerptTokens": [
             {
@@ -52,7 +49,6 @@
         },
         {
           "kind": "Function",
-          "containerKey": "failWithMissingReference|Function|0",
           "docComment": "/**\n * {@inheritDoc}\n *\n * @public\n */\n",
           "excerptTokens": [
             {
@@ -87,7 +83,6 @@
         },
         {
           "kind": "Namespace",
-          "containerKey": "MyNamespace|Namespace",
           "docComment": "/**\n * @public\n */\n",
           "excerptTokens": [
             {
@@ -108,7 +103,6 @@
           "members": [
             {
               "kind": "Class",
-              "containerKey": "MyClass|Class",
               "docComment": "",
               "excerptTokens": [
                 {
@@ -129,7 +123,6 @@
               "members": [
                 {
                   "kind": "Method",
-                  "containerKey": "myMethod|Method|instance|0",
                   "docComment": "/**\n * Summary for myMethod\n *\n * @remarks\n *\n * Remarks for myMethod\n *\n * @param x - the parameter\n *\n * @returns a number\n *\n * @beta\n */\n",
                   "excerptTokens": [
                     {
@@ -190,7 +183,6 @@
         },
         {
           "kind": "Function",
-          "containerKey": "succeedForNow|Function|0",
           "docComment": "/**\n * {@inheritDoc nonexistent-package#MyNamespace.MyClass.nonExistentMethod}\n *\n * @public\n */\n",
           "excerptTokens": [
             {
@@ -225,7 +217,6 @@
         },
         {
           "kind": "Function",
-          "containerKey": "testSimple|Function|0",
           "docComment": "/**\n * Summary for myMethod\n *\n * @remarks\n *\n * Remarks for myMethod\n *\n * @param x - the parameter\n *\n * @returns a number\n *\n * @public\n */\n",
           "excerptTokens": [
             {

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/docReferences2/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/docReferences2/api-extractor-scenarios.api.json
@@ -6,18 +6,18 @@
     "oldestForwardsCompatibleVersion": 1001
   },
   "kind": "Package",
-  "canonicalReference": "api-extractor-scenarios",
+  "containerKey": "api-extractor-scenarios",
   "docComment": "",
   "name": "api-extractor-scenarios",
   "members": [
     {
       "kind": "EntryPoint",
-      "canonicalReference": "",
+      "containerKey": "",
       "name": "",
       "members": [
         {
           "kind": "Class",
-          "canonicalReference": "(CyclicA:class)",
+          "containerKey": "CyclicA|Class",
           "docComment": "/**\n * @public\n */\n",
           "excerptTokens": [
             {
@@ -38,7 +38,7 @@
           "members": [
             {
               "kind": "Method",
-              "canonicalReference": "(methodA1:instance,0)",
+              "containerKey": "methodA1|Method|instance|0",
               "docComment": "/**\n * THE COMMENT\n */\n",
               "excerptTokens": [
                 {
@@ -70,7 +70,7 @@
             },
             {
               "kind": "Method",
-              "canonicalReference": "(methodA3:instance,0)",
+              "containerKey": "methodA3|Method|instance|0",
               "docComment": "/**\n * THE COMMENT\n */\n",
               "excerptTokens": [
                 {
@@ -105,7 +105,7 @@
         },
         {
           "kind": "Class",
-          "canonicalReference": "(CyclicB:class)",
+          "containerKey": "CyclicB|Class",
           "docComment": "/**\n * @public\n */\n",
           "excerptTokens": [
             {
@@ -126,7 +126,7 @@
           "members": [
             {
               "kind": "Method",
-              "canonicalReference": "(methodB2:instance,0)",
+              "containerKey": "methodB2|Method|instance|0",
               "docComment": "/**\n * THE COMMENT\n */\n",
               "excerptTokens": [
                 {
@@ -158,7 +158,7 @@
             },
             {
               "kind": "Method",
-              "canonicalReference": "(methodB4:instance,0)",
+              "containerKey": "methodB4|Method|instance|0",
               "docComment": "/**\n * THE COMMENT\n */\n",
               "excerptTokens": [
                 {
@@ -193,7 +193,7 @@
         },
         {
           "kind": "Class",
-          "canonicalReference": "(FailWithSelfReference:class)",
+          "containerKey": "FailWithSelfReference|Class",
           "docComment": "/**\n * @public\n */\n",
           "excerptTokens": [
             {
@@ -214,7 +214,7 @@
           "members": [
             {
               "kind": "Method",
-              "canonicalReference": "(method1:instance,0)",
+              "containerKey": "method1|Method|instance|0",
               "docComment": "",
               "excerptTokens": [
                 {
@@ -246,7 +246,7 @@
             },
             {
               "kind": "Method",
-              "canonicalReference": "(method2:instance,0)",
+              "containerKey": "method2|Method|instance|0",
               "docComment": "",
               "excerptTokens": [
                 {

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/docReferences2/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/docReferences2/api-extractor-scenarios.api.json
@@ -2,22 +2,19 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1001,
+    "schemaVersion": 1002,
     "oldestForwardsCompatibleVersion": 1001
   },
   "kind": "Package",
-  "containerKey": "api-extractor-scenarios",
   "docComment": "",
   "name": "api-extractor-scenarios",
   "members": [
     {
       "kind": "EntryPoint",
-      "containerKey": "",
       "name": "",
       "members": [
         {
           "kind": "Class",
-          "containerKey": "CyclicA|Class",
           "docComment": "/**\n * @public\n */\n",
           "excerptTokens": [
             {
@@ -38,7 +35,6 @@
           "members": [
             {
               "kind": "Method",
-              "containerKey": "methodA1|Method|instance|0",
               "docComment": "/**\n * THE COMMENT\n */\n",
               "excerptTokens": [
                 {
@@ -70,7 +66,6 @@
             },
             {
               "kind": "Method",
-              "containerKey": "methodA3|Method|instance|0",
               "docComment": "/**\n * THE COMMENT\n */\n",
               "excerptTokens": [
                 {
@@ -105,7 +100,6 @@
         },
         {
           "kind": "Class",
-          "containerKey": "CyclicB|Class",
           "docComment": "/**\n * @public\n */\n",
           "excerptTokens": [
             {
@@ -126,7 +120,6 @@
           "members": [
             {
               "kind": "Method",
-              "containerKey": "methodB2|Method|instance|0",
               "docComment": "/**\n * THE COMMENT\n */\n",
               "excerptTokens": [
                 {
@@ -158,7 +151,6 @@
             },
             {
               "kind": "Method",
-              "containerKey": "methodB4|Method|instance|0",
               "docComment": "/**\n * THE COMMENT\n */\n",
               "excerptTokens": [
                 {
@@ -193,7 +185,6 @@
         },
         {
           "kind": "Class",
-          "containerKey": "FailWithSelfReference|Class",
           "docComment": "/**\n * @public\n */\n",
           "excerptTokens": [
             {
@@ -214,7 +205,6 @@
           "members": [
             {
               "kind": "Method",
-              "containerKey": "method1|Method|instance|0",
               "docComment": "",
               "excerptTokens": [
                 {
@@ -246,7 +236,6 @@
             },
             {
               "kind": "Method",
-              "containerKey": "method2|Method|instance|0",
               "docComment": "",
               "excerptTokens": [
                 {

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/docReferences3/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/docReferences3/api-extractor-scenarios.api.json
@@ -2,22 +2,19 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1001,
+    "schemaVersion": 1002,
     "oldestForwardsCompatibleVersion": 1001
   },
   "kind": "Package",
-  "containerKey": "api-extractor-scenarios",
   "docComment": "",
   "name": "api-extractor-scenarios",
   "members": [
     {
       "kind": "EntryPoint",
-      "containerKey": "",
       "name": "",
       "members": [
         {
           "kind": "Interface",
-          "containerKey": "A|Interface",
           "docComment": "",
           "excerptTokens": [
             {
@@ -38,7 +35,6 @@
           "members": [
             {
               "kind": "PropertySignature",
-              "containerKey": "myProperty|PropertySignature",
               "docComment": "",
               "excerptTokens": [
                 {
@@ -70,7 +66,6 @@
         },
         {
           "kind": "Namespace",
-          "containerKey": "A|Namespace",
           "docComment": "/**\n * @public\n */\n",
           "excerptTokens": [
             {
@@ -91,7 +86,6 @@
           "members": [
             {
               "kind": "Class",
-              "containerKey": "B|Class",
               "docComment": "",
               "excerptTokens": [
                 {
@@ -112,7 +106,6 @@
               "members": [
                 {
                   "kind": "Method",
-                  "containerKey": "myMethod|Method|instance|0",
                   "docComment": "",
                   "excerptTokens": [
                     {
@@ -149,7 +142,6 @@
         },
         {
           "kind": "Function",
-          "containerKey": "failWithAmbiguity|Function|0",
           "docComment": "/**\n * {@link MyNamespace.MyClass.myMethod | the method}\n *\n * @public\n */\n",
           "excerptTokens": [
             {
@@ -184,7 +176,6 @@
         },
         {
           "kind": "Function",
-          "containerKey": "succeedWithExternalReference|Function|0",
           "docComment": "/**\n * NOTE: The broken link checker currently is not able to validate references to external packages. Tracked by: https://github.com/Microsoft/web-build-tools/issues/1195 {@link nonexistent#nonexistent}\n *\n * @public\n */\n",
           "excerptTokens": [
             {
@@ -219,7 +210,6 @@
         },
         {
           "kind": "Function",
-          "containerKey": "succeedWithSelector|Function|0",
           "docComment": "/**\n * {@link (A:namespace).B.myMethod | the method} {@link (A:interface).myProperty | the property}\n *\n * @public\n */\n",
           "excerptTokens": [
             {

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/docReferences3/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/docReferences3/api-extractor-scenarios.api.json
@@ -6,18 +6,18 @@
     "oldestForwardsCompatibleVersion": 1001
   },
   "kind": "Package",
-  "canonicalReference": "api-extractor-scenarios",
+  "containerKey": "api-extractor-scenarios",
   "docComment": "",
   "name": "api-extractor-scenarios",
   "members": [
     {
       "kind": "EntryPoint",
-      "canonicalReference": "",
+      "containerKey": "",
       "name": "",
       "members": [
         {
           "kind": "Interface",
-          "canonicalReference": "(A:interface)",
+          "containerKey": "A|Interface",
           "docComment": "",
           "excerptTokens": [
             {
@@ -38,7 +38,7 @@
           "members": [
             {
               "kind": "PropertySignature",
-              "canonicalReference": "myProperty",
+              "containerKey": "myProperty|PropertySignature",
               "docComment": "",
               "excerptTokens": [
                 {
@@ -70,7 +70,7 @@
         },
         {
           "kind": "Namespace",
-          "canonicalReference": "(A:namespace)",
+          "containerKey": "A|Namespace",
           "docComment": "/**\n * @public\n */\n",
           "excerptTokens": [
             {
@@ -91,7 +91,7 @@
           "members": [
             {
               "kind": "Class",
-              "canonicalReference": "(B:class)",
+              "containerKey": "B|Class",
               "docComment": "",
               "excerptTokens": [
                 {
@@ -112,7 +112,7 @@
               "members": [
                 {
                   "kind": "Method",
-                  "canonicalReference": "(myMethod:instance,0)",
+                  "containerKey": "myMethod|Method|instance|0",
                   "docComment": "",
                   "excerptTokens": [
                     {
@@ -149,7 +149,7 @@
         },
         {
           "kind": "Function",
-          "canonicalReference": "(failWithAmbiguity:0)",
+          "containerKey": "failWithAmbiguity|Function|0",
           "docComment": "/**\n * {@link MyNamespace.MyClass.myMethod | the method}\n *\n * @public\n */\n",
           "excerptTokens": [
             {
@@ -184,7 +184,7 @@
         },
         {
           "kind": "Function",
-          "canonicalReference": "(succeedWithExternalReference:0)",
+          "containerKey": "succeedWithExternalReference|Function|0",
           "docComment": "/**\n * NOTE: The broken link checker currently is not able to validate references to external packages. Tracked by: https://github.com/Microsoft/web-build-tools/issues/1195 {@link nonexistent#nonexistent}\n *\n * @public\n */\n",
           "excerptTokens": [
             {
@@ -219,7 +219,7 @@
         },
         {
           "kind": "Function",
-          "canonicalReference": "(succeedWithSelector:0)",
+          "containerKey": "succeedWithSelector|Function|0",
           "docComment": "/**\n * {@link (A:namespace).B.myMethod | the method} {@link (A:interface).myProperty | the property}\n *\n * @public\n */\n",
           "excerptTokens": [
             {

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/exportDuplicate/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/exportDuplicate/api-extractor-scenarios.api.json
@@ -2,22 +2,19 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1001,
+    "schemaVersion": 1002,
     "oldestForwardsCompatibleVersion": 1001
   },
   "kind": "Package",
-  "containerKey": "api-extractor-scenarios",
   "docComment": "",
   "name": "api-extractor-scenarios",
   "members": [
     {
       "kind": "EntryPoint",
-      "containerKey": "",
       "name": "",
       "members": [
         {
           "kind": "Class",
-          "containerKey": "X|Class",
           "docComment": "/**\n * @public\n */\n",
           "excerptTokens": [
             {

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/exportDuplicate/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/exportDuplicate/api-extractor-scenarios.api.json
@@ -6,18 +6,18 @@
     "oldestForwardsCompatibleVersion": 1001
   },
   "kind": "Package",
-  "canonicalReference": "api-extractor-scenarios",
+  "containerKey": "api-extractor-scenarios",
   "docComment": "",
   "name": "api-extractor-scenarios",
   "members": [
     {
       "kind": "EntryPoint",
-      "canonicalReference": "",
+      "containerKey": "",
       "name": "",
       "members": [
         {
           "kind": "Class",
-          "canonicalReference": "(X:class)",
+          "containerKey": "X|Class",
           "docComment": "/**\n * @public\n */\n",
           "excerptTokens": [
             {

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/exportEquals/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/exportEquals/api-extractor-scenarios.api.json
@@ -6,18 +6,18 @@
     "oldestForwardsCompatibleVersion": 1001
   },
   "kind": "Package",
-  "canonicalReference": "api-extractor-scenarios",
+  "containerKey": "api-extractor-scenarios",
   "docComment": "",
   "name": "api-extractor-scenarios",
   "members": [
     {
       "kind": "EntryPoint",
-      "canonicalReference": "",
+      "containerKey": "",
       "name": "",
       "members": [
         {
           "kind": "Interface",
-          "canonicalReference": "(ITeamsContext:interface)",
+          "containerKey": "ITeamsContext|Interface",
           "docComment": "/**\n * @public\n */\n",
           "excerptTokens": [
             {
@@ -38,7 +38,7 @@
           "members": [
             {
               "kind": "PropertySignature",
-              "canonicalReference": "context",
+              "containerKey": "context|PropertySignature",
               "docComment": "",
               "excerptTokens": [
                 {

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/exportEquals/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/exportEquals/api-extractor-scenarios.api.json
@@ -2,22 +2,19 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1001,
+    "schemaVersion": 1002,
     "oldestForwardsCompatibleVersion": 1001
   },
   "kind": "Package",
-  "containerKey": "api-extractor-scenarios",
   "docComment": "",
   "name": "api-extractor-scenarios",
   "members": [
     {
       "kind": "EntryPoint",
-      "containerKey": "",
       "name": "",
       "members": [
         {
           "kind": "Interface",
-          "containerKey": "ITeamsContext|Interface",
           "docComment": "/**\n * @public\n */\n",
           "excerptTokens": [
             {
@@ -38,7 +35,6 @@
           "members": [
             {
               "kind": "PropertySignature",
-              "containerKey": "context|PropertySignature",
               "docComment": "",
               "excerptTokens": [
                 {

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/exportImportedExternal/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/exportImportedExternal/api-extractor-scenarios.api.json
@@ -6,13 +6,13 @@
     "oldestForwardsCompatibleVersion": 1001
   },
   "kind": "Package",
-  "canonicalReference": "api-extractor-scenarios",
+  "containerKey": "api-extractor-scenarios",
   "docComment": "",
   "name": "api-extractor-scenarios",
   "members": [
     {
       "kind": "EntryPoint",
-      "canonicalReference": "",
+      "containerKey": "",
       "name": "",
       "members": []
     }

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/exportImportedExternal/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/exportImportedExternal/api-extractor-scenarios.api.json
@@ -2,17 +2,15 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1001,
+    "schemaVersion": 1002,
     "oldestForwardsCompatibleVersion": 1001
   },
   "kind": "Package",
-  "containerKey": "api-extractor-scenarios",
   "docComment": "",
   "name": "api-extractor-scenarios",
   "members": [
     {
       "kind": "EntryPoint",
-      "containerKey": "",
       "name": "",
       "members": []
     }

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/exportImportedExternal2/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/exportImportedExternal2/api-extractor-scenarios.api.json
@@ -6,13 +6,13 @@
     "oldestForwardsCompatibleVersion": 1001
   },
   "kind": "Package",
-  "canonicalReference": "api-extractor-scenarios",
+  "containerKey": "api-extractor-scenarios",
   "docComment": "",
   "name": "api-extractor-scenarios",
   "members": [
     {
       "kind": "EntryPoint",
-      "canonicalReference": "",
+      "containerKey": "",
       "name": "",
       "members": []
     }

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/exportImportedExternal2/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/exportImportedExternal2/api-extractor-scenarios.api.json
@@ -2,17 +2,15 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1001,
+    "schemaVersion": 1002,
     "oldestForwardsCompatibleVersion": 1001
   },
   "kind": "Package",
-  "containerKey": "api-extractor-scenarios",
   "docComment": "",
   "name": "api-extractor-scenarios",
   "members": [
     {
       "kind": "EntryPoint",
-      "containerKey": "",
       "name": "",
       "members": []
     }

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/exportStar/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/exportStar/api-extractor-scenarios.api.json
@@ -2,22 +2,19 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1001,
+    "schemaVersion": 1002,
     "oldestForwardsCompatibleVersion": 1001
   },
   "kind": "Package",
-  "containerKey": "api-extractor-scenarios",
   "docComment": "",
   "name": "api-extractor-scenarios",
   "members": [
     {
       "kind": "EntryPoint",
-      "containerKey": "",
       "name": "",
       "members": [
         {
           "kind": "Class",
-          "containerKey": "A|Class",
           "docComment": "/**\n * @public\n */\n",
           "excerptTokens": [
             {
@@ -40,7 +37,6 @@
         },
         {
           "kind": "Class",
-          "containerKey": "B|Class",
           "docComment": "/**\n * @public\n */\n",
           "excerptTokens": [
             {
@@ -63,7 +59,6 @@
         },
         {
           "kind": "Class",
-          "containerKey": "C|Class",
           "docComment": "/**\n * @public\n */\n",
           "excerptTokens": [
             {

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/exportStar/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/exportStar/api-extractor-scenarios.api.json
@@ -6,18 +6,18 @@
     "oldestForwardsCompatibleVersion": 1001
   },
   "kind": "Package",
-  "canonicalReference": "api-extractor-scenarios",
+  "containerKey": "api-extractor-scenarios",
   "docComment": "",
   "name": "api-extractor-scenarios",
   "members": [
     {
       "kind": "EntryPoint",
-      "canonicalReference": "",
+      "containerKey": "",
       "name": "",
       "members": [
         {
           "kind": "Class",
-          "canonicalReference": "(A:class)",
+          "containerKey": "A|Class",
           "docComment": "/**\n * @public\n */\n",
           "excerptTokens": [
             {
@@ -40,7 +40,7 @@
         },
         {
           "kind": "Class",
-          "canonicalReference": "(B:class)",
+          "containerKey": "B|Class",
           "docComment": "/**\n * @public\n */\n",
           "excerptTokens": [
             {
@@ -63,7 +63,7 @@
         },
         {
           "kind": "Class",
-          "canonicalReference": "(C:class)",
+          "containerKey": "C|Class",
           "docComment": "/**\n * @public\n */\n",
           "excerptTokens": [
             {

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/exportStar2/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/exportStar2/api-extractor-scenarios.api.json
@@ -2,22 +2,19 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1001,
+    "schemaVersion": 1002,
     "oldestForwardsCompatibleVersion": 1001
   },
   "kind": "Package",
-  "containerKey": "api-extractor-scenarios",
   "docComment": "",
   "name": "api-extractor-scenarios",
   "members": [
     {
       "kind": "EntryPoint",
-      "containerKey": "",
       "name": "",
       "members": [
         {
           "kind": "Class",
-          "containerKey": "A|Class",
           "docComment": "/**\n * @public\n */\n",
           "excerptTokens": [
             {

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/exportStar2/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/exportStar2/api-extractor-scenarios.api.json
@@ -6,18 +6,18 @@
     "oldestForwardsCompatibleVersion": 1001
   },
   "kind": "Package",
-  "canonicalReference": "api-extractor-scenarios",
+  "containerKey": "api-extractor-scenarios",
   "docComment": "",
   "name": "api-extractor-scenarios",
   "members": [
     {
       "kind": "EntryPoint",
-      "canonicalReference": "",
+      "containerKey": "",
       "name": "",
       "members": [
         {
           "kind": "Class",
-          "canonicalReference": "(A:class)",
+          "containerKey": "A|Class",
           "docComment": "/**\n * @public\n */\n",
           "excerptTokens": [
             {

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/exportStar3/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/exportStar3/api-extractor-scenarios.api.json
@@ -2,22 +2,19 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1001,
+    "schemaVersion": 1002,
     "oldestForwardsCompatibleVersion": 1001
   },
   "kind": "Package",
-  "containerKey": "api-extractor-scenarios",
   "docComment": "",
   "name": "api-extractor-scenarios",
   "members": [
     {
       "kind": "EntryPoint",
-      "containerKey": "",
       "name": "",
       "members": [
         {
           "kind": "Class",
-          "containerKey": "A|Class",
           "docComment": "/**\n * @public\n */\n",
           "excerptTokens": [
             {

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/exportStar3/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/exportStar3/api-extractor-scenarios.api.json
@@ -6,18 +6,18 @@
     "oldestForwardsCompatibleVersion": 1001
   },
   "kind": "Package",
-  "canonicalReference": "api-extractor-scenarios",
+  "containerKey": "api-extractor-scenarios",
   "docComment": "",
   "name": "api-extractor-scenarios",
   "members": [
     {
       "kind": "EntryPoint",
-      "canonicalReference": "",
+      "containerKey": "",
       "name": "",
       "members": [
         {
           "kind": "Class",
-          "canonicalReference": "(A:class)",
+          "containerKey": "A|Class",
           "docComment": "/**\n * @public\n */\n",
           "excerptTokens": [
             {

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/importEquals/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/importEquals/api-extractor-scenarios.api.json
@@ -2,22 +2,19 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1001,
+    "schemaVersion": 1002,
     "oldestForwardsCompatibleVersion": 1001
   },
   "kind": "Package",
-  "containerKey": "api-extractor-scenarios",
   "docComment": "",
   "name": "api-extractor-scenarios",
   "members": [
     {
       "kind": "EntryPoint",
-      "containerKey": "",
       "name": "",
       "members": [
         {
           "kind": "Function",
-          "containerKey": "useColors|Function|0",
           "docComment": "/**\n * @public\n */\n",
           "excerptTokens": [
             {

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/importEquals/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/importEquals/api-extractor-scenarios.api.json
@@ -6,18 +6,18 @@
     "oldestForwardsCompatibleVersion": 1001
   },
   "kind": "Package",
-  "canonicalReference": "api-extractor-scenarios",
+  "containerKey": "api-extractor-scenarios",
   "docComment": "",
   "name": "api-extractor-scenarios",
   "members": [
     {
       "kind": "EntryPoint",
-      "canonicalReference": "",
+      "containerKey": "",
       "name": "",
       "members": [
         {
           "kind": "Function",
-          "canonicalReference": "(useColors:0)",
+          "containerKey": "useColors|Function|0",
           "docComment": "/**\n * @public\n */\n",
           "excerptTokens": [
             {

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/inconsistentReleaseTags/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/inconsistentReleaseTags/api-extractor-scenarios.api.json
@@ -2,22 +2,19 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1001,
+    "schemaVersion": 1002,
     "oldestForwardsCompatibleVersion": 1001
   },
   "kind": "Package",
-  "containerKey": "api-extractor-scenarios",
   "docComment": "",
   "name": "api-extractor-scenarios",
   "members": [
     {
       "kind": "EntryPoint",
-      "containerKey": "",
       "name": "",
       "members": [
         {
           "kind": "Interface",
-          "containerKey": "IBeta|Interface",
           "docComment": "/**\n * @beta\n */\n",
           "excerptTokens": [
             {
@@ -38,7 +35,6 @@
           "members": [
             {
               "kind": "PropertySignature",
-              "containerKey": "x|PropertySignature",
               "docComment": "",
               "excerptTokens": [
                 {
@@ -70,7 +66,6 @@
         },
         {
           "kind": "Function",
-          "containerKey": "publicFunctionReturnsBeta|Function|0",
           "docComment": "/**\n * It's not okay for a \"public\" function to reference a \"beta\" symbol, because \"beta\" is less public than \"public\".\n *\n * @public\n */\n",
           "excerptTokens": [
             {

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/inconsistentReleaseTags/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/inconsistentReleaseTags/api-extractor-scenarios.api.json
@@ -6,18 +6,18 @@
     "oldestForwardsCompatibleVersion": 1001
   },
   "kind": "Package",
-  "canonicalReference": "api-extractor-scenarios",
+  "containerKey": "api-extractor-scenarios",
   "docComment": "",
   "name": "api-extractor-scenarios",
   "members": [
     {
       "kind": "EntryPoint",
-      "canonicalReference": "",
+      "containerKey": "",
       "name": "",
       "members": [
         {
           "kind": "Interface",
-          "canonicalReference": "(IBeta:interface)",
+          "containerKey": "IBeta|Interface",
           "docComment": "/**\n * @beta\n */\n",
           "excerptTokens": [
             {
@@ -38,7 +38,7 @@
           "members": [
             {
               "kind": "PropertySignature",
-              "canonicalReference": "x",
+              "containerKey": "x|PropertySignature",
               "docComment": "",
               "excerptTokens": [
                 {
@@ -70,7 +70,7 @@
         },
         {
           "kind": "Function",
-          "canonicalReference": "(publicFunctionReturnsBeta:0)",
+          "containerKey": "publicFunctionReturnsBeta|Function|0",
           "docComment": "/**\n * It's not okay for a \"public\" function to reference a \"beta\" symbol, because \"beta\" is less public than \"public\".\n *\n * @public\n */\n",
           "excerptTokens": [
             {

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/preapproved/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/preapproved/api-extractor-scenarios.api.json
@@ -6,13 +6,13 @@
     "oldestForwardsCompatibleVersion": 1001
   },
   "kind": "Package",
-  "canonicalReference": "api-extractor-scenarios",
+  "containerKey": "api-extractor-scenarios",
   "docComment": "",
   "name": "api-extractor-scenarios",
   "members": [
     {
       "kind": "EntryPoint",
-      "canonicalReference": "",
+      "containerKey": "",
       "name": "",
       "members": []
     }

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/preapproved/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/preapproved/api-extractor-scenarios.api.json
@@ -2,17 +2,15 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1001,
+    "schemaVersion": 1002,
     "oldestForwardsCompatibleVersion": 1001
   },
   "kind": "Package",
-  "containerKey": "api-extractor-scenarios",
   "docComment": "",
   "name": "api-extractor-scenarios",
   "members": [
     {
       "kind": "EntryPoint",
-      "containerKey": "",
       "name": "",
       "members": []
     }

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/typeOf/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/typeOf/api-extractor-scenarios.api.json
@@ -6,18 +6,18 @@
     "oldestForwardsCompatibleVersion": 1001
   },
   "kind": "Package",
-  "canonicalReference": "api-extractor-scenarios",
+  "containerKey": "api-extractor-scenarios",
   "docComment": "",
   "name": "api-extractor-scenarios",
   "members": [
     {
       "kind": "EntryPoint",
-      "canonicalReference": "",
+      "containerKey": "",
       "name": "",
       "members": [
         {
           "kind": "Function",
-          "canonicalReference": "(f:0)",
+          "containerKey": "f|Function|0",
           "docComment": "/**\n * Reference Lib1Class via \"typeof\"\n *\n * @public\n */\n",
           "excerptTokens": [
             {
@@ -60,7 +60,7 @@
         },
         {
           "kind": "Function",
-          "canonicalReference": "(g:0)",
+          "containerKey": "g|Function|0",
           "docComment": "/**\n * Reference IForgottenExport via \"typeof\"\n *\n * @public\n */\n",
           "excerptTokens": [
             {

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/typeOf/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/typeOf/api-extractor-scenarios.api.json
@@ -2,22 +2,19 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1001,
+    "schemaVersion": 1002,
     "oldestForwardsCompatibleVersion": 1001
   },
   "kind": "Package",
-  "containerKey": "api-extractor-scenarios",
   "docComment": "",
   "name": "api-extractor-scenarios",
   "members": [
     {
       "kind": "EntryPoint",
-      "containerKey": "",
       "name": "",
       "members": [
         {
           "kind": "Function",
-          "containerKey": "f|Function|0",
           "docComment": "/**\n * Reference Lib1Class via \"typeof\"\n *\n * @public\n */\n",
           "excerptTokens": [
             {
@@ -60,7 +57,6 @@
         },
         {
           "kind": "Function",
-          "containerKey": "g|Function|0",
           "docComment": "/**\n * Reference IForgottenExport via \"typeof\"\n *\n * @public\n */\n",
           "excerptTokens": [
             {

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/typeParameters/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/typeParameters/api-extractor-scenarios.api.json
@@ -6,18 +6,18 @@
     "oldestForwardsCompatibleVersion": 1001
   },
   "kind": "Package",
-  "canonicalReference": "api-extractor-scenarios",
+  "containerKey": "api-extractor-scenarios",
   "docComment": "",
   "name": "api-extractor-scenarios",
   "members": [
     {
       "kind": "EntryPoint",
-      "canonicalReference": "",
+      "containerKey": "",
       "name": "",
       "members": [
         {
           "kind": "Class",
-          "canonicalReference": "(ClassWithGenericMethod:class)",
+          "containerKey": "ClassWithGenericMethod|Class",
           "docComment": "/**\n * @public\n */\n",
           "excerptTokens": [
             {
@@ -38,7 +38,7 @@
           "members": [
             {
               "kind": "Method",
-              "canonicalReference": "(method:instance,0)",
+              "containerKey": "method|Method|instance|0",
               "docComment": "",
               "excerptTokens": [
                 {
@@ -94,7 +94,7 @@
         },
         {
           "kind": "Class",
-          "canonicalReference": "(GenericClass:class)",
+          "containerKey": "GenericClass|Class",
           "docComment": "/**\n * @public\n */\n",
           "excerptTokens": [
             {
@@ -138,7 +138,7 @@
         },
         {
           "kind": "Class",
-          "canonicalReference": "(GenericClassWithConstraint:class)",
+          "containerKey": "GenericClassWithConstraint|Class",
           "docComment": "/**\n * @public\n */\n",
           "excerptTokens": [
             {
@@ -190,7 +190,7 @@
         },
         {
           "kind": "Class",
-          "canonicalReference": "(GenericClassWithDefault:class)",
+          "containerKey": "GenericClassWithDefault|Class",
           "docComment": "/**\n * @public\n */\n",
           "excerptTokens": [
             {
@@ -242,7 +242,7 @@
         },
         {
           "kind": "Function",
-          "canonicalReference": "(genericFunction:0)",
+          "containerKey": "genericFunction|Function|0",
           "docComment": "/**\n * @public\n */\n",
           "excerptTokens": [
             {
@@ -298,7 +298,7 @@
         },
         {
           "kind": "Interface",
-          "canonicalReference": "(GenericInterface:interface)",
+          "containerKey": "GenericInterface|Interface",
           "docComment": "/**\n * @public\n */\n",
           "excerptTokens": [
             {
@@ -341,150 +341,8 @@
           "extendsTokenRanges": []
         },
         {
-          "kind": "Interface",
-          "canonicalReference": "(InterfaceWithGenericCallSignature:interface)",
-          "docComment": "/**\n * @public\n */\n",
-          "excerptTokens": [
-            {
-              "kind": "Content",
-              "text": "export interface "
-            },
-            {
-              "kind": "Reference",
-              "text": "InterfaceWithGenericCallSignature"
-            },
-            {
-              "kind": "Content",
-              "text": " "
-            }
-          ],
-          "releaseTag": "Public",
-          "name": "InterfaceWithGenericCallSignature",
-          "members": [
-            {
-              "kind": "CallSignature",
-              "canonicalReference": "(:call,0)",
-              "docComment": "",
-              "excerptTokens": [
-                {
-                  "kind": "Content",
-                  "text": "<"
-                },
-                {
-                  "kind": "Reference",
-                  "text": "T"
-                },
-                {
-                  "kind": "Content",
-                  "text": ">(): "
-                },
-                {
-                  "kind": "Content",
-                  "text": "void"
-                },
-                {
-                  "kind": "Content",
-                  "text": ";"
-                }
-              ],
-              "returnTypeTokenRange": {
-                "startIndex": 3,
-                "endIndex": 4
-              },
-              "releaseTag": "Public",
-              "overloadIndex": 0,
-              "parameters": [],
-              "typeParameters": [
-                {
-                  "typeParameterName": "T",
-                  "constraintTokenRange": {
-                    "startIndex": 0,
-                    "endIndex": 0
-                  },
-                  "defaultTypeTokenRange": {
-                    "startIndex": 0,
-                    "endIndex": 0
-                  }
-                }
-              ]
-            }
-          ],
-          "extendsTokenRanges": []
-        },
-        {
-          "kind": "Interface",
-          "canonicalReference": "(InterfaceWithGenericConstructSignature:interface)",
-          "docComment": "/**\n * @public\n */\n",
-          "excerptTokens": [
-            {
-              "kind": "Content",
-              "text": "export interface "
-            },
-            {
-              "kind": "Reference",
-              "text": "InterfaceWithGenericConstructSignature"
-            },
-            {
-              "kind": "Content",
-              "text": " "
-            }
-          ],
-          "releaseTag": "Public",
-          "name": "InterfaceWithGenericConstructSignature",
-          "members": [
-            {
-              "kind": "ConstructSignature",
-              "canonicalReference": "(:new,0)",
-              "docComment": "",
-              "excerptTokens": [
-                {
-                  "kind": "Content",
-                  "text": "new <"
-                },
-                {
-                  "kind": "Reference",
-                  "text": "T"
-                },
-                {
-                  "kind": "Content",
-                  "text": ">(): "
-                },
-                {
-                  "kind": "Reference",
-                  "text": "T"
-                },
-                {
-                  "kind": "Content",
-                  "text": ";"
-                }
-              ],
-              "returnTypeTokenRange": {
-                "startIndex": 3,
-                "endIndex": 4
-              },
-              "releaseTag": "Public",
-              "overloadIndex": 0,
-              "parameters": [],
-              "typeParameters": [
-                {
-                  "typeParameterName": "T",
-                  "constraintTokenRange": {
-                    "startIndex": 0,
-                    "endIndex": 0
-                  },
-                  "defaultTypeTokenRange": {
-                    "startIndex": 0,
-                    "endIndex": 0
-                  }
-                }
-              ]
-            }
-          ],
-          "extendsTokenRanges": []
-        },
-        {
           "kind": "TypeAlias",
-          "canonicalReference": "GenericTypeAlias",
+          "containerKey": "GenericTypeAlias|TypeAlias",
           "docComment": "/**\n * @public\n */\n",
           "excerptTokens": [
             {
@@ -535,6 +393,148 @@
             "startIndex": 5,
             "endIndex": 6
           }
+        },
+        {
+          "kind": "Interface",
+          "containerKey": "InterfaceWithGenericCallSignature|Interface",
+          "docComment": "/**\n * @public\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export interface "
+            },
+            {
+              "kind": "Reference",
+              "text": "InterfaceWithGenericCallSignature"
+            },
+            {
+              "kind": "Content",
+              "text": " "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "InterfaceWithGenericCallSignature",
+          "members": [
+            {
+              "kind": "CallSignature",
+              "containerKey": "|CallSignature|0",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "<"
+                },
+                {
+                  "kind": "Reference",
+                  "text": "T"
+                },
+                {
+                  "kind": "Content",
+                  "text": ">(): "
+                },
+                {
+                  "kind": "Content",
+                  "text": "void"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "returnTypeTokenRange": {
+                "startIndex": 3,
+                "endIndex": 4
+              },
+              "releaseTag": "Public",
+              "overloadIndex": 0,
+              "parameters": [],
+              "typeParameters": [
+                {
+                  "typeParameterName": "T",
+                  "constraintTokenRange": {
+                    "startIndex": 0,
+                    "endIndex": 0
+                  },
+                  "defaultTypeTokenRange": {
+                    "startIndex": 0,
+                    "endIndex": 0
+                  }
+                }
+              ]
+            }
+          ],
+          "extendsTokenRanges": []
+        },
+        {
+          "kind": "Interface",
+          "containerKey": "InterfaceWithGenericConstructSignature|Interface",
+          "docComment": "/**\n * @public\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export interface "
+            },
+            {
+              "kind": "Reference",
+              "text": "InterfaceWithGenericConstructSignature"
+            },
+            {
+              "kind": "Content",
+              "text": " "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "InterfaceWithGenericConstructSignature",
+          "members": [
+            {
+              "kind": "ConstructSignature",
+              "containerKey": "|ConstructSignature|0",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "new <"
+                },
+                {
+                  "kind": "Reference",
+                  "text": "T"
+                },
+                {
+                  "kind": "Content",
+                  "text": ">(): "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "T"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "returnTypeTokenRange": {
+                "startIndex": 3,
+                "endIndex": 4
+              },
+              "releaseTag": "Public",
+              "overloadIndex": 0,
+              "parameters": [],
+              "typeParameters": [
+                {
+                  "typeParameterName": "T",
+                  "constraintTokenRange": {
+                    "startIndex": 0,
+                    "endIndex": 0
+                  },
+                  "defaultTypeTokenRange": {
+                    "startIndex": 0,
+                    "endIndex": 0
+                  }
+                }
+              ]
+            }
+          ],
+          "extendsTokenRanges": []
         }
       ]
     }

--- a/build-tests/api-extractor-scenarios/etc/test-outputs/typeParameters/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/test-outputs/typeParameters/api-extractor-scenarios.api.json
@@ -2,22 +2,19 @@
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
     "toolVersion": "[test mode]",
-    "schemaVersion": 1001,
+    "schemaVersion": 1002,
     "oldestForwardsCompatibleVersion": 1001
   },
   "kind": "Package",
-  "containerKey": "api-extractor-scenarios",
   "docComment": "",
   "name": "api-extractor-scenarios",
   "members": [
     {
       "kind": "EntryPoint",
-      "containerKey": "",
       "name": "",
       "members": [
         {
           "kind": "Class",
-          "containerKey": "ClassWithGenericMethod|Class",
           "docComment": "/**\n * @public\n */\n",
           "excerptTokens": [
             {
@@ -38,7 +35,6 @@
           "members": [
             {
               "kind": "Method",
-              "containerKey": "method|Method|instance|0",
               "docComment": "",
               "excerptTokens": [
                 {
@@ -94,7 +90,6 @@
         },
         {
           "kind": "Class",
-          "containerKey": "GenericClass|Class",
           "docComment": "/**\n * @public\n */\n",
           "excerptTokens": [
             {
@@ -138,7 +133,6 @@
         },
         {
           "kind": "Class",
-          "containerKey": "GenericClassWithConstraint|Class",
           "docComment": "/**\n * @public\n */\n",
           "excerptTokens": [
             {
@@ -190,7 +184,6 @@
         },
         {
           "kind": "Class",
-          "containerKey": "GenericClassWithDefault|Class",
           "docComment": "/**\n * @public\n */\n",
           "excerptTokens": [
             {
@@ -242,7 +235,6 @@
         },
         {
           "kind": "Function",
-          "containerKey": "genericFunction|Function|0",
           "docComment": "/**\n * @public\n */\n",
           "excerptTokens": [
             {
@@ -298,7 +290,6 @@
         },
         {
           "kind": "Interface",
-          "containerKey": "GenericInterface|Interface",
           "docComment": "/**\n * @public\n */\n",
           "excerptTokens": [
             {
@@ -342,7 +333,6 @@
         },
         {
           "kind": "TypeAlias",
-          "containerKey": "GenericTypeAlias|TypeAlias",
           "docComment": "/**\n * @public\n */\n",
           "excerptTokens": [
             {
@@ -396,7 +386,6 @@
         },
         {
           "kind": "Interface",
-          "containerKey": "InterfaceWithGenericCallSignature|Interface",
           "docComment": "/**\n * @public\n */\n",
           "excerptTokens": [
             {
@@ -417,7 +406,6 @@
           "members": [
             {
               "kind": "CallSignature",
-              "containerKey": "|CallSignature|0",
               "docComment": "",
               "excerptTokens": [
                 {
@@ -467,7 +455,6 @@
         },
         {
           "kind": "Interface",
-          "containerKey": "InterfaceWithGenericConstructSignature|Interface",
           "docComment": "/**\n * @public\n */\n",
           "excerptTokens": [
             {
@@ -488,7 +475,6 @@
           "members": [
             {
               "kind": "ConstructSignature",
-              "containerKey": "|ConstructSignature|0",
               "docComment": "",
               "excerptTokens": [
                 {

--- a/common/changes/@microsoft/api-documenter/octogonz-ae-new-canonical-references_2019-07-20-06-23.json
+++ b/common/changes/@microsoft/api-documenter/octogonz-ae-new-canonical-references_2019-07-20-06-23.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@microsoft/api-documenter",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/api-documenter",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/api-extractor-model/octogonz-ae-new-canonical-references_2019-07-20-06-23.json
+++ b/common/changes/@microsoft/api-extractor-model/octogonz-ae-new-canonical-references_2019-07-20-06-23.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor-model",
+      "comment": "Rename `ApiItem.canonicalReference` to `.containerKey`; rename `ApiItemContainerMixin.tryGetMember()` to `.tryGetMemberByKey()`; rename `Api___.getCanonicalReference()` to `.getContainerKey()`",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor-model",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/api-extractor/octogonz-ae-new-canonical-references_2019-07-20-06-23.json
+++ b/common/changes/@microsoft/api-extractor/octogonz-ae-new-canonical-references_2019-07-20-06-23.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor",
+      "comment": "Update to use new api-extractor-model",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -3,7 +3,7 @@ dependencies:
   '@microsoft/rush-stack-compiler-3.2': 0.3.23
   '@microsoft/rush-stack-compiler-3.4': 0.1.11
   '@microsoft/teams-js': 1.3.0-beta.4
-  '@microsoft/tsdoc': 0.12.9
+  '@microsoft/tsdoc': 0.12.10
   '@pnpm/link-bins': 1.0.3
   '@pnpm/logger': 1.0.2
   '@rush-temp/api-documenter': 'file:projects/api-documenter.tgz'
@@ -143,7 +143,7 @@ dependencies:
   js-yaml: 3.13.1
   jsdom: 11.11.0
   loader-utils: 1.1.0
-  lodash: 4.17.14
+  lodash: 4.17.15
   lodash.merge: 4.3.5
   long: 4.0.0
   merge2: 1.0.3
@@ -208,7 +208,7 @@ packages:
       '@microsoft/ts-command-line': 4.2.6
       '@microsoft/tsdoc': 0.12.9
       colors: 1.2.5
-      lodash: 4.17.14
+      lodash: 4.17.15
       resolve: 1.8.1
       source-map: 0.6.1
       typescript: 3.5.3
@@ -223,7 +223,7 @@ packages:
       '@microsoft/ts-command-line': 4.2.6
       '@microsoft/tsdoc': 0.12.9
       colors: 1.2.5
-      lodash: 4.17.14
+      lodash: 4.17.15
       resolve: 1.8.1
       source-map: 0.6.1
       typescript: 3.5.3
@@ -358,6 +358,10 @@ packages:
     dev: false
     resolution:
       integrity: sha512-GFLPg9Z5yiNca3di/V6Zt3tAvj1de9EK0eL88tE+1eckQSH405UQcm7D+H8LbEhRpqpG+ZqN9LXCAEw4L5uchg==
+  /@microsoft/tsdoc/0.12.10:
+    dev: false
+    resolution:
+      integrity: sha512-tsog/HTdM88/WyR0Jz7XWTI0ghbJkt9soFXnQJrINDyaTGzbCoJjRttaW/IY5eAp4eqDyfg++jq6o+byEDOkIQ==
   /@microsoft/tsdoc/0.12.9:
     dev: false
     resolution:
@@ -1180,7 +1184,7 @@ packages:
       integrity: sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=
   /async/2.6.3:
     dependencies:
-      lodash: 4.17.14
+      lodash: 4.17.15
     dev: false
     resolution:
       integrity: sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==
@@ -1240,7 +1244,7 @@ packages:
       convert-source-map: 1.6.0
       debug: 2.6.9
       json5: 0.5.1
-      lodash: 4.17.14
+      lodash: 4.17.15
       minimatch: 3.0.4
       path-is-absolute: 1.0.1
       private: 0.1.8
@@ -1256,7 +1260,7 @@ packages:
       babel-types: 6.26.0
       detect-indent: 4.0.0
       jsesc: 1.3.0
-      lodash: 4.17.14
+      lodash: 4.17.15
       source-map: 0.5.7
       trim-right: 1.0.1
     dev: false
@@ -1352,7 +1356,7 @@ packages:
       babel-runtime: 6.26.0
       core-js: 2.6.9
       home-or-tmp: 2.0.0
-      lodash: 4.17.14
+      lodash: 4.17.15
       mkdirp: 0.5.1
       source-map-support: 0.4.18
     dev: false
@@ -1371,7 +1375,7 @@ packages:
       babel-traverse: 6.26.0
       babel-types: 6.26.0
       babylon: 6.18.0
-      lodash: 4.17.14
+      lodash: 4.17.15
     dev: false
     resolution:
       integrity: sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=
@@ -1385,7 +1389,7 @@ packages:
       debug: 2.6.9
       globals: 9.18.0
       invariant: 2.2.4
-      lodash: 4.17.14
+      lodash: 4.17.15
     dev: false
     resolution:
       integrity: sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=
@@ -1393,7 +1397,7 @@ packages:
     dependencies:
       babel-runtime: 6.26.0
       esutils: 2.0.2
-      lodash: 4.17.14
+      lodash: 4.17.15
       to-fast-properties: 1.0.3
     dev: false
     resolution:
@@ -3585,7 +3589,7 @@ packages:
   /globule/1.2.1:
     dependencies:
       glob: 7.1.4
-      lodash: 4.17.14
+      lodash: 4.17.15
       minimatch: 3.0.4
     dev: false
     engines:
@@ -3670,7 +3674,7 @@ packages:
       gulp-util: 3.0.8
       istanbul: 0.4.5
       istanbul-threshold-checker: 0.1.0
-      lodash: 4.17.14
+      lodash: 4.17.15
       through2: 2.0.5
     dev: false
     resolution:
@@ -4113,7 +4117,7 @@ packages:
       cli-width: 2.2.0
       external-editor: 3.1.0
       figures: 2.0.0
-      lodash: 4.17.14
+      lodash: 4.17.15
       mute-stream: 0.0.7
       run-async: 2.3.0
       rxjs: 6.5.2
@@ -5612,10 +5616,10 @@ packages:
     dev: false
     resolution:
       integrity: sha1-Umao9J3Zib5Pn2gbbyoMVShdDZo=
-  /lodash/4.17.14:
+  /lodash/4.17.15:
     dev: false
     resolution:
-      integrity: sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==
+      integrity: sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
   /lolex/1.3.2:
     dev: false
     resolution:
@@ -7236,7 +7240,7 @@ packages:
       integrity: sha512-AC0FiLS352pBBiZhd4VXB1Ab/lh0lEgpP+GGvZqbQh8a5cmXVoTe5EX/YeTFArnp4SRGTHh1qCHu9lGs1qG8sA==
   /request-promise-core/1.1.2_request@2.88.0:
     dependencies:
-      lodash: 4.17.14
+      lodash: 4.17.15
       request: 2.88.0
     dev: false
     engines:
@@ -7468,7 +7472,7 @@ packages:
   /sass-graph/2.2.4:
     dependencies:
       glob: 7.0.6
-      lodash: 4.17.14
+      lodash: 4.17.15
       scss-tokenizer: 0.2.3
       yargs: 7.1.0
     dev: false
@@ -8346,7 +8350,7 @@ packages:
       cpx: 1.5.0
       fs-extra: 6.0.0
       jest-config: 22.4.4
-      lodash: 4.17.14
+      lodash: 4.17.15
       pkg-dir: 2.0.0
       source-map-support: 0.5.12
       typescript: 3.0.3
@@ -8366,7 +8370,7 @@ packages:
       fs-extra: 6.0.0
       jest: 23.6.0
       jest-config: 22.4.4
-      lodash: 4.17.14
+      lodash: 4.17.15
       pkg-dir: 2.0.0
       source-map-support: 0.5.12
       typescript: 3.0.3
@@ -9183,7 +9187,7 @@ packages:
     version: 0.0.0
   'file:projects/api-documenter.tgz':
     dependencies:
-      '@microsoft/tsdoc': 0.12.9
+      '@microsoft/tsdoc': 0.12.10
       '@types/jest': 23.3.11
       '@types/js-yaml': 3.12.1
       '@types/node': 8.5.8
@@ -9194,7 +9198,7 @@ packages:
     dev: false
     name: '@rush-temp/api-documenter'
     resolution:
-      integrity: sha512-hU6N8mFkkCnYCV2HfiXjZXSsqkIj4ZHG5cAbrcBDalldUsdzElOkgaMPNQmtACsPTbWIJCuBgz407WSoqatI1Q==
+      integrity: sha512-m+uzYID8HWX0h508ZoL99MfET3WpfPaMHF/QYoVO4yxZ0nBLbKycYGAkFNn92NnSAPZEnXRes/h8u0vtVx/k4Q==
       tarball: 'file:projects/api-documenter.tgz'
     version: 0.0.0
   'file:projects/api-extractor-lib1-test.tgz':
@@ -9236,9 +9240,8 @@ packages:
   'file:projects/api-extractor-model.tgz':
     dependencies:
       '@microsoft/node-library-build': 6.0.71
-      '@microsoft/rush-stack-compiler-3.2': 0.3.23
       '@microsoft/rush-stack-compiler-3.4': 0.1.11
-      '@microsoft/tsdoc': 0.12.9
+      '@microsoft/tsdoc': 0.12.10
       '@types/jest': 23.3.11
       '@types/node': 8.5.8
       gulp: 3.9.1
@@ -9246,7 +9249,7 @@ packages:
     dev: false
     name: '@rush-temp/api-extractor-model'
     resolution:
-      integrity: sha512-yt0EP5GtXyt9s3H+j/I43IqIsrXHOyDF413kFpxcPAfRPaM7lFh9Jpk0LBYhx/l3CtUCHPP/bWlwhQFuX2kNDg==
+      integrity: sha512-jvtpkse1QV8q1G6bUH9dt5FFQnwx57+SQbQ+Q9cHPwryxcjEEoXgEUIFiJC+Mt7qaBYNLU9YO1su30Q1IpUiDg==
       tarball: 'file:projects/api-extractor-model.tgz'
     version: 0.0.0
   'file:projects/api-extractor-scenarios.tgz':
@@ -9315,28 +9318,26 @@ packages:
   'file:projects/api-extractor.tgz':
     dependencies:
       '@microsoft/node-library-build': 6.0.71
-      '@microsoft/rush-stack-compiler-3.2': 0.3.23
       '@microsoft/rush-stack-compiler-3.4': 0.1.11
-      '@microsoft/tsdoc': 0.12.9
+      '@microsoft/tsdoc': 0.12.10
       '@types/jest': 23.3.11
       '@types/lodash': 4.14.116
       '@types/node': 8.5.8
       colors: 1.2.5
       gulp: 3.9.1
-      lodash: 4.17.14
+      lodash: 4.17.15
       resolve: 1.8.1
       source-map: 0.6.1
       typescript: 3.5.3
     dev: false
     name: '@rush-temp/api-extractor'
     resolution:
-      integrity: sha512-fxpVT0fCrRl7E/kN+TKr8Iutrfstk5Gsgwyq65ozw2uPkJXjx0b9dyJNcJXFZbV1nY/6dafrGucW0zgP5SuUcw==
+      integrity: sha512-EZoV4FFsTkufwE6PW2QzX4NdHhdeMUTPQY87Ebka8kmXUoT82CYHPiiDWxRdpyn0JeZT7yOXbSkC2AQCqKBjkA==
       tarball: 'file:projects/api-extractor.tgz'
     version: 0.0.0
   'file:projects/gulp-core-build-mocha.tgz':
     dependencies:
       '@microsoft/node-library-build': 6.0.71
-      '@microsoft/rush-stack-compiler-3.2': 0.3.23
       '@microsoft/rush-stack-compiler-3.4': 0.1.11
       '@types/glob': 5.0.30
       '@types/gulp': 3.8.32
@@ -9408,7 +9409,6 @@ packages:
   'file:projects/gulp-core-build-typescript.tgz':
     dependencies:
       '@microsoft/node-library-build': 6.0.71
-      '@microsoft/rush-stack-compiler-3.2': 0.3.23
       '@microsoft/rush-stack-compiler-3.4': 0.1.11
       '@types/glob': 5.0.30
       '@types/node': 8.5.8
@@ -9447,7 +9447,6 @@ packages:
   'file:projects/gulp-core-build.tgz':
     dependencies:
       '@microsoft/node-library-build': 6.0.71
-      '@microsoft/rush-stack-compiler-3.2': 0.3.23
       '@microsoft/rush-stack-compiler-3.4': 0.1.11
       '@types/assertion-error': 1.0.30
       '@types/chai': 3.4.34
@@ -9544,7 +9543,7 @@ packages:
       chai: 3.5.0
       gulp: 3.9.1
       loader-utils: 1.1.0
-      lodash: 4.17.14
+      lodash: 4.17.15
       mocha: 5.2.0
     dev: false
     name: '@rush-temp/loader-set-webpack-public-path'
@@ -9555,7 +9554,6 @@ packages:
   'file:projects/node-core-library.tgz':
     dependencies:
       '@microsoft/node-library-build': 6.0.71
-      '@microsoft/rush-stack-compiler-3.2': 0.3.23
       '@microsoft/rush-stack-compiler-3.4': 0.1.11
       '@types/fs-extra': 5.0.4
       '@types/jest': 23.3.11
@@ -9650,7 +9648,7 @@ packages:
       https-proxy-agent: 2.2.2
       inquirer: 6.2.2
       js-yaml: 3.13.1
-      lodash: 4.17.14
+      lodash: 4.17.15
       minimatch: 3.0.4
       node-fetch: 2.1.2
       npm-package-arg: 5.1.2
@@ -9679,7 +9677,6 @@ packages:
   'file:projects/rush-stack-compiler-2.4.tgz':
     dependencies:
       '@microsoft/node-library-build': 6.0.71
-      '@microsoft/rush-stack-compiler-3.2': 0.3.23
       '@microsoft/rush-stack-compiler-3.4': 0.1.11
       '@types/node': 8.5.8
       gulp: 3.9.1
@@ -9705,7 +9702,6 @@ packages:
   'file:projects/rush-stack-compiler-2.7.tgz':
     dependencies:
       '@microsoft/node-library-build': 6.0.71
-      '@microsoft/rush-stack-compiler-3.2': 0.3.23
       '@microsoft/rush-stack-compiler-3.4': 0.1.11
       '@types/node': 8.5.8
       gulp: 3.9.1
@@ -9731,7 +9727,6 @@ packages:
   'file:projects/rush-stack-compiler-2.8.tgz':
     dependencies:
       '@microsoft/node-library-build': 6.0.71
-      '@microsoft/rush-stack-compiler-3.2': 0.3.23
       '@microsoft/rush-stack-compiler-3.4': 0.1.11
       '@types/node': 8.5.8
       gulp: 3.9.1
@@ -9757,7 +9752,6 @@ packages:
   'file:projects/rush-stack-compiler-2.9.tgz':
     dependencies:
       '@microsoft/node-library-build': 6.0.71
-      '@microsoft/rush-stack-compiler-3.2': 0.3.23
       '@microsoft/rush-stack-compiler-3.4': 0.1.11
       '@types/node': 8.5.8
       gulp: 3.9.1
@@ -9783,7 +9777,6 @@ packages:
   'file:projects/rush-stack-compiler-3.0.tgz':
     dependencies:
       '@microsoft/node-library-build': 6.0.71
-      '@microsoft/rush-stack-compiler-3.2': 0.3.23
       '@microsoft/rush-stack-compiler-3.4': 0.1.11
       '@types/node': 8.5.8
       gulp: 3.9.1
@@ -9809,7 +9802,6 @@ packages:
   'file:projects/rush-stack-compiler-3.1.tgz':
     dependencies:
       '@microsoft/node-library-build': 6.0.71
-      '@microsoft/rush-stack-compiler-3.2': 0.3.23
       '@microsoft/rush-stack-compiler-3.4': 0.1.11
       '@types/node': 8.5.8
       gulp: 3.9.1
@@ -9835,7 +9827,6 @@ packages:
   'file:projects/rush-stack-compiler-3.2.tgz':
     dependencies:
       '@microsoft/node-library-build': 6.0.71
-      '@microsoft/rush-stack-compiler-3.2': 0.3.23
       '@microsoft/rush-stack-compiler-3.4': 0.1.11
       '@types/node': 8.5.8
       gulp: 3.9.1
@@ -9861,7 +9852,6 @@ packages:
   'file:projects/rush-stack-compiler-3.3.tgz':
     dependencies:
       '@microsoft/node-library-build': 6.0.71
-      '@microsoft/rush-stack-compiler-3.2': 0.3.23
       '@microsoft/rush-stack-compiler-3.4': 0.1.11
       '@types/node': 8.5.8
       gulp: 3.9.1
@@ -9887,7 +9877,6 @@ packages:
   'file:projects/rush-stack-compiler-3.4.tgz':
     dependencies:
       '@microsoft/node-library-build': 6.0.71
-      '@microsoft/rush-stack-compiler-3.2': 0.3.23
       '@microsoft/rush-stack-compiler-3.4': 0.1.11
       '@types/node': 8.5.8
       gulp: 3.9.1
@@ -9907,7 +9896,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-3.5-library-test'
     resolution:
-      integrity: sha512-deIWCTHdHUkcg5FFpTRScLgSmWM+HCj3gahqEhmA73dp9bdsGu3d4pNQJWvpcxwWW62uUUh93YFZOiIxuBEKKg==
+      integrity: sha512-Qi1cfGBcFQfA5+2NiLPyMj3H9mOyzBh/4WL6lO9ewFc6mnDR1K2ohUjJLiDA8mZqTB9GdtuesG19Wg125MhHsw==
       tarball: 'file:projects/rush-stack-compiler-3.5-library-test.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-3.5.tgz':
@@ -9991,7 +9980,7 @@ packages:
       '@types/webpack': 4.4.0
       chai: 3.5.0
       gulp: 3.9.1
-      lodash: 4.17.14
+      lodash: 4.17.15
       mocha: 5.2.0
       uglify-js: 3.0.28
     dev: false
@@ -10018,7 +10007,6 @@ packages:
   'file:projects/ts-command-line.tgz':
     dependencies:
       '@microsoft/node-library-build': 6.0.71
-      '@microsoft/rush-stack-compiler-3.2': 0.3.23
       '@microsoft/rush-stack-compiler-3.4': 0.1.11
       '@types/argparse': 1.0.33
       '@types/jest': 23.3.11
@@ -10056,13 +10044,12 @@ packages:
       integrity: sha512-DfKMXq5zBvCU5DW5PJQPJbE57ZkDbIugRB/dvGBZMZntVp/+mXSGIxhSrRmxketLfPz6iNQFeAgITB/Ba5qbtw==
       tarball: 'file:projects/web-library-build.tgz'
     version: 0.0.0
-registry: ''
 specifiers:
   '@microsoft/node-library-build': 6.0.71
   '@microsoft/rush-stack-compiler-3.2': 0.3.23
   '@microsoft/rush-stack-compiler-3.4': 0.1.11
   '@microsoft/teams-js': 1.3.0-beta.4
-  '@microsoft/tsdoc': 0.12.9
+  '@microsoft/tsdoc': 0.12.10
   '@pnpm/link-bins': ~1.0.1
   '@pnpm/logger': ~1.0.1
   '@rush-temp/api-documenter': 'file:./projects/api-documenter.tgz'

--- a/common/reviews/api/api-extractor-model.api.md
+++ b/common/reviews/api/api-extractor-model.api.md
@@ -30,9 +30,9 @@ export class AedocDefinitions {
 export class ApiCallSignature extends ApiCallSignature_base {
     constructor(options: IApiCallSignatureOptions);
     // @override (undocumented)
-    readonly canonicalReference: string;
+    readonly containerKey: string;
     // (undocumented)
-    static getCanonicalReference(overloadIndex: number): string;
+    static getContainerKey(overloadIndex: number): string;
     // @override (undocumented)
     readonly kind: ApiItemKind;
 }
@@ -43,10 +43,10 @@ export class ApiCallSignature extends ApiCallSignature_base {
 export class ApiClass extends ApiClass_base {
     constructor(options: IApiClassOptions);
     // @override (undocumented)
-    readonly canonicalReference: string;
+    readonly containerKey: string;
     readonly extendsType: HeritageType | undefined;
     // (undocumented)
-    static getCanonicalReference(name: string): string;
+    static getContainerKey(name: string): string;
     readonly implementsTypes: ReadonlyArray<HeritageType>;
     // @override (undocumented)
     readonly kind: ApiItemKind;
@@ -65,9 +65,9 @@ export class ApiClass extends ApiClass_base {
 export class ApiConstructor extends ApiConstructor_base {
     constructor(options: IApiConstructorOptions);
     // @override (undocumented)
-    readonly canonicalReference: string;
+    readonly containerKey: string;
     // (undocumented)
-    static getCanonicalReference(overloadIndex: number): string;
+    static getContainerKey(overloadIndex: number): string;
     // @override (undocumented)
     readonly kind: ApiItemKind;
 }
@@ -78,9 +78,9 @@ export class ApiConstructor extends ApiConstructor_base {
 export class ApiConstructSignature extends ApiConstructSignature_base {
     constructor(options: IApiConstructSignatureOptions);
     // @override (undocumented)
-    readonly canonicalReference: string;
+    readonly containerKey: string;
     // (undocumented)
-    static getCanonicalReference(overloadIndex: number): string;
+    static getContainerKey(overloadIndex: number): string;
     // @override (undocumented)
     readonly kind: ApiItemKind;
 }
@@ -121,7 +121,7 @@ export class ApiDocumentedItem extends ApiItem {
 export class ApiEntryPoint extends ApiEntryPoint_base {
     constructor(options: IApiEntryPointOptions);
     // @override (undocumented)
-    readonly canonicalReference: string;
+    readonly containerKey: string;
     // @override (undocumented)
     readonly kind: ApiItemKind;
 }
@@ -134,9 +134,9 @@ export class ApiEnum extends ApiEnum_base {
     // @override (undocumented)
     addMember(member: ApiEnumMember): void;
     // @override (undocumented)
-    readonly canonicalReference: string;
+    readonly containerKey: string;
     // (undocumented)
-    static getCanonicalReference(name: string): string;
+    static getContainerKey(name: string): string;
     // @override (undocumented)
     readonly kind: ApiItemKind;
     // @override (undocumented)
@@ -149,9 +149,9 @@ export class ApiEnum extends ApiEnum_base {
 export class ApiEnumMember extends ApiEnumMember_base {
     constructor(options: IApiEnumMemberOptions);
     // @override (undocumented)
-    readonly canonicalReference: string;
+    readonly containerKey: string;
     // (undocumented)
-    static getCanonicalReference(name: string): string;
+    static getContainerKey(name: string): string;
     readonly initializerExcerpt: Excerpt;
     // @override (undocumented)
     readonly kind: ApiItemKind;
@@ -169,9 +169,9 @@ export class ApiEnumMember extends ApiEnumMember_base {
 export class ApiFunction extends ApiFunction_base {
     constructor(options: IApiFunctionOptions);
     // @override (undocumented)
-    readonly canonicalReference: string;
+    readonly containerKey: string;
     // (undocumented)
-    static getCanonicalReference(name: string, overloadIndex: number): string;
+    static getContainerKey(name: string, overloadIndex: number): string;
     // @override (undocumented)
     readonly kind: ApiItemKind;
 }
@@ -182,9 +182,9 @@ export class ApiFunction extends ApiFunction_base {
 export class ApiIndexSignature extends ApiIndexSignature_base {
     constructor(options: IApiIndexSignatureOptions);
     // @override (undocumented)
-    readonly canonicalReference: string;
+    readonly containerKey: string;
     // (undocumented)
-    static getCanonicalReference(overloadIndex: number): string;
+    static getContainerKey(overloadIndex: number): string;
     // @override (undocumented)
     readonly kind: ApiItemKind;
 }
@@ -195,10 +195,10 @@ export class ApiIndexSignature extends ApiIndexSignature_base {
 export class ApiInterface extends ApiInterface_base {
     constructor(options: IApiInterfaceOptions);
     // @override (undocumented)
-    readonly canonicalReference: string;
+    readonly containerKey: string;
     readonly extendsTypes: ReadonlyArray<HeritageType>;
     // (undocumented)
-    static getCanonicalReference(name: string): string;
+    static getContainerKey(name: string): string;
     // @override (undocumented)
     readonly kind: ApiItemKind;
     // Warning: (ae-forgotten-export) The symbol "IApiInterfaceJson" needs to be exported by the entry point index.d.ts
@@ -214,8 +214,8 @@ export class ApiItem {
     // (undocumented)
     [ApiItem_parent]: ApiItem | undefined;
     constructor(options: IApiItemOptions);
-    // @virtual (undocumented)
-    readonly canonicalReference: string;
+    // @virtual
+    readonly containerKey: string;
     // (undocumented)
     static deserialize(jsonObject: IApiItemJson, context: DeserializerContext): ApiItem;
     // @virtual
@@ -225,7 +225,7 @@ export class ApiItem {
     getScopedNameWithinPackage(): string;
     // @virtual (undocumented)
     getSortKey(): string;
-    // @virtual (undocumented)
+    // @virtual
     readonly kind: ApiItemKind;
     // @virtual
     readonly members: ReadonlyArray<ApiItem>;
@@ -247,7 +247,7 @@ export interface ApiItemContainerMixin extends ApiItem {
     readonly members: ReadonlyArray<ApiItem>;
     // @override (undocumented)
     serializeInto(jsonObject: Partial<IApiItemJson>): void;
-    tryGetMember(canonicalReference: string): ApiItem | undefined;
+    tryGetMemberByKey(containerKey: string): ApiItem | undefined;
 }
 
 // @public
@@ -305,9 +305,9 @@ export const enum ApiItemKind {
 export class ApiMethod extends ApiMethod_base {
     constructor(options: IApiMethodOptions);
     // @override (undocumented)
-    readonly canonicalReference: string;
+    readonly containerKey: string;
     // (undocumented)
-    static getCanonicalReference(name: string, isStatic: boolean, overloadIndex: number): string;
+    static getContainerKey(name: string, isStatic: boolean, overloadIndex: number): string;
     // @override (undocumented)
     readonly kind: ApiItemKind;
 }
@@ -318,9 +318,9 @@ export class ApiMethod extends ApiMethod_base {
 export class ApiMethodSignature extends ApiMethodSignature_base {
     constructor(options: IApiMethodSignatureOptions);
     // @override (undocumented)
-    readonly canonicalReference: string;
+    readonly containerKey: string;
     // (undocumented)
-    static getCanonicalReference(name: string, overloadIndex: number): string;
+    static getContainerKey(name: string, overloadIndex: number): string;
     // @override (undocumented)
     readonly kind: ApiItemKind;
 }
@@ -333,7 +333,7 @@ export class ApiModel extends ApiModel_base {
     // @override (undocumented)
     addMember(member: ApiPackage): void;
     // @override (undocumented)
-    readonly canonicalReference: string;
+    readonly containerKey: string;
     // @override (undocumented)
     readonly kind: ApiItemKind;
     // (undocumented)
@@ -366,9 +366,9 @@ export namespace ApiNameMixin {
 export class ApiNamespace extends ApiNamespace_base {
     constructor(options: IApiNamespaceOptions);
     // @override (undocumented)
-    readonly canonicalReference: string;
+    readonly containerKey: string;
     // (undocumented)
-    static getCanonicalReference(name: string): string;
+    static getContainerKey(name: string): string;
     // @override (undocumented)
     readonly kind: ApiItemKind;
 }
@@ -381,7 +381,7 @@ export class ApiPackage extends ApiPackage_base {
     // @override (undocumented)
     addMember(member: ApiEntryPoint): void;
     // @override (undocumented)
-    readonly canonicalReference: string;
+    readonly containerKey: string;
     // (undocumented)
     readonly entryPoints: ReadonlyArray<ApiEntryPoint>;
     // (undocumented)
@@ -416,9 +416,9 @@ export namespace ApiParameterListMixin {
 export class ApiProperty extends ApiProperty_base {
     constructor(options: IApiPropertyOptions);
     // @override (undocumented)
-    readonly canonicalReference: string;
+    readonly containerKey: string;
     // (undocumented)
-    static getCanonicalReference(name: string, isStatic: boolean): string;
+    static getContainerKey(name: string, isStatic: boolean): string;
     // @override (undocumented)
     readonly kind: ApiItemKind;
 }
@@ -442,9 +442,9 @@ export class ApiPropertyItem extends ApiPropertyItem_base {
 export class ApiPropertySignature extends ApiPropertyItem {
     constructor(options: IApiPropertySignatureOptions);
     // @override (undocumented)
-    readonly canonicalReference: string;
+    readonly containerKey: string;
     // (undocumented)
-    static getCanonicalReference(name: string): string;
+    static getContainerKey(name: string): string;
     // @override (undocumented)
     readonly kind: ApiItemKind;
 }
@@ -502,9 +502,9 @@ export namespace ApiStaticMixin {
 export class ApiTypeAlias extends ApiTypeAlias_base {
     constructor(options: IApiTypeAliasOptions);
     // @override (undocumented)
-    readonly canonicalReference: string;
+    readonly containerKey: string;
     // (undocumented)
-    static getCanonicalReference(name: string): string;
+    static getContainerKey(name: string): string;
     // @override (undocumented)
     readonly kind: ApiItemKind;
     // Warning: (ae-forgotten-export) The symbol "IApiTypeAliasJson" needs to be exported by the entry point index.d.ts
@@ -537,9 +537,9 @@ export namespace ApiTypeParameterListMixin {
 export class ApiVariable extends ApiVariable_base {
     constructor(options: IApiVariableOptions);
     // @override (undocumented)
-    readonly canonicalReference: string;
+    readonly containerKey: string;
     // (undocumented)
-    static getCanonicalReference(name: string): string;
+    static getContainerKey(name: string): string;
     // @override (undocumented)
     readonly kind: ApiItemKind;
     // Warning: (ae-forgotten-export) The symbol "IApiVariableJson" needs to be exported by the entry point index.d.ts


### PR DESCRIPTION
As part of the work to support hyperlinks for types that appear in the documentation (PR #1337) we need to introduce a new API for building **canonical references** using the new notation that @rbuckton prototyped in https://github.com/microsoft/tsdoc/pull/172.

However, **api-extractor-model** already has a set of legacy APIs that used the name "canonicalReference" to describe subcomponents of the TSDoc **declaration reference** notation.  This PR renames those APIs as follows:

- `ApiItem.canonicalReference` --> `.containerKey`
- `ApiItemContainerMixin.tryGetMember()` --> `.tryGetMemberByKey()`
- `Api___.getCanonicalReference()` --> `.getContainerKey()`
- `ApiItemContainerMixin.tryGetMember()` --> `.tryGetMemberByKey()`

The new name "containerKey" reflects that this is a very special-purpose string, whose only purpose is as a lookup key for the `ApiItemContainerMixin.tryGetMemberByKey()` API.

The container key APIs are not believed to be used by any code outside of API Extractor; they are so obscure that I'm considering this a "minor" SemVer change.

This PR also temporarily removes the `canonicalReference` field from the .api.json file format.  We will reintroduce it in the next PR using the new notation.  Because this data field was for informational purposes only (i.e. ignored by the deserializer) it is not a breaking change for the file format.  The `ApiJsonSchemaVersion` version bump is merely for bookkeeping purposes.