### PR TITLE
Support pnpm hardened resolution suffixes

### DIFF
--- a/apps/rush-lib/src/logic/pnpm/PnpmShrinkwrapFile.ts
+++ b/apps/rush-lib/src/logic/pnpm/PnpmShrinkwrapFile.ts
@@ -114,9 +114,10 @@ export function extractVersionFromPnpmVersionSpecifier(version: string): string 
     return versionParts[3]; // e.g. "3.1.1"
   }
 
-  if (semver.valid(versionParts[versionParts.length - 1]) !== null) {
+  const trimmedVersion = versionParts[versionParts.length - 1].split('_')[0];
+  if (semver.valid(trimmedVersion) !== null) {
     // Example: "path.pkgs.visualstudio.com/@scope/depame/1.4.0"
-    return versionParts[versionParts.length - 1];  // e.g. "1.4.0"
+    return trimmedVersion;  // e.g. "1.4.0"
   }
 
   return undefined;

--- a/common/changes/@microsoft/rush/patch-1_2019-09-02-17-49.json
+++ b/common/changes/@microsoft/rush/patch-1_2019-09-02-17-49.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Fixing the bug with pnpm-lock.yaml syntax",
+      "packageName": "@microsoft/rush",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "jabher@users.noreply.github.com"
+}


### PR DESCRIPTION
So, while working on why https://github.com/microsoft/web-build-tools/issues/1500 is happening and how it can be fixed I've discovered that PNPM has *valid* syntax for modules like `X.X.X_{packageName@packageVersion}[+packageName@packageVersion]*`.

It is uncommon case, and I've encountered it for the first time ever, but it is 100% valid behavior of pnpm, as implemented here: [pnpm/.../resolvePeers.ts#L400](https://github.com/pnpm/pnpm/blob/856653ea2f6d42bbe6ceee4fee132d0aa788e1a2/packages/supi/src/install/resolvePeers.ts#L400).

There is no other way to fix this, and this can be an unexpected work-stopper for any large repo.