### PR TITLE
Fix validation of "hotfix" changes

### DIFF
--- a/apps/rush-lib/src/logic/ChangeFiles.ts
+++ b/apps/rush-lib/src/logic/ChangeFiles.ts
@@ -37,10 +37,14 @@ export class ChangeFiles {
       const changeFile: IChangeInfo = JsonFile.load(filePath);
 
       if (rushConfiguration.hotfixChangeEnabled) {
-        if (changeFile.type !== 'none' && changeFile.type !== 'hotfix') {
-          throw new Error(
-            `Change file ${filePath} specifies a type of '${changeFile.type}' ` +
-            `but only 'hotfix' and 'none' change types may be used in a branch with 'hotfixChangeEnabled'.`);
+        if (changeFile && changeFile.changes) {
+          for (const change of changeFile.changes) {
+            if (change.type !== 'none' && change.type !== 'hotfix') {
+              throw new Error(
+                `Change file ${filePath} specifies a type of '${change.type}' ` +
+                `but only 'hotfix' and 'none' change types may be used in a branch with 'hotfixChangeEnabled'.`);
+            }
+          }
         }
       }
 

--- a/apps/rush-lib/src/logic/test/ChangeFiles.test.ts
+++ b/apps/rush-lib/src/logic/test/ChangeFiles.test.ts
@@ -52,6 +52,12 @@ describe('ChangeFiles', () => {
       }).toThrow(Error);
     });
 
+    it('allows a hotfix in a hotfix branch.', () => {
+      const changeFile: string = path.join(__dirname, 'multipleHotfixChanges', 'change1.json');
+      const changedPackages: string[] = ['a'];
+      ChangeFiles.validate([changeFile], changedPackages, { hotfixChangeEnabled: true } as RushConfiguration);
+    });
+
     it('throws when there is any missing package.', () => {
       const changeFile: string = path.join(__dirname, 'verifyChanges', 'changes.json');
       const changedPackages: string[] = ['a', 'b', 'c'];

--- a/common/changes/@microsoft/rush/master_2019-08-15-16-25.json
+++ b/common/changes/@microsoft/rush/master_2019-08-15-16-25.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Fix validation of hotfix changes in a hotfix-enabled branch",
+      "packageName": "@microsoft/rush",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "ThomasMichon@users.noreply.github.com"
+}


### PR DESCRIPTION
Fixed an issue where a recent change to validate change files in a branch is `hotfixChangeEnabled` was in fact rejecting *all* changes because it was checking the wrong fields from the JSON.
Added a unit test to verify the 'negative' case of hotfix validation, and fixed the validation step.