### PR TITLE
[rush] Do not terminate rush execution if a temp project lacks an entry in the PNPM shrinkwrap

### DIFF
--- a/apps/rush-lib/src/logic/pnpm/PnpmShrinkwrapFile.ts
+++ b/apps/rush-lib/src/logic/pnpm/PnpmShrinkwrapFile.ts
@@ -201,7 +201,7 @@ export class PnpmShrinkwrapFile extends BaseShrinkwrapFile {
     const tempProjectDependencyKey: string | undefined = this.getTopLevelDependencyVersion(tempProjectName);
 
     if (!tempProjectDependencyKey) {
-      throw new Error(`Cannot get dependency key for temp project: ${tempProjectName}`);
+      return undefined;
     }
 
     const packageDescription: IPnpmShrinkwrapDependencyYaml | undefined =

--- a/common/changes/@microsoft/rush/sachinjoseph-fix1418_2019-07-26-07-48.json
+++ b/common/changes/@microsoft/rush/sachinjoseph-fix1418_2019-07-26-07-48.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Do not terminate rush execution if a temp project lacks an entry in the PNPM shrinkwrap. Instead, allow the program to continue so that PNPM can update the outdated shrinkwrap. This fixes #1418 https://github.com/microsoft/web-build-tools/issues/1418.",
+      "packageName": "@microsoft/rush",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "sachinjoseph@users.noreply.github.com"
+}


### PR DESCRIPTION
Do not terminate rush execution if a temp project lacks an entry in the PNPM shrinkwrap. Instead, allow the program to continue so that PNPM can update the outdated shrinkwrap.