### PR TITLE
[api-documenter] Generate DocFX UIDs using new DeclarationReference algorithm

### DIFF
--- a/apps/api-documenter/src/documenters/YamlDocumenter.ts
+++ b/apps/api-documenter/src/documenters/YamlDocumenter.ts
@@ -28,7 +28,6 @@ import {
   ApiEnumMember,
   ApiClass,
   ApiInterface,
-  ApiParameterListMixin,
   ApiMethod,
   ApiMethodSignature,
   ApiConstructor,
@@ -551,36 +550,10 @@ export class YamlDocumenter {
 
   /**
    * Calculate the DocFX "uid" for the ApiItem
-   * Example:  node-core-library.JsonFile.load
+   * Example:  `node-core-library!JsonFile#load`
    */
   protected _getUid(apiItem: ApiItem): string {
-    let result: string = '';
-    for (const hierarchyItem of apiItem.getHierarchy()) {
-
-      // For overloaded methods, add a suffix such as "MyClass.myMethod_2".
-      let qualifiedName: string = hierarchyItem.displayName;
-      if (ApiParameterListMixin.isBaseClassOf(hierarchyItem)) {
-        if (hierarchyItem.overloadIndex > 1) {
-          // Subtract one for compatibility with earlier releases of API Documenter.
-          // (This will get revamped when we fix GitHub issue #1308)
-          qualifiedName += `_${hierarchyItem.overloadIndex - 1}`;
-        }
-      }
-
-      switch (hierarchyItem.kind) {
-        case ApiItemKind.Model:
-        case ApiItemKind.EntryPoint:
-          break;
-        case ApiItemKind.Package:
-          result += PackageName.getUnscopedName(hierarchyItem.displayName);
-          break;
-        default:
-          result += '.';
-          result += qualifiedName;
-          break;
-      }
-    }
-    return result;
+    return apiItem.canonicalReference.toString();
   }
 
   /**
@@ -679,7 +652,7 @@ export class YamlDocumenter {
     if (apiItem.parent && apiItem.parent.kind === ApiItemKind.Namespace) {
       // For members a namespace, show the full name excluding the package part:
       // Example: excel.Excel.Binding --> Excel.Binding
-      return this._getUid(apiItem).replace(/^[^.]+\./, '');
+      return apiItem.getScopedNameWithinPackage();
     }
     return Utilities.getConciseSignature(apiItem);
   }

--- a/build-tests/api-documenter-test/etc/yaml/api-documenter-test.yml
+++ b/build-tests/api-documenter-test/etc/yaml/api-documenter-test.yml
@@ -44,8 +44,8 @@ items:
             - number
   - uid: 'api-documenter-test!OuterNamespace.InnerNamespace.nestedFunction:function(1)'
     summary: A function inside a namespace
-    name: OuterNamespace.InnerNamespace.nestedFunction()
-    fullName: OuterNamespace.InnerNamespace.nestedFunction()
+    name: OuterNamespace.InnerNamespace.nestedFunction(x)
+    fullName: OuterNamespace.InnerNamespace.nestedFunction(x)
     langs:
       - typeScript
     type: function

--- a/build-tests/api-documenter-test/etc/yaml/api-documenter-test.yml
+++ b/build-tests/api-documenter-test/etc/yaml/api-documenter-test.yml
@@ -1,6 +1,6 @@
 ### YamlMime:UniversalReference
 items:
-  - uid: api-documenter-test
+  - uid: api-documenter-test!
     summary: |-
       api-extractor-test-05
 
@@ -11,20 +11,20 @@ items:
       - typeScript
     type: package
     children:
-      - api-documenter-test.DocBaseClass
-      - api-documenter-test.DocClass1
-      - api-documenter-test.DocEnum
-      - api-documenter-test.Generic
-      - api-documenter-test.globalFunction
-      - api-documenter-test.IDocInterface1
-      - api-documenter-test.IDocInterface2
-      - api-documenter-test.IDocInterface3
-      - api-documenter-test.IDocInterface4
-      - api-documenter-test.IDocInterface5
-      - api-documenter-test.IDocInterface6
-      - api-documenter-test.OuterNamespace.InnerNamespace.nestedFunction
-      - api-documenter-test.SystemEvent
-  - uid: api-documenter-test.globalFunction
+      - 'api-documenter-test!DocBaseClass:class'
+      - 'api-documenter-test!DocClass1:class'
+      - 'api-documenter-test!DocEnum:enum'
+      - 'api-documenter-test!Generic:class'
+      - 'api-documenter-test!globalFunction:function(1)'
+      - 'api-documenter-test!IDocInterface1:interface'
+      - 'api-documenter-test!IDocInterface2:interface'
+      - 'api-documenter-test!IDocInterface3:interface'
+      - 'api-documenter-test!IDocInterface4:interface'
+      - 'api-documenter-test!IDocInterface5:interface'
+      - 'api-documenter-test!IDocInterface6:interface'
+      - 'api-documenter-test!OuterNamespace.InnerNamespace.nestedFunction:function(1)'
+      - 'api-documenter-test!SystemEvent:class'
+  - uid: 'api-documenter-test!globalFunction:function(1)'
     summary: An exported function
     name: globalFunction(x)
     fullName: globalFunction(x)
@@ -42,10 +42,10 @@ items:
           description: ''
           type:
             - number
-  - uid: api-documenter-test.OuterNamespace.InnerNamespace.nestedFunction
+  - uid: 'api-documenter-test!OuterNamespace.InnerNamespace.nestedFunction:function(1)'
     summary: A function inside a namespace
-    name: OuterNamespace.InnerNamespace.nestedFunction
-    fullName: OuterNamespace.InnerNamespace.nestedFunction
+    name: OuterNamespace.InnerNamespace.nestedFunction()
+    fullName: OuterNamespace.InnerNamespace.nestedFunction()
     langs:
       - typeScript
     type: function
@@ -61,25 +61,25 @@ items:
           type:
             - number
 references:
-  - uid: api-documenter-test.DocBaseClass
+  - uid: 'api-documenter-test!DocBaseClass:class'
     name: DocBaseClass
-  - uid: api-documenter-test.DocClass1
+  - uid: 'api-documenter-test!DocClass1:class'
     name: DocClass1
-  - uid: api-documenter-test.DocEnum
+  - uid: 'api-documenter-test!DocEnum:enum'
     name: DocEnum
-  - uid: api-documenter-test.Generic
+  - uid: 'api-documenter-test!Generic:class'
     name: Generic
-  - uid: api-documenter-test.IDocInterface1
+  - uid: 'api-documenter-test!IDocInterface1:interface'
     name: IDocInterface1
-  - uid: api-documenter-test.IDocInterface2
+  - uid: 'api-documenter-test!IDocInterface2:interface'
     name: IDocInterface2
-  - uid: api-documenter-test.IDocInterface3
+  - uid: 'api-documenter-test!IDocInterface3:interface'
     name: IDocInterface3
-  - uid: api-documenter-test.IDocInterface4
+  - uid: 'api-documenter-test!IDocInterface4:interface'
     name: IDocInterface4
-  - uid: api-documenter-test.IDocInterface5
+  - uid: 'api-documenter-test!IDocInterface5:interface'
     name: IDocInterface5
-  - uid: api-documenter-test.IDocInterface6
+  - uid: 'api-documenter-test!IDocInterface6:interface'
     name: IDocInterface6
-  - uid: api-documenter-test.SystemEvent
+  - uid: 'api-documenter-test!SystemEvent:class'
     name: SystemEvent

--- a/build-tests/api-documenter-test/etc/yaml/api-documenter-test/docbaseclass.yml
+++ b/build-tests/api-documenter-test/etc/yaml/api-documenter-test/docbaseclass.yml
@@ -1,17 +1,17 @@
 ### YamlMime:UniversalReference
 items:
-  - uid: api-documenter-test.DocBaseClass
+  - uid: 'api-documenter-test!DocBaseClass:class'
     summary: Example base class
     name: DocBaseClass
     fullName: DocBaseClass
     langs:
       - typeScript
     type: class
-    package: api-documenter-test
+    package: api-documenter-test!
     children:
-      - api-documenter-test.DocBaseClass.(constructor)
-      - api-documenter-test.DocBaseClass.(constructor)_1
-  - uid: api-documenter-test.DocBaseClass.(constructor)
+      - 'api-documenter-test!DocBaseClass:constructor(1)'
+      - 'api-documenter-test!DocBaseClass:constructor(2)'
+  - uid: 'api-documenter-test!DocBaseClass:constructor(1)'
     summary: The simple constructor for `DocBaseClass`
     name: (constructor)()
     fullName: (constructor)()
@@ -20,7 +20,7 @@ items:
     type: constructor
     syntax:
       content: constructor();
-  - uid: api-documenter-test.DocBaseClass.(constructor)_1
+  - uid: 'api-documenter-test!DocBaseClass:constructor(2)'
     summary: The overloaded constructor for `DocBaseClass`
     name: (constructor)(x)
     fullName: (constructor)(x)

--- a/build-tests/api-documenter-test/etc/yaml/api-documenter-test/docclass1.yml
+++ b/build-tests/api-documenter-test/etc/yaml/api-documenter-test/docclass1.yml
@@ -1,6 +1,6 @@
 ### YamlMime:UniversalReference
 items:
-  - uid: api-documenter-test.DocClass1
+  - uid: 'api-documenter-test!DocClass1:class'
     summary: This is an example class.
     remarks: >-
       These are some remarks.
@@ -14,22 +14,22 @@ items:
       - typeScript
     type: class
     extends:
-      - api-documenter-test.DocBaseClass
+      - 'api-documenter-test!DocBaseClass:class'
     implements:
-      - api-documenter-test.IDocInterface1
-      - api-documenter-test.IDocInterface2
-    package: api-documenter-test
+      - 'api-documenter-test!IDocInterface1:interface'
+      - 'api-documenter-test!IDocInterface2:interface'
+    package: api-documenter-test!
     children:
-      - api-documenter-test.DocClass1.deprecatedExample
-      - api-documenter-test.DocClass1.exampleFunction
-      - api-documenter-test.DocClass1.exampleFunction_1
-      - api-documenter-test.DocClass1.interestingEdgeCases
-      - api-documenter-test.DocClass1.malformedEvent
-      - api-documenter-test.DocClass1.modifiedEvent
-      - api-documenter-test.DocClass1.regularProperty
-      - api-documenter-test.DocClass1.sumWithExample
-      - api-documenter-test.DocClass1.tableExample
-  - uid: api-documenter-test.DocClass1.deprecatedExample
+      - 'api-documenter-test!DocClass1#deprecatedExample:member(1)'
+      - 'api-documenter-test!DocClass1#exampleFunction:member(1)'
+      - 'api-documenter-test!DocClass1#exampleFunction:member(2)'
+      - 'api-documenter-test!DocClass1#interestingEdgeCases:member(1)'
+      - 'api-documenter-test!DocClass1#malformedEvent:member'
+      - 'api-documenter-test!DocClass1#modifiedEvent:member'
+      - 'api-documenter-test!DocClass1#regularProperty:member'
+      - 'api-documenter-test!DocClass1.sumWithExample:member(1)'
+      - 'api-documenter-test!DocClass1#tableExample:member(1)'
+  - uid: 'api-documenter-test!DocClass1#deprecatedExample:member(1)'
     deprecated:
       content: Use `otherThing()` instead.
     name: deprecatedExample()
@@ -43,7 +43,7 @@ items:
         type:
           - void
         description: ''
-  - uid: api-documenter-test.DocClass1.exampleFunction
+  - uid: 'api-documenter-test!DocClass1#exampleFunction:member(1)'
     summary: This is an overloaded function.
     name: 'exampleFunction(a, b)'
     fullName: 'exampleFunction(a, b)'
@@ -65,7 +65,7 @@ items:
           description: the second string
           type:
             - string
-  - uid: api-documenter-test.DocClass1.exampleFunction_1
+  - uid: 'api-documenter-test!DocClass1#exampleFunction:member(2)'
     summary: This is also an overloaded function.
     name: exampleFunction(x)
     fullName: exampleFunction(x)
@@ -83,7 +83,7 @@ items:
           description: the number
           type:
             - number
-  - uid: api-documenter-test.DocClass1.interestingEdgeCases
+  - uid: 'api-documenter-test!DocClass1#interestingEdgeCases:member(1)'
     summary: |-
       Example: "<!-- -->{ \\<!-- -->"maxItemsToShow<!-- -->\\<!-- -->": 123 }<!-- -->"
 
@@ -99,7 +99,7 @@ items:
         type:
           - void
         description: ''
-  - uid: api-documenter-test.DocClass1.malformedEvent
+  - uid: 'api-documenter-test!DocClass1#malformedEvent:member'
     summary: This event should have been marked as readonly.
     name: malformedEvent
     fullName: malformedEvent
@@ -110,8 +110,8 @@ items:
       content: 'malformedEvent: SystemEvent;'
       return:
         type:
-          - api-documenter-test.SystemEvent
-  - uid: api-documenter-test.DocClass1.modifiedEvent
+          - 'api-documenter-test!SystemEvent:class'
+  - uid: 'api-documenter-test!DocClass1#modifiedEvent:member'
     summary: This event is fired whenever the object is modified.
     name: modifiedEvent
     fullName: modifiedEvent
@@ -122,8 +122,8 @@ items:
       content: 'readonly modifiedEvent: SystemEvent;'
       return:
         type:
-          - api-documenter-test.SystemEvent
-  - uid: api-documenter-test.DocClass1.regularProperty
+          - 'api-documenter-test!SystemEvent:class'
+  - uid: 'api-documenter-test!DocClass1#regularProperty:member'
     summary: This is a regular property that happens to use the SystemEvent type.
     name: regularProperty
     fullName: regularProperty
@@ -134,8 +134,8 @@ items:
       content: 'regularProperty: SystemEvent;'
       return:
         type:
-          - api-documenter-test.SystemEvent
-  - uid: api-documenter-test.DocClass1.sumWithExample
+          - 'api-documenter-test!SystemEvent:class'
+  - uid: 'api-documenter-test!DocClass1.sumWithExample:member(1)'
     summary: Returns the sum of two numbers.
     remarks: This illustrates usage of the `@example` block tag.
     name: 'sumWithExample(x, y)'
@@ -158,7 +158,7 @@ items:
           description: the second number to add
           type:
             - number
-  - uid: api-documenter-test.DocClass1.tableExample
+  - uid: 'api-documenter-test!DocClass1#tableExample:member(1)'
     summary: 'An example with tables:'
     remarks: <table> <tr> <td>John</td> <td>Doe</td> </tr> </table>
     name: tableExample()

--- a/build-tests/api-documenter-test/etc/yaml/api-documenter-test/docenum.yml
+++ b/build-tests/api-documenter-test/etc/yaml/api-documenter-test/docenum.yml
@@ -1,18 +1,18 @@
 ### YamlMime:UniversalReference
 items:
-  - uid: api-documenter-test.DocEnum
+  - uid: 'api-documenter-test!DocEnum:enum'
     summary: Docs for DocEnum
     name: DocEnum
     fullName: DocEnum
     langs:
       - typeScript
     type: enum
-    package: api-documenter-test
+    package: api-documenter-test!
     children:
-      - api-documenter-test.DocEnum.One
-      - api-documenter-test.DocEnum.Two
-      - api-documenter-test.DocEnum.Zero
-  - uid: api-documenter-test.DocEnum.One
+      - 'api-documenter-test!DocEnum.One:member'
+      - 'api-documenter-test!DocEnum.Two:member'
+      - 'api-documenter-test!DocEnum.Zero:member'
+  - uid: 'api-documenter-test!DocEnum.One:member'
     summary: These are some docs for One
     name: One
     fullName: One
@@ -20,7 +20,7 @@ items:
       - typeScript
     type: field
     numericValue: '1'
-  - uid: api-documenter-test.DocEnum.Two
+  - uid: 'api-documenter-test!DocEnum.Two:member'
     summary: These are some docs for Two
     name: Two
     fullName: Two
@@ -28,7 +28,7 @@ items:
       - typeScript
     type: field
     numericValue: '2'
-  - uid: api-documenter-test.DocEnum.Zero
+  - uid: 'api-documenter-test!DocEnum.Zero:member'
     summary: These are some docs for Zero
     name: Zero
     fullName: Zero

--- a/build-tests/api-documenter-test/etc/yaml/api-documenter-test/generic.yml
+++ b/build-tests/api-documenter-test/etc/yaml/api-documenter-test/generic.yml
@@ -1,10 +1,10 @@
 ### YamlMime:UniversalReference
 items:
-  - uid: api-documenter-test.Generic
+  - uid: 'api-documenter-test!Generic:class'
     summary: Generic class.
     name: Generic
     fullName: Generic
     langs:
       - typeScript
     type: class
-    package: api-documenter-test
+    package: api-documenter-test!

--- a/build-tests/api-documenter-test/etc/yaml/api-documenter-test/idocinterface1.yml
+++ b/build-tests/api-documenter-test/etc/yaml/api-documenter-test/idocinterface1.yml
@@ -1,15 +1,15 @@
 ### YamlMime:UniversalReference
 items:
-  - uid: api-documenter-test.IDocInterface1
+  - uid: 'api-documenter-test!IDocInterface1:interface'
     name: IDocInterface1
     fullName: IDocInterface1
     langs:
       - typeScript
     type: interface
-    package: api-documenter-test
+    package: api-documenter-test!
     children:
-      - api-documenter-test.IDocInterface1.regularProperty
-  - uid: api-documenter-test.IDocInterface1.regularProperty
+      - 'api-documenter-test!IDocInterface1#regularProperty:member'
+  - uid: 'api-documenter-test!IDocInterface1#regularProperty:member'
     summary: Does something
     name: regularProperty
     fullName: regularProperty
@@ -20,4 +20,4 @@ items:
       content: 'regularProperty: SystemEvent;'
       return:
         type:
-          - api-documenter-test.SystemEvent
+          - 'api-documenter-test!SystemEvent:class'

--- a/build-tests/api-documenter-test/etc/yaml/api-documenter-test/idocinterface2.yml
+++ b/build-tests/api-documenter-test/etc/yaml/api-documenter-test/idocinterface2.yml
@@ -1,17 +1,17 @@
 ### YamlMime:UniversalReference
 items:
-  - uid: api-documenter-test.IDocInterface2
+  - uid: 'api-documenter-test!IDocInterface2:interface'
     name: IDocInterface2
     fullName: IDocInterface2
     langs:
       - typeScript
     type: interface
     extends:
-      - api-documenter-test.IDocInterface1
-    package: api-documenter-test
+      - 'api-documenter-test!IDocInterface1:interface'
+    package: api-documenter-test!
     children:
-      - api-documenter-test.IDocInterface2.deprecatedExample
-  - uid: api-documenter-test.IDocInterface2.deprecatedExample
+      - 'api-documenter-test!IDocInterface2#deprecatedExample:member(1)'
+  - uid: 'api-documenter-test!IDocInterface2#deprecatedExample:member(1)'
     deprecated:
       content: Use `otherThing()` instead.
     name: deprecatedExample()

--- a/build-tests/api-documenter-test/etc/yaml/api-documenter-test/idocinterface3.yml
+++ b/build-tests/api-documenter-test/etc/yaml/api-documenter-test/idocinterface3.yml
@@ -1,18 +1,18 @@
 ### YamlMime:UniversalReference
 items:
-  - uid: api-documenter-test.IDocInterface3
+  - uid: 'api-documenter-test!IDocInterface3:interface'
     summary: Some less common TypeScript declaration kinds.
     name: IDocInterface3
     fullName: IDocInterface3
     langs:
       - typeScript
     type: interface
-    package: api-documenter-test
+    package: api-documenter-test!
     children:
-      - 'api-documenter-test.IDocInterface3."[not.a.symbol]"'
-      - 'api-documenter-test.IDocInterface3.[EcmaSmbols.example]'
-      - api-documenter-test.IDocInterface3.redundantQuotes
-  - uid: 'api-documenter-test.IDocInterface3."[not.a.symbol]"'
+      - 'api-documenter-test!IDocInterface3#"[not.a.symbol]":member'
+      - 'api-documenter-test!IDocInterface3#[EcmaSmbols.example]:member'
+      - 'api-documenter-test!IDocInterface3#redundantQuotes:member'
+  - uid: 'api-documenter-test!IDocInterface3#"[not.a.symbol]":member'
     summary: An identifier that does needs quotes. It misleadingly looks like an ECMAScript symbol.
     name: '"[not.a.symbol]"'
     fullName: '"[not.a.symbol]"'
@@ -24,7 +24,7 @@ items:
       return:
         type:
           - string
-  - uid: 'api-documenter-test.IDocInterface3.[EcmaSmbols.example]'
+  - uid: 'api-documenter-test!IDocInterface3#[EcmaSmbols.example]:member'
     summary: ECMAScript symbol
     name: '[EcmaSmbols.example]'
     fullName: '[EcmaSmbols.example]'
@@ -36,7 +36,7 @@ items:
       return:
         type:
           - string
-  - uid: api-documenter-test.IDocInterface3.redundantQuotes
+  - uid: 'api-documenter-test!IDocInterface3#redundantQuotes:member'
     summary: A quoted identifier with redundant quotes.
     name: redundantQuotes
     fullName: redundantQuotes

--- a/build-tests/api-documenter-test/etc/yaml/api-documenter-test/idocinterface4.yml
+++ b/build-tests/api-documenter-test/etc/yaml/api-documenter-test/idocinterface4.yml
@@ -1,19 +1,19 @@
 ### YamlMime:UniversalReference
 items:
-  - uid: api-documenter-test.IDocInterface4
+  - uid: 'api-documenter-test!IDocInterface4:interface'
     summary: Type union in an interface.
     name: IDocInterface4
     fullName: IDocInterface4
     langs:
       - typeScript
     type: interface
-    package: api-documenter-test
+    package: api-documenter-test!
     children:
-      - api-documenter-test.IDocInterface4.Context
-      - api-documenter-test.IDocInterface4.generic
-      - api-documenter-test.IDocInterface4.numberOrFunction
-      - api-documenter-test.IDocInterface4.stringOrNumber
-  - uid: api-documenter-test.IDocInterface4.Context
+      - 'api-documenter-test!IDocInterface4#Context:member'
+      - 'api-documenter-test!IDocInterface4#generic:member'
+      - 'api-documenter-test!IDocInterface4#numberOrFunction:member'
+      - 'api-documenter-test!IDocInterface4#stringOrNumber:member'
+  - uid: 'api-documenter-test!IDocInterface4#Context:member'
     summary: Test newline rendering when code blocks are used in tables
     name: Context
     fullName: Context
@@ -31,7 +31,7 @@ items:
             ({ children }: {
                     children: string;
                 }) => boolean
-  - uid: api-documenter-test.IDocInterface4.generic
+  - uid: 'api-documenter-test!IDocInterface4#generic:member'
     summary: make sure html entities are escaped in tables.
     name: generic
     fullName: generic
@@ -43,7 +43,7 @@ items:
       return:
         type:
           - Generic<number>
-  - uid: api-documenter-test.IDocInterface4.numberOrFunction
+  - uid: 'api-documenter-test!IDocInterface4#numberOrFunction:member'
     summary: a union type with a function
     name: numberOrFunction
     fullName: numberOrFunction
@@ -55,7 +55,7 @@ items:
       return:
         type:
           - number | (() => number)
-  - uid: api-documenter-test.IDocInterface4.stringOrNumber
+  - uid: 'api-documenter-test!IDocInterface4#stringOrNumber:member'
     summary: a union type
     name: stringOrNumber
     fullName: stringOrNumber

--- a/build-tests/api-documenter-test/etc/yaml/api-documenter-test/idocinterface5.yml
+++ b/build-tests/api-documenter-test/etc/yaml/api-documenter-test/idocinterface5.yml
@@ -1,16 +1,16 @@
 ### YamlMime:UniversalReference
 items:
-  - uid: api-documenter-test.IDocInterface5
+  - uid: 'api-documenter-test!IDocInterface5:interface'
     summary: Interface without inline tag to test custom TOC
     name: IDocInterface5
     fullName: IDocInterface5
     langs:
       - typeScript
     type: interface
-    package: api-documenter-test
+    package: api-documenter-test!
     children:
-      - api-documenter-test.IDocInterface5.regularProperty
-  - uid: api-documenter-test.IDocInterface5.regularProperty
+      - 'api-documenter-test!IDocInterface5#regularProperty:member'
+  - uid: 'api-documenter-test!IDocInterface5#regularProperty:member'
     summary: Property of type string that does something
     name: regularProperty
     fullName: regularProperty

--- a/build-tests/api-documenter-test/etc/yaml/api-documenter-test/idocinterface6.yml
+++ b/build-tests/api-documenter-test/etc/yaml/api-documenter-test/idocinterface6.yml
@@ -1,16 +1,16 @@
 ### YamlMime:UniversalReference
 items:
-  - uid: api-documenter-test.IDocInterface6
+  - uid: 'api-documenter-test!IDocInterface6:interface'
     summary: Interface without inline tag to test custom TOC with injection
     name: IDocInterface6
     fullName: IDocInterface6
     langs:
       - typeScript
     type: interface
-    package: api-documenter-test
+    package: api-documenter-test!
     children:
-      - api-documenter-test.IDocInterface6.regularProperty
-  - uid: api-documenter-test.IDocInterface6.regularProperty
+      - 'api-documenter-test!IDocInterface6#regularProperty:member'
+  - uid: 'api-documenter-test!IDocInterface6#regularProperty:member'
     summary: Property of type number that does something
     name: regularProperty
     fullName: regularProperty

--- a/build-tests/api-documenter-test/etc/yaml/api-documenter-test/systemevent.yml
+++ b/build-tests/api-documenter-test/etc/yaml/api-documenter-test/systemevent.yml
@@ -1,16 +1,16 @@
 ### YamlMime:UniversalReference
 items:
-  - uid: api-documenter-test.SystemEvent
+  - uid: 'api-documenter-test!SystemEvent:class'
     summary: A class used to exposed events.
     name: SystemEvent
     fullName: SystemEvent
     langs:
       - typeScript
     type: class
-    package: api-documenter-test
+    package: api-documenter-test!
     children:
-      - api-documenter-test.SystemEvent.addHandler
-  - uid: api-documenter-test.SystemEvent.addHandler
+      - 'api-documenter-test!SystemEvent#addHandler:member(1)'
+  - uid: 'api-documenter-test!SystemEvent#addHandler:member(1)'
     summary: Adds an handler for the event.
     name: addHandler(handler)
     fullName: addHandler(handler)

--- a/build-tests/api-documenter-test/etc/yaml/toc.yml
+++ b/build-tests/api-documenter-test/etc/yaml/toc.yml
@@ -10,38 +10,38 @@ items:
           - name: DocBaseClass
             items:
               - name: DocBaseClass
-                uid: api-documenter-test.DocBaseClass
+                uid: 'api-documenter-test!DocBaseClass:class'
               - name: IDocInterface1
-                uid: api-documenter-test.IDocInterface1
+                uid: 'api-documenter-test!IDocInterface1:interface'
               - name: IDocInterface2
-                uid: api-documenter-test.IDocInterface2
+                uid: 'api-documenter-test!IDocInterface2:interface'
           - name: DocClass1
             items:
               - name: DocClass1
-                uid: api-documenter-test.DocClass1
+                uid: 'api-documenter-test!DocClass1:class'
               - name: IDocInterface3
-                uid: api-documenter-test.IDocInterface3
+                uid: 'api-documenter-test!IDocInterface3:interface'
               - name: IDocInterface4
-                uid: api-documenter-test.IDocInterface4
+                uid: 'api-documenter-test!IDocInterface4:interface'
       - name: Interfaces
         items:
           - name: Interface5
             items:
               - name: IDocInterface5
-                uid: api-documenter-test.IDocInterface5
+                uid: 'api-documenter-test!IDocInterface5:interface'
           - name: Interface6
             items:
               - name: InjectedCustomInterface
                 uid: customUid
               - name: IDocInterface6
-                uid: api-documenter-test.IDocInterface6
+                uid: 'api-documenter-test!IDocInterface6:interface'
       - name: References
         items:
           - name: InjectedCustomItem
             uid: customUrl
           - name: DocEnum
-            uid: api-documenter-test.DocEnum
+            uid: 'api-documenter-test!DocEnum:enum'
           - name: Generic
-            uid: api-documenter-test.Generic
+            uid: 'api-documenter-test!Generic:class'
           - name: SystemEvent
-            uid: api-documenter-test.SystemEvent
+            uid: 'api-documenter-test!SystemEvent:class'

--- a/common/changes/@microsoft/api-documenter/octogonz-ad-new-yaml-uids_2019-08-08-05-42.json
+++ b/common/changes/@microsoft/api-documenter/octogonz-ad-new-yaml-uids_2019-08-08-05-42.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-documenter",
+      "comment": "Improve algorithm for UID generation to prevent certain naming collisions (e.g. between static/instance members with the same name)",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/api-documenter",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}


### PR DESCRIPTION
Update **api-documenter** to generate DocFX UIDs using use @rbuckton's new [DeclarationReference](https://github.com/microsoft/tsdoc/blob/master/tsdoc/src/beta/DeclarationReference.grammarkdown) syntax.  

Fixes https://github.com/microsoft/web-build-tools/issues/1252

Fixes https://github.com/microsoft/web-build-tools/issues/1052

@Vitalius1 @AlexJerabek @natalieethell Could you test this on your DocFX projects and make sure that (1) nothing is broken and (2) the above issues are fixed?

(I will tackle the filename/URL naming in a subsequent PR, because I'm realizing the solution for that problem is slightly different.)

Huge thanks to @rbuckton for designing the new UIDs! 😊🎉