### PR TITLE
[rush] Add logic to normalize the casing of paths that Rush uses.

### DIFF
--- a/apps/rush-lib/package.json
+++ b/apps/rush-lib/package.json
@@ -46,6 +46,7 @@
     "semver": "~5.3.0",
     "strict-uri-encode": "~2.0.0",
     "tar": "~4.4.1",
+    "true-case-path": "~2.2.1",
     "wordwrap": "~1.0.0",
     "z-schema": "~3.18.3"
   },

--- a/apps/rush-lib/src/api/RushConfiguration.ts
+++ b/apps/rush-lib/src/api/RushConfiguration.ts
@@ -309,13 +309,15 @@ export class RushConfiguration {
    */
   public static loadFromConfigurationFile(rushJsonFilename: string): RushConfiguration {
     let resolvedRushJsonFilename: string = path.resolve(rushJsonFilename);
+    // Load the rush.json before we fix the casing. If the case is wrong on a case-sensitive filesystem,
+    // the next line show throw.
+    const rushConfigurationJson: IRushConfigurationJson = JsonFile.load(resolvedRushJsonFilename);
+
     try {
       resolvedRushJsonFilename = trueCasePathSync(resolvedRushJsonFilename);
     } catch (error) {
-      throw new Error(`Unable to resolve rush.json filename. Inner error: ${error}`);
+      /* ignore errors from true-case-path */
     }
-
-    const rushConfigurationJson: IRushConfigurationJson = JsonFile.load(resolvedRushJsonFilename);
 
     // Check the Rush version *before* we validate the schema, since if the version is outdated
     // then the schema may have changed. This should no longer be a problem after Rush 4.0 and the C2R wrapper,

--- a/apps/rush-lib/src/api/RushConfiguration.ts
+++ b/apps/rush-lib/src/api/RushConfiguration.ts
@@ -1016,6 +1016,18 @@ export class RushConfiguration {
         }
       }
     }
+
+    // Ensure the rush.json filename has the casing that exists on the filesystem
+    const correctlyCasedRushJsonFilename: string | undefined = Utilities.getCorrectlyCasedPath(rushJsonFilename);
+    if (!correctlyCasedRushJsonFilename) {
+      console.warn(
+        `The rush.json file ${rushJsonFilename} does not exist. This is unexpected and is likely to ` +
+        'produce incorrect behavior.'
+      );
+    } else {
+      rushJsonFilename = correctlyCasedRushJsonFilename;
+    }
+
     this._rushJsonFile = rushJsonFilename;
     this._rushJsonFolder = path.dirname(rushJsonFilename);
 

--- a/apps/rush-lib/src/utilities/Utilities.ts
+++ b/apps/rush-lib/src/utilities/Utilities.ts
@@ -564,65 +564,6 @@ export class Utilities {
     return new Error('Unable to find rush.json configuration file');
   }
 
-  /**
-    * Gets a path to a file or folder on disk with the exact character casing that exists on disk.
-    *
-    * If the file or folder specified doesn't exist on disk, undefined is returned
-    *
-    * @example
-    * getCorrectlyCasedPath('c:\\uppercase-folder\\LOWERCASE-FILE') => 'C:\\UPPERCASE-FOLDER\\lowercase-file'
-    * getCorrectlyCasedPath('/uppercase-folder/LOWERCASE-FILE') => '/UPPERCASE-FOLDER/lowercase-file'
-    *
-    * @remarks
-    * This function assumes the path passed to it is absolute and is on the local filesystem
-    */
-  public static getCorrectlyCasedPath(pathToNormalize: string): string | undefined {
-    const parsedPath: path.ParsedPath = path.parse(pathToNormalize);
-    const root: string = parsedPath.root.toUpperCase();
-    const pathWithoutRoot: string = parsedPath.dir.substr(root.length);
-    const pathSections: string[] = [...pathWithoutRoot.split(path.sep), parsedPath.base];
-
-    let constructedPath: string = root;
-    for (let i: number = 0; i < pathSections.length; i++) {
-      const pathSection: string = pathSections[i];
-      if (!pathSection) {
-        // If we encounter an empty path section, just skip over it
-        continue;
-      }
-
-      const folderContents: string[] = FileSystem.readFolder(constructedPath);
-
-      let foundCasedPathSection: string | undefined = undefined;
-      let foundCaseInsensitivePathSection: string | undefined = undefined;
-
-      for (let j: number = 0; j < folderContents.length; j++) {
-        const folderElement: string = folderContents[j];
-        // First, check if we see an item in the folder with the same casing as the path we're normalizing. This is
-        // to ensure we disambiguate between items with the same (case-insensitive) name on case-sensitive filesystems.
-        if (folderElement === pathSection) {
-          foundCasedPathSection = folderElement;
-          // If we find an item in the folder with the same casing as the path we're normalizing, break out
-          // because that's the path we'll use.
-          break;
-        }
-
-        if (folderElement.toUpperCase() === pathSection.toUpperCase()) {
-          foundCaseInsensitivePathSection = folderElement;
-        }
-      }
-
-      const pathSectionToUse: string | undefined = foundCasedPathSection || foundCaseInsensitivePathSection;
-      if (pathSectionToUse) {
-        constructedPath = path.join(constructedPath, pathSectionToUse);
-      } else {
-        // We didn't find this path section, so the item doesn't exist
-        return undefined;
-      }
-    }
-
-    return constructedPath;
-  }
-
   private static _executeLifecycleCommandInternal<TCommandResult>(
     command: string,
     spawnFunction: (command: String, args: string[], spawnOptions: child_process.SpawnOptions) => TCommandResult,

--- a/common/changes/@microsoft/rush/ianc-rush-path-casing_2019-07-26-05-52.json
+++ b/common/changes/@microsoft/rush/ianc-rush-path-casing_2019-07-26-05-52.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Ensure the filesystem paths that Rush uses have the same character casing that exists on disk.",
+      "packageName": "@microsoft/rush",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/common/config/rush/nonbrowser-approved-packages.json
+++ b/common/config/rush/nonbrowser-approved-packages.json
@@ -483,6 +483,10 @@
       "allowedCategories": [ "libraries" ]
     },
     {
+      "name": "true-case-path",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
       "name": "ts-jest",
       "allowedCategories": [ "libraries", "tests" ]
     },

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -167,6 +167,7 @@ dependencies:
   sudo: 1.0.3
   tar: 4.4.10
   through2: 2.0.5
+  true-case-path: 2.2.1
   ts-jest: 22.4.6
   tslint: 5.12.1
   tslint-microsoft-contrib: 5.2.1
@@ -8727,6 +8728,10 @@ packages:
     dev: false
     resolution:
       integrity: sha512-m6s2OdQe5wgpFMC+pAJ+q9djG82O2jcHPOI6RNg1yy9rCYR+WD6Nbpl32fDpfC56nirdRy+opFa/Vk7HYhqaew==
+  /true-case-path/2.2.1:
+    dev: false
+    resolution:
+      integrity: sha512-0z3j8R7MCjy10kc/g+qg7Ln3alJTodw9aDuVWZa3uiWqfuBMKeAeP2ocWcxoyM3D73yz3Jt/Pu4qPr4wHSdB/Q==
   /ts-jest/22.4.6:
     dependencies:
       babel-core: 6.26.3
@@ -10138,12 +10143,13 @@ packages:
       semver: 5.3.0
       strict-uri-encode: 2.0.0
       tar: 4.4.10
+      true-case-path: 2.2.1
       wordwrap: 1.0.0
       z-schema: 3.18.4
     dev: false
     name: '@rush-temp/rush-lib'
     resolution:
-      integrity: sha512-rIQWW5cCD+MtyGPU1f4ye2zlGsjnNqNOS4esrmQwuSywFrSH6W+J+aKzR+hBoGuau7JJRdrXwK69UdXnL0rDEA==
+      integrity: sha512-aO4oRdBc1gGS5/t4YGUCGt4AAJRboTWaHxfTySKOEWMP/Co5JtRnj2zqInK9+EJIarwOAJReIif97fMe2Pfnpg==
       tarball: 'file:projects/rush-lib.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-2.4-library-test.tgz':
@@ -10524,6 +10530,7 @@ packages:
       integrity: sha512-3T1D8T+obRzYE6eWTRaALuoSJvd9DBj44S/Q3vwWuA7dxgQd6/vFOfpY+OIuV/ci3AE1953yEvcVuI6Ya9mCdQ==
       tarball: 'file:projects/web-library-build.tgz'
     version: 0.0.0
+registry: ''
 specifiers:
   '@microsoft/node-library-build': 6.0.71
   '@microsoft/rush-stack-compiler-3.4': 0.1.11
@@ -10693,6 +10700,7 @@ specifiers:
   sudo: ~1.0.3
   tar: ~4.4.1
   through2: ~2.0.1
+  true-case-path: ~2.2.1
   ts-jest: ~22.4.6
   tslint: ~5.12.1
   tslint-microsoft-contrib: ~5.2.1


### PR DESCRIPTION
Currently, if you run Rush in a console where the working directory's casing doesn't match the casing on disk (for example `c:\code\myrepo` is the cwd, but the actual path is `C:\code\myrepo`), symlinks to installed dependencies can get incorrect casing.

This causes problems when tools (like the TypeScript compiler and Webpack) reference a module in an installed dependency once with the incorrectly-cased path and again with the correct path in the same compilation run. Both tools have functionality to prevent referencing the same file twice with different casing, which can cause builds to fail.

Here's an example of such a failure from Webpack. Notice that one path contains a `D:/` and another contains a `d:/`:

```
D:/repo/common/temp/node_modules/.registry.npmjs.org/css-loader/0.28.11/node_modules/css-loader/lib/css-base.js
There are multiple modules with names that only differ in casing.
This can lead to unexpected behavior when compiling on a filesystem with other case-semantic.
Use equal casing. Compare these module identifiers:
* D:/repo/common/temp/node_modules/.registry.npmjs.org/source-map-loader/0.2.4/node_modules/source-map-loader/index.js!D:/repo/common/temp/node_modules/.registry.npmjs.org/css-loader/0.28.11/node_modules/css-loader/lib/css-base.js
    Used by 1 module(s), i. e.
    D:/repo/common/temp/node_modules/.registry.npmjs.org/css-loader/0.28.11/node_modules/css-loader/index.js??ref--4-1!D:/repo/common/temp/node_modules/.registry.npmjs.org/cropperjs/1.5.1/node_modules/cropperjs/dist/cropper.min.css
* D:/repo/common/temp/node_modules/.registry.npmjs.org/source-map-loader/0.2.4/node_modules/source-map-loader/index.js!d:/repo/common/temp/node_modules/.registry.npmjs.org/css-loader/0.28.11/node_modules/css-loader/lib/css-base.js
    Used by 12 module(s), i. e.
    d:/repo/common/temp/node_modules/.registry.npmjs.org/css-loader/0.28.11/node_modules/css-loader/index.js??ref--4-1!d:/dbs/el/osct/libraries/sp-webpart-shared/lib/richImage/styles/SPImage.module.css
  @ D:/repo/common/temp/node_modules/.registry.npmjs.org/css-loader/0.28.11/node_modules/css-loader/lib/css-base.js
  @ D:/repo/common/temp/node_modules/.registry.npmjs.org/css-loader/0.28.11/node_modules/css-loader??ref--4-1!D:/repo/common/temp/node_modules/.registry.npmjs.org/cropperjs/1.5.1/node_modules/cropperjs/dist/cropper.min.css
```