### PR TITLE
[rush] Task selection optimizations for repos with a large number of projects.

### DIFF
--- a/apps/rush-lib/src/logic/TaskSelector.ts
+++ b/apps/rush-lib/src/logic/TaskSelector.ts
@@ -26,8 +26,6 @@ export interface ITaskSelectorConstructor {
  *  - based on to/from flags, solving the dependency graph and figuring out which projects need to be run
  *  - creating a ProjectTask for each project that needs to be built
  *  - registering the necessary ProjectTasks with the TaskRunner, which actually orchestrates execution
- *
- * This class is currently only used by CustomRushAction
  */
 export class TaskSelector {
   private _taskCollection: TaskCollection;

--- a/apps/rush-lib/src/logic/TaskSelector.ts
+++ b/apps/rush-lib/src/logic/TaskSelector.ts
@@ -80,16 +80,18 @@ export class TaskSelector {
     }
 
     // Register any dependencies it may have
-    dependencies.forEach(dep => this._registerTask(this._options.rushConfiguration.getProjectByName(dep)));
+    for (const dependency of dependencies) {
+      this._registerTask(this._options.rushConfiguration.getProjectByName(dependency));
+    }
 
     if (!this._options.ignoreDependencyOrder) {
       // Add ordering relationships for each dependency
-      dependencies.forEach(dependency => {
+      for (const dependency of dependencies) {
         this._taskCollection.addDependencies(
           dependency,
           this._rushLinkJson.localLinks[dependency] || []
         );
-      });
+      }
     }
   }
 
@@ -108,19 +110,19 @@ export class TaskSelector {
     }
 
     // Register all downstream dependents
-    dependents.forEach(dependent => {
+    for (const dependent of dependents) {
       this._registerTask(this._options.rushConfiguration.getProjectByName(dependent));
-    });
+    }
 
     if (!this._options.ignoreDependencyOrder) {
       // Only add ordering relationships for projects which have been registered
       // e.g. package C may depend on A & B, but if we are only building A's downstream, we will ignore B
-      dependents.forEach(dependent => {
+      for (const dependent of dependents) {
         this._taskCollection.addDependencies(
           dependent,
           (this._rushLinkJson.localLinks[dependent] || []).filter(dep => dependents.has(dep))
         );
-      });
+      }
     }
   }
 
@@ -145,8 +147,8 @@ export class TaskSelector {
     if (!result.has(project)) {
       result.add(project);
 
-      for (const dep of this._rushLinkJson.localLinks[project] || []) {
-        this._collectAllDependencies(dep, result);
+      for (const dependency of this._rushLinkJson.localLinks[project] || []) {
+        this._collectAllDependencies(dependency, result);
       }
     }
   }
@@ -158,8 +160,8 @@ export class TaskSelector {
     if (!result.has(project)) {
       result.add(project);
 
-      for (const dep of (this._dependentList.get(project) || new Set<string>())) {
-        this._collectAllDependents(dep, result);
+      for (const dependent of (this._dependentList.get(project) || new Set<string>())) {
+        this._collectAllDependents(dependent, result);
       }
     }
   }
@@ -171,14 +173,15 @@ export class TaskSelector {
   private _buildDependentGraph(): void {
     this._dependentList = new Map<string, Set<string>>();
 
-    Object.keys(this._rushLinkJson.localLinks).forEach(project => {
-      this._rushLinkJson.localLinks[project].forEach(dep => {
+    for (const project of Object.keys(this._rushLinkJson.localLinks)) {
+      for (const dep of this._rushLinkJson.localLinks[project]) {
         if (!this._dependentList.has(dep)) {
           this._dependentList.set(dep, new Set<string>());
         }
+
         this._dependentList.get(dep)!.add(project);
-      });
-    });
+      }
+    }
   }
 
   private _registerTask(project: RushConfigurationProject | undefined): void {

--- a/apps/rush-lib/src/logic/TaskSelector.ts
+++ b/apps/rush-lib/src/logic/TaskSelector.ts
@@ -165,8 +165,7 @@ export class TaskSelector {
   }
 
   /**
-   * Inverts the localLinks to arrive at the dependent graph, rather than using the dependency graph
-   * this helps when using the --from flag
+   * Inverts the localLinks to arrive at the dependent graph. This helps when using the --from flag
    */
   private _buildDependentGraph(): void {
     this._dependentList = new Map<string, Set<string>>();

--- a/common/changes/@microsoft/rush/ianc-faster-collect-deps_2019-08-21-08-47.json
+++ b/common/changes/@microsoft/rush/ianc-faster-collect-deps_2019-08-21-08-47.json
@@ -1,7 +1,7 @@
 {
   "changes": [
     {
-      "comment": "Some optmizations for --to, --from, and cyclic dependency detection for repos with large numbers of projects.",
+      "comment": "Some optimizations for --to, --from, and cyclic dependency detection for repos with large numbers of projects.",
       "packageName": "@microsoft/rush",
       "type": "none"
     }

--- a/common/changes/@microsoft/rush/ianc-faster-collect-deps_2019-08-21-08-47.json
+++ b/common/changes/@microsoft/rush/ianc-faster-collect-deps_2019-08-21-08-47.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Some optmizations for --to, --from, and cyclic dependency detection for repos with large numbers of projects.",
+      "packageName": "@microsoft/rush",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "iclanton@users.noreply.github.com"
+}


### PR DESCRIPTION
Running `rush [re]build` on repo with a large number of projects, or running `rush [re]build --to project-with-lots-of-dependencies` or `rush [re]build --from project-with-lots-of-dependents` can cause the process to stall for a long time before starting the actual build. If the dependency graph has a lot of intertwined dependencies, rush will end up doing a lot of repeated computations to determine dependencies/dependents (for `--to`/`--from`) and to ensure there are no cyclic dependencies.

This PR prevents those repeated computations.