### PR TITLE
[rush] Allow custom commands to override default rush commands

### DIFF
--- a/apps/rush-lib/src/api/CommandLineJson.ts
+++ b/apps/rush-lib/src/api/CommandLineJson.ts
@@ -13,6 +13,7 @@ export interface IBaseCommandJson {
    */
   description?: string;
   safeForSimultaneousRushProcesses: boolean;
+  overrideDefaultCommand?: boolean;
 }
 
 /**

--- a/apps/rush-lib/src/cli/RushCommandLineParser.ts
+++ b/apps/rush-lib/src/cli/RushCommandLineParser.ts
@@ -250,7 +250,7 @@ export class RushCommandLineParser extends CommandLineParser {
 
     // Register each custom command
     for (const command of commandLineConfiguration.commands) {
-      if (this.tryGetAction(command.name)) {
+      if (!command.overrideDefaultCommand && this.tryGetAction(command.name)) {
         throw new Error(`${RushConstants.commandLineFilename} defines a command "${command.name}"`
           + ` using a name that already exists`);
       }

--- a/apps/rush-lib/src/schemas/command-line.schema.json
+++ b/apps/rush-lib/src/schemas/command-line.schema.json
@@ -46,6 +46,11 @@
           "title": "Safe For Simultaneous Rush Processes",
           "description": "By default, Rush operations acquire a lock file which prevents multiple commands from executing simultaneously in the same repo folder.  (For example, it would be a mistake to run \"rush install\" and \"rush build\" at the same time.)  If your command makes sense to run concurrently with other operations, set safeForSimultaneousRushProcesses=true to disable this protection.  In particular, this is needed for custom scripts that invoke other Rush commands.",
           "type": "boolean"
+        },
+        "overrideDefaultCommand": {
+          "title": "Override Default Command",
+          "description": "By default, Rush does not allow users to specify custom commands with the same name as existing actions. If true, the custom command can be used to replace a default one.",
+          "type": "boolean"
         }
       }
     },

--- a/common/changes/@microsoft/rush/cbub-alias-default-commands_2019-08-16-18-18.json
+++ b/common/changes/@microsoft/rush/cbub-alias-default-commands_2019-08-16-18-18.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Allow override default commands",
+      "packageName": "@microsoft/rush",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "cbub@users.noreply.github.com"
+}


### PR DESCRIPTION
Adding support for users to choose to override default rush commands with their custom commands.

Why: My team is switching to use a different tool to publish packages but continuing to use rush for building. Our normal dev flow includes running rush change and to minimize confusion during the transition I'd like to map that command to a custom command!

I am uncertain how to test this change in your repo. What would you recommend?