### PR TITLE
[rush] Add simple support for incremental builds in custom commands (untested)

### DIFF
--- a/apps/rush-lib/src/api/CommandLineJson.ts
+++ b/apps/rush-lib/src/api/CommandLineJson.ts
@@ -24,6 +24,7 @@ export interface IBulkCommandJson extends IBaseCommandJson {
   ignoreDependencyOrder?: boolean;
   ignoreMissingScript?: boolean;
   allowWarningsInSuccessfulBuild?: boolean;
+  enableIncrementalBuild: boolean;
 }
 
 /**

--- a/apps/rush-lib/src/cli/RushCommandLineParser.ts
+++ b/apps/rush-lib/src/cli/RushCommandLineParser.ts
@@ -215,7 +215,8 @@ export class RushCommandLineParser extends CommandLineParser {
         enableParallelism: true,
         ignoreMissingScript: false,
         ignoreDependencyOrder: false,
-        allowWarningsInSuccessfulBuild: false
+        allowWarningsInSuccessfulBuild: false,
+        enableIncrementalBuild: false
       }));
     }
 
@@ -238,7 +239,8 @@ export class RushCommandLineParser extends CommandLineParser {
         enableParallelism: true,
         ignoreMissingScript: false,
         ignoreDependencyOrder: false,
-        allowWarningsInSuccessfulBuild: false
+        allowWarningsInSuccessfulBuild: false,
+        enableIncrementalBuild: false
       }));
     }
   }
@@ -271,7 +273,8 @@ export class RushCommandLineParser extends CommandLineParser {
             enableParallelism: command.enableParallelism,
             ignoreMissingScript: command.ignoreMissingScript || false,
             ignoreDependencyOrder: command.ignoreDependencyOrder || false,
-            allowWarningsInSuccessfulBuild: !!command.allowWarningsInSuccessfulBuild
+            allowWarningsInSuccessfulBuild: !!command.allowWarningsInSuccessfulBuild,
+            enableIncrementalBuild: command.enableIncrementalBuild
           }));
           break;
         case 'global':

--- a/apps/rush-lib/src/cli/scriptActions/BaseScriptAction.ts
+++ b/apps/rush-lib/src/cli/scriptActions/BaseScriptAction.ts
@@ -26,6 +26,7 @@ export interface IBaseScriptActionOptions extends IBaseRushActionOptions {
 export abstract class BaseScriptAction extends BaseRushAction {
   protected readonly _commandLineConfiguration: CommandLineConfiguration | undefined;
   protected readonly customParameters: CommandLineParameter[] = [];
+  protected _isIncrementalBuildAllowed: boolean;
 
   constructor(
     options: IBaseScriptActionOptions

--- a/apps/rush-lib/src/cli/scriptActions/BulkScriptAction.ts
+++ b/apps/rush-lib/src/cli/scriptActions/BulkScriptAction.ts
@@ -32,6 +32,7 @@ export interface IBulkScriptActionOptions extends IBaseScriptActionOptions {
   ignoreMissingScript: boolean;
   ignoreDependencyOrder: boolean;
   allowWarningsInSuccessfulBuild: boolean;
+  enableIncrementalBuild: boolean;
 
   /**
    * Optional command to run. Otherwise, use the `actionName` as the command to run.
@@ -66,6 +67,7 @@ export class BulkScriptAction extends BaseScriptAction {
     super(options);
     this._enableParallelism = options.enableParallelism;
     this._ignoreMissingScript = options.ignoreMissingScript;
+    this._isIncrementalBuildAllowed = options.enableIncrementalBuild;
     this._commandToRun = options.commandToRun || options.actionName;
     this._ignoreDependencyOrder = options.ignoreDependencyOrder;
     this._allowWarningsInSuccessfulBuild = options.allowWarningsInSuccessfulBuild;

--- a/apps/rush-lib/src/schemas/command-line.schema.json
+++ b/apps/rush-lib/src/schemas/command-line.schema.json
@@ -82,6 +82,11 @@
               "title": "Allow Warnings in Successful Build",
               "description": "By default, Rush returns a nonzero exit code if errors or warnings occur during build. If this option is set to \"true\", Rush will return a zero exit code if warnings occur.",
               "type": "boolean"
+            },
+            "enableIncrementalBuild": {
+              "title": "Allow to skip build if source and build parameters are unchanged",
+              "description": "Allow Rush to skip the build if it was previously built successfully without errors, and if the same build parameters were used again.",
+              "type": "boolean"
             }
           }
         },

--- a/common/changes/@microsoft/rush/master_2019-08-12-20-03.json
+++ b/common/changes/@microsoft/rush/master_2019-08-12-20-03.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Allow to enable incremental builds for custom commands",
+      "packageName": "@microsoft/rush",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "wbern@users.noreply.github.com"
+}


### PR DESCRIPTION
I tried to get a local rush instance to work but the schema validation kept failing for me for command-line.json.

```
ERROR: JSON validation failed:
C:\Users\wbern\Repos\rush-example\common\config\rush\command-line.json
Error: #/commands/0
Data does not match any schemas from 'oneOf'
Error: #/commands/0
Additional properties not allowed: enableIncrementalBuild
Error: #/commands/0
Additional properties not allowed: enableIncrementalBuild,ignoreMissingScript,ignoreDependencyOrder,enableParallelism
```

Since I saw there was a PR already (https://github.com/microsoft/web-build-tools/pull/1403) for this type of change that is more substantial, I wanted to bring about a very minimal change to get this feature out in the mean time.