### PR TITLE
[eslint-config-scalable-ts] Initial draft

### DIFF
--- a/common/changes/@microsoft/eslint-config-scalable-ts/octogonz-eslint_2019-08-15-01-29.json
+++ b/common/changes/@microsoft/eslint-config-scalable-ts/octogonz-eslint_2019-08-15-01-29.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/eslint-config-scalable-ts",
+      "comment": "Initial release",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@microsoft/eslint-config-scalable-ts",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/config/azure-pipelines/templates/buildAndPublish.yaml
+++ b/common/config/azure-pipelines/templates/buildAndPublish.yaml
@@ -4,5 +4,5 @@ steps:
 - template: ./build.yaml
 - script: 'node common\scripts\install-run-rush.js version --bump --version-policy $(VersionPolicy) --target-branch $(Build.SourceBranchName)'
   displayName: 'Rush Version'
-- script: 'node common\scripts\install-run-rush.js publish --apply --publish --include-all --target-branch $(Build.SourceBranchName) --npm-auth-token $(npmToken) --add-commit-details'
+- script: 'node common\scripts\install-run-rush.js publish --apply --publish --include-all --target-branch $(Build.SourceBranchName) --npm-auth-token $(npmToken) --add-commit-details --set-access-level public'
   displayName: 'Rush Publish'

--- a/common/config/rush/common-versions.json
+++ b/common/config/rush/common-versions.json
@@ -18,6 +18,11 @@
      * instead of the latest version.
      */
     // "some-library": "1.2.3"
+
+    // From the allowedAlternativeVersions list below, this should be the TypeScript version that's used to
+    // build most of the projects in the repo.  Preferring it avoids errors for indirect dependencies
+    // that request it as a peer dependency.
+    "typescript": "~3.4.3"
   },
 
   /**

--- a/common/config/rush/nonbrowser-approved-packages.json
+++ b/common/config/rush/nonbrowser-approved-packages.json
@@ -147,6 +147,22 @@
       "allowedCategories": [ "libraries" ]
     },
     {
+      "name": "@typescript-eslint/eslint-plugin",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
+      "name": "@typescript-eslint/experimental-utils",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
+      "name": "@typescript-eslint/parser",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
+      "name": "@typescript-eslint/typescript-estree",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
       "name": "@yarnpkg/lockfile",
       "allowedCategories": [ "libraries" ]
     },
@@ -216,6 +232,26 @@
     },
     {
       "name": "end-of-stream",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
+      "name": "eslint",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
+      "name": "eslint-plugin-no-null",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
+      "name": "eslint-plugin-promise",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
+      "name": "eslint-plugin-react",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
+      "name": "eslint-plugin-security",
       "allowedCategories": [ "libraries" ]
     },
     {

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -106,6 +106,10 @@ dependencies:
   '@types/webpack-env': 1.13.0
   '@types/yargs': 0.0.34
   '@types/z-schema': 3.16.31
+  '@typescript-eslint/eslint-plugin': 2.0.0
+  '@typescript-eslint/experimental-utils': 2.0.0
+  '@typescript-eslint/parser': 2.0.0
+  '@typescript-eslint/typescript-estree': 2.0.0
   '@yarnpkg/lockfile': 1.0.2
   argparse: 1.0.10
   autoprefixer: 9.1.5
@@ -118,6 +122,11 @@ dependencies:
   decomment: 0.9.2
   del: 2.2.2
   end-of-stream: 1.1.0
+  eslint: 6.1.0
+  eslint-plugin-no-null: 1.0.2
+  eslint-plugin-promise: 4.2.1
+  eslint-plugin-react: 7.14.3
+  eslint-plugin-security: 1.4.0
   express: 4.16.4
   fs-extra: 7.0.1
   git-repo-info: 2.1.0
@@ -171,6 +180,7 @@ dependencies:
   ts-jest: 22.4.6
   tslint: 5.12.1
   tslint-microsoft-contrib: 5.2.1
+  typescript: 3.4.5
   uglify-js: 3.0.28
   vinyl: 2.2.0
   webpack: 3.11.0
@@ -346,7 +356,7 @@ packages:
       normalize-path: 3.0.0
       p-filter: 1.0.0
       ramda: 0.25.0
-      read-package-json: 2.0.13
+      read-package-json: 2.1.0
     dev: false
     engines:
       node: '>=4'
@@ -370,7 +380,7 @@ packages:
       normalize-path: 3.0.0
       p-filter: 1.0.0
       ramda: 0.25.0
-      read-package-json: 2.0.13
+      read-package-json: 2.1.0
     dev: false
     engines:
       node: '>=4'
@@ -434,6 +444,10 @@ packages:
     dev: false
     resolution:
       integrity: sha512-4r8qa0quOvh7lGD0pre62CAb1oni1OO6ecJLGCezTmhQ8Fz50Arx9RUszryR8KlgK6avuSXvviL6yWyViQABOg==
+  /@types/eslint-visitor-keys/1.0.0:
+    dev: false
+    resolution:
+      integrity: sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==
   /@types/express-serve-static-core/4.11.0:
     dependencies:
       '@types/node': 8.5.8
@@ -508,6 +522,10 @@ packages:
     dev: false
     resolution:
       integrity: sha512-SGGAhXLHDx+PK4YLNcNGa6goPf9XRWQNAUUbffkwVGGXIxmDKWyGGL4inzq2sPmExu431Ekb9aEMn9BkPqEYFA==
+  /@types/json-schema/7.0.3:
+    dev: false
+    resolution:
+      integrity: sha512-Il2DtDVRGDcqjDtE+rF8iqg1CArehSK84HZJCT7AMITlyXRBpuPhqGLDQMowraqqu1coEaimg4ZOqggt6L6L+A==
   /@types/loader-utils/1.1.3:
     dependencies:
       '@types/node': 8.5.8
@@ -771,6 +789,101 @@ packages:
     dev: false
     resolution:
       integrity: sha1-LrHQCl5Ow/pYx2r94S4YK2bcXBw=
+  /@typescript-eslint/eslint-plugin/2.0.0:
+    dependencies:
+      '@typescript-eslint/experimental-utils': 2.0.0
+      eslint-utils: 1.4.0
+      functional-red-black-tree: 1.0.1
+      regexpp: 2.0.1
+      tsutils: 3.17.1
+    dev: false
+    engines:
+      node: ^8.10.0 || ^10.13.0 || >=11.10.1
+    peerDependencies:
+      '@typescript-eslint/parser': ^2.0.0-alpha.0
+      eslint: ^5.0.0 || ^6.0.0
+      typescript: '*'
+    resolution:
+      integrity: sha512-Mo45nxTTELODdl7CgpZKJISvLb+Fu64OOO2ZFc2x8sYSnUpFrBUW3H+H/ZGYmEkfnL6VkdtOSxgdt+Av79j0sA==
+  /@typescript-eslint/eslint-plugin/2.0.0_2597c16b46d7eff3ec2c0c583ca4ae44:
+    dependencies:
+      '@typescript-eslint/experimental-utils': 2.0.0_eslint@6.1.0
+      '@typescript-eslint/parser': 2.0.0_eslint@6.1.0
+      eslint: 6.1.0
+      eslint-utils: 1.4.0
+      functional-red-black-tree: 1.0.1
+      regexpp: 2.0.1
+      tsutils: 3.17.1_typescript@3.5.3
+    dev: false
+    engines:
+      node: ^8.10.0 || ^10.13.0 || >=11.10.1
+    peerDependencies:
+      '@typescript-eslint/parser': ^2.0.0-alpha.0
+      eslint: ^5.0.0 || ^6.0.0
+      typescript: '*'
+    resolution:
+      integrity: sha512-Mo45nxTTELODdl7CgpZKJISvLb+Fu64OOO2ZFc2x8sYSnUpFrBUW3H+H/ZGYmEkfnL6VkdtOSxgdt+Av79j0sA==
+  /@typescript-eslint/experimental-utils/2.0.0:
+    dependencies:
+      '@types/json-schema': 7.0.3
+      '@typescript-eslint/typescript-estree': 2.0.0
+      eslint-scope: 4.0.3
+    dev: false
+    engines:
+      node: ^8.10.0 || ^10.13.0 || >=11.10.1
+    peerDependencies:
+      eslint: '*'
+    resolution:
+      integrity: sha512-XGJG6GNBXIEx/mN4eTRypN/EUmsd0VhVGQ1AG+WTgdvjHl0G8vHhVBHrd/5oI6RRYBRnedNymSYWW1HAdivtmg==
+  /@typescript-eslint/experimental-utils/2.0.0_eslint@6.1.0:
+    dependencies:
+      '@types/json-schema': 7.0.3
+      '@typescript-eslint/typescript-estree': 2.0.0
+      eslint: 6.1.0
+      eslint-scope: 4.0.3
+    dev: false
+    engines:
+      node: ^8.10.0 || ^10.13.0 || >=11.10.1
+    peerDependencies:
+      eslint: '*'
+    resolution:
+      integrity: sha512-XGJG6GNBXIEx/mN4eTRypN/EUmsd0VhVGQ1AG+WTgdvjHl0G8vHhVBHrd/5oI6RRYBRnedNymSYWW1HAdivtmg==
+  /@typescript-eslint/parser/2.0.0:
+    dependencies:
+      '@types/eslint-visitor-keys': 1.0.0
+      '@typescript-eslint/experimental-utils': 2.0.0
+      '@typescript-eslint/typescript-estree': 2.0.0
+      eslint-visitor-keys: 1.1.0
+    dev: false
+    engines:
+      node: ^8.10.0 || ^10.13.0 || >=11.10.1
+    peerDependencies:
+      eslint: ^5.0.0 || ^6.0.0
+    resolution:
+      integrity: sha512-ibyMBMr0383ZKserIsp67+WnNVoM402HKkxqXGlxEZsXtnGGurbnY90pBO3e0nBUM7chEEOcxUhgw9aPq7fEBA==
+  /@typescript-eslint/parser/2.0.0_eslint@6.1.0:
+    dependencies:
+      '@types/eslint-visitor-keys': 1.0.0
+      '@typescript-eslint/experimental-utils': 2.0.0_eslint@6.1.0
+      '@typescript-eslint/typescript-estree': 2.0.0
+      eslint: 6.1.0
+      eslint-visitor-keys: 1.1.0
+    dev: false
+    engines:
+      node: ^8.10.0 || ^10.13.0 || >=11.10.1
+    peerDependencies:
+      eslint: ^5.0.0 || ^6.0.0
+    resolution:
+      integrity: sha512-ibyMBMr0383ZKserIsp67+WnNVoM402HKkxqXGlxEZsXtnGGurbnY90pBO3e0nBUM7chEEOcxUhgw9aPq7fEBA==
+  /@typescript-eslint/typescript-estree/2.0.0:
+    dependencies:
+      lodash.unescape: 4.0.1
+      semver: 6.3.0
+    dev: false
+    engines:
+      node: ^8.10.0 || ^10.13.0 || >=11.10.1
+    resolution:
+      integrity: sha512-NXbmzA3vWrSgavymlzMWNecgNOuiMMp62MO3kI7awZRLRcsA1QrYWo6q08m++uuAGVbXH/prZi2y1AWuhSu63w==
   /@yarnpkg/lockfile/1.0.2:
     dev: false
     resolution:
@@ -814,11 +927,19 @@ packages:
       integrity: sha1-x1K9IQvvZ5UBtsbLf8hPj0cVjMQ=
   /acorn-globals/4.3.3:
     dependencies:
-      acorn: 6.2.1
+      acorn: 6.3.0
       acorn-walk: 6.2.0
     dev: false
     resolution:
       integrity: sha512-vkR40VwS2SYO98AIeFvzWWh+xyc2qi9s7OoXSFEGIP/rOJKzjnhykaZJNnHdoq4BL2gGxI5EZOU16z896EYnOQ==
+  /acorn-jsx/5.0.1_acorn@6.3.0:
+    dependencies:
+      acorn: 6.3.0
+    dev: false
+    peerDependencies:
+      acorn: ^6.0.0
+    resolution:
+      integrity: sha512-HJ7CfNHrfJLlNTzIEUTj43LNWGkqpRLxm3YjAlcD0ACydk9XynzYsCBHxut+iqt+1aBXkx9UP/w/ZqMr13XIzg==
   /acorn-walk/6.2.0:
     dev: false
     engines:
@@ -839,13 +960,13 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==
-  /acorn/6.2.1:
+  /acorn/6.3.0:
     dev: false
     engines:
       node: '>=0.4.0'
     hasBin: true
     resolution:
-      integrity: sha512-JD0xT5FCRDNyjDda3Lrg/IxFscp9q4tiYtxE1/nOzlKCk7hIRuYjhq1kCNkbPjMRMZuFq20HNQn1I9k8Oj0E+Q==
+      integrity: sha512-/czfa8BwS88b9gWQVhc8eknunSA2DoJpJyTQkhheIf5E48u1N0R4q/YxxsAeqRrmK9TQ/uYfgLDfZo91UlANIA==
   /agent-base/4.3.0:
     dependencies:
       es6-promisify: 5.0.0
@@ -901,6 +1022,14 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==
+  /ansi-escapes/4.2.1:
+    dependencies:
+      type-fest: 0.5.2
+    dev: false
+    engines:
+      node: '>=8'
+    resolution:
+      integrity: sha512-Cg3ymMAdN10wOk/VYfLV7KCQyv7EDirJ64500sU7n9UlmioEtDuU5Gd+hj73hXSU/ex7tHJSssmyftDdkMLO8Q==
   /ansi-gray/0.1.1:
     dependencies:
       ansi-wrap: 0.1.0
@@ -1060,10 +1189,6 @@ packages:
     dev: false
     resolution:
       integrity: sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=
-  /array-filter/0.0.1:
-    dev: false
-    resolution:
-      integrity: sha1-fajPLiZijtcygDWB/SH2fKzS7uw=
   /array-find-index/1.0.2:
     dev: false
     engines:
@@ -1074,6 +1199,15 @@ packages:
     dev: false
     resolution:
       integrity: sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=
+  /array-includes/3.0.3:
+    dependencies:
+      define-properties: 1.1.3
+      es-abstract: 1.13.0
+    dev: false
+    engines:
+      node: '>= 0.4'
+    resolution:
+      integrity: sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=
   /array-initial/1.1.0:
     dependencies:
       array-slice: 1.1.0
@@ -1091,14 +1225,6 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha512-eOCut5rXlI6aCOS7Z7kCplKRKyiFQ6dHFBem4PwlwKeNFk2/XxTrhRh5T9PyaEWGy/NHTZWbY+nsZlNFJu9rYg==
-  /array-map/0.0.0:
-    dev: false
-    resolution:
-      integrity: sha1-iKK6tz0c97zVwbEYoAP2b2ZfpmI=
-  /array-reduce/0.0.0:
-    dev: false
-    resolution:
-      integrity: sha1-FziZ0//Rx9k4PkR5Ul2+J4yrXys=
   /array-slice/1.1.0:
     dev: false
     engines:
@@ -1687,8 +1813,8 @@ packages:
   /browserslist/4.6.6:
     dependencies:
       caniuse-lite: 1.0.30000989
-      electron-to-chromium: 1.3.219
-      node-releases: 1.1.26
+      electron-to-chromium: 1.3.226
+      node-releases: 1.1.27
     dev: false
     hasBin: true
     resolution:
@@ -1771,6 +1897,12 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=
+  /callsites/3.1.0:
+    dev: false
+    engines:
+      node: '>=6'
+    resolution:
+      integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
   /camelcase-keys/2.1.0:
     dependencies:
       camelcase: 2.1.1
@@ -1938,6 +2070,14 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=
+  /cli-cursor/3.1.0:
+    dependencies:
+      restore-cursor: 3.1.0
+    dev: false
+    engines:
+      node: '>=8'
+    resolution:
+      integrity: sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==
   /cli-table/0.3.1:
     dependencies:
       colors: 1.0.3
@@ -2196,7 +2336,7 @@ packages:
       mkdirp: 0.5.1
       resolve: 1.8.1
       safe-buffer: 5.2.0
-      shell-quote: 1.6.1
+      shell-quote: 1.7.1
       subarg: 1.0.0
     dev: false
     hasBin: true
@@ -2249,7 +2389,7 @@ packages:
     dependencies:
       nice-try: 1.0.5
       path-key: 2.0.1
-      semver: 5.7.0
+      semver: 5.7.1
       shebang-command: 1.2.0
       which: 1.3.1
     dev: false
@@ -2394,6 +2534,12 @@ packages:
     dev: false
     resolution:
       integrity: sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
+  /debug/4.1.1:
+    dependencies:
+      ms: 2.1.2
+    dev: false
+    resolution:
+      integrity: sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
   /debuglog/1.0.1:
     dev: false
     resolution:
@@ -2492,7 +2638,7 @@ packages:
       object-assign: 4.1.1
       pify: 2.3.0
       pinkie-promise: 2.0.1
-      rimraf: 2.6.3
+      rimraf: 2.7.1
     dev: false
     engines:
       node: '>=0.10.0'
@@ -2566,6 +2712,22 @@ packages:
     dev: false
     resolution:
       integrity: sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==
+  /doctrine/2.1.0:
+    dependencies:
+      esutils: 2.0.3
+    dev: false
+    engines:
+      node: '>=0.10.0'
+    resolution:
+      integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==
+  /doctrine/3.0.0:
+    dependencies:
+      esutils: 2.0.3
+    dev: false
+    engines:
+      node: '>=6.0.0'
+    resolution:
+      integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
   /domain-browser/1.2.0:
     dev: false
     engines:
@@ -2616,10 +2778,10 @@ packages:
     dev: false
     resolution:
       integrity: sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
-  /electron-to-chromium/1.3.219:
+  /electron-to-chromium/1.3.226:
     dev: false
     resolution:
-      integrity: sha512-xANtM7YNFQGCMl+a0ZceXnPedpAatcIIyDNM56nQKzJFwuCyIzKVtBvLzyMOU0cczwO900TP309EkSeudrGRbQ==
+      integrity: sha512-Qnj+JyUodfuzzPbs66CxO5oz1/bOrIhXh/4qh24GMOYzjuUt0sq7mFlhq78dP68CR38NkZ6KOAfhGP6kElU65A==
   /elliptic/6.5.0:
     dependencies:
       bn.js: 4.11.8
@@ -2632,6 +2794,14 @@ packages:
     dev: false
     resolution:
       integrity: sha512-eFOJTMyCYb7xtE/caJ6JJu+bhi67WCYNbkGSknu20pmM8Ke/bqOfdnZWxyoGN26JgfxTbXrsCkEw4KheCT/KGg==
+  /emoji-regex/7.0.3:
+    dev: false
+    resolution:
+      integrity: sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==
+  /emoji-regex/8.0.0:
+    dev: false
+    resolution:
+      integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
   /emojis-list/2.1.0:
     dev: false
     engines:
@@ -2658,7 +2828,7 @@ packages:
       integrity: sha1-6TUyWLqpEIll78QcsO+K3i88+wc=
   /enhanced-resolve/3.4.1:
     dependencies:
-      graceful-fs: 4.2.1
+      graceful-fs: 4.2.2
       memory-fs: 0.4.1
       object-assign: 4.1.1
       tapable: 0.2.9
@@ -2776,10 +2946,10 @@ packages:
       node: '>=0.8.0'
     resolution:
       integrity: sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
-  /escodegen/1.11.1:
+  /escodegen/1.12.0:
     dependencies:
       esprima: 3.1.3
-      estraverse: 4.2.0
+      estraverse: 4.3.0
       esutils: 2.0.3
       optionator: 0.8.2
     dev: false
@@ -2789,7 +2959,7 @@ packages:
     optionalDependencies:
       source-map: 0.6.1
     resolution:
-      integrity: sha512-JwiqFD9KdGVVpeuRa68yU3zZnBEOcPs0nKW7wZzXky8Z7tffdYUHbe11bPCV5jYlK6DVdKLWLm0f5I/QlL0Kmw==
+      integrity: sha512-TuA+EhsanGcme5T3R0L80u4t8CpbXQjegRmf7+FPTJrtCTErXFeelblRgHQa1FofEzqYYJmJ/OqjTwREp9qgmg==
   /escodegen/1.7.1:
     dependencies:
       esprima: 1.2.5
@@ -2823,12 +2993,166 @@ packages:
       es6-map: 0.1.5
       es6-weak-map: 2.0.3
       esrecurse: 4.2.1
-      estraverse: 4.2.0
+      estraverse: 4.3.0
     dev: false
     engines:
       node: '>=0.4.0'
     resolution:
       integrity: sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=
+  /eslint-plugin-no-null/1.0.2:
+    dev: false
+    engines:
+      node: '>=5.0.0'
+    peerDependencies:
+      eslint: '>=3.0.0'
+    resolution:
+      integrity: sha1-EjaoEjkTkKGHetQAfCbnRTQclR8=
+  /eslint-plugin-no-null/1.0.2_eslint@6.1.0:
+    dependencies:
+      eslint: 6.1.0
+    dev: false
+    engines:
+      node: '>=5.0.0'
+    peerDependencies:
+      eslint: '>=3.0.0'
+    resolution:
+      integrity: sha1-EjaoEjkTkKGHetQAfCbnRTQclR8=
+  /eslint-plugin-promise/4.2.1:
+    dev: false
+    engines:
+      node: '>=6'
+    resolution:
+      integrity: sha512-VoM09vT7bfA7D+upt+FjeBO5eHIJQBUWki1aPvB+vbNiHS3+oGIJGIeyBtKQTME6UPXXy3vV07OL1tHd3ANuDw==
+  /eslint-plugin-react/7.14.3:
+    dependencies:
+      array-includes: 3.0.3
+      doctrine: 2.1.0
+      has: 1.0.3
+      jsx-ast-utils: 2.2.1
+      object.entries: 1.1.0
+      object.fromentries: 2.0.0
+      object.values: 1.1.0
+      prop-types: 15.7.2
+      resolve: 1.12.0
+    dev: false
+    engines:
+      node: '>=4'
+    peerDependencies:
+      eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0
+    resolution:
+      integrity: sha512-EzdyyBWC4Uz2hPYBiEJrKCUi2Fn+BJ9B/pJQcjw5X+x/H2Nm59S4MJIvL4O5NEE0+WbnQwEBxWY03oUk+Bc3FA==
+  /eslint-plugin-react/7.14.3_eslint@6.1.0:
+    dependencies:
+      array-includes: 3.0.3
+      doctrine: 2.1.0
+      eslint: 6.1.0
+      has: 1.0.3
+      jsx-ast-utils: 2.2.1
+      object.entries: 1.1.0
+      object.fromentries: 2.0.0
+      object.values: 1.1.0
+      prop-types: 15.7.2
+      resolve: 1.12.0
+    dev: false
+    engines:
+      node: '>=4'
+    peerDependencies:
+      eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0
+    resolution:
+      integrity: sha512-EzdyyBWC4Uz2hPYBiEJrKCUi2Fn+BJ9B/pJQcjw5X+x/H2Nm59S4MJIvL4O5NEE0+WbnQwEBxWY03oUk+Bc3FA==
+  /eslint-plugin-security/1.4.0:
+    dependencies:
+      safe-regex: 1.1.0
+    dev: false
+    resolution:
+      integrity: sha512-xlS7P2PLMXeqfhyf3NpqbvbnW04kN8M9NtmhpR3XGyOvt/vNKS7XPXT5EDbwKW9vCjWH4PpfQvgD/+JgN0VJKA==
+  /eslint-scope/4.0.3:
+    dependencies:
+      esrecurse: 4.2.1
+      estraverse: 4.3.0
+    dev: false
+    engines:
+      node: '>=4.0.0'
+    resolution:
+      integrity: sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==
+  /eslint-scope/5.0.0:
+    dependencies:
+      esrecurse: 4.2.1
+      estraverse: 4.3.0
+    dev: false
+    engines:
+      node: '>=8.0.0'
+    resolution:
+      integrity: sha512-oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==
+  /eslint-utils/1.4.0:
+    dependencies:
+      eslint-visitor-keys: 1.1.0
+    dev: false
+    engines:
+      node: '>=6'
+    resolution:
+      integrity: sha512-7ehnzPaP5IIEh1r1tkjuIrxqhNkzUJa9z3R92tLJdZIVdWaczEhr3EbhGtsMrVxi1KeR8qA7Off6SWc5WNQqyQ==
+  /eslint-visitor-keys/1.1.0:
+    dev: false
+    engines:
+      node: '>=4'
+    resolution:
+      integrity: sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==
+  /eslint/6.1.0:
+    dependencies:
+      '@babel/code-frame': 7.5.5
+      ajv: 6.10.2
+      chalk: 2.4.2
+      cross-spawn: 6.0.5
+      debug: 4.1.1
+      doctrine: 3.0.0
+      eslint-scope: 5.0.0
+      eslint-utils: 1.4.0
+      eslint-visitor-keys: 1.1.0
+      espree: 6.0.0
+      esquery: 1.0.1
+      esutils: 2.0.3
+      file-entry-cache: 5.0.1
+      functional-red-black-tree: 1.0.1
+      glob-parent: 5.0.0
+      globals: 11.12.0
+      ignore: 4.0.6
+      import-fresh: 3.1.0
+      imurmurhash: 0.1.4
+      inquirer: 6.5.1
+      is-glob: 4.0.1
+      js-yaml: 3.13.1
+      json-stable-stringify-without-jsonify: 1.0.1
+      levn: 0.3.0
+      lodash: 4.17.15
+      minimatch: 3.0.4
+      mkdirp: 0.5.1
+      natural-compare: 1.4.0
+      optionator: 0.8.2
+      progress: 2.0.3
+      regexpp: 2.0.1
+      semver: 6.3.0
+      strip-ansi: 5.2.0
+      strip-json-comments: 3.0.1
+      table: 5.4.5
+      text-table: 0.2.0
+      v8-compile-cache: 2.1.0
+    dev: false
+    engines:
+      node: ^8.10.0 || ^10.13.0 || >=11.10.1
+    hasBin: true
+    resolution:
+      integrity: sha512-QhrbdRD7ofuV09IuE2ySWBz0FyXCq0rriLTZXZqaWSI79CVtHVRdkFuFTViiqzZhkCgfOh9USpriuGN2gIpZDQ==
+  /espree/6.0.0:
+    dependencies:
+      acorn: 6.3.0
+      acorn-jsx: 5.0.1_acorn@6.3.0
+      eslint-visitor-keys: 1.1.0
+    dev: false
+    engines:
+      node: '>=6.0.0'
+    resolution:
+      integrity: sha512-lJvCS6YbCn3ImT3yKkPe0+tJ+mH6ljhGNjHQH9mRtiO6gjhVAOhVXW1yjnwqGwTkK3bGbye+hb00nFNmu0l/1Q==
   /esprima/1.2.5:
     dev: false
     engines:
@@ -2864,9 +3188,17 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
+  /esquery/1.0.1:
+    dependencies:
+      estraverse: 4.3.0
+    dev: false
+    engines:
+      node: '>=0.6'
+    resolution:
+      integrity: sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==
   /esrecurse/4.2.1:
     dependencies:
-      estraverse: 4.2.0
+      estraverse: 4.3.0
     dev: false
     engines:
       node: '>=4.0'
@@ -2878,12 +3210,12 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q=
-  /estraverse/4.2.0:
+  /estraverse/4.3.0:
     dev: false
     engines:
-      node: '>=0.10.0'
+      node: '>=4.0'
     resolution:
-      integrity: sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=
+      integrity: sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==
   /esutils/2.0.3:
     dev: false
     engines:
@@ -3188,6 +3520,22 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=
+  /figures/3.0.0:
+    dependencies:
+      escape-string-regexp: 1.0.5
+    dev: false
+    engines:
+      node: '>=8'
+    resolution:
+      integrity: sha512-HKri+WoWoUgr83pehn/SIgLOMZ9nAWC6dcGj26RY2R4F50u4+RTUz0RCrUlOV3nKRAICW1UGzyb+kcX2qK1S/g==
+  /file-entry-cache/5.0.1:
+    dependencies:
+      flat-cache: 2.0.1
+    dev: false
+    engines:
+      node: '>=4'
+    resolution:
+      integrity: sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==
   /filename-regex/2.0.1:
     dev: false
     engines:
@@ -3320,6 +3668,20 @@ packages:
       node: '>= 0.10'
     resolution:
       integrity: sha512-lNaHNVymajmk0OJMBn8fVUAU1BtDeKIqKoVhk4xAALB57aALg6b4W0MfJ/cUE0g9YBXy5XhSlPIpYIJ7HaY/3Q==
+  /flat-cache/2.0.1:
+    dependencies:
+      flatted: 2.0.1
+      rimraf: 2.6.3
+      write: 1.0.3
+    dev: false
+    engines:
+      node: '>=4'
+    resolution:
+      integrity: sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==
+  /flatted/2.0.1:
+    dev: false
+    resolution:
+      integrity: sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==
   /flush-write-stream/1.1.1:
     dependencies:
       inherits: 2.0.4
@@ -3406,7 +3768,7 @@ packages:
       integrity: sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=
   /fs-extra/6.0.0:
     dependencies:
-      graceful-fs: 4.2.1
+      graceful-fs: 4.2.2
       jsonfile: 4.0.0
       universalify: 0.1.2
     dev: false
@@ -3414,7 +3776,7 @@ packages:
       integrity: sha512-lk2cUCo8QzbiEWEbt7Cw3m27WMiRG321xsssbcIpfMhpRjrlC08WBOVQqj1/nQYYNnPtyIhP1oqLO3QwT2tPCw==
   /fs-extra/7.0.1:
     dependencies:
-      graceful-fs: 4.2.1
+      graceful-fs: 4.2.2
       jsonfile: 4.0.0
       universalify: 0.1.2
     dev: false
@@ -3430,7 +3792,7 @@ packages:
       integrity: sha512-crhvyXcMejjv3Z5d2Fa9sf5xLYVCF5O1c71QxbVnbLsmYMBEvDAftewesN/HhY03YRoA7zOMxjNGrF5svGaaeQ==
   /fs-mkdirp-stream/1.0.0:
     dependencies:
-      graceful-fs: 4.2.1
+      graceful-fs: 4.2.2
       through2: 2.0.5
     dev: false
     engines:
@@ -3455,10 +3817,10 @@ packages:
       integrity: sha512-oeyj2H3EjjonWcFjD5NvZNE9Rqe4UW+nQBU2HNeKw0koVLEFIhtyETyAakeAM3de7Z/SW5kcA+fZUait9EApnw==
   /fstream/1.0.12:
     dependencies:
-      graceful-fs: 4.2.1
+      graceful-fs: 4.2.2
       inherits: 2.0.4
       mkdirp: 0.5.1
-      rimraf: 2.6.3
+      rimraf: 2.7.1
     dev: false
     engines:
       node: '>=0.6'
@@ -3468,6 +3830,10 @@ packages:
     dev: false
     resolution:
       integrity: sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
+  /functional-red-black-tree/1.0.1:
+    dev: false
+    resolution:
+      integrity: sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
   /gauge/2.7.4:
     dependencies:
       aproba: 1.2.0
@@ -3557,6 +3923,14 @@ packages:
     dev: false
     resolution:
       integrity: sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=
+  /glob-parent/5.0.0:
+    dependencies:
+      is-glob: 4.0.1
+    dev: false
+    engines:
+      node: '>= 6'
+    resolution:
+      integrity: sha512-Z2RwiujPRGluePM6j699ktJYxmPpJKCfpGA13jz2hmFZC7gKetzrWvg5KN3+OsIFmydGyZ1AVwERCq1w/ZZwRg==
   /glob-stream/6.1.0:
     dependencies:
       extend: 3.0.2
@@ -3660,6 +4034,12 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=
+  /globals/11.12.0:
+    dev: false
+    engines:
+      node: '>=4'
+    resolution:
+      integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==
   /globals/9.18.0:
     dev: false
     engines:
@@ -3697,10 +4077,10 @@ packages:
       node: '>= 0.10'
     resolution:
       integrity: sha512-5mwUoSuBk44Y4EshyiqcH95ZntbDdTQqA3QYSrxmzj28Ai0vXBGMH1ApSANH14j2sIRtqCEyg6PfsuP7ElOEDA==
-  /graceful-fs/4.2.1:
+  /graceful-fs/4.2.2:
     dev: false
     resolution:
-      integrity: sha512-b9usnbDGnD928gJB3LrCmxoibr3VE4U2SMo5PBuBnokWyDADTqDPXg4YpwKF1trpH+UbGp7QLicO3+aWEy0+mw==
+      integrity: sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q==
   /growl/1.10.5:
     dev: false
     engines:
@@ -4030,12 +4410,10 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==
-  /hosted-git-info/2.8.2:
-    dependencies:
-      lru-cache: 5.1.1
+  /hosted-git-info/2.8.4:
     dev: false
     resolution:
-      integrity: sha512-CyjlXII6LMsPMyUzxpTt8fzh5QwzGqPmQXgY/Jyf4Zfp27t/FvfhwoE/8laaMUcMy816CkWF20I7NeQhwwY88w==
+      integrity: sha512-pzXIvANXEFrc5oFFXRMkbLPQ2rXRoDERwDLyrcUxGhaZhgP54BBSl9Oheh7Vv0T090cszWBxPjkQQ5Sq1PbBRQ==
   /html-encoding-sniffer/1.0.2:
     dependencies:
       whatwg-encoding: 1.0.5
@@ -4132,6 +4510,21 @@ packages:
     dev: false
     resolution:
       integrity: sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==
+  /ignore/4.0.6:
+    dev: false
+    engines:
+      node: '>= 4'
+    resolution:
+      integrity: sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
+  /import-fresh/3.1.0:
+    dependencies:
+      parent-module: 1.0.1
+      resolve-from: 4.0.0
+    dev: false
+    engines:
+      node: '>=6'
+    resolution:
+      integrity: sha512-PpuksHKGt8rXfWEr9m9EHIpgyyaltBy8+eF6GJM0QCAxMgxCfucMF3mjecK2QsJr0amJW7gTqh5/wht0z2UhEQ==
   /import-local/1.0.0:
     dependencies:
       pkg-dir: 2.0.0
@@ -4212,6 +4605,26 @@ packages:
       node: '>=6.0.0'
     resolution:
       integrity: sha512-Z2rREiXA6cHRR9KBOarR3WuLlFzlIfAEIiB45ll5SSadMg7WqOh1MKEjjndfuH5ewXdixWCxqnVfGOQzPeiztA==
+  /inquirer/6.5.1:
+    dependencies:
+      ansi-escapes: 4.2.1
+      chalk: 2.4.2
+      cli-cursor: 3.1.0
+      cli-width: 2.2.0
+      external-editor: 3.1.0
+      figures: 3.0.0
+      lodash: 4.17.15
+      mute-stream: 0.0.8
+      run-async: 2.3.0
+      rxjs: 6.5.2
+      string-width: 4.1.0
+      strip-ansi: 5.2.0
+      through: 2.3.8
+    dev: false
+    engines:
+      node: '>=6.0.0'
+    resolution:
+      integrity: sha512-uxNHBeQhRXIoHWTSNYUFhQVrHYFThIt6IVo2fFmSe8aBwdR3/w6b58hJpiL/fMukFkvGzjg+hSxFtwvVmKZmXw==
   /interpret/1.2.0:
     dev: false
     engines:
@@ -4400,6 +4813,12 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=
+  /is-fullwidth-code-point/3.0.0:
+    dev: false
+    engines:
+      node: '>=8'
+    resolution:
+      integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==
   /is-generator-fn/1.0.0:
     dev: false
     engines:
@@ -4656,7 +5075,7 @@ packages:
       debug: 3.2.6
       istanbul-lib-coverage: 1.2.1
       mkdirp: 0.5.1
-      rimraf: 2.6.3
+      rimraf: 2.7.1
       source-map: 0.5.7
     dev: false
     resolution:
@@ -4749,7 +5168,7 @@ packages:
       chalk: 2.4.2
       exit: 0.1.2
       glob: 7.1.4
-      graceful-fs: 4.2.1
+      graceful-fs: 4.2.2
       import-local: 1.0.0
       is-ci: 1.2.1
       istanbul-api: 1.3.7
@@ -4773,7 +5192,7 @@ packages:
       micromatch: 2.3.11
       node-notifier: 5.4.1
       realpath-native: 1.1.0
-      rimraf: 2.6.3
+      rimraf: 2.7.1
       slash: 1.0.0
       string-length: 2.0.0
       strip-ansi: 4.0.0
@@ -4791,7 +5210,7 @@ packages:
       chalk: 2.4.2
       exit: 0.1.2
       glob: 7.1.4
-      graceful-fs: 4.2.1
+      graceful-fs: 4.2.2
       import-local: 1.0.0
       is-ci: 1.2.1
       istanbul-api: 1.3.7
@@ -4817,7 +5236,7 @@ packages:
       node-notifier: 5.4.1
       prompts: 0.1.14
       realpath-native: 1.1.0
-      rimraf: 2.6.3
+      rimraf: 2.7.1
       slash: 1.0.0
       string-length: 2.0.0
       strip-ansi: 4.0.0
@@ -4938,7 +5357,7 @@ packages:
   /jest-haste-map/22.4.3:
     dependencies:
       fb-watchman: 2.0.0
-      graceful-fs: 4.2.1
+      graceful-fs: 4.2.2
       jest-docblock: 22.4.3
       jest-serializer: 22.4.3
       jest-worker: 22.4.3
@@ -4950,7 +5369,7 @@ packages:
   /jest-haste-map/23.6.0:
     dependencies:
       fb-watchman: 2.0.0
-      graceful-fs: 4.2.1
+      graceful-fs: 4.2.2
       invariant: 2.2.4
       jest-docblock: 23.2.0
       jest-serializer: 23.0.1
@@ -4965,7 +5384,7 @@ packages:
       chalk: 2.4.2
       co: 4.6.0
       expect: 22.4.3
-      graceful-fs: 4.2.1
+      graceful-fs: 4.2.2
       is-generator-fn: 1.0.0
       jest-diff: 22.4.3
       jest-matcher-utils: 22.4.3
@@ -5104,7 +5523,7 @@ packages:
   /jest-runner/23.6.0:
     dependencies:
       exit: 0.1.2
-      graceful-fs: 4.2.1
+      graceful-fs: 4.2.2
       jest-config: 23.6.0
       jest-docblock: 23.2.0
       jest-haste-map: 23.6.0
@@ -5127,7 +5546,7 @@ packages:
       chalk: 2.4.2
       convert-source-map: 1.6.0
       exit: 0.1.2
-      graceful-fs: 4.2.1
+      graceful-fs: 4.2.2
       jest-config: 22.4.4
       jest-haste-map: 22.4.3
       jest-regex-util: 22.4.3
@@ -5153,7 +5572,7 @@ packages:
       convert-source-map: 1.6.0
       exit: 0.1.2
       fast-json-stable-stringify: 2.0.0
-      graceful-fs: 4.2.1
+      graceful-fs: 4.2.2
       jest-config: 23.6.0
       jest-haste-map: 23.6.0
       jest-message-util: 23.4.0
@@ -5202,7 +5621,7 @@ packages:
       mkdirp: 0.5.1
       natural-compare: 1.4.0
       pretty-format: 23.6.0
-      semver: 5.7.0
+      semver: 5.7.1
     dev: false
     resolution:
       integrity: sha512-tM7/Bprftun6Cvj2Awh/ikS7zV3pVwjRYU2qNYS51VZHgaAMBs5l4o/69AiDHhQrj5+LA2Lq4VIvK7zYk/bswg==
@@ -5210,7 +5629,7 @@ packages:
     dependencies:
       callsites: 2.0.0
       chalk: 2.4.2
-      graceful-fs: 4.2.1
+      graceful-fs: 4.2.2
       is-ci: 1.2.1
       jest-message-util: 22.4.3
       mkdirp: 0.5.1
@@ -5222,7 +5641,7 @@ packages:
     dependencies:
       callsites: 2.0.0
       chalk: 2.4.2
-      graceful-fs: 4.2.1
+      graceful-fs: 4.2.2
       is-ci: 1.2.1
       jest-message-util: 23.4.0
       mkdirp: 0.5.1
@@ -5318,7 +5737,7 @@ packages:
       cssstyle: 0.3.1
       data-urls: 1.1.0
       domexception: 1.0.1
-      escodegen: 1.11.1
+      escodegen: 1.12.0
       html-encoding-sniffer: 1.0.2
       left-pad: 1.3.0
       nwsapi: 2.1.4
@@ -5387,7 +5806,7 @@ packages:
   /jsonfile/4.0.0:
     dev: false
     optionalDependencies:
-      graceful-fs: 4.2.1
+      graceful-fs: 4.2.2
     resolution:
       integrity: sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=
   /jsonify/0.0.0:
@@ -5405,6 +5824,15 @@ packages:
       '0': node >=0.6.0
     resolution:
       integrity: sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=
+  /jsx-ast-utils/2.2.1:
+    dependencies:
+      array-includes: 3.0.3
+      object.assign: 4.1.0
+    dev: false
+    engines:
+      node: '>=4.0'
+    resolution:
+      integrity: sha512-v3FxCcAf20DayI+uxnCuw795+oOIkVu6EnJ1+kSzhqqTZHNkTZ7B66ZgLp4oLJ/gbA64cI0B7WRoHZMSRdyVRQ==
   /just-debounce/1.0.0:
     dev: false
     resolution:
@@ -5533,7 +5961,7 @@ packages:
       integrity: sha512-XPQH8Z2GDP/Hwz2PCDrh2mth4yFejwA1OZ/81Ti3LgKyhDcEjsSsqFWZojHG0va/duGd+WyosY7eXLDoOyqcPw==
   /load-json-file/1.1.0:
     dependencies:
-      graceful-fs: 4.2.1
+      graceful-fs: 4.2.2
       parse-json: 2.2.0
       pify: 2.3.0
       pinkie-promise: 2.0.1
@@ -5545,7 +5973,7 @@ packages:
       integrity: sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=
   /load-json-file/2.0.0:
     dependencies:
-      graceful-fs: 4.2.1
+      graceful-fs: 4.2.2
       parse-json: 2.2.0
       pify: 2.3.0
       strip-bom: 3.0.0
@@ -5695,6 +6123,10 @@ packages:
     dev: false
     resolution:
       integrity: sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=
+  /lodash.unescape/4.0.1:
+    dev: false
+    resolution:
+      integrity: sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw=
   /lodash/3.6.0:
     dev: false
     resolution:
@@ -5740,12 +6172,6 @@ packages:
     dev: false
     resolution:
       integrity: sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==
-  /lru-cache/5.1.1:
-    dependencies:
-      yallist: 3.0.3
-    dev: false
-    resolution:
-      integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==
   /make-iterator/1.0.1:
     dependencies:
       kind-of: 6.0.2
@@ -5956,6 +6382,12 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==
+  /mimic-fn/2.1.0:
+    dev: false
+    engines:
+      node: '>=6'
+    resolution:
+      integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
   /minimalistic-assert/1.0.1:
     dev: false
     resolution:
@@ -6161,13 +6593,13 @@ packages:
     dependencies:
       fstream: 1.0.12
       glob: 7.0.6
-      graceful-fs: 4.2.1
+      graceful-fs: 4.2.2
       mkdirp: 0.5.1
       nopt: 3.0.6
       npmlog: 4.1.2
       osenv: 0.1.5
       request: 2.88.0
-      rimraf: 2.6.3
+      rimraf: 2.7.1
       semver: 5.3.0
       tar: 2.2.2
       which: 1.3.1
@@ -6201,7 +6633,7 @@ packages:
       stream-browserify: 2.0.2
       stream-http: 2.8.3
       string_decoder: 1.3.0
-      timers-browserify: 2.0.10
+      timers-browserify: 2.0.11
       tty-browserify: 0.0.0
       url: 0.11.0
       util: 0.11.1
@@ -6222,18 +6654,18 @@ packages:
     dependencies:
       growly: 1.3.0
       is-wsl: 1.1.0
-      semver: 5.7.0
+      semver: 5.7.1
       shellwords: 0.1.1
       which: 1.3.1
     dev: false
     resolution:
       integrity: sha512-p52B+onAEHKW1OF9MGO/S7k/ahGEHfhP5/tvwYzog/5XLYOd8ZuD6vdNZdUuWMONRnKPneXV43v3s6Snx1wsCQ==
-  /node-releases/1.1.26:
+  /node-releases/1.1.27:
     dependencies:
       semver: 5.3.0
     dev: false
     resolution:
-      integrity: sha512-fZPsuhhUHMTlfkhDLGtfY80DSJTjOcx+qD1j5pqPkuhUHVS7xHZIg9EE4DHK8O3f0zTxXHX5VIkDG8pu98/wfQ==
+      integrity: sha512-9iXUqHKSGo6ph/tdXVbHFbhRVQln4ZDTIBJCzsa90HimnBYc5jw8RWYt4wBYFHehGyC3koIz5O4mb2fHrbPOuA==
   /node-sass/4.12.0:
     dependencies:
       async-foreach: 0.1.3
@@ -6269,7 +6701,7 @@ packages:
       integrity: sha1-xkZdvwirzU2zWTF/eaxopkayj/k=
   /normalize-package-data/2.5.0:
     dependencies:
-      hosted-git-info: 2.8.2
+      hosted-git-info: 2.8.4
       resolve: 1.12.0
       semver: 5.3.0
       validate-npm-package-license: 3.0.4
@@ -6306,7 +6738,7 @@ packages:
       integrity: sha512-KGvQ0cB70AQfg107Xvs/Fbu+dGmZoTRJp2TaPwcwQm3/7PteUyN2BCgk8KBMPGBUXZdVwyWS8fDCGFygBm19UQ==
   /npm-package-arg/5.1.2:
     dependencies:
-      hosted-git-info: 2.8.2
+      hosted-git-info: 2.8.4
       osenv: 0.1.5
       semver: 5.3.0
       validate-npm-package-name: 3.0.0
@@ -6417,6 +6849,17 @@ packages:
       node: '>= 0.4'
     resolution:
       integrity: sha512-l+H6EQ8qzGRxbkHOd5I/aHRhHDKoQXQ8g0BYt4uSweQU1/J6dZUOyWh9a2Vky35YCKjzmgxOzta2hH6kf9HuXA==
+  /object.fromentries/2.0.0:
+    dependencies:
+      define-properties: 1.1.3
+      es-abstract: 1.13.0
+      function-bind: 1.1.1
+      has: 1.0.3
+    dev: false
+    engines:
+      node: '>= 0.4'
+    resolution:
+      integrity: sha512-9iLiI6H083uiqUuvzyY6qrlmc/Gz8hLQFOcb/Ri/0xXFkSNS3ctV+CbE6yM2+AnkYfOB3dGjdzC0wrMLIhQICA==
   /object.getownpropertydescriptors/2.0.3:
     dependencies:
       define-properties: 1.1.3
@@ -6461,6 +6904,17 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-b+NI8qx/oPlcpiEiZZkJaCW7A60=
+  /object.values/1.1.0:
+    dependencies:
+      define-properties: 1.1.3
+      es-abstract: 1.13.0
+      function-bind: 1.1.1
+      has: 1.0.3
+    dev: false
+    engines:
+      node: '>= 0.4'
+    resolution:
+      integrity: sha512-8mf0nKLAoFX6VlNVdhGj31SVYpaNFtUnuoOXWyFEstsWRgU837AK+JYM0iAxwkSzGRbwn8cbFmgbyxj1j4VbXg==
   /on-finished/2.3.0:
     dependencies:
       ee-first: 1.1.1
@@ -6489,6 +6943,14 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=
+  /onetime/5.1.0:
+    dependencies:
+      mimic-fn: 2.1.0
+    dev: false
+    engines:
+      node: '>=6'
+    resolution:
+      integrity: sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==
   /opn/5.2.0:
     dependencies:
       is-wsl: 1.1.0
@@ -6631,6 +7093,14 @@ packages:
     dev: false
     resolution:
       integrity: sha512-0DTvPVU3ed8+HNXOu5Bs+o//Mbdj9VNQMUOe9oKCwh8l0GNwpTDMKCWbRjgtD291AWnkAgkqA/LOnQS8AmS1tw==
+  /parent-module/1.0.1:
+    dependencies:
+      callsites: 3.1.0
+    dev: false
+    engines:
+      node: '>=6'
+    resolution:
+      integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==
   /parse-asn1/5.1.4:
     dependencies:
       asn1.js: 4.10.1
@@ -6761,7 +7231,7 @@ packages:
       integrity: sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=
   /path-type/1.1.0:
     dependencies:
-      graceful-fs: 4.2.1
+      graceful-fs: 4.2.2
       pify: 2.3.0
       pinkie-promise: 2.0.1
     dev: false
@@ -6981,6 +7451,12 @@ packages:
       node: '>= 0.6.0'
     resolution:
       integrity: sha1-czIwDoQBYb2j5podHZGn1LwW8YI=
+  /progress/2.0.3:
+    dev: false
+    engines:
+      node: '>=0.4.0'
+    resolution:
+      integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
   /prompts/0.1.14:
     dependencies:
       kleur: 2.0.2
@@ -6990,6 +7466,14 @@ packages:
       node: '>= 6'
     resolution:
       integrity: sha512-rxkyiE9YH6zAz/rZpywySLKkpaj0NMVyNw1qhsubdbjjSgcayjTShDreZGlFMcGSu5sab3bAKPfFk78PB90+8w==
+  /prop-types/15.7.2:
+    dependencies:
+      loose-envify: 1.4.0
+      object-assign: 4.1.1
+      react-is: 16.9.0
+    dev: false
+    resolution:
+      integrity: sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
   /proxy-addr/2.0.5:
     dependencies:
       forwarded: 0.1.2
@@ -7137,7 +7621,11 @@ packages:
       node: '>= 0.8'
     resolution:
       integrity: sha512-9esiElv1BrZoI3rCDuOuKCBRbuApGGaDPQfjSflGxdy4oyzqghxu6klEkkVIvBje+FF0BX9coEv8KqW6X/7njw==
-  /read-package-json/2.0.13:
+  /react-is/16.9.0:
+    dev: false
+    resolution:
+      integrity: sha512-tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw==
+  /read-package-json/2.1.0:
     dependencies:
       glob: 7.1.4
       json-parse-better-errors: 1.0.2
@@ -7145,15 +7633,15 @@ packages:
       slash: 1.0.0
     dev: false
     optionalDependencies:
-      graceful-fs: 4.2.1
+      graceful-fs: 4.2.2
     resolution:
-      integrity: sha512-/1dZ7TRZvGrYqE0UAfN6qQb5GYBsNcqS1C0tNK601CFOJmtHI7NIGXwetEPU/OtoFHZL3hDxm4rolFFVE9Bnmg==
+      integrity: sha512-KLhu8M1ZZNkMcrq1+0UJbR8Dii8KZUqB0Sha4mOx/bknfKI/fyrQVrG/YIt2UOtG667sD8+ee4EXMM91W9dC+A==
   /read-package-tree/5.1.6:
     dependencies:
       debuglog: 1.0.1
       dezalgo: 1.0.3
       once: 1.4.0
-      read-package-json: 2.0.13
+      read-package-json: 2.1.0
       readdir-scoped-modules: 1.1.0
     dev: false
     resolution:
@@ -7229,14 +7717,14 @@ packages:
     dependencies:
       debuglog: 1.0.1
       dezalgo: 1.0.3
-      graceful-fs: 4.2.1
+      graceful-fs: 4.2.2
       once: 1.4.0
     dev: false
     resolution:
       integrity: sha512-asaikDeqAQg7JifRsZn1NJZXo9E+VwlyCfbkZhwyISinqk5zNS6266HS5kah6P0SaQKGF6SkNnZVHUzHFYxYDw==
   /readdirp/2.2.1:
     dependencies:
-      graceful-fs: 4.2.1
+      graceful-fs: 4.2.2
       micromatch: 3.1.10
       readable-stream: 2.3.6
     dev: false
@@ -7294,6 +7782,12 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==
+  /regexpp/2.0.1:
+    dev: false
+    engines:
+      node: '>=6.5.0'
+    resolution:
+      integrity: sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==
   /regexpu-core/1.0.0:
     dependencies:
       regenerate: 1.4.0
@@ -7470,6 +7964,12 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha1-six699nWiBvItuZTM17rywoYh0g=
+  /resolve-from/4.0.0:
+    dev: false
+    engines:
+      node: '>=4'
+    resolution:
+      integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==
   /resolve-options/1.1.0:
     dependencies:
       value-or-function: 3.0.0
@@ -7507,6 +8007,15 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha1-n37ih/gv0ybU/RYpI9YhKe7g368=
+  /restore-cursor/3.1.0:
+    dependencies:
+      onetime: 5.1.0
+      signal-exit: 3.0.2
+    dev: false
+    engines:
+      node: '>=8'
+    resolution:
+      integrity: sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==
   /ret/0.1.15:
     dev: false
     engines:
@@ -7528,6 +8037,13 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==
+  /rimraf/2.7.1:
+    dependencies:
+      glob: 7.1.4
+    dev: false
+    hasBin: true
+    resolution:
+      integrity: sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
   /ripemd160/2.0.2:
     dependencies:
       hash-base: 3.0.4
@@ -7632,11 +8148,16 @@ packages:
     hasBin: true
     resolution:
       integrity: sha1-myzl094C0XxgEq0yaqa00M9U+U8=
-  /semver/5.7.0:
+  /semver/5.7.1:
     dev: false
     hasBin: true
     resolution:
-      integrity: sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==
+      integrity: sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
+  /semver/6.3.0:
+    dev: false
+    hasBin: true
+    resolution:
+      integrity: sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
   /send/0.13.2:
     dependencies:
       debug: 2.2.0
@@ -7787,15 +8308,10 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=
-  /shell-quote/1.6.1:
-    dependencies:
-      array-filter: 0.0.1
-      array-map: 0.0.0
-      array-reduce: 0.0.0
-      jsonify: 0.0.0
+  /shell-quote/1.7.1:
     dev: false
     resolution:
-      integrity: sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=
+      integrity: sha512-2kUqeAGnMAu6YrTPX4E3LfxacH9gKljzVjlkUeSqY0soGwK4KLl7TURXCem712tkhBCeeaFP9QK4dKn88s3Icg==
   /shellwords/0.1.1:
     dev: false
     resolution:
@@ -7825,6 +8341,16 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=
+  /slice-ansi/2.1.0:
+    dependencies:
+      ansi-styles: 3.2.1
+      astral-regex: 1.0.0
+      is-fullwidth-code-point: 2.0.0
+    dev: false
+    engines:
+      node: '>=6'
+    resolution:
+      integrity: sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==
   /snapdragon-node/2.1.1:
     dependencies:
       define-property: 1.0.0
@@ -8108,6 +8634,26 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==
+  /string-width/3.1.0:
+    dependencies:
+      emoji-regex: 7.0.3
+      is-fullwidth-code-point: 2.0.0
+      strip-ansi: 5.2.0
+    dev: false
+    engines:
+      node: '>=6'
+    resolution:
+      integrity: sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==
+  /string-width/4.1.0:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 5.2.0
+    dev: false
+    engines:
+      node: '>=8'
+    resolution:
+      integrity: sha512-NrX+1dVVh+6Y9dnQ19pR0pP4FiEIlUvdTGn8pw6CKTNq5sgib2nIhmUNT5TAmhWmvKr3WcxBcP3E8nWezuipuQ==
   /string_decoder/0.10.31:
     dev: false
     resolution:
@@ -8177,6 +8723,12 @@ packages:
     hasBin: true
     resolution:
       integrity: sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=
+  /strip-json-comments/3.0.1:
+    dev: false
+    engines:
+      node: '>=8'
+    resolution:
+      integrity: sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw==
   /subarg/1.0.0:
     dependencies:
       minimist: 1.2.0
@@ -8246,6 +8798,17 @@ packages:
     dev: false
     resolution:
       integrity: sha1-O5hzuKkB5Hxu/iFSajrDcu8ou8c=
+  /table/5.4.5:
+    dependencies:
+      ajv: 6.10.2
+      lodash: 4.17.15
+      slice-ansi: 2.1.0
+      string-width: 3.1.0
+    dev: false
+    engines:
+      node: '>=6.0.0'
+    resolution:
+      integrity: sha512-oGa2Hl7CQjfoaogtrOHEJroOcYILTx7BZWLGsJIlzoWmB2zmguhNfPJZsWPKYek/MgCxfco54gEi31d1uN2hFA==
   /tapable/0.2.9:
     dev: false
     engines:
@@ -8295,6 +8858,10 @@ packages:
     dev: false
     resolution:
       integrity: sha512-SYbXgY64PT+4GAL2ocI3HwPa4Q4TBKm0cwAVeKOt/Aoc0gSpNRjJX8w0pA1LMKZ3LBmd8pYBqApFNQLII9kavA==
+  /text-table/0.2.0:
+    dev: false
+    resolution:
+      integrity: sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
   /textextensions/1.0.2:
     dev: false
     resolution:
@@ -8341,14 +8908,14 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-dkpaEa9QVhkhsTPztE5hhofg9cM=
-  /timers-browserify/2.0.10:
+  /timers-browserify/2.0.11:
     dependencies:
       setimmediate: 1.0.5
     dev: false
     engines:
       node: '>=0.6.0'
     resolution:
-      integrity: sha512-YvC1SV1XdOUaL6gx5CoGroT3Gu49pK9+TZ38ErPldOWW4j49GI1HKs9DV+KGq/w6y+LZ72W1c8cKz2vzY+qpzg==
+      integrity: sha512-60aV6sgJ5YEbzUdn9c8kYGIqOubPoUdqQCul3SBAsRCZ40s6Y5cMcrW4dt3/k/EsbLVJNl9n6Vz3fTc+k2GeKQ==
   /tiny-lr/0.2.1:
     dependencies:
       body-parser: 1.14.2
@@ -8580,6 +9147,27 @@ packages:
       typescript: '>=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >= 3.0.0-dev || >= 3.1.0-dev'
     resolution:
       integrity: sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==
+  /tsutils/3.17.1:
+    dependencies:
+      tslib: 1.10.0
+    dev: false
+    engines:
+      node: '>= 6'
+    peerDependencies:
+      typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
+    resolution:
+      integrity: sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==
+  /tsutils/3.17.1_typescript@3.5.3:
+    dependencies:
+      tslib: 1.10.0
+      typescript: 3.5.3
+    dev: false
+    engines:
+      node: '>= 6'
+    peerDependencies:
+      typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
+    resolution:
+      integrity: sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==
   /tty-browserify/0.0.0:
     dev: false
     resolution:
@@ -8610,6 +9198,12 @@ packages:
     dev: false
     resolution:
       integrity: sha1-diIXzAbbJY7EiQihKY6LlRIejqI=
+  /type-fest/0.5.2:
+    dev: false
+    engines:
+      node: '>=6'
+    resolution:
+      integrity: sha512-DWkS49EQKVX//Tbupb9TFa19c7+MK1XmzkrZUR8TAktmE/DizXoaoJV6TZ/tSIPXipqNiRI6CyAe7x69Jb6RSw==
   /type-is/1.6.18:
     dependencies:
       media-typer: 0.3.0
@@ -8888,6 +9482,10 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
+  /v8-compile-cache/2.1.0:
+    dev: false
+    resolution:
+      integrity: sha512-usZBT3PW+LOjM25wbqIlZwPeJV+3OSz3M1k1Ws8snlW39dZyYL9lOGC5FgPVHfk0jKmjiDV8Z0mIbVQPiwFs7g==
   /v8flags/3.1.3:
     dependencies:
       homedir-polyfill: 1.0.3
@@ -8941,7 +9539,7 @@ packages:
     dependencies:
       fs-mkdirp-stream: 1.0.0
       glob-stream: 6.1.0
-      graceful-fs: 4.2.1
+      graceful-fs: 4.2.2
       is-valid-glob: 1.0.0
       lazystream: 1.0.0
       lead: 1.0.0
@@ -8965,7 +9563,7 @@ packages:
     dependencies:
       append-buffer: 1.0.2
       convert-source-map: 1.6.0
-      graceful-fs: 4.2.1
+      graceful-fs: 4.2.2
       normalize-path: 2.1.1
       now-and-later: 2.0.1
       remove-bom-buffer: 3.0.0
@@ -9027,7 +9625,7 @@ packages:
   /watchpack/1.6.0:
     dependencies:
       chokidar: 2.1.6
-      graceful-fs: 4.2.1
+      graceful-fs: 4.2.2
       neo-async: 2.6.1
     dev: false
     resolution:
@@ -9180,12 +9778,20 @@ packages:
       integrity: sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
   /write-file-atomic/2.4.3:
     dependencies:
-      graceful-fs: 4.2.1
+      graceful-fs: 4.2.2
       imurmurhash: 0.1.4
       signal-exit: 3.0.2
     dev: false
     resolution:
       integrity: sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==
+  /write/1.0.3:
+    dependencies:
+      mkdirp: 0.5.1
+    dev: false
+    engines:
+      node: '>=4'
+    resolution:
+      integrity: sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==
   /ws/4.1.0:
     dependencies:
       async-limiter: 1.0.1
@@ -9362,7 +9968,7 @@ packages:
     dev: false
     name: '@rush-temp/api-documenter-test'
     resolution:
-      integrity: sha512-OkrveKOOFHgyFIKfWbTZsSHcaOSc2LhX6byyNaQsOqPtL16fD6ytHgjVADHrxXY+uIogt9o1Ge8zOl2ki5I6Dw==
+      integrity: sha512-DiH9X1lVwWJttJ9mnIXEJXW6Hc1Avoh4NNzIqhQ3vz0mL5DycyT9WMfbtADlW5wXXNf7BAuVTpZAk73Tszwatg==
       tarball: 'file:projects/api-documenter-test.tgz'
     version: 0.0.0
   'file:projects/api-documenter.tgz':
@@ -9378,7 +9984,7 @@ packages:
     dev: false
     name: '@rush-temp/api-documenter'
     resolution:
-      integrity: sha512-ZS599Oq9FNBl5T2YnkKvn1gOG/9LfyWULZTWnbXj0SA2h55dC8iRjksQqpcRwNIrp5t3sh555O4/n1hMbKdhKA==
+      integrity: sha512-jUDoIgYow5D5wjAbGl5PyuQtBWPbnTCVvHrnsPa1Od6XSNyn4QuSoPd0flbfnFQ3yMNrbsfi6c7RDLMBOCV7fA==
       tarball: 'file:projects/api-documenter.tgz'
     version: 0.0.0
   'file:projects/api-extractor-lib1-test.tgz':
@@ -9390,7 +9996,7 @@ packages:
     dev: false
     name: '@rush-temp/api-extractor-lib1-test'
     resolution:
-      integrity: sha512-HOvERE0Bf07MxF5ofvOY207CXH1nhG4N9lRGbHHhMrsVc7p2cwTtzf8Lbe2ilTUUlJ8SGHAIIgufWiuiWbDFVQ==
+      integrity: sha512-HwlXev/5iZ1cqJ5YiDKwAEJzswiy6ASmoRbwNK8EgoV2ulskgJN/AUfljO4HCGFslveSHHJ7aQCq018xR0wNmg==
       tarball: 'file:projects/api-extractor-lib1-test.tgz'
     version: 0.0.0
   'file:projects/api-extractor-lib2-test.tgz':
@@ -9402,7 +10008,7 @@ packages:
     dev: false
     name: '@rush-temp/api-extractor-lib2-test'
     resolution:
-      integrity: sha512-irtDexkfugH64//1kd0uYXLD8IQxDpzV4Al5C7gQMua+LT3MAe+TE7Ysq+666/xx7rLQBqrCSTcOamsuOsngJw==
+      integrity: sha512-R7mgIZp90sgI8j6m8WiYXuHkffnxU4Dd2btSlvGxopUzilpiprFCpL78acnm8/8WqADfRGCDZJRsDWurFWMLuA==
       tarball: 'file:projects/api-extractor-lib2-test.tgz'
     version: 0.0.0
   'file:projects/api-extractor-lib3-test.tgz':
@@ -9414,7 +10020,7 @@ packages:
     dev: false
     name: '@rush-temp/api-extractor-lib3-test'
     resolution:
-      integrity: sha512-qlYjPJJLSF2XMnw2XV2U6HoL25QLx0nOhUOppjNvmInQjmLXr9BmLTEUdO/n7GXJ6Jhp9kwmsUwgh6fmuzoAUA==
+      integrity: sha512-x1mpKFTgs1oG53xga8nLd9SIRCgVsBgdgKZW87U0bPdJYNqA7UXRlBA5Y//nWRiXI+E3sZgINryUjcedIGS1Sw==
       tarball: 'file:projects/api-extractor-lib3-test.tgz'
     version: 0.0.0
   'file:projects/api-extractor-model.tgz':
@@ -9429,7 +10035,7 @@ packages:
     dev: false
     name: '@rush-temp/api-extractor-model'
     resolution:
-      integrity: sha512-WfZSinnjHady2flpEuZe7Q1qLjqLNO4pHYF0PLeHFKhEjDOw1Jnwwu61EV1rQHiIduqu20iyGPx8GlSqs0GWJQ==
+      integrity: sha512-mxTGlD88fmJmvCW2a0qJxfsoqIGScBMCuuQO7VSR2IyFgnpp2dsQU/unz2tRlM/tqdAI3+UpaGwsFrPuq3Cfug==
       tarball: 'file:projects/api-extractor-model.tgz'
     version: 0.0.0
   'file:projects/api-extractor-scenarios.tgz':
@@ -9443,7 +10049,7 @@ packages:
     dev: false
     name: '@rush-temp/api-extractor-scenarios'
     resolution:
-      integrity: sha512-qwoXGC/FYoqBOK+8ogW4hAYlxRrOjzGkGz1PjPyQo44ZsCJnPYaHSXheWjfJirBXzj9J/g0iL/lX9joC3Wr11Q==
+      integrity: sha512-LZ6QSi73PWgixHzt5JekhcAi+8BMO6qflYJnbC+Z/ZdFPWRhz8hFj8JZSYgj1LynmoBNQQBAseLRHOdSPUsgrQ==
       tarball: 'file:projects/api-extractor-scenarios.tgz'
     version: 0.0.0
   'file:projects/api-extractor-test-01.tgz':
@@ -9457,7 +10063,7 @@ packages:
     dev: false
     name: '@rush-temp/api-extractor-test-01'
     resolution:
-      integrity: sha512-wJb+zIFTZwFiTsY1XCV5feLlC9q6gyYi+X9lWJZckTDZG0bMfkgsLwJgjnBnCmcL9bGPQ9pnRgoFw5gC6o1VkA==
+      integrity: sha512-AcdnZ0n39Ms3xKGSiB4tsBd5+vIUN3yL2fpKJ4wJr9r0y4wxZqAoCtF3kbN3wgjSHNLp5LFIpjrvZ5AuHcU+6w==
       tarball: 'file:projects/api-extractor-test-01.tgz'
     version: 0.0.0
   'file:projects/api-extractor-test-02.tgz':
@@ -9470,7 +10076,7 @@ packages:
     dev: false
     name: '@rush-temp/api-extractor-test-02'
     resolution:
-      integrity: sha512-5Qgyx4bBITyNOcvG0NMlnxjtdqFTGHcxnXoZ/WuTPbPg3CR0sSSp69n7kp09aypqh750w5GnGWbCWe3iy2lJoA==
+      integrity: sha512-Mye8nSy9z78Pq9GT2SSfZNCuhlLUsu/P5x9URMdx2dYefWRVwxN4FAUM7w5moni4619gIJpy6JtNEV+Ug63Ijw==
       tarball: 'file:projects/api-extractor-test-02.tgz'
     version: 0.0.0
   'file:projects/api-extractor-test-03.tgz':
@@ -9492,7 +10098,7 @@ packages:
     dev: false
     name: '@rush-temp/api-extractor-test-04'
     resolution:
-      integrity: sha512-Vn6Qf2NRD4iGEh0ijg97LgIFyH6lEuvtjYi/pCwJrkUWWUH4XS1jWjon97dW9O40UYNcSCwW2I0vlI34/JrEng==
+      integrity: sha512-/D8ugc9FnJSFOips5NSAKMuDAV9jaVBbXhD5v++rmrvjUWsGJaH380nhwoogGapw9gZhLWM4x496FRllVWkRYw==
       tarball: 'file:projects/api-extractor-test-04.tgz'
     version: 0.0.0
   'file:projects/api-extractor.tgz':
@@ -9512,14 +10118,25 @@ packages:
     dev: false
     name: '@rush-temp/api-extractor'
     resolution:
-      integrity: sha512-El5j2d8l9FqYErjfOKvDTS4/VVM/I6KrPeFX5Qrp2k0boSSAjgzGpq72xtM627D5DVfcNtkdVUVGFxiA5OKnBg==
+      integrity: sha512-+QawwxlVhXcXKB6tDwiWkj+XRhT8NYcpiVq8u4A4qyXrQ/zDE8qhEBiSaq+otgWV/FMW/bD2OoxgTEJ8Km4eRA==
       tarball: 'file:projects/api-extractor.tgz'
     version: 0.0.0
   'file:projects/eslint-config-scalable-ts.tgz':
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 2.0.0_2597c16b46d7eff3ec2c0c583ca4ae44
+      '@typescript-eslint/experimental-utils': 2.0.0_eslint@6.1.0
+      '@typescript-eslint/parser': 2.0.0_eslint@6.1.0
+      '@typescript-eslint/typescript-estree': 2.0.0
+      eslint: 6.1.0
+      eslint-plugin-no-null: 1.0.2_eslint@6.1.0
+      eslint-plugin-promise: 4.2.1
+      eslint-plugin-react: 7.14.3_eslint@6.1.0
+      eslint-plugin-security: 1.4.0
+      typescript: 3.5.3
     dev: false
     name: '@rush-temp/eslint-config-scalable-ts'
     resolution:
-      integrity: sha512-zhg1vSzSofNBG5wbvvMHCX5Tm7Q41uZxHupJuxK87mKaTWVDxdEVdxkxsy50NtbcczZPJSurcpgtQyxYK3atlA==
+      integrity: sha512-KM6ataZ/8i8xuh0r+QndnoldcUBxa4ATnx5ggt9JtljM/KJtc76LSC3cm5B/HeBFGq5U/LSraqQxqF19y0zfVA==
       tarball: 'file:projects/eslint-config-scalable-ts.tgz'
     version: 0.0.0
   'file:projects/gulp-core-build-mocha.tgz':
@@ -9539,7 +10156,7 @@ packages:
     dev: false
     name: '@rush-temp/gulp-core-build-mocha'
     resolution:
-      integrity: sha512-70/ZfAhOFvBVyl5ZsGsCAk5tKL8Ar5FD7uuXuQYQK9grBx1cukQUlT2mvFnemn/tfiDm8ZiQ2qQ6fQw+GRudug==
+      integrity: sha512-l/reSlQ8rMKTRzouSTcSZlJcs9adVQEu1g68claL29ZTRGkhpzEGUpt/xR3tCgpQNP4JmvBC8iBvatddE3L8zQ==
       tarball: 'file:projects/gulp-core-build-mocha.tgz'
     version: 0.0.0
   'file:projects/gulp-core-build-sass.tgz':
@@ -9561,7 +10178,7 @@ packages:
     dev: false
     name: '@rush-temp/gulp-core-build-sass'
     resolution:
-      integrity: sha512-OpTFtuvefnfT1MCswT/zgF4miD/83yXaEYg6A+LAian2dZaxYhQ6fHzHMVHoIcu/Zy/ThikWqCzSoH8Ck8jBPQ==
+      integrity: sha512-/GIU7ybgWUsdJPZ1J9eBDq6XZw4jAdk/sKwmYmXM40fXa4syubWnO+VrfER077IOYlj2QGZkTwSwYjBI5vsHEw==
       tarball: 'file:projects/gulp-core-build-sass.tgz'
     version: 0.0.0
   'file:projects/gulp-core-build-serve.tgz':
@@ -9587,7 +10204,7 @@ packages:
     dev: false
     name: '@rush-temp/gulp-core-build-serve'
     resolution:
-      integrity: sha512-tH6lxeCuE5/1I317NwvJxULVu6TG6+0/k4da/CKu36uKjTBgxWOX2r0WidPqOMAs9JJoOfeh9di1O4gaf2h+Zw==
+      integrity: sha512-0nif8o/vLt2Y9rkVbqDAcn7UBwnUQoFgOwn9jTokvySIk3xm1X6SgpysPird3lhinZ8f1rtXIGDznjcVj6nLPw==
       tarball: 'file:projects/gulp-core-build-serve.tgz'
     version: 0.0.0
   'file:projects/gulp-core-build-typescript.tgz':
@@ -9607,7 +10224,7 @@ packages:
     dev: false
     name: '@rush-temp/gulp-core-build-typescript'
     resolution:
-      integrity: sha512-0+sqw8vJPYzGSYg/pVTr2MTRfCl0hG1XYEN2cf7vP8fBT9buvFVytjLag/szaotMDucGCdJCYF6J0FqbBPpqyw==
+      integrity: sha512-/LBnoHLDKPpZK6EGeG/Nn3smNipd2ZGF4mW+/wpTWzcpApuFddrbBg+e/V0ica2qh9EO95V8ItXqbPWbZfqO1A==
       tarball: 'file:projects/gulp-core-build-typescript.tgz'
     version: 0.0.0
   'file:projects/gulp-core-build-webpack.tgz':
@@ -9624,7 +10241,7 @@ packages:
     dev: false
     name: '@rush-temp/gulp-core-build-webpack'
     resolution:
-      integrity: sha512-HxJnzL4sgZzSF1XOoePR1maNG5cqd4StqAEJBVxl6Wq9q8sXqFzZaMh/ZZXHGv19XYil0/8AwNUZcgSK5dnFlQ==
+      integrity: sha512-xqPSqg7jOasv86Tblad20g6O52dORxjKdPJ5iRAYKA4ilwK58md1YeGYRHqclVD6FQrE3ZAtquZw5t/n29XCBA==
       tarball: 'file:projects/gulp-core-build-webpack.tgz'
     version: 0.0.0
   'file:projects/gulp-core-build.tgz':
@@ -9671,7 +10288,7 @@ packages:
     dev: false
     name: '@rush-temp/gulp-core-build'
     resolution:
-      integrity: sha512-T8KGhYRgKzjYK1nekwXiHycGxNvie8x2ReBE4AXqm4PihjdaHnvlRZ9GagUP11E+ilatj1VMyv4qRBwXAY+xKQ==
+      integrity: sha512-rwmhB3OKX8fu9jhXk09BxQXyJUa4RlXVQocPhhB9aEs5y9ieNCn5opfvrr94CG0+ziYclpME65rXIvYPOkF87g==
       tarball: 'file:projects/gulp-core-build.tgz'
     version: 0.0.0
   'file:projects/load-themed-styles.tgz':
@@ -9684,7 +10301,7 @@ packages:
     dev: false
     name: '@rush-temp/load-themed-styles'
     resolution:
-      integrity: sha512-JBYUgxNXh0AeH3afLvTMXQwREXg/nHkwUdN4dvQCrad0X7D6mHivHuZZ2bgvfcQQ6/8v2C2xlQwUkS98KAXL/Q==
+      integrity: sha512-F7Tsur9QP0WlKAQJrLaXpldsWp4t18uSQolO0ZVVIQghSrUlFnlYM4zfZbTqsC1U6JneK+pP9ywt+4V0X96v+w==
       tarball: 'file:projects/load-themed-styles.tgz'
     version: 0.0.0
   'file:projects/loader-load-themed-styles.tgz':
@@ -9699,7 +10316,7 @@ packages:
     dev: false
     name: '@rush-temp/loader-load-themed-styles'
     resolution:
-      integrity: sha512-CdRb9/ySWBtPso//fQY2eKTBfe2oJqCfjHn9wWz3ou2YlUzYJnFEgYc29yKFOyic4hFSrOgY1MFO9T5NmC9q4w==
+      integrity: sha512-LYMQW2asjmalfNhq0ldAFRlW4OBYIH1eHmILjqOqRFITX4AeJBgBvK04SeTsRchasl9NYIDdtxcf8eyWaRW4zQ==
       tarball: 'file:projects/loader-load-themed-styles.tgz'
     version: 0.0.0
   'file:projects/loader-raw-script.tgz':
@@ -9713,7 +10330,7 @@ packages:
     dev: false
     name: '@rush-temp/loader-raw-script'
     resolution:
-      integrity: sha512-1o3NEfN3u+4gPCtPiIWFOqLl6CfhNfmBXbft09tcaE6s+FuN0XUSmdZlt+4QActbR7EuLQX0YDPaaAsscw6Kgg==
+      integrity: sha512-fk2hGquymSv127b+Ux1e6YMIEnL1CDSbF9LZAFdYMtxdThDFaF4vW1P7ipzlniUT9ernuitzd9nEICOc3YRIBw==
       tarball: 'file:projects/loader-raw-script.tgz'
     version: 0.0.0
   'file:projects/loader-set-webpack-public-path.tgz':
@@ -9729,7 +10346,7 @@ packages:
     dev: false
     name: '@rush-temp/loader-set-webpack-public-path'
     resolution:
-      integrity: sha512-60NK5dSgfgnbBnvu+yNRgb7ZxEr7USVG8I1kMd8d9zQr2cTI2bbEAH/y5sXR8PRCPXvcQOzZBHR1yH2LVkm4xQ==
+      integrity: sha512-d/Yme0VipREkmwW8ly1Q+z0GO/WTmouN9sOjmYG1XlLXT+F5rlXwlfMmQGL3kPQl8gwVaLQygMWkSHPHXPd0Mw==
       tarball: 'file:projects/loader-set-webpack-public-path.tgz'
     version: 0.0.0
   'file:projects/node-core-library.tgz':
@@ -9762,7 +10379,7 @@ packages:
     dev: false
     name: '@rush-temp/node-library-build-test'
     resolution:
-      integrity: sha512-UrZe1UdUHELDoi8BOTgu0VweFOOVi1e8xUu8mYIStYser2M1h7gqrmlcD7KEHFMmVX+S0jTerSE+6PvolemUVg==
+      integrity: sha512-Q7VqRpW+JL02nUdfp+PN+zJal0daCJYteSazGyuxKbahvL999KU9T+b883i6KQHxZn51TLAI4Y7Qvx0YlGlV+g==
       tarball: 'file:projects/node-library-build-test.tgz'
     version: 0.0.0
   'file:projects/node-library-build.tgz':
@@ -9773,7 +10390,7 @@ packages:
     dev: false
     name: '@rush-temp/node-library-build'
     resolution:
-      integrity: sha512-9lKMB5nLxE+kca2NWm/Juo7108axBFiC/VsTWrzyKyeGPln8EwEATtLjv+P83gM+Hm2Nua0i+Vjwhtsj/9vfYw==
+      integrity: sha512-RMCc3hQn+2ty3PDkr8wpGfm/KP68JsJD4P32rBawBLL0TEHOqSGqX0rqd8F87Bh6081QVqrAllOrADA7u/oXdg==
       tarball: 'file:projects/node-library-build.tgz'
     version: 0.0.0
   'file:projects/package-deps-hash.tgz':
@@ -9786,7 +10403,7 @@ packages:
     dev: false
     name: '@rush-temp/package-deps-hash'
     resolution:
-      integrity: sha512-zmyWlH1T7hSccqCUN2pwmswe3nOMcvkSVcPejm4Mr8OaoOBB8KZd6aiFsjhJUSitA3fM0cggdefjkAMJfmTKlg==
+      integrity: sha512-pOiihwcLZ3PxvFrXUkvpcrlL+EBWlVTiyNFz6KBHnN+sOfk75+YNClLZy4qaZOq4VSc5eZUgunefrYCjzHgQIg==
       tarball: 'file:projects/package-deps-hash.tgz'
     version: 0.0.0
   'file:projects/resolve-chunk-plugin.tgz':
@@ -9799,7 +10416,7 @@ packages:
     dev: false
     name: '@rush-temp/resolve-chunk-plugin'
     resolution:
-      integrity: sha512-C4BRGv/0+5eKpRJtTP5b1g1QvfxNMxozto2qERdqruC7YJMRRtMZUmsFeJELT3M1s0aqCCBccHI0q5fjfs4ZGg==
+      integrity: sha512-faZXEpqT9QjXqzLhNt0lZnHINi2L0VSYI6yQHuMcdUSBwYGQzN4Hl8DjD1iUq6776pqpZmyUIjZ7UkkaNmyCCQ==
       tarball: 'file:projects/resolve-chunk-plugin.tgz'
     version: 0.0.0
   'file:projects/rush-buildxl.tgz':
@@ -9810,7 +10427,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-buildxl'
     resolution:
-      integrity: sha512-RPJ38K1cwStXwxR2uCMCQ3WSvy45RsZq3MAcTj8J2Aq0Te0fpPdy1HhFfU0G4RVqrr2p+XOXjHp+4YGmkU3YzQ==
+      integrity: sha512-VYRFLiTikJ8FR175M3vBfS8Z1RzbRsplzXeq4EMkhuzzUizp9TJZlMw1g4d1ktxngLppIsj94sy9Q/Re95bu1g==
       tarball: 'file:projects/rush-buildxl.tgz'
     version: 0.0.0
   'file:projects/rush-lib.tgz':
@@ -9853,7 +10470,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-lib'
     resolution:
-      integrity: sha512-dz8FCirSZyKlImerNE6MXfTtpsfZuIl38nGyu86J7ni/QtikGp8WyHEJcA12APFTYK8XAiA/htfnyZNW0QxwJg==
+      integrity: sha512-Q0URCZTIYmtWJ0L1y1wLiuMrROAe5Hn9RbDgqeoFY6ipfwCVUglUzN0f4aGGfn0nufp3AX8DYZDXmLq2qtIPMQ==
       tarball: 'file:projects/rush-lib.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-2.4-library-test.tgz':
@@ -9863,7 +10480,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-2.4-library-test'
     resolution:
-      integrity: sha512-wZAPKl/2qY048FR9ZTVqSHVmNiIDrVE3tuCC4YetueDv9dwkkSGph5liifgrp8kh67ph0u1+Yx/W5mSKKPjnlA==
+      integrity: sha512-Xowayqh4BPN6z9DN/afv9zvhSsIERTjnx/QynOUZP6RQ7hj8k3qyPRYVkdAo4ClRyviN8+Nf3h0aNJfIDhabmg==
       tarball: 'file:projects/rush-stack-compiler-2.4-library-test.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-2.4.tgz':
@@ -9878,7 +10495,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-2.4'
     resolution:
-      integrity: sha512-bgrEYOljkCWVfUqXahUX6nBJfDH/4v4Ar3GPH0yzM+afJBBWk4mp8B7IyqLs4Cw/ECvrIIr24AfptAtpyWZHaw==
+      integrity: sha512-xtw2qzVKHXwe9u7byl3QCYy+YsXqOIfCj3YYi5O87oernU9/9ITQ5eMolpbTuFfCbuhXwLnB7ReQriesys5L6A==
       tarball: 'file:projects/rush-stack-compiler-2.4.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-2.7-library-test.tgz':
@@ -9888,7 +10505,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-2.7-library-test'
     resolution:
-      integrity: sha512-w4q4MC35vaO/HurjO+EPM8S/iZfDZEca8OSi0zgLCZ7nlXbzpXUeq2a/Nn306/h/W1KqF95wyQcj2soaLiHwSw==
+      integrity: sha512-e1E/ZwRYFiYZ7vzqPJYwd5Vw9nOuOHMcrjLS79U3HFGdTjEAv06Vm2/6iGV956KHzOI9Ob6/4qVZfW8c1InMgg==
       tarball: 'file:projects/rush-stack-compiler-2.7-library-test.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-2.7.tgz':
@@ -9903,7 +10520,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-2.7'
     resolution:
-      integrity: sha512-AW9XzcwigaOrnMgaBJkQgDQqPxrAcG4NUWFvB0jiJ+ehsjc3gu4H/H8mibt0CU9oC2Asz6/g5G6214+oVsf+6A==
+      integrity: sha512-zH2e1tmSKTl8t7XMI/tIkmg8sdljJzIvXrzfKpKAnKooVfZvGKgA/t6iW1qSyrtQ2GTBoepXDpRWLEItZHTHkg==
       tarball: 'file:projects/rush-stack-compiler-2.7.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-2.8-library-test.tgz':
@@ -9913,7 +10530,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-2.8-library-test'
     resolution:
-      integrity: sha512-ryux0ia+gtGncjoB2ZMzKIn7KZ5bL6n5xb47HqlFKO09g/AGx8rIAQ/cKg9k4TCPN2KKWovaP/zSkhSZAeTsLw==
+      integrity: sha512-wG6i6R3QGe4VfVzO9awsyOe/GXeaOzev8KfC3c8VJZ1cbR5d19jMMt7fkuTTBExZsDJgrBW30W6zoBEF0YI8LQ==
       tarball: 'file:projects/rush-stack-compiler-2.8-library-test.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-2.8.tgz':
@@ -9928,7 +10545,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-2.8'
     resolution:
-      integrity: sha512-iz1WkKF7jY4PyvWzeCHSTNRHI2EWjxFD1WZyJIA/ipkdo7hhTYm5ND1Jh2XaVRKaQsyW0vFk1eAmMcFhIv++1A==
+      integrity: sha512-gLpdh5Bj6wM3HblBz0PcmdT/ppZfTswPbhSS/DPUkY5Rh28b+l46gbgRP9mpwbr2GRfHt+J+HrMFo1EuHtEW1A==
       tarball: 'file:projects/rush-stack-compiler-2.8.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-2.9-library-test.tgz':
@@ -9938,7 +10555,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-2.9-library-test'
     resolution:
-      integrity: sha512-lx4P2qEIusy1ANHINzPWQuPY2bw1Bxkj7J54s6e+a+kuL/I1iClOeYfGSPoc6rOs86ITvrBOPRN+21WlYnxk6g==
+      integrity: sha512-KFmfDxmIaa5mrhhfMWPLnB9RzpatQQoTPrdUEWUGTLu5YDi2OSw0lPKLVb59M1KHrV7giyULuGzlIA6XpCfm8Q==
       tarball: 'file:projects/rush-stack-compiler-2.9-library-test.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-2.9.tgz':
@@ -9953,7 +10570,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-2.9'
     resolution:
-      integrity: sha512-cLnLdFr8uQEdvxm6eFKHOdSC/SL6mTwp271yiNehTQ5XAaD1xUAwhpQcnnCPIEry+jW+ZDXuzo5pfGTuEIQeVA==
+      integrity: sha512-xSIlQrzIrC+tMK5jCOfhvndK597BiAtoKfZLmeyogq0+lhcdiIsaBaK1g213JQI1WNXVKtN49p+Y3brlMaFeIQ==
       tarball: 'file:projects/rush-stack-compiler-2.9.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-3.0-library-test.tgz':
@@ -9963,7 +10580,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-3.0-library-test'
     resolution:
-      integrity: sha512-hO9ctC2nebhKETxMEbVWJmgxRZ2Tb30PLH39Qk4uQ2yDTGMv//1jmXtQACz7qQu4fpO08+9oxLILd7/8SQ+U7A==
+      integrity: sha512-Y93xnqS8GczrOr67Ds0TYv2g+B45nLUzrxMbqeFWlekDKnlHhyFEsPsI1ha5sCa0yB5rHKCOIUe3TPTbWS0+ew==
       tarball: 'file:projects/rush-stack-compiler-3.0-library-test.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-3.0.tgz':
@@ -9978,7 +10595,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-3.0'
     resolution:
-      integrity: sha512-OTyRARv4fockdhoQ3e6HEBFQopbSt7IZORKvdNa5iFNWqH1vtNOOSbFUjCfZn+TAVxEXYfCqPDohV83svGzm5w==
+      integrity: sha512-kmjbVvIRb815VoDJ3VjOdakT2uloF9KX5T9F23+Fwb/kVuZkCqtRxVHpUW0bG+MVlW63iAA88fvrK/vFT0Do5A==
       tarball: 'file:projects/rush-stack-compiler-3.0.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-3.1-library-test.tgz':
@@ -9988,7 +10605,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-3.1-library-test'
     resolution:
-      integrity: sha512-pT2ZMGFOY2V/b2AtGs1FM3TXDow0RSfSCDGeMgQJtX6/I4eb6hMEc84G0/aqwZnZ8hQp5XlRdaWtRuBb1NzG5w==
+      integrity: sha512-nbpIG+GdcdYQs6hecdyw01hzidDboP8XvUfEq+n5O7S1IduJeoLAjmiUg7DV7Yz7hQ3JOLzjn7BdUCZLYdinCA==
       tarball: 'file:projects/rush-stack-compiler-3.1-library-test.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-3.1.tgz':
@@ -10003,7 +10620,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-3.1'
     resolution:
-      integrity: sha512-ZznSbZY3g13anf0X1GtO6NKGHqC+asRphrPBj/MhnRRjubDFvkV7SRKnWQ8UeSZOqtGHJITz0Rt021RtRGl1hw==
+      integrity: sha512-hgTTmgyS370t2g/OvtVRFo0nlmYyB0S97HMgH/Psw6rAaF9oF9fWsoiwZ9q8byJN8APuBRGO88RmYKUIrqtQEw==
       tarball: 'file:projects/rush-stack-compiler-3.1.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-3.2-library-test.tgz':
@@ -10013,7 +10630,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-3.2-library-test'
     resolution:
-      integrity: sha512-ve2Mu/cnwFdUKba0QsHJy7w2YFJlP/f0fUFpAbph/S/IdGif7HuLG4NGhPLAYO7nFLjCY6WLqJ/juxuF0DV+6Q==
+      integrity: sha512-h1fU85j7D2EtstXwDWW4T7v9kyYMoK+TsSsvyAlfTBRusqNCLoetdyLx7jApfZvJq9n8jhYV3mCUY3ytbXwWUg==
       tarball: 'file:projects/rush-stack-compiler-3.2-library-test.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-3.2.tgz':
@@ -10028,7 +10645,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-3.2'
     resolution:
-      integrity: sha512-aUNJJ/PyBbvnMuKDjJF9FN7rgZt3QAw7QbTMaA2oHUjGQIxl9O1TkFPPQDQfPinbR0wgvFOBNyTcmD7K+mQeig==
+      integrity: sha512-f22Y/CpSZpv2dZwpGVFF8m1YuypLO9vDAZLTrDzIHSbNwONzszaHrc6QRGjQSkTzBwucFSQyRiwhI8xo+cAjkw==
       tarball: 'file:projects/rush-stack-compiler-3.2.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-3.3-library-test.tgz':
@@ -10038,7 +10655,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-3.3-library-test'
     resolution:
-      integrity: sha512-QfaEd+AyI4nQEXILtHoWhvPD1E3IEJ1bXRflx2LU10YNPm2kQ3sbL5l7QSWX/nNv1jbSv6mtWcFw0nRb0LpG/A==
+      integrity: sha512-grQtOYKbqxDHzFlJejCjM3Z6dTzj8usJzYrr5GJ767ogZOW0YKiRvDG+Sv2POeAYbmLQRID7gLqFRusDPcp2UQ==
       tarball: 'file:projects/rush-stack-compiler-3.3-library-test.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-3.3.tgz':
@@ -10053,7 +10670,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-3.3'
     resolution:
-      integrity: sha512-8pR+VPKbr0VfY5SoaLR9GRj30IowNthXSCH8mYLWVa6BaShgF/7T2XuKgc5n1HMxt6lMhWyKd3albC8C4Mia4A==
+      integrity: sha512-FTwg6sxKigjjeRt3f/GFKeejVBbbEtbmSSwsk0bm8WNPO+2QIi63/cE+hemFjoWOXw4l2gauOavO9SHxLyofyA==
       tarball: 'file:projects/rush-stack-compiler-3.3.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-3.4-library-test.tgz':
@@ -10063,7 +10680,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-3.4-library-test'
     resolution:
-      integrity: sha512-awKl6bq4epRUuZATL4CwzT+cBLQi0ZZB8D8lDnNOX0IPdPWcE5+DifpeivIlpHnxDyCWKHUgaaabWFG/ctjfNA==
+      integrity: sha512-WY1PsEOCBcFn5j/pwBCgEcolaLDqKk02Zz2HRxnEmWwAhXjkhecrB6XMHEx4Hw8VebM6EH+A5Jfl8qBrcKTTXA==
       tarball: 'file:projects/rush-stack-compiler-3.4-library-test.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-3.4.tgz':
@@ -10078,7 +10695,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-3.4'
     resolution:
-      integrity: sha512-lLo+eOx9KAWKbn8tmVkrQKXUjxaoRji5C4HYEymeVEFvF8PJRNbyH01MJhQ/pvwh8k4v7J1bOIW3CaFblSWxrg==
+      integrity: sha512-lxfdeebacL7fR/uiSHuPdomKcEQwnPKDAEaTV2R8A3tPV0+KJvznaKb7XToyvl8qN70piy2Q6yD+fNtLHrPRDQ==
       tarball: 'file:projects/rush-stack-compiler-3.4.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-3.5-library-test.tgz':
@@ -10088,7 +10705,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-3.5-library-test'
     resolution:
-      integrity: sha512-wd5IrTgDsHJKARJZj7nYBAlu7ssSQTWh6VTeeb2tghCyzCM/sAUpkMNYblyQmWQnbl9xKQkhgxB4ji8+B+WdeA==
+      integrity: sha512-0oaG7OjfAKjNaAvwhbfRxPUTrLTSwCDZ+OsO478URpMZ67+k/qU2ORh6Q/NoOb2VzCvFDUJyixKf5vJcHc//RA==
       tarball: 'file:projects/rush-stack-compiler-3.5-library-test.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-3.5.tgz':
@@ -10103,7 +10720,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-3.5'
     resolution:
-      integrity: sha512-hZlGSNmB/Ds6CLeNM+wBL6uqLXhmjzctNatuYpb7ann86mIJeys218AA9og4dCrDEBJmmKdwHRBoxRoz/r6gnA==
+      integrity: sha512-8nQvIzqStzXKYshMqD10IbtLoJJox4l4q9mKhPydUwdyqSMYz/oG/g8c2pB/DfvlvuLsUHLCmSAZ6ayf+beEow==
       tarball: 'file:projects/rush-stack-compiler-3.5.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-shared.tgz':
@@ -10117,7 +10734,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-library-test'
     resolution:
-      integrity: sha512-mVNA+coAehE4FuEgCcVUNqbq+TlqGZk9K1GBJKPZGp/TINlPEoHfJodtIyBOwakJK3KLoJHWfYQoxSAIgAyEeg==
+      integrity: sha512-ihdMKfSx903gAkBcA2E6aZFM+ZY4gHYHYxeoUnYldkI6QJU73M7kdNGxFFx2hJ+qht67rL4+D0BHYwndj5kacw==
       tarball: 'file:projects/rush-stack-library-test.tgz'
     version: 0.0.0
   'file:projects/rush-stack.tgz':
@@ -10128,7 +10745,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack'
     resolution:
-      integrity: sha512-gPH6FcZRDX1G29wgs/uYQyaD5cPL4Wh6qmm9bFL/R5GOpJFl0w79lBCDGPaxY0WfFHC5+Xqxi7D356qZAMRLtg==
+      integrity: sha512-iyToEi4c077p4qdk6WUUD11kxnmxnr+kyNC26fMsO9QLCyRsV27jU35i5Fzp3hjSUf3ppoWM1nYrDl3WWxAMLg==
       tarball: 'file:projects/rush-stack.tgz'
     version: 0.0.0
   'file:projects/rush.tgz':
@@ -10146,7 +10763,7 @@ packages:
     dev: false
     name: '@rush-temp/rush'
     resolution:
-      integrity: sha512-lubbIScB3MtPtw8vUOqrg9g5NryQ4WjGAe+IAswiKtHNEWUHjsGai+AJhr/X03XUyhYEIXaCws1sk9Bojdb12Q==
+      integrity: sha512-XdD2Sg06xAR9xybVmhVkxiYUjr/1LFb0Z0ae6pbLynw6VbVcYba8EFCSHgANoJgb2uwyPBEJBfWhcgduuynGRg==
       tarball: 'file:projects/rush.tgz'
     version: 0.0.0
   'file:projects/rushell.tgz':
@@ -10159,7 +10776,7 @@ packages:
     dev: false
     name: '@rush-temp/rushell'
     resolution:
-      integrity: sha512-0YaN/KPyqf7EA3pcnTacFgQlFfjO4FDD24oant3SaJFeXF4rOFFXXNH3Tngnd4NAlqFNXfGmYt3PQSg7XPRHYQ==
+      integrity: sha512-wEtok2Sj2W71vwhEi9PPzIkSHrv7JDLIDxkqIsFFwfQgS1s2G4jvOwRKUgvauyO47ATtuS5mnc3Tm9/Ua69CKQ==
       tarball: 'file:projects/rushell.tgz'
     version: 0.0.0
   'file:projects/set-webpack-public-path-plugin.tgz':
@@ -10178,7 +10795,7 @@ packages:
     dev: false
     name: '@rush-temp/set-webpack-public-path-plugin'
     resolution:
-      integrity: sha512-jZBUXeLzjT9LqG8lV8DWP1zYxs1LI4Ewlj2QCSZ2qjxn8W6drRV7130J7CPMbQYhQ/OJahMS9Obo+HIHc6gvqA==
+      integrity: sha512-mLm52mjIC7fqaM3I+rm2x7iLX6vC9PtZ/7w/VIHNBJNX4mPZp1HJNI9wz1rqsLfaIZyYzMNMLoVAuoZdwbU/9Q==
       tarball: 'file:projects/set-webpack-public-path-plugin.tgz'
     version: 0.0.0
   'file:projects/stream-collator.tgz':
@@ -10193,7 +10810,7 @@ packages:
     dev: false
     name: '@rush-temp/stream-collator'
     resolution:
-      integrity: sha512-Oo3xRdkT/3HyUeivPymWP7UusyZF/7cgMZWdAfse8Nk10VX0KjHn/Hsn7jSaPJyoNRkInfnkkgsbLnZ/szTdvQ==
+      integrity: sha512-OScdbjOHIPeGhH23sDmRq+KqXcCUw1Q/MIYW5bMFC/QhpDG6z3CorCJ6279EK84KjEhRUxmuZAJMtZVzBCI3VA==
       tarball: 'file:projects/stream-collator.tgz'
     version: 0.0.0
   'file:projects/ts-command-line.tgz':
@@ -10220,7 +10837,7 @@ packages:
     dev: false
     name: '@rush-temp/web-library-build-test'
     resolution:
-      integrity: sha512-K4VgFxMsYXg6Gy/bp533POekrn9JBbgzOMpW3xDltQqmAstV8exoynh/ItDJcs65IL56+km3xXmbkhHO+BnPuA==
+      integrity: sha512-qwrTHE3EcrckkH2WwGOThpN1L45jypkf0zMGay6xtiH9O6XUWiCl+JSF4Kkjfs5TEDkSjhbL5Wg0faXSizYsBw==
       tarball: 'file:projects/web-library-build-test.tgz'
     version: 0.0.0
   'file:projects/web-library-build.tgz':
@@ -10232,7 +10849,7 @@ packages:
     dev: false
     name: '@rush-temp/web-library-build'
     resolution:
-      integrity: sha512-2C4yTrXduyHy5moeozmCnXFJddoJpKlNoeSE4nSpPbxX1CmskclUvYZLOE7a6+gCs33I05oVbSoqpx5IN3pUOA==
+      integrity: sha512-lSWR7HNAKTr2dJdVMgznHqVy5iffGhJYtuN0TIFVYNoSCvWWzBXHr0SyzISeEAYexAQ7Zs6bSjONYHyFw9kb6A==
       tarball: 'file:projects/web-library-build.tgz'
     version: 0.0.0
 specifiers:
@@ -10343,6 +10960,10 @@ specifiers:
   '@types/webpack-env': 1.13.0
   '@types/yargs': 0.0.34
   '@types/z-schema': 3.16.31
+  '@typescript-eslint/eslint-plugin': 2.0.0
+  '@typescript-eslint/experimental-utils': 2.0.0
+  '@typescript-eslint/parser': 2.0.0
+  '@typescript-eslint/typescript-estree': 2.0.0
   '@yarnpkg/lockfile': ~1.0.2
   argparse: ~1.0.9
   autoprefixer: ~9.1.3
@@ -10355,6 +10976,11 @@ specifiers:
   decomment: ~0.9.1
   del: ^2.2.2
   end-of-stream: ~1.1.0
+  eslint: ^6.0.0
+  eslint-plugin-no-null: ~1.0.2
+  eslint-plugin-promise: ~4.2.1
+  eslint-plugin-react: ~7.14.3
+  eslint-plugin-security: ~1.4.0
   express: ~4.16.2
   fs-extra: ~7.0.1
   git-repo-info: ~2.1.0
@@ -10408,6 +11034,7 @@ specifiers:
   ts-jest: ~22.4.6
   tslint: ~5.12.1
   tslint-microsoft-contrib: ~5.2.1
+  typescript: ~3.4.3
   uglify-js: ~3.0.28
   vinyl: ~2.2.0
   webpack: ~3.11.0

--- a/libraries/eslint-config-scalable-ts/index.js
+++ b/libraries/eslint-config-scalable-ts/index.js
@@ -187,7 +187,7 @@ module.exports = {
           "error",
           {
             "arrayDestructuring": false,
-            "arrowParameter": true,
+            "arrowParameter": false,
             "memberVariableDeclaration": true,
             "parameter": true,
             "objectDestructuring": false,

--- a/libraries/eslint-config-scalable-ts/index.js
+++ b/libraries/eslint-config-scalable-ts/index.js
@@ -120,14 +120,16 @@ module.exports = {
         // STANDARDIZED BY:   @typescript-eslint\eslint-plugin\dist\configs\recommended.json
         "@typescript-eslint/no-misused-new": "error",
 
-        // RATIONALE:         The "module" keyword should only be used for declaring typings for legacy JavaScript
-        //                    libraries.  The "namespace" keyword is not recommended for organizing code because
-        //                    JavaScript lacks a "using" statement to traverse namespaces.  For functions/variables,
-        //                    it's better to group them as members of a class, since the exercise of choosing a
-        //                    meaningful class name tends to produce more discoverable APIs.  Also, a bulk search for
-        //                    e.g. "Text.reverse()" will be more accurate than a short name like "reverse()".
-        //                    If you have too many classes, it's recommended to group them into an NPM package
-        //                    which forces dependencies to be tracked more conscientiously.
+        // RATIONALE:         The "namespace" keyword is not recommended for organizing code because JavaScript lacks
+        //                    a "using" statement to traverse namespaces.  Nested namespaces prevent certain bundler
+        //                    optimizations.  If you are declaring loose functions/variables, it's better to make them
+        //                    static members of a class, since classes support property getters and their private
+        //                    members are accessible by unit tests.  Also, the exercise of choosing a meaningful
+        //                    class name tends to produce more discoverable APIs: for example, search+replacing
+        //                    the function "reverse()" is likely to return many false matches, whereas if we always
+        //                    write "Text.reverse()" is more unique.  For large scale organization, it's recommended
+        //                    to decompose your code into separate NPM packages, which ensures that component
+        //                    dependencies are tracked more conscientiously.
         //
         // STANDARDIZED BY:   @typescript-eslint\eslint-plugin\dist\configs\recommended.json
         "@typescript-eslint/no-namespace": [

--- a/libraries/eslint-config-scalable-ts/index.js
+++ b/libraries/eslint-config-scalable-ts/index.js
@@ -36,7 +36,12 @@ module.exports = {
         "@typescript-eslint/camelcase": "error",
 
         // STANDARDIZED BY:   @typescript-eslint\eslint-plugin\dist\configs\recommended.json
-        "@typescript-eslint/class-name-casing": "error",
+        "@typescript-eslint/class-name-casing": [
+          "error",
+          {
+            "allowUnderscorePrefix": true
+          }
+        ],
 
         // RATIONALE:         We require "x as number" instead of "<number>x" to avoid conflicts with JSX.
         "@typescript-eslint/consistent-type-assertions": "error",
@@ -71,7 +76,13 @@ module.exports = {
         //                    objects, here the "I" prefix also helps by avoiding spurious conflicts with classes
         //                    by the same name.
         //
-        "@typescript-eslint/interface-name-prefix": [ "error", "always" ],
+        "@typescript-eslint/interface-name-prefix": [
+          "error",
+          {
+            "prefixWithI": "always",
+            "allowUnderscorePrefix": true
+          }
+        ],
 
         // RATIONALE:         Requiring private members to be prefixed with an underscore prevents accidental access
         //                    by scripts that are coded in plain JavaScript and cannot see the TypeScript visibility

--- a/libraries/eslint-config-scalable-ts/index.js
+++ b/libraries/eslint-config-scalable-ts/index.js
@@ -4,6 +4,7 @@ module.exports = {
 
   plugins: [
     "@typescript-eslint/eslint-plugin",
+    "eslint-plugin-no-null",
     "eslint-plugin-promise",
     "eslint-plugin-security"
   ],
@@ -454,8 +455,21 @@ module.exports = {
 
         // STANDARDIZED BY:   eslint\conf\eslint-recommended.js
         "use-isnan": "error",
+
+        // RATIONALE:         Most programming languages have a "null" or "nil" value that serves several purposes:
+        //                    (1) the initial value for an uninitialized variable, (2) the value of x.y or x["y"]
+        //                    when x has no such key, and (3) a special token that developers can assign to indicate
+        //                    an unknown or empty state.  In JavaScript, the "undefined" value fulfills all three
+        //                    roles.  JavaScript's "null" value is a redundant secondary token that only fulfills #3,
+        //                    even though its name confusingly implies otherwise.  The "null" value was arguably
+        //                    a mistake in the original JavaScript language design, but it cannot be banned entirely
+        //                    because it is returned by some entrenched system APIs such as JSON.parse(), and also
+        //                    some popular NPM packages.  To avoid requiring lint suppressions when interacting with
+        //                    these legacy APIs, the "no-null" rule prohibits the value but not the type annotation.
+        //                    In other words, it tolerates preexisting nulls but blocks new ones from being
+        //                    introduced.
+        "no-null/no-null": "error",
       }
     }
   ]
 };
-//https://eslint.org/docs/rules/func-style

--- a/libraries/eslint-config-scalable-ts/index.js
+++ b/libraries/eslint-config-scalable-ts/index.js
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
 module.exports = {
   // Disable the parser by default
   parser: "",

--- a/libraries/eslint-config-scalable-ts/index.js
+++ b/libraries/eslint-config-scalable-ts/index.js
@@ -54,7 +54,11 @@ module.exports = {
         // STANDARDIZED BY:   @typescript-eslint\eslint-plugin\dist\configs\recommended.json
         "@typescript-eslint/explicit-function-return-type": [
           "error",
-          { allowTypedFunctionExpressions: true }
+          {
+            allowExpressions: true,
+            allowTypedFunctionExpressions: true,
+            allowHigherOrderFunctions: false,
+          },
         ],
 
         // STANDARDIZED BY:   @typescript-eslint\eslint-plugin\dist\configs\recommended.json
@@ -208,9 +212,6 @@ module.exports = {
         // RATIONALE:         Catches a common coding mistake.
         "accessor-pairs": "error",
 
-        // RATIONALE:         Catches a common coding mistake.
-        "array-callback-return": "error",
-
         // RATIONALE:         In TypeScript, if you write x["y"] instead of x.y, it disables type checking.
         "dot-notation": "error",
 
@@ -313,9 +314,6 @@ module.exports = {
 
         // RATIONALE:         Catches a common coding mistake.
         "no-implied-eval": "error",
-
-        // STANDARDIZED BY:   eslint\conf\eslint-recommended.js
-        "no-inner-declarations": "error",
 
         // STANDARDIZED BY:   eslint\conf\eslint-recommended.js
         "no-invalid-regexp": "error",
@@ -438,3 +436,4 @@ module.exports = {
     }
   ]
 };
+//https://eslint.org/docs/rules/func-style

--- a/libraries/eslint-config-scalable-ts/index.js
+++ b/libraries/eslint-config-scalable-ts/index.js
@@ -52,7 +52,10 @@ module.exports = {
         //                    but writing code is a much less important activity than reading it.
         //
         // STANDARDIZED BY:   @typescript-eslint\eslint-plugin\dist\configs\recommended.json
-        "@typescript-eslint/explicit-function-return-type": "error",
+        "@typescript-eslint/explicit-function-return-type": [
+          "error",
+          { allowTypedFunctionExpressions: true }
+        ],
 
         // STANDARDIZED BY:   @typescript-eslint\eslint-plugin\dist\configs\recommended.json
         "@typescript-eslint/explicit-member-accessibility": "error",
@@ -64,8 +67,7 @@ module.exports = {
         //                    objects, here the "I" prefix also helps by avoiding spurious conflicts with classes
         //                    by the same name.
         //
-        // STANDARDIZED BY:   @typescript-eslint\eslint-plugin\dist\configs\recommended.json
-        "@typescript-eslint/interface-name-prefix": "error",
+        "@typescript-eslint/interface-name-prefix": [ "error", "always" ],
 
         // RATIONALE:         Requiring private members to be prefixed with an underscore prevents accidental access
         //                    by scripts that are coded in plain JavaScript and cannot see the TypeScript visibility
@@ -242,9 +244,6 @@ module.exports = {
 
         // RATIONALE:         Deprecated language feature.
         "no-caller": "error",
-
-        // STANDARDIZED BY:   eslint\conf\eslint-recommended.js
-        "no-case-declarations": "error",
 
         // STANDARDIZED BY:   eslint\conf\eslint-recommended.js
         "no-compare-neg-zero": "error",

--- a/libraries/eslint-config-scalable-ts/index.js
+++ b/libraries/eslint-config-scalable-ts/index.js
@@ -17,6 +17,12 @@ module.exports = {
         // The "project" path is resolved relative to parserOptions.tsconfigRootDir.
         // Your local .eslintrc.js must specify that parserOptions.tsconfigRootDir=__dirname.
         project: "./tsconfig.json",
+
+        // Allow parsing of newer ECMAScript constructs used in TypeScript source code.  Although tsconfig.json
+        // may allow only a small subset of ES2018 features, this liberal setting ensures that ESLint will correctly
+        // parse whatever is encountered.
+        ecmaVersion: 2018,
+
         sourceType: "module"
       },
 

--- a/libraries/eslint-config-scalable-ts/index.js
+++ b/libraries/eslint-config-scalable-ts/index.js
@@ -213,7 +213,12 @@ module.exports = {
         "accessor-pairs": "error",
 
         // RATIONALE:         In TypeScript, if you write x["y"] instead of x.y, it disables type checking.
-        "dot-notation": "error",
+        "dot-notation": [
+          "error",
+          {
+            "allowPattern": "^_"
+          }
+        ],
 
         // RATIONALE:         Catches a common coding mistake.
         "eqeqeq": "error",

--- a/libraries/eslint-config-scalable-ts/index.js
+++ b/libraries/eslint-config-scalable-ts/index.js
@@ -157,7 +157,16 @@ module.exports = {
         //                    may impact performance.
         //
         // STANDARDIZED BY:   @typescript-eslint\eslint-plugin\dist\configs\recommended.json
-        "@typescript-eslint/no-unused-vars": "error",
+        "@typescript-eslint/no-unused-vars": [
+          "error",
+          {
+            "vars": "all",
+            // Unused function arguments often indicate a mistake in JavaScript code.  However in TypeScript code,
+            // the compiler catches most of those mistakes, and unused arguments are fairly common for type signatures
+            // that are overriding a base class method or implementing an interface.
+            "args": "none"
+          }
+        ],
 
         // STANDARDIZED BY:   @typescript-eslint\eslint-plugin\dist\configs\recommended.json
         "@typescript-eslint/no-use-before-define": "error",

--- a/libraries/eslint-config-scalable-ts/index.js
+++ b/libraries/eslint-config-scalable-ts/index.js
@@ -3,7 +3,9 @@ module.exports = {
   parser: "",
 
   plugins: [
-    "@typescript-eslint"
+    "@typescript-eslint/eslint-plugin",
+    "eslint-plugin-promise",
+    "eslint-plugin-security"
   ],
 
   overrides: [
@@ -410,39 +412,6 @@ module.exports = {
 
         // RATIONALE:         Catches a common coding mistake where "resolve" and "reject" are confused.
         "promise/param-names": "error",
-
-        // RATIONALE:         When React components are added to an array, they generally need a "key".
-        "react/jsx-key": "error",
-
-        // RATIONALE:         Catches a common coding practice that significantly impacts performance.
-        "react/jsx-no-bind": "error",
-
-        // RATIONALE:         Catches a common coding mistake.
-        "react/jsx-no-comment-textnodes": "error",
-
-        // RATIONALE:         Security risk.
-        "react/jsx-no-target-blank": "error",
-
-        // RATIONALE:         Catches a common coding mistake.
-        "react/no-children-prop": "error",
-
-        // RATIONALE:         Catches a common coding mistake.
-        "react/no-danger-with-children": "error",
-
-        // RATIONALE:         Catches a common coding mistake.
-        "react/no-direct-mutation-state": "error",
-
-        // RATIONALE:         Avoids a potential performance problem.
-        "react/no-find-dom-node": "error",
-
-        // RATIONALE:         Deprecated API.
-        "react/no-is-mounted": "error",
-
-        // RATIONALE:         Deprecated API.
-        "react/no-render-return-value": "error",
-
-        // RATIONALE:         Deprecated API.
-        "react/no-string-refs": "error",
 
         // STANDARDIZED BY:   eslint\conf\eslint-recommended.js
         "require-atomic-updates": "error",

--- a/libraries/eslint-config-scalable-ts/index.js
+++ b/libraries/eslint-config-scalable-ts/index.js
@@ -1,0 +1,461 @@
+module.exports = {
+  // Disable the parser by default
+  parser: "",
+
+  plugins: [
+    "@typescript-eslint"
+  ],
+
+  overrides: [
+    {
+      // Declare an override that applies to TypeScript files only
+      "files": [ "*.ts", "*.tsx" ],
+      parser: "@typescript-eslint/parser",
+      parserOptions: {
+        // The "project" path is resolved relative to parserOptions.tsconfigRootDir.
+        // Your local .eslintrc.js must specify that parserOptions.tsconfigRootDir=__dirname.
+        project: "./tsconfig.json",
+        sourceType: "module"
+      },
+
+      rules: {
+        // STANDARDIZED BY:   @typescript-eslint\eslint-plugin\dist\configs\recommended.json
+        "@typescript-eslint/adjacent-overload-signatures": "error",
+
+        // STANDARDIZED BY:   @typescript-eslint\eslint-plugin\dist\configs\recommended.json
+        "@typescript-eslint/array-type": "error",
+
+        // STANDARDIZED BY:   @typescript-eslint\eslint-plugin\dist\configs\recommended.json
+        //
+        // CONFIGURATION:     By default, these are banned: String, Boolean, Number, Object, Symbol
+        "@typescript-eslint/ban-types": "error",
+
+        // STANDARDIZED BY:   @typescript-eslint\eslint-plugin\dist\configs\recommended.json
+        "@typescript-eslint/camelcase": "error",
+
+        // STANDARDIZED BY:   @typescript-eslint\eslint-plugin\dist\configs\recommended.json
+        "@typescript-eslint/class-name-casing": "error",
+
+        // RATIONALE:         We require "x as number" instead of "<number>x" to avoid conflicts with JSX.
+        "@typescript-eslint/consistent-type-assertions": "error",
+
+        // RATIONALE:         We prefer "interface IBlah { x: number }" over "type Blah = { x: number }"
+        //                    because code is more readable when it is built from stereotypical forms
+        //                    (interfaces, enums, functions, etc.) instead of freeform type algebra.
+        "@typescript-eslint/consistent-type-definitions": "error",
+
+        // RATIONALE:         Code is more readable when the type of every variable is immediately obvious.
+        //                    Even if the compiler may be able to infer a type, this inference will be unavailable
+        //                    to a person who is reviewing a GitHub diff.  This rule makes writing code harder,
+        //                    but writing code is a much less important activity than reading it.
+        //
+        // STANDARDIZED BY:   @typescript-eslint\eslint-plugin\dist\configs\recommended.json
+        "@typescript-eslint/explicit-function-return-type": "error",
+
+        // STANDARDIZED BY:   @typescript-eslint\eslint-plugin\dist\configs\recommended.json
+        "@typescript-eslint/explicit-member-accessibility": "error",
+
+        // RATIONALE:         It is very common for a class to implement an interface of the same name.
+        //                    For example, the Widget class may implement the IWidget interface.  The "I" prefix
+        //                    avoids the need to invent a separate name such as "AbstractWidget" or "WidgetInterface".
+        //                    In TypeScript it is also common to declare interfaces that are implemented by primitive
+        //                    objects, here the "I" prefix also helps by avoiding spurious conflicts with classes
+        //                    by the same name.
+        //
+        // STANDARDIZED BY:   @typescript-eslint\eslint-plugin\dist\configs\recommended.json
+        "@typescript-eslint/interface-name-prefix": "error",
+
+        // RATIONALE:         Requiring private members to be prefixed with an underscore prevents accidental access
+        //                    by scripts that are coded in plain JavaScript and cannot see the TypeScript visibility
+        //                    declarations.  Also, using underscore prefixes allows the private field to be exposed
+        //                    by a public getter/setter with the same name (but omitting the underscore).
+        "@typescript-eslint/member-naming": ["error", { "private": "^_" }],
+
+        // RATIONALE:         Object-oriented programming organizes code into "classes" that associate
+        //                    data structures (the class's fields) and the operations performed on those
+        //                    data structures (the class's members).  Studying the fields often reveals the "idea"
+        //                    behind a class.  The choice of which class a field belongs to may greatly impact
+        //                    the code readability and complexity.  Thus, we group the fields prominently at the top
+        //                    of the class declaration.  We do NOT enforce sorting based on public/protected/private
+        //                    or static/instance, because these designations tend to change as code evolves, and
+        //                    reordering methods produces spurious diffs that make PRs hard to read.  For classes
+        //                    with lots of methods, alphabetization is probably a more useful secondary ordering.
+        "@typescript-eslint/member-ordering": [
+          "error",
+          {
+            "default": "never",
+            "classes": [
+              "field",
+              "constructor",
+              "method"
+            ]
+          }
+        ],
+
+        // STANDARDIZED BY:   @typescript-eslint\eslint-plugin\dist\configs\recommended.json
+        "@typescript-eslint/no-array-constructor": "error",
+
+        // STANDARDIZED BY:   @typescript-eslint\eslint-plugin\dist\configs\recommended.json
+        //
+        // RATIONALE:         The "any" keyword disables static type checking, the main benefit of using TypeScript.
+        //                    This rule should be suppressed only in very special cases such as JSON.stringify()
+        //                    where the type really can be anything.  Even if the type is flexible, another type
+        //                    may be more appropriate such as "unknown", "{}", or "Record<k,V>".
+        "@typescript-eslint/no-explicit-any": "error",
+
+        // RATIONALE:         The #1 rule of promises is that every promise chain must be terminated by a catch()
+        //                    handler.  Thus wherever a Promise arises, the code must either append a catch handler,
+        //                    or else return the object to a caller (who assumes this responsibility).  Unterminated
+        //                    promise chains are a serious issue.  Besides causing errors to be silently ignored,
+        //                    they can also cause a NodeJS process to terminate unexpectedly.
+        "@typescript-eslint/no-floating-promises": "error",
+
+        // RATIONALE:         Catches a common coding mistake.
+        "@typescript-eslint/no-for-in-array": "error",
+
+        // STANDARDIZED BY:   @typescript-eslint\eslint-plugin\dist\configs\recommended.json
+        "@typescript-eslint/no-misused-new": "error",
+
+        // RATIONALE:         The "module" keyword should only be used for declaring typings for legacy JavaScript
+        //                    libraries.  The "namespace" keyword is not recommended for organizing code because
+        //                    JavaScript lacks a "using" statement to traverse namespaces.  For functions/variables,
+        //                    it's better to group them as members of a class, since the exercise of choosing a
+        //                    meaningful class name tends to produce more discoverable APIs.  Also, a bulk search for
+        //                    e.g. "Text.reverse()" will be more accurate than a short name like "reverse()".
+        //                    If you have too many classes, it's recommended to group them into an NPM package
+        //                    which forces dependencies to be tracked more conscientiously.
+        //
+        // STANDARDIZED BY:   @typescript-eslint\eslint-plugin\dist\configs\recommended.json
+        "@typescript-eslint/no-namespace": [
+          "error",
+          {
+            // Discourage "namespace" in .ts and .tsx files
+            "allowDeclarations": false,
+
+            // Allow it in .d.ts files that describe legacy libraries
+            "allowDefinitionFiles": false
+          }
+        ],
+
+        // RATIONALE:         Parameter properties provide a shorthand such as "constructor(public title: string)"
+        //                    that avoids the effort of declaring "title" as a field.  This TypeScript feature makes
+        //                    code easier to write, but arguably sacrifices readability:  In the notes for
+        //                    "@typescript-eslint/member-ordering" we pointed out that fields are central to
+        //                    a class's design, so we wouldn't want to bury them in a constructor signature
+        //                    just to save some typing.
+        //
+        // STANDARDIZED BY:   @typescript-eslint\eslint-plugin\dist\configs\recommended.json
+        "@typescript-eslint/no-parameter-properties": "error",
+
+        // RATIONALE:         When left in shipping code, unused variables often indicate a mistake.  Dead code
+        //                    may impact performance.
+        //
+        // STANDARDIZED BY:   @typescript-eslint\eslint-plugin\dist\configs\recommended.json
+        "@typescript-eslint/no-unused-vars": "error",
+
+        // STANDARDIZED BY:   @typescript-eslint\eslint-plugin\dist\configs\recommended.json
+        "@typescript-eslint/no-use-before-define": "error",
+
+        // RATIONALE:         The require() API is generally obsolete.  Use "import" instead.
+        //
+        // STANDARDIZED BY:   @typescript-eslint\eslint-plugin\dist\configs\recommended.json
+        "@typescript-eslint/no-var-requires": "error",
+
+        // RATIONALE:         The "module" keyword is deprecated except when describing legacy libraries.
+        //
+        // STANDARDIZED BY:   @typescript-eslint\eslint-plugin\dist\configs\recommended.json
+        "@typescript-eslint/prefer-namespace-keyword": "error",
+
+        // RATIONALE:         We require explicit type annotations, even when the compiler could infer the type.
+        //                    This is a controversial rule because it makes code more verbose.  The reason is that
+        //                    type inference is useless when reviewing the diff for a pull request or a Git history.
+        //                    Unless the person is already familiar with every file (unlikely in a large project),
+        //                    it can be very difficult to guess the types for a typical statement such as
+        //                    "let item = provider.fetch(options);".  In this situation, explicit type annotations
+        //                    greatly increase readability and justify the extra effort required to write them.
+        //                    Requiring type annotations also discourages anonymous type algebra, and code is easier
+        //                    to reason about when its authors went through the exercise of choosing meaningful names.
+        //
+        // STANDARDIZED BY:   @typescript-eslint\eslint-plugin\dist\configs\recommended.json
+        "@typescript-eslint/typedef": [
+          "error",
+          {
+            "arrayDestructuring": false,
+            "arrowParameter": true,
+            "memberVariableDeclaration": true,
+            "parameter": true,
+            "objectDestructuring": false,
+            "propertyDeclaration": true,
+            "variableDeclaration": true
+          },
+        ],
+
+        // RATIONALE:         Catches a common coding mistake.
+        "accessor-pairs": "error",
+
+        // RATIONALE:         Catches a common coding mistake.
+        "array-callback-return": "error",
+
+        // RATIONALE:         In TypeScript, if you write x["y"] instead of x.y, it disables type checking.
+        "dot-notation": "error",
+
+        // RATIONALE:         Catches a common coding mistake.
+        "eqeqeq": "error",
+
+        // STANDARDIZED BY:   eslint\conf\eslint-recommended.js
+        "for-direction": "error",
+
+        // RATIONALE:         Catches a common coding mistake.
+        "guard-for-in": "error",
+
+        // RATIONALE:         If you have more than 1,000 lines in a single source file, it's probably time
+        //                    to split up your code.
+        "max-lines": ["error", { "max": 1000 }],
+
+        // STANDARDIZED BY:   eslint\conf\eslint-recommended.js
+        "no-async-promise-executor": "error",
+
+        // RATIONALE:         "|" and "&" are relatively rare, and are more likely to appear as a mistake when
+        //                    someone meant "||" or "&&".  (But nobody types the other operators by mistake.)
+        "no-bitwise": [
+          "error",
+          {
+            allow: [
+              "^",
+              // "|",
+              // "&",
+              "<<",
+              ">>",
+              ">>>",
+              "^=",
+              // "|=",
+              //"&=",
+              "<<=",
+              ">>=",
+              ">>>=",
+              "~"
+            ]
+          }
+        ],
+
+        // RATIONALE:         Deprecated language feature.
+        "no-caller": "error",
+
+        // STANDARDIZED BY:   eslint\conf\eslint-recommended.js
+        "no-case-declarations": "error",
+
+        // STANDARDIZED BY:   eslint\conf\eslint-recommended.js
+        "no-compare-neg-zero": "error",
+
+        // STANDARDIZED BY:   eslint\conf\eslint-recommended.js
+        "no-cond-assign": "error",
+
+        // STANDARDIZED BY:   eslint\conf\eslint-recommended.js
+        "no-constant-condition": "error",
+
+        // STANDARDIZED BY:   eslint\conf\eslint-recommended.js
+        "no-control-regex": "error",
+
+        // STANDARDIZED BY:   eslint\conf\eslint-recommended.js
+        "no-debugger": "error",
+
+        // STANDARDIZED BY:   eslint\conf\eslint-recommended.js
+        "no-delete-var": "error",
+
+        // STANDARDIZED BY:   eslint\conf\eslint-recommended.js
+        "no-duplicate-case": "error",
+
+        // STANDARDIZED BY:   eslint\conf\eslint-recommended.js
+        "no-empty": "error",
+
+        // STANDARDIZED BY:   eslint\conf\eslint-recommended.js
+        "no-empty-character-class": "error",
+
+        // STANDARDIZED BY:   eslint\conf\eslint-recommended.js
+        "no-empty-pattern": "error",
+
+        // RATIONALE:         Eval is a security concern and a performance concern.
+        "no-eval": "error",
+
+        // STANDARDIZED BY:   eslint\conf\eslint-recommended.js
+        "no-ex-assign": "error",
+
+        // RATIONALE:         System types are global and should not be tampered with in a scalable code base.
+        //                    If two different libraries (or two versions of the same library) both try to modify
+        //                    a type, only one of them can win.  Polyfills are acceptable because they implement
+        //                    a standardized interoperable contract, but polyfills are generally coded in plain
+        //                    JavaScript.
+        "no-extend-native": "error",
+
+        // STANDARDIZED BY:   eslint\conf\eslint-recommended.js
+        "no-extra-boolean-cast": "error",
+
+        // RATIONALE:         Catches a common coding mistake.
+        "no-extra-label": "error",
+
+        // STANDARDIZED BY:   eslint\conf\eslint-recommended.js
+        "no-fallthrough": "error",
+
+        // STANDARDIZED BY:   eslint\conf\eslint-recommended.js
+        "no-func-assign": "error",
+
+        // RATIONALE:         Catches a common coding mistake.
+        "no-implied-eval": "error",
+
+        // STANDARDIZED BY:   eslint\conf\eslint-recommended.js
+        "no-inner-declarations": "error",
+
+        // STANDARDIZED BY:   eslint\conf\eslint-recommended.js
+        "no-invalid-regexp": "error",
+
+        // RATIONALE:         Catches a common coding mistake.
+        "no-label-var": "error",
+
+        // RATIONALE:         Eliminates redundant code.
+        "no-lone-blocks": "error",
+
+        // STANDARDIZED BY:   eslint\conf\eslint-recommended.js
+        "no-misleading-character-class": "error",
+
+        // RATIONALE:         Catches a common coding mistake.
+        "no-multi-str": "error",
+
+        // RATIONALE:         It's generally a bad practice to call "new Thing()" without assigning the result to
+        //                    a variable.  Either it's part of an awkward expression like "(new Thing()).doSomething()",
+        //                    or else implies that the constructor is doing nontrivial computations, which is often
+        //                    a poor class design.
+        "no-new": "error",
+
+        // RATIONALE:         Obsolete notation that is error-prone.
+        "no-new-func": "error",
+
+        // RATIONALE:         Obsolete notation.
+        "no-new-object": "error",
+
+        // RATIONALE:         Obsolete notation.
+        "no-new-wrappers": "error",
+
+        // STANDARDIZED BY:   eslint\conf\eslint-recommended.js
+        "no-octal": "error",
+
+        // RATIONALE:         Catches a common coding mistake.
+        "no-octal-escape": "error",
+
+        // STANDARDIZED BY:   eslint\conf\eslint-recommended.js
+        "no-regex-spaces": "error",
+
+        // RATIONALE:         Catches a common coding mistake.
+        "no-return-assign": "error",
+
+        // RATIONALE:         Security risk.
+        "no-script-url": "error",
+
+        // STANDARDIZED BY:   eslint\conf\eslint-recommended.js
+        "no-self-assign": "error",
+
+        // RATIONALE:         Catches a common coding mistake.
+        "no-self-compare": "error",
+
+        // RATIONALE:         This avoids statements such as "while (a = next(), a && a.length);" that use
+        //                    commas to create compound expressions.  In general code is more readable if each
+        //                    step is split onto a separate line.  This also makes it easier to set breakpoints
+        //                    in the debugger.
+        "no-sequences": "error",
+
+        // STANDARDIZED BY:   eslint\conf\eslint-recommended.js
+        "no-shadow-restricted-names": "error",
+
+        // STANDARDIZED BY:   eslint\conf\eslint-recommended.js
+        "no-sparse-arrays": "error",
+
+        // RATIONALE:         Although in theory JavaScript allows any possible data type to be thrown as an exception,
+        //                    such flexibility adds pointless complexity, by requiring every catch block to test
+        //                    the type of the object that it receives.  Whereas if catch blocks can always assume
+        //                    that their object implements the "Error" contract, then the code is simpler, and
+        //                    we generally get useful additional information like a call stack.
+        "no-throw-literal": "error",
+
+        // RATIONALE:         Catches a common coding mistake.
+        "no-unmodified-loop-condition": "error",
+
+        // STANDARDIZED BY:   eslint\conf\eslint-recommended.js
+        "no-unsafe-finally": "error",
+
+        // RATIONALE:         Catches a common coding mistake.
+        "no-unused-expressions": "error",
+
+        // STANDARDIZED BY:   eslint\conf\eslint-recommended.js
+        "no-unused-labels": "error",
+
+        // STANDARDIZED BY:   eslint\conf\eslint-recommended.js
+        "no-useless-catch": "error",
+
+        // RATIONALE:         Avoids a potential performance problem.
+        "no-useless-concat": "error",
+
+        // RATIONALE:         The "var" keyword is deprecated because of its confusing "hoisting" behavior.
+        //                    Always use "let" or "const" instead.
+        //
+        // STANDARDIZED BY:   @typescript-eslint\eslint-plugin\dist\configs\recommended.json
+        "no-var": "error",
+
+        // RATIONALE:         Generally not needed in modern code.
+        "no-void": "error",
+
+        // STANDARDIZED BY:   eslint\conf\eslint-recommended.js
+        "no-with": "error",
+
+        // @typescript-eslint\eslint-plugin\dist\configs\eslint-recommended.js
+        "prefer-const": "error",
+
+        // RATIONALE:         Catches a common coding mistake where "resolve" and "reject" are confused.
+        "promise/param-names": "error",
+
+        // RATIONALE:         When React components are added to an array, they generally need a "key".
+        "react/jsx-key": "error",
+
+        // RATIONALE:         Catches a common coding practice that significantly impacts performance.
+        "react/jsx-no-bind": "error",
+
+        // RATIONALE:         Catches a common coding mistake.
+        "react/jsx-no-comment-textnodes": "error",
+
+        // RATIONALE:         Security risk.
+        "react/jsx-no-target-blank": "error",
+
+        // RATIONALE:         Catches a common coding mistake.
+        "react/no-children-prop": "error",
+
+        // RATIONALE:         Catches a common coding mistake.
+        "react/no-danger-with-children": "error",
+
+        // RATIONALE:         Catches a common coding mistake.
+        "react/no-direct-mutation-state": "error",
+
+        // RATIONALE:         Avoids a potential performance problem.
+        "react/no-find-dom-node": "error",
+
+        // RATIONALE:         Deprecated API.
+        "react/no-is-mounted": "error",
+
+        // RATIONALE:         Deprecated API.
+        "react/no-render-return-value": "error",
+
+        // RATIONALE:         Deprecated API.
+        "react/no-string-refs": "error",
+
+        // STANDARDIZED BY:   eslint\conf\eslint-recommended.js
+        "require-atomic-updates": "error",
+
+        // STANDARDIZED BY:   eslint\conf\eslint-recommended.js
+        "require-yield": "error",
+
+        // "Use strict" is redundant when using the TypeScript compiler.
+        "strict": ["error", "never"],
+
+        // STANDARDIZED BY:   eslint\conf\eslint-recommended.js
+        "use-isnan": "error",
+      }
+    }
+  ]
+};

--- a/libraries/eslint-config-scalable-ts/package.json
+++ b/libraries/eslint-config-scalable-ts/package.json
@@ -19,8 +19,10 @@
     "typescript": ">=3.0.0"
   },
   "dependencies": {
-    "@typescript-eslint/eslint-plugin": "2.0.0-alpha.5",
-    "@typescript-eslint/parser": "2.0.0-alpha.5",
+    "@typescript-eslint/eslint-plugin": "2.0.0",
+    "@typescript-eslint/experimental-utils": "2.0.0",
+    "@typescript-eslint/parser": "2.0.0",
+    "@typescript-eslint/typescript-estree": "2.0.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-promise": "~4.2.1",
     "eslint-plugin-react": "~7.14.3",

--- a/libraries/eslint-config-scalable-ts/package.json
+++ b/libraries/eslint-config-scalable-ts/package.json
@@ -15,15 +15,19 @@
     "eslint-config"
   ],
   "peerDependencies": {
-    "eslint": "^5.0.0"
+    "eslint": "^6.0.0",
+    "typescript": ">=3.0.0"
+  },
+  "dependencies": {
+    "@typescript-eslint/eslint-plugin": "2.0.0-alpha.5",
+    "@typescript-eslint/parser": "2.0.0-alpha.5",
+    "eslint-plugin-no-null": "~1.0.2",
+    "eslint-plugin-promise": "~4.2.1",
+    "eslint-plugin-react": "~7.14.3",
+    "eslint-plugin-security": "~1.4.0"
   },
   "devDependencies": {
-    "@typescript-eslint/eslint-plugin": "^2.0.0-alpha.4",
-    "@typescript-eslint/parser": "^1.13.0",
-    "eslint-plugin-promise": "^4.2.1",
-    "eslint-plugin-react": "^7.14.3",
-    "eslint-plugin-security": "^1.4.0",
-    "eslint": "^5.0.0",
+    "eslint": "^6.0.0",
     "typescript": "~3.5.3"
   }
 }

--- a/libraries/eslint-config-scalable-ts/package.json
+++ b/libraries/eslint-config-scalable-ts/package.json
@@ -13,5 +13,15 @@
     "eslint",
     "typescript",
     "eslint-config"
-  ]
+  ],
+  "peerDependencies": {
+    "eslint": "^5.0.0"
+  },
+  "devDependencies": {
+    "@typescript-eslint/eslint-plugin": "^1.12.0",
+    "@typescript-eslint/parser": "^1.12.0",
+    "eslint": "^5.0.0",
+    "eslint-config-prettier": "^6.0.0",
+    "typescript": "^3.5.3"
+  }
 }

--- a/libraries/eslint-config-scalable-ts/package.json
+++ b/libraries/eslint-config-scalable-ts/package.json
@@ -18,11 +18,11 @@
     "eslint": "^5.0.0"
   },
   "devDependencies": {
-    "@typescript-eslint/eslint-plugin": "~1.12.0",
-    "@typescript-eslint/parser": "~1.12.0",
-    "eslint-plugin-promise": "~4.2.1",
-    "eslint-plugin-react": "~7.14.3",
-    "eslint-plugin-security": "~1.4.0",
+    "@typescript-eslint/eslint-plugin": "^2.0.0-alpha.4",
+    "@typescript-eslint/parser": "^1.13.0",
+    "eslint-plugin-promise": "^4.2.1",
+    "eslint-plugin-react": "^7.14.3",
+    "eslint-plugin-security": "^1.4.0",
     "eslint": "^5.0.0",
     "typescript": "~3.5.3"
   }

--- a/libraries/eslint-config-scalable-ts/package.json
+++ b/libraries/eslint-config-scalable-ts/package.json
@@ -18,10 +18,12 @@
     "eslint": "^5.0.0"
   },
   "devDependencies": {
-    "@typescript-eslint/eslint-plugin": "^1.12.0",
-    "@typescript-eslint/parser": "^1.12.0",
+    "@typescript-eslint/eslint-plugin": "~1.12.0",
+    "@typescript-eslint/parser": "~1.12.0",
+    "eslint-plugin-promise": "~4.2.1",
+    "eslint-plugin-react": "~7.14.3",
+    "eslint-plugin-security": "~1.4.0",
     "eslint": "^5.0.0",
-    "eslint-config-prettier": "^6.0.0",
-    "typescript": "^3.5.3"
+    "typescript": "~3.5.3"
   }
 }

--- a/libraries/eslint-config-scalable-ts/patch-eslint6.js
+++ b/libraries/eslint-config-scalable-ts/patch-eslint6.js
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
 // This is a workaround for https://github.com/eslint/eslint/issues/3458
 //
 // To correct how ESLint searches for plugin packages, add this line to the top of your project's .eslintrc.js file:

--- a/libraries/eslint-config-scalable-ts/patch-eslint6.js
+++ b/libraries/eslint-config-scalable-ts/patch-eslint6.js
@@ -1,0 +1,41 @@
+// This is a workaround for https://github.com/eslint/eslint/issues/3458
+//
+// To correct how ESLint searches for plugin packages, add this line to the top of your project's .eslintrc.js file:
+//
+//    require("@microsoft/eslint-config-scalable-ts/patch-eslint");
+//
+const path = require('path');
+
+let currentModule = module;
+while (!/[\\/]eslint[\\/]lib[\\/]cli-engine[\\/]config-array-factory\.js/i.test(currentModule.filename)) {
+  if (!currentModule.parent) {
+    // This was tested with ESLint 6.1.0; other versions may not work
+    throw new Error('Failed to patch ESLint because the calling module was not recognized');
+  }
+  currentModule = currentModule.parent;
+}
+const eslintFolder = path.join(path.dirname(currentModule.filename), '../..');
+
+const configArrayFactoryPath = path.join(eslintFolder, "lib/cli-engine/config-array-factory");
+const ConfigArrayFactory = require(configArrayFactoryPath).ConfigArrayFactory;
+
+if (!ConfigArrayFactory.__patched) {
+  ConfigArrayFactory.__patched = true;
+
+  const moduleResolverPath = path.join(eslintFolder, "lib/shared/relative-module-resolver");
+  const ModuleResolver = require(moduleResolverPath);
+
+  const originalLoadPlugin = ConfigArrayFactory.prototype._loadPlugin;
+  ConfigArrayFactory.prototype._loadPlugin = function(name, importerPath, importerName) {
+    const originalResolve = ModuleResolver.resolve;
+    try {
+      ModuleResolver.resolve = function (moduleName, relativeToPath) {
+        // resolve using importerPath instead of relativeToPath
+        return originalResolve.call(this, moduleName, importerPath);
+      };
+      return originalLoadPlugin.apply(this, arguments);
+    } finally {
+      ModuleResolver.resolve = originalResolve;
+    }
+  }
+}

--- a/libraries/eslint-config-scalable-ts/react.js
+++ b/libraries/eslint-config-scalable-ts/react.js
@@ -1,0 +1,53 @@
+module.exports = {
+  plugins: [
+    "eslint-plugin-react"
+  ],
+
+  settings: {
+    react: {
+      "version": "detect"
+    }
+  },
+
+  overrides: [
+    {
+      // Declare an override that applies to TypeScript files only
+      "files": [ "*.ts", "*.tsx" ],
+
+      rules: {
+        // RATIONALE:         When React components are added to an array, they generally need a "key".
+        "react/jsx-key": "error",
+
+        // RATIONALE:         Catches a common coding practice that significantly impacts performance.
+        "react/jsx-no-bind": "error",
+
+        // RATIONALE:         Catches a common coding mistake.
+        "react/jsx-no-comment-textnodes": "error",
+
+        // RATIONALE:         Security risk.
+        "react/jsx-no-target-blank": "error",
+
+        // RATIONALE:         Catches a common coding mistake.
+        "react/no-children-prop": "error",
+
+        // RATIONALE:         Catches a common coding mistake.
+        "react/no-danger-with-children": "error",
+
+        // RATIONALE:         Catches a common coding mistake.
+        "react/no-direct-mutation-state": "error",
+
+        // RATIONALE:         Avoids a potential performance problem.
+        "react/no-find-dom-node": "error",
+
+        // RATIONALE:         Deprecated API.
+        "react/no-is-mounted": "error",
+
+        // RATIONALE:         Deprecated API.
+        "react/no-render-return-value": "error",
+
+        // RATIONALE:         Deprecated API.
+        "react/no-string-refs": "error",
+      }
+    }
+  ]
+};

--- a/libraries/eslint-config-scalable-ts/react.js
+++ b/libraries/eslint-config-scalable-ts/react.js
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
 module.exports = {
   plugins: [
     "eslint-plugin-react"

--- a/rush.json
+++ b/rush.json
@@ -584,7 +584,7 @@
       "packageName": "@microsoft/eslint-config-scalable-ts",
       "projectFolder": "libraries/eslint-config-scalable-ts",
       "reviewCategory": "libraries",
-      "shouldPublish": false // For now
+      "shouldPublish": true
     },
     {
       "packageName": "@microsoft/load-themed-styles",


### PR DESCRIPTION
This spring Palantir [announced](https://medium.com/palantir/tslint-in-2019-1a144c2317a9) that they are deprecating TSLint, and instead joining forces to integrate TypeScript linting into ESLint.  This is part of a general effort to enhance ESLint to support parsers for other languages.  As of ESLint 6 and `@typescript-eslint/eslint-plugin` 2.0.0, the implementation now seems to be mature enough for adoption.

This PR is an initial TypeScript rule set for ESLint, based on my earlier conversations with @iclanton.  It follows the spirit of the TSLint rule set for Rush Stack / GCB, but represents a complete ground-up audit of all the rules:

- I started with the union of: "recommended" rules from (1) ESLint for JavaScript, (2) the typescript-eslint plugin, (3) the Prettier plugin, and (4) the React plugin
- I eliminated rules that don't work right on TypeScript files, or are superseded by TypeScript-aware variants, or address issues that aren't relevant to TypeScript
- Tuned these rules based on our goals for a "scalable" monorepo
- Tested the ruleset using symlinked builds of WBT, TSDoc, and also our main internal monorepo at HBO
- Opened a number of issues/PRs for the upstream ESLint project, and ensured all the important issues were addressed before the 2.0.0 release

This PR will publish an initial 0.1.0 release of the new `@microsoft/eslint-config-scalable-ts` package for testing purposes.  Please consider this package "experimental" until the 1.0.0 version bump.  I'll review the rule set in detail with @iclanton when next week he's back; until then, I'm publishing it so we can start converting some projects to to check for any remaining bugs.