### PR TITLE
[eslint-config-scalable-ts] Enable some more React rules

### DIFF
--- a/common/changes/@microsoft/eslint-config-scalable-ts/octogonz-ecst-react-rules_2019-08-21-21-17.json
+++ b/common/changes/@microsoft/eslint-config-scalable-ts/octogonz-ecst-react-rules_2019-08-21-21-17.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/eslint-config-scalable-ts",
+      "comment": "Enable react/no-deprecated, react/no-unescaped-entities, and react/self-closing-comp",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@microsoft/eslint-config-scalable-ts",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/libraries/eslint-config-scalable-ts/react.js
+++ b/libraries/eslint-config-scalable-ts/react.js
@@ -42,8 +42,16 @@ module.exports = {
         // RATIONALE:         Catches a common coding mistake.
         "react/no-danger-with-children": "error",
 
+        // RATIONALE:         Avoids usage of deprecated APIs.
+        //
+        // Note that the set of deprecated APIs is determined by the "react.version" setting.
+        "react/no-deprecated": "error",
+
         // RATIONALE:         Catches a common coding mistake.
         "react/no-direct-mutation-state": "error",
+
+        // RATIONALE:         Catches some common coding mistakes.
+        "react/no-unescaped-entities": "error",
 
         // RATIONALE:         Avoids a potential performance problem.
         "react/no-find-dom-node": "error",
@@ -56,6 +64,9 @@ module.exports = {
 
         // RATIONALE:         Deprecated API.
         "react/no-string-refs": "error",
+
+        // RATIONALE:         Improves syntax for some cases that are not already handled by Prettier.
+        "react/self-closing-comp": "error",
       }
     }
   ]


### PR DESCRIPTION
Enable:
- **react/no-deprecated**:  Don't allow usage of deprecated React APIs
- **react/no-unescaped-entities**:  Catch some common mistakes
- **react/self-closing-comp**:  Require `<div />` instead of `<div></div>`.  Prettier previously implemented this, but removed it due to [a conflict with format-on-save](https://github.com/prettier/prettier/pull/6240)