### PR TITLE
[rush] Clarify that "rush update --full" should be run when changing certain settings

### DIFF
--- a/apps/rush-lib/assets/rush-init/common/config/rush/common-versions.json
+++ b/apps/rush-lib/assets/rush-init/common/config/rush/common-versions.json
@@ -10,6 +10,9 @@
    * is typically used to hold an indirect dependency back to a specific version, however generally
    * it can be any SemVer range specifier (e.g. "~1.2.3"), and it will narrow any (compatible)
    * SemVer range specifier.  See the Rush documentation for details about this feature.
+   *
+   * After modifying this field, it's recommended to run "rush update --full" so that the package manager
+   * will recalculate all version selections.
    */
   "preferredVersions": {
 

--- a/apps/rush-lib/assets/rush-init/common/config/rush/pnpmfile.js
+++ b/apps/rush-lib/assets/rush-init/common/config/rush/pnpmfile.js
@@ -9,8 +9,8 @@
  * https://pnpm.js.org/docs/en/hooks.html
  *
  * IMPORTANT: SINCE THIS FILE CONTAINS EXECUTABLE CODE, MODIFYING IT IS LIKELY TO INVALIDATE
- * ANY CACHED DEPENDENCY ANALYSIS.  After any modification to pnpmfile, it's recommended to run
- * "rush update --full" so that the package manager will recalculate all version selections.
+ * ANY CACHED DEPENDENCY ANALYSIS.  After any modification to pnpmfile.js, it's recommended to run
+ * "rush update --full" so that PNPM will recalculate all version selections.
  */
 module.exports = {
   hooks: {

--- a/apps/rush-lib/assets/rush-init/common/config/rush/pnpmfile.js
+++ b/apps/rush-lib/assets/rush-init/common/config/rush/pnpmfile.js
@@ -8,10 +8,9 @@
  * For details, see the PNPM documentation:
  * https://pnpm.js.org/docs/en/hooks.html
  *
- * IMPORTANT: SINCE THIS FILE CONTAINS EXECUTABLE CODE, MODIFYING IT IS LIKELY
- * TO INVALIDATE ANY CACHED DEPENDENCY ANALYSIS.  We recommend to run "rush update --full"
- * after any modification to pnpmfile.js.
- *
+ * IMPORTANT: SINCE THIS FILE CONTAINS EXECUTABLE CODE, MODIFYING IT IS LIKELY TO INVALIDATE
+ * ANY CACHED DEPENDENCY ANALYSIS.  After any modification to pnpmfile, it's recommended to run
+ * "rush update --full" so that the package manager will recalculate all version selections.
  */
 module.exports = {
   hooks: {

--- a/apps/rush-lib/assets/rush-init/rush.json
+++ b/apps/rush-lib/assets/rush-init/rush.json
@@ -57,6 +57,9 @@
      * be incompatible with certain packages, for example the "@types" packages from DefinitelyTyped.  Rush's default
      * is "fewer-dependencies", which causes PNPM to avoid installing a newer version if an already installed version
      * can be reused; this is more similar to NPM's algorithm.
+     *
+     * After modifying this field, it's recommended to run "rush update --full" so that the package manager
+     * will recalculate all version selections.
      */
     /*[LINE "HYPOTHETICAL"]*/ "resolutionStrategy": "fast"
   },

--- a/common/changes/@microsoft/rush/octogonz-improve-rushjson-docs_2019-07-30-20-21.json
+++ b/common/changes/@microsoft/rush/octogonz-improve-rushjson-docs_2019-07-30-20-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Clarify that \"rush update --full\" should be run when changing certain settings",
+      "packageName": "@microsoft/rush",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}


### PR DESCRIPTION
@abirmingham [recently had trouble](https://gitter.im/web-build-tools/web-build-tools?at=5d406c7e8aab922429eaae74) where a change to `preferredVersions` did not take effect because of running `rush update` instead of `rush update --full`.  Clarify the docs.