### PR TITLE
[rush] Refactor build action to allow generating build graph statically

### DIFF
--- a/apps/rush-lib/src/cli/scriptActions/BulkScriptAction.ts
+++ b/apps/rush-lib/src/cli/scriptActions/BulkScriptAction.ts
@@ -21,6 +21,8 @@ import { Stopwatch } from '../../utilities/Stopwatch';
 import { AlreadyReportedError } from '../../utilities/AlreadyReportedError';
 import { BaseScriptAction, IBaseScriptActionOptions } from './BaseScriptAction';
 import { FileSystem } from '@microsoft/node-core-library';
+import { TaskRunner } from '../../logic/taskRunner/TaskRunner';
+import { TaskCollection } from '../../logic/taskRunner/TaskCollection';
 
 /**
  * Constructor parameters for BulkScriptAction.
@@ -94,22 +96,29 @@ export class BulkScriptAction extends BaseScriptAction {
 
     const changedProjectsOnly: boolean = this.actionName === 'build' && this._changedProjectsOnly.value;
 
-    const tasks: TaskSelector = new TaskSelector({
+    const taskSelector: TaskSelector = new TaskSelector({
       rushConfiguration: this.rushConfiguration,
       toFlags: this._mergeToProjects(),
       fromFlags: this._fromFlag.values,
       commandToRun: this._commandToRun,
       customParameterValues,
-      isQuietMode,
-      parallelism,
+      isQuietMode: isQuietMode,
       isIncrementalBuildAllowed: this.actionName === 'build',
-      changedProjectsOnly,
       ignoreMissingScript: this._ignoreMissingScript,
-      ignoreDependencyOrder: this._ignoreDependencyOrder,
+      ignoreDependencyOrder: this._ignoreDependencyOrder
+    });
+
+    // Register all tasks with the task collection
+    const taskCollection: TaskCollection = taskSelector.registerTasks();
+
+    const taskRunner: TaskRunner = new TaskRunner(taskCollection.getOrderedTasks(), {
+      quietMode: isQuietMode,
+      parallelism: parallelism,
+      changedProjectsOnly: changedProjectsOnly,
       allowWarningsInSuccessfulBuild: this._allowWarningsInSuccessfulBuild
     });
 
-    return tasks.execute().then(() => {
+    return taskRunner.execute().then(() => {
       stopwatch.stop();
       console.log(colors.green(`rush ${this.actionName} (${stopwatch.toString()})`));
       this._doAfterTask(stopwatch, true);

--- a/apps/rush-lib/src/logic/TaskSelector.ts
+++ b/apps/rush-lib/src/logic/TaskSelector.ts
@@ -5,9 +5,9 @@ import {
 import { RushConfigurationProject } from '../api/RushConfigurationProject';
 import { JsonFile } from '@microsoft/node-core-library';
 
-import { TaskRunner } from '../logic/taskRunner/TaskRunner';
 import { ProjectTask } from '../logic/taskRunner/ProjectTask';
 import { PackageChangeAnalyzer } from './PackageChangeAnalyzer';
+import { TaskCollection } from './taskRunner/TaskCollection';
 
 export interface ITaskSelectorConstructor {
   rushConfiguration: RushConfiguration;
@@ -16,12 +16,9 @@ export interface ITaskSelectorConstructor {
   commandToRun: string;
   customParameterValues: string[];
   isQuietMode: boolean;
-  parallelism: string | undefined;
   isIncrementalBuildAllowed: boolean;
-  changedProjectsOnly: boolean;
   ignoreMissingScript: boolean;
   ignoreDependencyOrder: boolean;
-  allowWarningsInSuccessfulBuild: boolean;
 }
 
 /**
@@ -33,7 +30,7 @@ export interface ITaskSelectorConstructor {
  * This class is currently only used by CustomRushAction
  */
 export class TaskSelector {
-  private _taskRunner: TaskRunner;
+  private _taskCollection: TaskCollection;
   private _dependentList: Map<string, Set<string>>;
   private _rushLinkJson: IRushLinkJson;
   private _options: ITaskSelectorConstructor;
@@ -43,11 +40,8 @@ export class TaskSelector {
     this._options = options;
 
     this._packageChangeAnalyzer = new PackageChangeAnalyzer(options.rushConfiguration);
-    this._taskRunner = new TaskRunner({
-      quietMode: this._options.isQuietMode,
-      parallelism: this._options.parallelism,
-      changedProjectsOnly: this._options.changedProjectsOnly,
-      allowWarningsInSuccessfulBuild: this._options.allowWarningsInSuccessfulBuild
+    this._taskCollection = new TaskCollection({
+      quietMode: options.isQuietMode
     });
 
     try {
@@ -56,7 +50,9 @@ export class TaskSelector {
       throw new Error(`Could not read "${this._options.rushConfiguration.rushLinkJsonFilename}".`
         + ` Did you run "rush install" or "rush update"?`);
     }
+  }
 
+  public registerTasks(): TaskCollection {
     if (this._options.toFlags.length > 0) {
       this._registerToFlags(this._options.toFlags);
     }
@@ -66,10 +62,8 @@ export class TaskSelector {
     if (this._options.toFlags.length === 0 && this._options.fromFlags.length === 0) {
       this._registerAll();
     }
-  }
 
-  public execute(): Promise<void> {
-    return this._taskRunner.execute();
+    return this._taskCollection;
   }
 
   private _registerToFlags(toFlags: ReadonlyArray<string>): void {
@@ -87,7 +81,7 @@ export class TaskSelector {
 
       if (!this._options.ignoreDependencyOrder) {
         // Add ordering relationships for each dependency
-        deps.forEach(dep => this._taskRunner.addDependencies(dep, this._rushLinkJson.localLinks[dep] || []));
+        deps.forEach(dep => this._taskCollection.addDependencies(dep, this._rushLinkJson.localLinks[dep] || []));
       }
     }
   }
@@ -116,7 +110,7 @@ export class TaskSelector {
         // Only add ordering relationships for projects which have been registered
         // e.g. package C may depend on A & B, but if we are only building A's downstream, we will ignore B
         dependents.forEach(dependent =>
-          this._taskRunner.addDependencies(dependent,
+          this._taskCollection.addDependencies(dependent,
             (this._rushLinkJson.localLinks[dependent] || []).filter(dep => dependents.has(dep))));
       }
     }
@@ -130,7 +124,7 @@ export class TaskSelector {
     if (!this._options.ignoreDependencyOrder) {
       // Add ordering relationships for each dependency
       for (const projectName of Object.keys(this._rushLinkJson.localLinks)) {
-        this._taskRunner.addDependencies(projectName, this._rushLinkJson.localLinks[projectName]);
+        this._taskCollection.addDependencies(projectName, this._rushLinkJson.localLinks[projectName]);
       }
     }
   }
@@ -186,8 +180,8 @@ export class TaskSelector {
         packageChangeAnalyzer: this._packageChangeAnalyzer
       });
 
-      if (!this._taskRunner.hasTask(projectTask.name)) {
-        this._taskRunner.addTask(projectTask);
+      if (!this._taskCollection.hasTask(projectTask.name)) {
+        this._taskCollection.addTask(projectTask);
       }
     }
   }

--- a/apps/rush-lib/src/logic/taskRunner/ProjectTask.ts
+++ b/apps/rush-lib/src/logic/taskRunner/ProjectTask.ts
@@ -3,7 +3,6 @@
 
 import * as child_process from 'child_process';
 import * as path from 'path';
-import * as process from 'process';
 import { JsonFile, Text, FileSystem } from '@microsoft/node-core-library';
 import { ITaskWriter } from '@microsoft/stream-collator';
 import { IPackageDeps } from '@microsoft/package-deps-hash';
@@ -27,9 +26,7 @@ export interface IProjectTaskOptions {
   rushProject: RushConfigurationProject;
   rushConfiguration: RushConfiguration;
   commandToRun: string;
-  customParameterValues: string[];
   isIncrementalBuildAllowed: boolean;
-  ignoreMissingScript: boolean;
   packageChangeAnalyzer: PackageChangeAnalyzer;
 }
 
@@ -48,40 +45,35 @@ export class ProjectTask implements ITaskDefinition {
   private _rushProject: RushConfigurationProject;
   private _rushConfiguration: RushConfiguration;
   private _commandToRun: string;
-  private _customParameterValues: string[];
-  private _ignoreMissingScript: boolean;
   private _packageChangeAnalyzer: PackageChangeAnalyzer;
 
   constructor(options: IProjectTaskOptions) {
     this._rushProject = options.rushProject;
     this._rushConfiguration = options.rushConfiguration;
     this._commandToRun = options.commandToRun;
-    this._customParameterValues = options.customParameterValues;
     this.isIncrementalBuildAllowed = options.isIncrementalBuildAllowed;
-    this._ignoreMissingScript = options.ignoreMissingScript;
     this._packageChangeAnalyzer = options.packageChangeAnalyzer;
-  }
+}
 
   public execute(writer: ITaskWriter): Promise<TaskStatus> {
     try {
-      const taskCommand: string = this._getScriptToRun();
-      if (!taskCommand) {
+      if (!this._commandToRun) {
         this.hadEmptyScript = true;
       }
-      const deps: IPackageDependencies | undefined = this._getPackageDependencies(taskCommand, writer);
-      return this._executeTask(taskCommand, writer, deps);
+      const deps: IPackageDependencies | undefined = this._getPackageDependencies(writer);
+      return this._executeTask(writer, deps);
     } catch (error) {
       return Promise.reject(new TaskError('executing', error.message));
     }
   }
 
-  private _getPackageDependencies(taskCommand: string, writer: ITaskWriter): IPackageDependencies | undefined {
+  private _getPackageDependencies(writer: ITaskWriter): IPackageDependencies | undefined {
     let deps: IPackageDependencies | undefined = undefined;
     this._rushConfiguration = this._rushConfiguration;
     try {
       deps = {
         files: this._packageChangeAnalyzer.getPackageDepsHash(this._rushProject.packageName)!.files,
-        arguments: taskCommand
+        arguments: this._commandToRun
       };
     } catch (error) {
       writer.writeLine('Unable to calculate incremental build state. ' +
@@ -92,7 +84,6 @@ export class ProjectTask implements ITaskDefinition {
   }
 
   private _executeTask(
-    taskCommand: string,
     writer: ITaskWriter,
     currentPackageDeps: IPackageDependencies | undefined
   ): Promise<TaskStatus> {
@@ -131,7 +122,7 @@ export class ProjectTask implements ITaskDefinition {
         // If the deps file exists, remove it before starting a build.
         FileSystem.deleteFile(currentDepsPath);
 
-        if (!taskCommand) {
+        if (!this._commandToRun) {
           writer.writeLine(`The task command ${this._commandToRun} was registered in the package.json but is blank,`
             + ` so no action will be taken.`);
 
@@ -145,13 +136,9 @@ export class ProjectTask implements ITaskDefinition {
 
         // Run the task
 
-        const normalizedTaskCommand: string = process.platform === 'win32'
-          ? convertSlashesForWindows(taskCommand)
-          : taskCommand;
-
-        writer.writeLine(normalizedTaskCommand);
+        writer.writeLine(this._commandToRun);
         const task: child_process.ChildProcess = Utilities.executeLifecycleCommandAsync(
-          normalizedTaskCommand,
+          this._commandToRun,
           {
             rushConfiguration: this._rushConfiguration,
             workingDirectory: projectFolder,
@@ -200,38 +187,6 @@ export class ProjectTask implements ITaskDefinition {
       this._writeLogsToDisk(writer);
       return Promise.reject(new TaskError('error', error.toString()));
     }
-  }
-
-  private _getScriptToRun(): string {
-    const script: string | undefined = this._getScriptCommand(this._commandToRun);
-
-    if (script === undefined && !this._ignoreMissingScript) {
-      // tslint:disable-next-line:max-line-length
-      throw new Error(`The project [${this._rushProject.packageName}] does not define a '${this._commandToRun}' command in the 'scripts' section of its package.json`);
-    }
-
-    if (!script) {
-      return '';
-    }
-
-    // TODO: Properly escape these strings
-    return `${script} ${this._customParameterValues.join(' ')}`;
-  }
-
-  private _getScriptCommand(script: string): string | undefined {
-    // tslint:disable-next-line:no-string-literal
-    if (!this._rushProject.packageJson.scripts) {
-      return undefined;
-    }
-
-    const rawCommand: string = this._rushProject.packageJson.scripts[script];
-
-    // tslint:disable-next-line:no-null-keyword
-    if (rawCommand === undefined || rawCommand === null) {
-      return undefined;
-    }
-
-    return rawCommand;
   }
 
   // @todo #179371: add log files to list of things that get gulp cleaned

--- a/apps/rush-lib/src/logic/taskRunner/TaskCollection.ts
+++ b/apps/rush-lib/src/logic/taskRunner/TaskCollection.ts
@@ -15,7 +15,7 @@ export interface ITaskCollectionOptions {
 }
 
 /**
- * A class which manages the execution of a set of tasks with interdependencies.
+ * This class manages the execution of a set of tasks with interdependencies.
  * Any class of task definition may be registered, and dependencies between tasks are
  * easily specified. Initially, and at the end of each task execution, all unblocked tasks
  * are added to a ready queue which is then executed. This is done continually until all

--- a/apps/rush-lib/src/logic/taskRunner/TaskCollection.ts
+++ b/apps/rush-lib/src/logic/taskRunner/TaskCollection.ts
@@ -18,7 +18,7 @@ export interface ITaskCollectionOptions {
  * This class manages the execution of a set of tasks with interdependencies.
  * Any class of task definition may be registered, and dependencies between tasks are
  * easily specified. Initially, and at the end of each task execution, all unblocked tasks
- * are added to a ready queue which is then executed. This is done continually until all
+ * are added to a ready queue which is then executed. This is done in a loop until all
  * tasks are complete, or prematurely fails if any of the tasks fail.
  */
 export class TaskCollection {

--- a/apps/rush-lib/src/logic/taskRunner/TaskCollection.ts
+++ b/apps/rush-lib/src/logic/taskRunner/TaskCollection.ts
@@ -87,8 +87,8 @@ export class TaskCollection {
   }
 
   /**
-   * Executes all tasks which have been registered, returning a promise which is resolved when all the
-   * tasks are completed successfully, or rejects when any task fails.
+   * Returns the tasks registered with the collection ordered by the critical path.
+   * It also makes sure there are no cyclic dependencies in the tasks.
    */
   public getOrderedTasks(): ITask[] {
     this._checkForCyclicDependencies(this._tasks.values(), []);

--- a/apps/rush-lib/src/logic/taskRunner/TaskCollection.ts
+++ b/apps/rush-lib/src/logic/taskRunner/TaskCollection.ts
@@ -15,11 +15,9 @@ export interface ITaskCollectionOptions {
 }
 
 /**
- * This class manages the execution of a set of tasks with interdependencies.
- * Any class of task definition may be registered, and dependencies between tasks are
- * easily specified. Initially, and at the end of each task execution, all unblocked tasks
- * are added to a ready queue which is then executed. This is done in a loop until all
- * tasks are complete, or prematurely fails if any of the tasks fail.
+ * This class represents a set of tasks with interdependencies.  Any class of task definition 
+ * may be registered, and dependencies between tasks are easily specified. There is a check for
+ * cyclic dependencies and tasks are ordered based on critical path.
  */
 export class TaskCollection {
   private _tasks: Map<string, ITask>;

--- a/apps/rush-lib/src/logic/taskRunner/TaskCollection.ts
+++ b/apps/rush-lib/src/logic/taskRunner/TaskCollection.ts
@@ -15,7 +15,7 @@ export interface ITaskCollectionOptions {
 }
 
 /**
- * This class represents a set of tasks with interdependencies.  Any class of task definition 
+ * This class represents a set of tasks with interdependencies.  Any class of task definition
  * may be registered, and dependencies between tasks are easily specified. There is a check for
  * cyclic dependencies and tasks are ordered based on critical path.
  */

--- a/apps/rush-lib/src/logic/taskRunner/TaskCollection.ts
+++ b/apps/rush-lib/src/logic/taskRunner/TaskCollection.ts
@@ -1,0 +1,153 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import {
+  Terminal,
+  ConsoleTerminalProvider
+} from '@microsoft/node-core-library';
+
+import { ITask, ITaskDefinition } from './ITask';
+import { TaskStatus } from './TaskStatus';
+
+export interface ITaskCollectionOptions {
+  quietMode: boolean;
+  terminal?: Terminal;
+}
+
+/**
+ * A class which manages the execution of a set of tasks with interdependencies.
+ * Any class of task definition may be registered, and dependencies between tasks are
+ * easily specified. Initially, and at the end of each task execution, all unblocked tasks
+ * are added to a ready queue which is then executed. This is done continually until all
+ * tasks are complete, or prematurely fails if any of the tasks fail.
+ */
+export class TaskCollection {
+  private _tasks: Map<string, ITask>;
+  private _quietMode: boolean;
+  private _terminal: Terminal;
+
+  constructor(options: ITaskCollectionOptions) {
+    const {
+      quietMode,
+      terminal = new Terminal(new ConsoleTerminalProvider())
+    } = options;
+    this._tasks = new Map<string, ITask>();
+    this._quietMode = quietMode;
+    this._terminal = terminal;
+  }
+
+  /**
+   * Registers a task definition to the map of defined tasks
+   */
+  public addTask(taskDefinition: ITaskDefinition): void {
+    if (this._tasks.has(taskDefinition.name)) {
+      throw new Error('A task with that name has already been registered.');
+    }
+
+    const task: ITask = taskDefinition as ITask;
+    task.dependencies = new Set<ITask>();
+    task.dependents = new Set<ITask>();
+    task.status = TaskStatus.Ready;
+    task.criticalPathLength = undefined;
+    this._tasks.set(task.name, task);
+
+    if (!this._quietMode) {
+      this._terminal.writeLine(`Registered ${task.name}`);
+    }
+  }
+
+  /**
+   * Returns true if a task with that name has been registered
+   */
+  public hasTask(taskName: string): boolean {
+    return this._tasks.has(taskName);
+  }
+
+  /**
+   * Defines the list of dependencies for an individual task.
+   * @param taskName - the string name of the task for which we are defining dependencies. A task with this
+   * name must already have been registered.
+   */
+  public addDependencies(taskName: string, taskDependencies: string[]): void {
+    const task: ITask | undefined = this._tasks.get(taskName);
+
+    if (!task) {
+      throw new Error(`The task '${taskName}' has not been registered`);
+    }
+    if (!taskDependencies) {
+      throw new Error('The list of dependencies must be defined');
+    }
+
+    for (const dependencyName of taskDependencies) {
+      if (!this._tasks.has(dependencyName)) {
+        throw new Error(`The project '${dependencyName}' has not been registered.`);
+      }
+      const dependency: ITask = this._tasks.get(dependencyName)!;
+      task.dependencies.add(dependency);
+      dependency.dependents.add(task);
+    }
+  }
+
+  /**
+   * Executes all tasks which have been registered, returning a promise which is resolved when all the
+   * tasks are completed successfully, or rejects when any task fails.
+   */
+  public getOrderedTasks(): ITask[] {
+    this._checkForCyclicDependencies(this._tasks.values(), []);
+
+    // Precalculate the number of dependent packages
+    this._tasks.forEach((task: ITask) => {
+      this._calculateCriticalPaths(task);
+    });
+
+    const buildQueue: ITask[] = [];
+    // Add everything to the buildQueue
+    this._tasks.forEach((task: ITask) => {
+      buildQueue.push(task);
+    });
+
+    // Sort the queue in descending order, nothing will mess with the order
+    buildQueue.sort((taskA: ITask, taskB: ITask): number => {
+      return taskB.criticalPathLength! - taskA.criticalPathLength!;
+    });
+
+    return buildQueue;
+  }
+
+  /**
+   * Checks for projects that indirectly depend on themselves.
+   */
+  private _checkForCyclicDependencies(tasks: Iterable<ITask>, dependencyChain: string[]): void {
+    for (const task of tasks) {
+      if (dependencyChain.indexOf(task.name) >= 0) {
+        throw new Error('A cyclic dependency was encountered:\n'
+          + '  ' + [...dependencyChain, task.name].reverse().join('\n  -> ')
+          + '\nConsider using the cyclicDependencyProjects option for rush.json.');
+      }
+      dependencyChain.push(task.name);
+      this._checkForCyclicDependencies(task.dependents, dependencyChain);
+      dependencyChain.pop();
+    }
+  }
+
+  /**
+   * Calculate the number of packages which must be built before we reach
+   * the furthest away "root" node
+   */
+  private _calculateCriticalPaths(task: ITask): number {
+    // Return the memoized value
+    if (task.criticalPathLength !== undefined) {
+      return task.criticalPathLength;
+    }
+
+    // If no dependents, we are in a "root"
+    if (task.dependents.size === 0) {
+      return task.criticalPathLength = 0;
+    } else {
+      // Otherwise we are as long as the longest package + 1
+      const depsLengths: number[] = [];
+      task.dependents.forEach(dep => depsLengths.push(this._calculateCriticalPaths(dep)));
+      return task.criticalPathLength = Math.max(...depsLengths) + 1;
+    }
+  }
+}

--- a/apps/rush-lib/src/logic/taskRunner/TaskRunner.ts
+++ b/apps/rush-lib/src/logic/taskRunner/TaskRunner.ts
@@ -26,8 +26,7 @@ export interface ITaskRunnerOptions {
 
 /**
  * A class which manages the execution of a set of tasks with interdependencies.
- * Any class of task definition may be registered, and dependencies between tasks are
- * easily specified. Initially, and at the end of each task execution, all unblocked tasks
+ * Initially, and at the end of each task execution, all unblocked tasks
  * are added to a ready queue which is then executed. This is done continually until all
  * tasks are complete, or prematurely fails if any of the tasks fail.
  */

--- a/apps/rush-lib/src/logic/taskRunner/TaskRunner.ts
+++ b/apps/rush-lib/src/logic/taskRunner/TaskRunner.ts
@@ -11,7 +11,7 @@ import {
 } from '@microsoft/node-core-library';
 
 import { Stopwatch } from '../../utilities/Stopwatch';
-import { ITask, ITaskDefinition } from './ITask';
+import { ITask } from './ITask';
 import { TaskStatus } from './TaskStatus';
 import { TaskError } from './TaskError';
 import { AlreadyReportedError } from '../../utilities/AlreadyReportedError';
@@ -32,7 +32,7 @@ export interface ITaskRunnerOptions {
  * tasks are complete, or prematurely fails if any of the tasks fail.
  */
 export class TaskRunner {
-  private _tasks: Map<string, ITask>;
+  private _tasks: ITask[];
   private _changedProjectsOnly: boolean;
   private _allowWarningsInSuccessfulBuild: boolean;
   private _buildQueue: ITask[];
@@ -45,7 +45,7 @@ export class TaskRunner {
   private _completedTasks: number;
   private _terminal: Terminal;
 
-  constructor(options: ITaskRunnerOptions) {
+  constructor(orderedTasks: ITask[], options: ITaskRunnerOptions) {
     const {
       quietMode,
       parallelism,
@@ -53,8 +53,8 @@ export class TaskRunner {
       allowWarningsInSuccessfulBuild,
       terminal = new Terminal(new ConsoleTerminalProvider())
     } = options;
-    this._tasks = new Map<string, ITask>();
-    this._buildQueue = [];
+    this._tasks = orderedTasks;
+    this._buildQueue = orderedTasks.slice(0);
     this._quietMode = quietMode;
     this._hasAnyFailures = false;
     this._hasAnyWarnings = false;
@@ -93,83 +93,14 @@ export class TaskRunner {
   }
 
   /**
-   * Registers a task definition to the map of defined tasks
-   */
-  public addTask(taskDefinition: ITaskDefinition): void {
-    if (this._tasks.has(taskDefinition.name)) {
-      throw new Error('A task with that name has already been registered.');
-    }
-
-    const task: ITask = taskDefinition as ITask;
-    task.dependencies = new Set<ITask>();
-    task.dependents = new Set<ITask>();
-    task.status = TaskStatus.Ready;
-    task.criticalPathLength = undefined;
-    this._tasks.set(task.name, task);
-
-    if (!this._quietMode) {
-      this._terminal.writeLine(`Registered ${task.name}`);
-    }
-  }
-
-  /**
-   * Returns true if a task with that name has been registered
-   */
-  public hasTask(taskName: string): boolean {
-    return this._tasks.has(taskName);
-  }
-
-  /**
-   * Defines the list of dependencies for an individual task.
-   * @param taskName - the string name of the task for which we are defining dependencies. A task with this
-   * name must already have been registered.
-   */
-  public addDependencies(taskName: string, taskDependencies: string[]): void {
-    const task: ITask | undefined = this._tasks.get(taskName);
-
-    if (!task) {
-      throw new Error(`The task '${taskName}' has not been registered`);
-    }
-    if (!taskDependencies) {
-      throw new Error('The list of dependencies must be defined');
-    }
-
-    for (const dependencyName of taskDependencies) {
-      if (!this._tasks.has(dependencyName)) {
-        throw new Error(`The project '${dependencyName}' has not been registered.`);
-      }
-      const dependency: ITask = this._tasks.get(dependencyName)!;
-      task.dependencies.add(dependency);
-      dependency.dependents.add(task);
-    }
-  }
-
-  /**
    * Executes all tasks which have been registered, returning a promise which is resolved when all the
    * tasks are completed successfully, or rejects when any task fails.
    */
   public execute(): Promise<void> {
     this._currentActiveTasks = 0;
     this._completedTasks = 0;
-    this._totalTasks = this._tasks.size;
+    this._totalTasks = this._buildQueue.length;
     this._terminal.writeLine(`Executing a maximum of ${this._parallelism} simultaneous processes...${os.EOL}`);
-
-    this._checkForCyclicDependencies(this._tasks.values(), []);
-
-    // Precalculate the number of dependent packages
-    this._tasks.forEach((task: ITask) => {
-      this._calculateCriticalPaths(task);
-    });
-
-    // Add everything to the buildQueue
-    this._tasks.forEach((task: ITask) => {
-      this._buildQueue.push(task);
-    });
-
-    // Sort the queue in descending order, nothing will mess with the order
-    this._buildQueue.sort((taskA: ITask, taskB: ITask): number => {
-      return taskB.criticalPathLength! - taskA.criticalPathLength!;
-    });
 
     return this._startAvailableTasks().then(() => {
       this._printTaskStatus();
@@ -337,43 +268,6 @@ export class TaskRunner {
 
   private _getCurrentCompletedTaskString(): string {
     return `${this._completedTasks} of ${this._totalTasks}: `;
-  }
-
-  /**
-   * Checks for projects that indirectly depend on themselves.
-   */
-  private _checkForCyclicDependencies(tasks: Iterable<ITask>, dependencyChain: string[]): void {
-    for (const task of tasks) {
-      if (dependencyChain.indexOf(task.name) >= 0) {
-        throw new Error('A cyclic dependency was encountered:\n'
-          + '  ' + [...dependencyChain, task.name].reverse().join('\n  -> ')
-          + '\nConsider using the cyclicDependencyProjects option for rush.json.');
-      }
-      dependencyChain.push(task.name);
-      this._checkForCyclicDependencies(task.dependents, dependencyChain);
-      dependencyChain.pop();
-    }
-  }
-
-  /**
-   * Calculate the number of packages which must be built before we reach
-   * the furthest away "root" node
-   */
-  private _calculateCriticalPaths(task: ITask): number {
-    // Return the memoized value
-    if (task.criticalPathLength !== undefined) {
-      return task.criticalPathLength;
-    }
-
-    // If no dependents, we are in a "root"
-    if (task.dependents.size === 0) {
-      return task.criticalPathLength = 0;
-    } else {
-      // Otherwise we are as long as the longest package + 1
-      const depsLengths: number[] = [];
-      task.dependents.forEach(dep => depsLengths.push(this._calculateCriticalPaths(dep)));
-      return task.criticalPathLength = Math.max(...depsLengths) + 1;
-    }
   }
 
   /**

--- a/apps/rush-lib/src/logic/taskRunner/test/TaskCollection.test.ts
+++ b/apps/rush-lib/src/logic/taskRunner/test/TaskCollection.test.ts
@@ -1,0 +1,81 @@
+import { TaskCollection } from '../TaskCollection';
+import { ITaskWriter } from '@microsoft/stream-collator';
+import { TaskStatus } from '../TaskStatus';
+import { ITaskDefinition, ITask } from '../ITask';
+import { StringBufferTerminalProvider } from '@microsoft/node-core-library';
+
+function createDummyTask(name: string, action?: () => void): ITaskDefinition {
+  return {
+    name,
+    isIncrementalBuildAllowed: false,
+    execute: (writer: ITaskWriter) => {
+      if (action) {
+        action();
+      }
+      return Promise.resolve(TaskStatus.Success);
+    },
+    hadEmptyScript: false
+  };
+}
+
+function checkConsoleOutput(terminalProvider: StringBufferTerminalProvider): void {
+  expect(terminalProvider.getOutput()).toMatchSnapshot();
+  expect(terminalProvider.getVerbose()).toMatchSnapshot();
+  expect(terminalProvider.getWarningOutput()).toMatchSnapshot();
+  expect(terminalProvider.getErrorOutput()).toMatchSnapshot();
+}
+
+describe('TaskCollection', () => {
+  let terminalProvider: StringBufferTerminalProvider;
+  let taskCollection: TaskCollection;
+
+  beforeEach(() => {
+    terminalProvider = new StringBufferTerminalProvider(true);
+  });
+
+  describe('Dependencies', () => {
+    beforeEach(() => {
+      taskCollection = new TaskCollection({
+          quietMode: false
+      });
+    });
+
+    it('throwsErrorOnNonExistentTask', () => {
+      expect(() => taskCollection.addDependencies('foo', []))
+        .toThrowErrorMatchingSnapshot();
+    });
+
+    it('throwsErrorOnNonExistentDependency', () => {
+      taskCollection.addTask(createDummyTask('foo'));
+      expect(() => taskCollection.addDependencies('foo', ['bar']))
+        .toThrowErrorMatchingSnapshot();
+    });
+
+    it('detectsDependencyCycle', () => {
+      taskCollection.addTask(createDummyTask('foo'));
+      taskCollection.addTask(createDummyTask('bar'));
+      taskCollection.addDependencies('foo', ['bar']);
+      taskCollection.addDependencies('bar', ['foo']);
+      expect(() => taskCollection.getOrderedTasks()).toThrowErrorMatchingSnapshot();
+    });
+
+    it('respectsDependencyOrder', () => {
+      const result: Array<string> = [];
+      taskCollection.addTask(createDummyTask('two', () => result.push('2')));
+      taskCollection.addTask(createDummyTask('one', () => result.push('1')));
+      taskCollection.addDependencies('two', ['one']);
+
+      const tasks: ITask[] = taskCollection.getOrderedTasks();
+      expect(tasks.map((t) => t.name).join(',')).toEqual('one,two');
+      checkConsoleOutput(terminalProvider);
+    });
+  });
+
+  describe('Error logging', () => {
+    beforeEach(() => {
+      taskCollection = new TaskCollection({
+        quietMode: false
+      });
+    });
+  });
+});

--- a/apps/rush-lib/src/logic/taskRunner/test/__snapshots__/TaskCollection.test.ts.snap
+++ b/apps/rush-lib/src/logic/taskRunner/test/__snapshots__/TaskCollection.test.ts.snap
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TaskCollection Dependencies detectsDependencyCycle 1`] = `
+"A cyclic dependency was encountered:
+  foo
+  -> bar
+  -> foo
+Consider using the cyclicDependencyProjects option for rush.json."
+`;
+
+exports[`TaskCollection Dependencies respectsDependencyOrder 1`] = `""`;
+
+exports[`TaskCollection Dependencies respectsDependencyOrder 2`] = `""`;
+
+exports[`TaskCollection Dependencies respectsDependencyOrder 3`] = `""`;
+
+exports[`TaskCollection Dependencies respectsDependencyOrder 4`] = `""`;
+
+exports[`TaskCollection Dependencies throwsErrorOnNonExistentDependency 1`] = `"The project 'bar' has not been registered."`;
+
+exports[`TaskCollection Dependencies throwsErrorOnNonExistentTask 1`] = `"The task 'foo' has not been registered"`;

--- a/apps/rush-lib/src/logic/taskRunner/test/__snapshots__/TaskRunner.test.ts.snap
+++ b/apps/rush-lib/src/logic/taskRunner/test/__snapshots__/TaskRunner.test.ts.snap
@@ -2,29 +2,9 @@
 
 exports[`TaskRunner Constructor throwsErrorOnInvalidParallelism 1`] = `"Invalid parallelism value of 'tequila', expected a number or 'max'"`;
 
-exports[`TaskRunner Dependencies detectsDependencyCycle 1`] = `
-"A cyclic dependency was encountered:
-  foo
-  -> bar
-  -> foo
-Consider using the cyclicDependencyProjects option for rush.json."
-`;
-
-exports[`TaskRunner Dependencies respectsDependencyOrder 1`] = `"Registered two[n]Registered one[n]Executing a maximum of 1 simultaneous processes...[-n-][n][x][37m[one] started[x][39m[n][x][32m1 of 2: [one] completed successfully in 0.00 seconds[x][39m[n][x][37m[two] started[x][39m[n][x][32m2 of 2: [two] completed successfully in 0.00 seconds[x][39m[n][n][x][32mSUCCESS (2)[x][39m[n][x][32m================================[x][39m[n][x][32mtwo (0.00 seconds)[x][39m[n][x][32mone (0.00 seconds)[x][39m[n][x][32m================================[-n-][x][39m[n][n]"`;
-
-exports[`TaskRunner Dependencies respectsDependencyOrder 2`] = `""`;
-
-exports[`TaskRunner Dependencies respectsDependencyOrder 3`] = `""`;
-
-exports[`TaskRunner Dependencies respectsDependencyOrder 4`] = `""`;
-
-exports[`TaskRunner Dependencies throwsErrorOnNonExistentDependency 1`] = `"The project 'bar' has not been registered."`;
-
-exports[`TaskRunner Dependencies throwsErrorOnNonExistentTask 1`] = `"The task 'foo' has not been registered"`;
-
 exports[`TaskRunner Error logging preservedLeadingBlanksButTrimmedTrailingBlanks 1`] = `"Project(s) failed to build"`;
 
-exports[`TaskRunner Error logging preservedLeadingBlanksButTrimmedTrailingBlanks 2`] = `"Registered large stderr with leading and trailing blanks[n]Executing a maximum of 1 simultaneous processes...[-n-][n][x][37m[large stderr with leading and trailing blanks] started[x][39m[n][n][x][31mFAILURE (1)[x][39m[n][x][31m================================[x][39m[n][x][31mlarge stderr with leading and trailing blanks (0.00 seconds)[x][39m[n]List of errors:[-n-] - error #1;[-n-] - error #2;[-n-] - error #3;[-n-] - error #4;[-n-] - error #5;[-n-] - error #6;[-n-] - error #7;[-n-] - error #8;[-n-] - error #9;[-n-][...21 lines omitted...][-n-] - error #31;[-n-] - error #32;[-n-] - error #33;[-n-] - error #34;[-n-] - error #35;[-n-] - error #36;[-n-] - error #37;[-n-] - error #38;[-n-] - error #39;[-n-] - error #40;[-n-] - error #41;[-n-] - error #42;[-n-] - error #43;[-n-] - error #44;[-n-] - error #45;[-n-] - error #46;[-n-] - error #47;[-n-] - error #48;[-n-] - error #49;[-n-] - error #50;[n][x][31m================================[-n-][x][39m[n][n]"`;
+exports[`TaskRunner Error logging preservedLeadingBlanksButTrimmedTrailingBlanks 2`] = `"Executing a maximum of 1 simultaneous processes...[-n-][n][x][37m[large stderr with leading and trailing blanks] started[x][39m[n][n][x][31mFAILURE (1)[x][39m[n][x][31m================================[x][39m[n][x][31mlarge stderr with leading and trailing blanks (0.00 seconds)[x][39m[n]List of errors:[-n-] - error #1;[-n-] - error #2;[-n-] - error #3;[-n-] - error #4;[-n-] - error #5;[-n-] - error #6;[-n-] - error #7;[-n-] - error #8;[-n-] - error #9;[-n-][...21 lines omitted...][-n-] - error #31;[-n-] - error #32;[-n-] - error #33;[-n-] - error #34;[-n-] - error #35;[-n-] - error #36;[-n-] - error #37;[-n-] - error #38;[-n-] - error #39;[-n-] - error #40;[-n-] - error #41;[-n-] - error #42;[-n-] - error #43;[-n-] - error #44;[-n-] - error #45;[-n-] - error #46;[-n-] - error #47;[-n-] - error #48;[-n-] - error #49;[-n-] - error #50;[n][x][31m================================[-n-][x][39m[n][n]"`;
 
 exports[`TaskRunner Error logging preservedLeadingBlanksButTrimmedTrailingBlanks 3`] = `""`;
 
@@ -34,7 +14,7 @@ exports[`TaskRunner Error logging preservedLeadingBlanksButTrimmedTrailingBlanks
 
 exports[`TaskRunner Error logging printedAbridgedStdoutAfterErrorWithEmptyStderr 1`] = `"Project(s) failed to build"`;
 
-exports[`TaskRunner Error logging printedAbridgedStdoutAfterErrorWithEmptyStderr 2`] = `"Registered large stdout only[n]Executing a maximum of 1 simultaneous processes...[-n-][n][x][37m[large stdout only] started[x][39m[n][n][x][31mFAILURE (1)[x][39m[n][x][31m================================[x][39m[n][x][31mlarge stdout only (0.00 seconds)[x][39m[n]Building units...[-n-] - unit #1;[-n-] - unit #2;[-n-] - unit #3;[-n-] - unit #4;[-n-] - unit #5;[-n-] - unit #6;[-n-] - unit #7;[-n-] - unit #8;[-n-] - unit #9;[-n-][...21 lines omitted...][-n-] - unit #31;[-n-] - unit #32;[-n-] - unit #33;[-n-] - unit #34;[-n-] - unit #35;[-n-] - unit #36;[-n-] - unit #37;[-n-] - unit #38;[-n-] - unit #39;[-n-] - unit #40;[-n-] - unit #41;[-n-] - unit #42;[-n-] - unit #43;[-n-] - unit #44;[-n-] - unit #45;[-n-] - unit #46;[-n-] - unit #47;[-n-] - unit #48;[-n-] - unit #49;[-n-] - unit #50;[n][x][31m================================[-n-][x][39m[n][n]"`;
+exports[`TaskRunner Error logging printedAbridgedStdoutAfterErrorWithEmptyStderr 2`] = `"Executing a maximum of 1 simultaneous processes...[-n-][n][x][37m[large stdout only] started[x][39m[n][n][x][31mFAILURE (1)[x][39m[n][x][31m================================[x][39m[n][x][31mlarge stdout only (0.00 seconds)[x][39m[n]Building units...[-n-] - unit #1;[-n-] - unit #2;[-n-] - unit #3;[-n-] - unit #4;[-n-] - unit #5;[-n-] - unit #6;[-n-] - unit #7;[-n-] - unit #8;[-n-] - unit #9;[-n-][...21 lines omitted...][-n-] - unit #31;[-n-] - unit #32;[-n-] - unit #33;[-n-] - unit #34;[-n-] - unit #35;[-n-] - unit #36;[-n-] - unit #37;[-n-] - unit #38;[-n-] - unit #39;[-n-] - unit #40;[-n-] - unit #41;[-n-] - unit #42;[-n-] - unit #43;[-n-] - unit #44;[-n-] - unit #45;[-n-] - unit #46;[-n-] - unit #47;[-n-] - unit #48;[-n-] - unit #49;[-n-] - unit #50;[n][x][31m================================[-n-][x][39m[n][n]"`;
 
 exports[`TaskRunner Error logging printedAbridgedStdoutAfterErrorWithEmptyStderr 3`] = `""`;
 
@@ -44,7 +24,7 @@ exports[`TaskRunner Error logging printedAbridgedStdoutAfterErrorWithEmptyStderr
 
 exports[`TaskRunner Error logging printedStderrAfterError 1`] = `"Project(s) failed to build"`;
 
-exports[`TaskRunner Error logging printedStderrAfterError 2`] = `"Registered stdout+stderr[n]Executing a maximum of 1 simultaneous processes...[-n-][n][x][37m[stdout+stderr] started[x][39m[n][n][x][31mFAILURE (1)[x][39m[n][x][31m================================[x][39m[n][x][31mstdout+stderr (0.00 seconds)[x][39m[n]Error: step 1 failed[n][x][31m================================[-n-][x][39m[n][n]"`;
+exports[`TaskRunner Error logging printedStderrAfterError 2`] = `"Executing a maximum of 1 simultaneous processes...[-n-][n][x][37m[stdout+stderr] started[x][39m[n][n][x][31mFAILURE (1)[x][39m[n][x][31m================================[x][39m[n][x][31mstdout+stderr (0.00 seconds)[x][39m[n]Error: step 1 failed[n][x][31m================================[-n-][x][39m[n][n]"`;
 
 exports[`TaskRunner Error logging printedStderrAfterError 3`] = `""`;
 
@@ -54,7 +34,7 @@ exports[`TaskRunner Error logging printedStderrAfterError 5`] = `"[x][31m[-n-]1 
 
 exports[`TaskRunner Error logging printedStdoutAfterErrorWithEmptyStderr 1`] = `"Project(s) failed to build"`;
 
-exports[`TaskRunner Error logging printedStdoutAfterErrorWithEmptyStderr 2`] = `"Registered stdout only[n]Executing a maximum of 1 simultaneous processes...[-n-][n][x][37m[stdout only] started[x][39m[n][n][x][31mFAILURE (1)[x][39m[n][x][31m================================[x][39m[n][x][31mstdout only (0.00 seconds)[x][39m[n]Build step 1[-n-]Error: step 1 failed[n][x][31m================================[-n-][x][39m[n][n]"`;
+exports[`TaskRunner Error logging printedStdoutAfterErrorWithEmptyStderr 2`] = `"Executing a maximum of 1 simultaneous processes...[-n-][n][x][37m[stdout only] started[x][39m[n][n][x][31mFAILURE (1)[x][39m[n][x][31m================================[x][39m[n][x][31mstdout only (0.00 seconds)[x][39m[n]Build step 1[-n-]Error: step 1 failed[n][x][31m================================[-n-][x][39m[n][n]"`;
 
 exports[`TaskRunner Error logging printedStdoutAfterErrorWithEmptyStderr 3`] = `""`;
 
@@ -64,7 +44,7 @@ exports[`TaskRunner Error logging printedStdoutAfterErrorWithEmptyStderr 5`] = `
 
 exports[`TaskRunner Warning logging Fail on warning Logs warnings correctly 1`] = `"An error occurred."`;
 
-exports[`TaskRunner Warning logging Fail on warning Logs warnings correctly 2`] = `"Registered success with warnings (failure)[n]Executing a maximum of 1 simultaneous processes...[-n-][n][x][37m[success with warnings (failure)] started[x][39m[n][n][x][33m[x][4mSUCCESS WITH WARNINGS (1)[x][24m[x][39m[n][x][33m================================[x][39m[n][x][33m[x][4msuccess with warnings (failure) (0.00 seconds)[x][24m[x][39m[n]Build step 1[-n-]Warning: step 1 succeeded with warnings[n][x][33m================================[-n-][x][39m[n][n]"`;
+exports[`TaskRunner Warning logging Fail on warning Logs warnings correctly 2`] = `"Executing a maximum of 1 simultaneous processes...[-n-][n][x][37m[success with warnings (failure)] started[x][39m[n][n][x][33m[x][4mSUCCESS WITH WARNINGS (1)[x][24m[x][39m[n][x][33m================================[x][39m[n][x][33m[x][4msuccess with warnings (failure) (0.00 seconds)[x][24m[x][39m[n]Build step 1[-n-]Warning: step 1 succeeded with warnings[n][x][33m================================[-n-][x][39m[n][n]"`;
 
 exports[`TaskRunner Warning logging Fail on warning Logs warnings correctly 3`] = `""`;
 
@@ -72,7 +52,7 @@ exports[`TaskRunner Warning logging Fail on warning Logs warnings correctly 4`] 
 
 exports[`TaskRunner Warning logging Fail on warning Logs warnings correctly 5`] = `""`;
 
-exports[`TaskRunner Warning logging Success on warning Logs warnings correctly 1`] = `"Registered success with warnings (success)[n]Executing a maximum of 1 simultaneous processes...[-n-][n][x][37m[success with warnings (success)] started[x][39m[n][n][x][33m[x][4mSUCCESS WITH WARNINGS (1)[x][24m[x][39m[n][x][33m================================[x][39m[n][x][33m[x][4msuccess with warnings (success) (0.00 seconds)[x][24m[x][39m[n]Build step 1[-n-]Warning: step 1 succeeded with warnings[n][x][33m================================[-n-][x][39m[n][n]"`;
+exports[`TaskRunner Warning logging Success on warning Logs warnings correctly 1`] = `"Executing a maximum of 1 simultaneous processes...[-n-][n][x][37m[success with warnings (success)] started[x][39m[n][n][x][33m[x][4mSUCCESS WITH WARNINGS (1)[x][24m[x][39m[n][x][33m================================[x][39m[n][x][33m[x][4msuccess with warnings (success) (0.00 seconds)[x][24m[x][39m[n]Build step 1[-n-]Warning: step 1 succeeded with warnings[n][x][33m================================[-n-][x][39m[n][n]"`;
 
 exports[`TaskRunner Warning logging Success on warning Logs warnings correctly 2`] = `""`;
 

--- a/common/changes/@microsoft/rush/dependency-graph_2019-07-26-21-14.json
+++ b/common/changes/@microsoft/rush/dependency-graph_2019-07-26-21-14.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Refactor build action to allow generating build graph statically",
+      "packageName": "@microsoft/rush",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "nayanshah@users.noreply.github.com"
+}


### PR DESCRIPTION
* Split TaskRunner and decouple it from TaskSelector
* Compute the project build command before execution

With these changes, TaskSelector can be called to get the list of build tasks without executing them. Plan is to expose these as an api for rush-buildxl next. 