### PR TITLE
[rush] Don't delete pnpm store for rush install retry

### DIFF
--- a/apps/rush-lib/src/logic/InstallManager.ts
+++ b/apps/rush-lib/src/logic/InstallManager.ts
@@ -942,14 +942,14 @@ export class InstallManager {
             undefined,
             false, () => {
               if (this._rushConfiguration.packageManager === 'pnpm') {
-                // If there is a failure in pnpm, it is possible that it left the
-                // store in a bad state. Therefore, we should clean out the store
-                // before attempting the install again.
-
                 console.log(colors.yellow(`Deleting the "node_modules" folder`));
                 this._commonTempFolderRecycler.moveFolder(commonNodeModulesFolder);
-                console.log(colors.yellow(`Deleting the "pnpm-store" folder`));
-                this._commonTempFolderRecycler.moveFolder(this._rushConfiguration.pnpmStoreFolder);
+
+                // pnpm-store is managed by PNPM internally, so leave it as is for the retry.
+                // This also ensures that packages that have already been downloaded need not be
+                // downloaded again for the retry, thereby potentially increasing the chances of
+                // successful install. If the installation fails again, rush purge shall be used to
+                // clear the common/temp folder.
 
                 Utilities.createFolderWithRetry(commonNodeModulesFolder);
               }

--- a/apps/rush-lib/src/logic/InstallManager.ts
+++ b/apps/rush-lib/src/logic/InstallManager.ts
@@ -947,9 +947,9 @@ export class InstallManager {
 
                 // pnpm-store is managed by PNPM internally, so leave it as is for the retry.
                 // This also ensures that packages that have already been downloaded need not be
-                // downloaded again for the retry, thereby potentially increasing the chances of
-                // successful install. If the installation fails again, rush purge shall be used to
-                // clear the common/temp folder.
+                // downloaded again, thereby potentially increasing the chances of a successful
+                // install. If the installation fails again, rush purge may be used to clear
+                // the common/temp folder.
 
                 Utilities.createFolderWithRetry(commonNodeModulesFolder);
               }

--- a/common/changes/@microsoft/rush/sachinjoseph-dontDeletePnpmStoreForInstallRetry_2019-08-27-17-25.json
+++ b/common/changes/@microsoft/rush/sachinjoseph-dontDeletePnpmStoreForInstallRetry_2019-08-27-17-25.json
@@ -1,7 +1,7 @@
 {
   "changes": [
     {
-      "comment": "Do not delete the store if an installation retry fails. Delete store if and only if all the retry attempts fail.",
+      "comment": "Do not delete the pnpm store if an installation retry fails. Delete the pnpm store if and only if all the installation retry attempts fail.",
       "packageName": "@microsoft/rush",
       "type": "none"
     }

--- a/common/changes/@microsoft/rush/sachinjoseph-dontDeletePnpmStoreForInstallRetry_2019-08-27-17-25.json
+++ b/common/changes/@microsoft/rush/sachinjoseph-dontDeletePnpmStoreForInstallRetry_2019-08-27-17-25.json
@@ -1,7 +1,7 @@
 {
   "changes": [
     {
-      "comment": "Do not delete the pnpm-store for a rush install retry.",
+      "comment": "Do not delete the store if an installation retry fails. Delete store if and only if all the retry attempts fail.",
       "packageName": "@microsoft/rush",
       "type": "none"
     }

--- a/common/changes/@microsoft/rush/sachinjoseph-dontDeletePnpmStoreForInstallRetry_2019-08-27-17-25.json
+++ b/common/changes/@microsoft/rush/sachinjoseph-dontDeletePnpmStoreForInstallRetry_2019-08-27-17-25.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Do not delete the pnpm-store for a rush install retry.",
+      "packageName": "@microsoft/rush",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "sachinjoseph@users.noreply.github.com"
+}


### PR DESCRIPTION
`pnpm-store` is managed by PNPM internally, so leave it as is for the retry. This also ensures that packages that have already been downloaded need not be downloaded again, thereby potentially increasing the chances of a successful install. If the installation fails again, `rush purge` may be used to clear the `common/temp` folder.