### PR TITLE
[eslint-config-scalable-ts] Upgrade @typescript-eslint/eslint-plugin

### DIFF
--- a/common/changes/@microsoft/eslint-config-scalable-ts/octogonz-ecst-upgrade-plugin_2019-09-03-22-31.json
+++ b/common/changes/@microsoft/eslint-config-scalable-ts/octogonz-ecst-upgrade-plugin_2019-09-03-22-31.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/eslint-config-scalable-ts",
+      "comment": "Upgrade to @typescript-eslint/eslint-plugin 2.1.0",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/eslint-config-scalable-ts",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -106,10 +106,10 @@ dependencies:
   '@types/webpack-env': 1.13.0
   '@types/yargs': 0.0.34
   '@types/z-schema': 3.16.31
-  '@typescript-eslint/eslint-plugin': 2.0.0
-  '@typescript-eslint/experimental-utils': 2.0.0
-  '@typescript-eslint/parser': 2.0.0
-  '@typescript-eslint/typescript-estree': 2.0.0
+  '@typescript-eslint/eslint-plugin': 2.1.0
+  '@typescript-eslint/experimental-utils': 2.1.0
+  '@typescript-eslint/parser': 2.1.0
+  '@typescript-eslint/typescript-estree': 2.1.0
   '@yarnpkg/lockfile': 1.0.2
   argparse: 1.0.10
   autoprefixer: 9.1.5
@@ -788,9 +788,9 @@ packages:
     dev: false
     resolution:
       integrity: sha1-LrHQCl5Ow/pYx2r94S4YK2bcXBw=
-  /@typescript-eslint/eslint-plugin/2.0.0:
+  /@typescript-eslint/eslint-plugin/2.1.0:
     dependencies:
-      '@typescript-eslint/experimental-utils': 2.0.0
+      '@typescript-eslint/experimental-utils': 2.1.0
       eslint-utils: 1.4.2
       functional-red-black-tree: 1.0.1
       regexpp: 2.0.1
@@ -799,15 +799,15 @@ packages:
     engines:
       node: ^8.10.0 || ^10.13.0 || >=11.10.1
     peerDependencies:
-      '@typescript-eslint/parser': ^2.0.0-alpha.0
+      '@typescript-eslint/parser': ^2.0.0
       eslint: ^5.0.0 || ^6.0.0
       typescript: '*'
     resolution:
-      integrity: sha512-Mo45nxTTELODdl7CgpZKJISvLb+Fu64OOO2ZFc2x8sYSnUpFrBUW3H+H/ZGYmEkfnL6VkdtOSxgdt+Av79j0sA==
-  /@typescript-eslint/eslint-plugin/2.0.0_d51a29263799c2687000fd5b6fe704f3:
+      integrity: sha512-3i/dLPwxaVfCsaLu3HkB8CAA1Uw3McAegrTs+VBJ0BrGRKW7nUwSqRfHfCS7sw7zSbf62q3v0v6pOS8MyaYItg==
+  /@typescript-eslint/eslint-plugin/2.1.0_c10ced963ec7292cbfc7658a8880d356:
     dependencies:
-      '@typescript-eslint/experimental-utils': 2.0.0_eslint@6.2.2
-      '@typescript-eslint/parser': 2.0.0_eslint@6.2.2
+      '@typescript-eslint/experimental-utils': 2.1.0_eslint@6.2.2
+      '@typescript-eslint/parser': 2.1.0_eslint@6.2.2
       eslint: 6.2.2
       eslint-utils: 1.4.2
       functional-red-black-tree: 1.0.1
@@ -817,15 +817,15 @@ packages:
     engines:
       node: ^8.10.0 || ^10.13.0 || >=11.10.1
     peerDependencies:
-      '@typescript-eslint/parser': ^2.0.0-alpha.0
+      '@typescript-eslint/parser': ^2.0.0
       eslint: ^5.0.0 || ^6.0.0
       typescript: '*'
     resolution:
-      integrity: sha512-Mo45nxTTELODdl7CgpZKJISvLb+Fu64OOO2ZFc2x8sYSnUpFrBUW3H+H/ZGYmEkfnL6VkdtOSxgdt+Av79j0sA==
-  /@typescript-eslint/experimental-utils/2.0.0:
+      integrity: sha512-3i/dLPwxaVfCsaLu3HkB8CAA1Uw3McAegrTs+VBJ0BrGRKW7nUwSqRfHfCS7sw7zSbf62q3v0v6pOS8MyaYItg==
+  /@typescript-eslint/experimental-utils/2.1.0:
     dependencies:
       '@types/json-schema': 7.0.3
-      '@typescript-eslint/typescript-estree': 2.0.0
+      '@typescript-eslint/typescript-estree': 2.1.0
       eslint-scope: 4.0.3
     dev: false
     engines:
@@ -833,11 +833,11 @@ packages:
     peerDependencies:
       eslint: '*'
     resolution:
-      integrity: sha512-XGJG6GNBXIEx/mN4eTRypN/EUmsd0VhVGQ1AG+WTgdvjHl0G8vHhVBHrd/5oI6RRYBRnedNymSYWW1HAdivtmg==
-  /@typescript-eslint/experimental-utils/2.0.0_eslint@6.2.2:
+      integrity: sha512-ZJGLYXa4nxjNzomaEk1qts38B/vludg2LOM7dRc7SppEKsMPTS1swaTKS/pom+x4d/luJGoG00BDIss7PR1NQA==
+  /@typescript-eslint/experimental-utils/2.1.0_eslint@6.2.2:
     dependencies:
       '@types/json-schema': 7.0.3
-      '@typescript-eslint/typescript-estree': 2.0.0
+      '@typescript-eslint/typescript-estree': 2.1.0
       eslint: 6.2.2
       eslint-scope: 4.0.3
     dev: false
@@ -846,12 +846,12 @@ packages:
     peerDependencies:
       eslint: '*'
     resolution:
-      integrity: sha512-XGJG6GNBXIEx/mN4eTRypN/EUmsd0VhVGQ1AG+WTgdvjHl0G8vHhVBHrd/5oI6RRYBRnedNymSYWW1HAdivtmg==
-  /@typescript-eslint/parser/2.0.0:
+      integrity: sha512-ZJGLYXa4nxjNzomaEk1qts38B/vludg2LOM7dRc7SppEKsMPTS1swaTKS/pom+x4d/luJGoG00BDIss7PR1NQA==
+  /@typescript-eslint/parser/2.1.0:
     dependencies:
       '@types/eslint-visitor-keys': 1.0.0
-      '@typescript-eslint/experimental-utils': 2.0.0
-      '@typescript-eslint/typescript-estree': 2.0.0
+      '@typescript-eslint/experimental-utils': 2.1.0
+      '@typescript-eslint/typescript-estree': 2.1.0
       eslint-visitor-keys: 1.1.0
     dev: false
     engines:
@@ -859,12 +859,12 @@ packages:
     peerDependencies:
       eslint: ^5.0.0 || ^6.0.0
     resolution:
-      integrity: sha512-ibyMBMr0383ZKserIsp67+WnNVoM402HKkxqXGlxEZsXtnGGurbnY90pBO3e0nBUM7chEEOcxUhgw9aPq7fEBA==
-  /@typescript-eslint/parser/2.0.0_eslint@6.2.2:
+      integrity: sha512-0+hzirRJoqE1T4lSSvCfKD+kWjIpDWfbGBiisK5CENcr+22pPkHB2sfV1giON+UxHV4A08SSrQonZk7X2zIQdw==
+  /@typescript-eslint/parser/2.1.0_eslint@6.2.2:
     dependencies:
       '@types/eslint-visitor-keys': 1.0.0
-      '@typescript-eslint/experimental-utils': 2.0.0_eslint@6.2.2
-      '@typescript-eslint/typescript-estree': 2.0.0
+      '@typescript-eslint/experimental-utils': 2.1.0_eslint@6.2.2
+      '@typescript-eslint/typescript-estree': 2.1.0
       eslint: 6.2.2
       eslint-visitor-keys: 1.1.0
     dev: false
@@ -873,16 +873,18 @@ packages:
     peerDependencies:
       eslint: ^5.0.0 || ^6.0.0
     resolution:
-      integrity: sha512-ibyMBMr0383ZKserIsp67+WnNVoM402HKkxqXGlxEZsXtnGGurbnY90pBO3e0nBUM7chEEOcxUhgw9aPq7fEBA==
-  /@typescript-eslint/typescript-estree/2.0.0:
+      integrity: sha512-0+hzirRJoqE1T4lSSvCfKD+kWjIpDWfbGBiisK5CENcr+22pPkHB2sfV1giON+UxHV4A08SSrQonZk7X2zIQdw==
+  /@typescript-eslint/typescript-estree/2.1.0:
     dependencies:
+      glob: 7.1.4
+      is-glob: 4.0.1
       lodash.unescape: 4.0.1
       semver: 6.3.0
     dev: false
     engines:
       node: ^8.10.0 || ^10.13.0 || >=11.10.1
     resolution:
-      integrity: sha512-NXbmzA3vWrSgavymlzMWNecgNOuiMMp62MO3kI7awZRLRcsA1QrYWo6q08m++uuAGVbXH/prZi2y1AWuhSu63w==
+      integrity: sha512-482ErJJ7QYghBh+KA9G+Fwcuk/PLTy+9NBMz8S+6UFrUUnVvHRNAL7I70kdws2te0FBYEZW7pkDaXoT+y8UARw==
   /@yarnpkg/lockfile/1.0.2:
     dev: false
     resolution:
@@ -9883,7 +9885,7 @@ packages:
     dev: false
     name: '@rush-temp/api-documenter-test'
     resolution:
-      integrity: sha512-DiH9X1lVwWJttJ9mnIXEJXW6Hc1Avoh4NNzIqhQ3vz0mL5DycyT9WMfbtADlW5wXXNf7BAuVTpZAk73Tszwatg==
+      integrity: sha512-rVlMGGENSkKngBjZbfCgOrRJo67HNrYD6VXju1j/o2ORgzHn8LQhb2cPC90IrRZ7hitl0G893TmHYAmqKibdjw==
       tarball: 'file:projects/api-documenter-test.tgz'
     version: 0.0.0
   'file:projects/api-documenter.tgz':
@@ -9899,7 +9901,7 @@ packages:
     dev: false
     name: '@rush-temp/api-documenter'
     resolution:
-      integrity: sha512-jUDoIgYow5D5wjAbGl5PyuQtBWPbnTCVvHrnsPa1Od6XSNyn4QuSoPd0flbfnFQ3yMNrbsfi6c7RDLMBOCV7fA==
+      integrity: sha512-5zWUmDkGwML3x/VOXpt6l3sgdMjtqX41GvOfhG3IoK2ZyVXHRegAVwcoyn0QUJLCtoUAobKeKPTSHaFd2Vne+Q==
       tarball: 'file:projects/api-documenter.tgz'
     version: 0.0.0
   'file:projects/api-extractor-lib1-test.tgz':
@@ -9911,7 +9913,7 @@ packages:
     dev: false
     name: '@rush-temp/api-extractor-lib1-test'
     resolution:
-      integrity: sha512-HwlXev/5iZ1cqJ5YiDKwAEJzswiy6ASmoRbwNK8EgoV2ulskgJN/AUfljO4HCGFslveSHHJ7aQCq018xR0wNmg==
+      integrity: sha512-K7XBN3UkMPQvg4FTtWWuAoofwvq8tjBTIISlFcxuJdbMMvG7p0hbwNViA/JftEIh+qi4vHJzBRf0GmF1zv0xzQ==
       tarball: 'file:projects/api-extractor-lib1-test.tgz'
     version: 0.0.0
   'file:projects/api-extractor-lib2-test.tgz':
@@ -9923,7 +9925,7 @@ packages:
     dev: false
     name: '@rush-temp/api-extractor-lib2-test'
     resolution:
-      integrity: sha512-R7mgIZp90sgI8j6m8WiYXuHkffnxU4Dd2btSlvGxopUzilpiprFCpL78acnm8/8WqADfRGCDZJRsDWurFWMLuA==
+      integrity: sha512-6Ct129gDZnw+kpm9rpAW0zK/fcE2pn/69nPWgWtHTQC/GO2/ElvzyMMfRXvuLtw0jUB+ZMqCQQGsv167LH/ohQ==
       tarball: 'file:projects/api-extractor-lib2-test.tgz'
     version: 0.0.0
   'file:projects/api-extractor-lib3-test.tgz':
@@ -9935,7 +9937,7 @@ packages:
     dev: false
     name: '@rush-temp/api-extractor-lib3-test'
     resolution:
-      integrity: sha512-x1mpKFTgs1oG53xga8nLd9SIRCgVsBgdgKZW87U0bPdJYNqA7UXRlBA5Y//nWRiXI+E3sZgINryUjcedIGS1Sw==
+      integrity: sha512-WCpSgWUYD1Ogvx3DOfNU+OLv0Sy1NgcSkReg170FukWymY8YjUGXadatjxSEN60Z/V5l7uP0RBqUeTjT0/mHAA==
       tarball: 'file:projects/api-extractor-lib3-test.tgz'
     version: 0.0.0
   'file:projects/api-extractor-model.tgz':
@@ -9964,7 +9966,7 @@ packages:
     dev: false
     name: '@rush-temp/api-extractor-scenarios'
     resolution:
-      integrity: sha512-LZ6QSi73PWgixHzt5JekhcAi+8BMO6qflYJnbC+Z/ZdFPWRhz8hFj8JZSYgj1LynmoBNQQBAseLRHOdSPUsgrQ==
+      integrity: sha512-yf1icwqtjZadZWwjj3g/FiaG9Xb78liwkDjl6nMVQNKxpCR14hOcQNjvPte+8wydv+8/jI1d8n7e3LNdEeDt6A==
       tarball: 'file:projects/api-extractor-scenarios.tgz'
     version: 0.0.0
   'file:projects/api-extractor-test-01.tgz':
@@ -9978,7 +9980,7 @@ packages:
     dev: false
     name: '@rush-temp/api-extractor-test-01'
     resolution:
-      integrity: sha512-AcdnZ0n39Ms3xKGSiB4tsBd5+vIUN3yL2fpKJ4wJr9r0y4wxZqAoCtF3kbN3wgjSHNLp5LFIpjrvZ5AuHcU+6w==
+      integrity: sha512-mhfRvBiy1KRA1o7pW/8I3uH/5oYn0lq/oIHMLK4gwky9Vgv5BP2zjDI0kZ3OhxOCVLYzzVQtnxcUcVCz73VhOg==
       tarball: 'file:projects/api-extractor-test-01.tgz'
     version: 0.0.0
   'file:projects/api-extractor-test-02.tgz':
@@ -9991,7 +9993,7 @@ packages:
     dev: false
     name: '@rush-temp/api-extractor-test-02'
     resolution:
-      integrity: sha512-Mye8nSy9z78Pq9GT2SSfZNCuhlLUsu/P5x9URMdx2dYefWRVwxN4FAUM7w5moni4619gIJpy6JtNEV+Ug63Ijw==
+      integrity: sha512-0sm1UmTyWxqhsQ7sLdVU3PEBiyw7zgtxI9caDVkW0RZcnwBkjjyp4eBc3RUk/IZVtcdXjogQQ7I9e4tkOlNDzg==
       tarball: 'file:projects/api-extractor-test-02.tgz'
     version: 0.0.0
   'file:projects/api-extractor-test-03.tgz':
@@ -10013,7 +10015,7 @@ packages:
     dev: false
     name: '@rush-temp/api-extractor-test-04'
     resolution:
-      integrity: sha512-/D8ugc9FnJSFOips5NSAKMuDAV9jaVBbXhD5v++rmrvjUWsGJaH380nhwoogGapw9gZhLWM4x496FRllVWkRYw==
+      integrity: sha512-QwebvPjUbPNhcd5cTvKxgLybXaWgvRNeFDHX43EDuZ8ttLPI5TEijVB88J374+Fc+PWbaTRCD00MzacxET0QBA==
       tarball: 'file:projects/api-extractor-test-04.tgz'
     version: 0.0.0
   'file:projects/api-extractor.tgz':
@@ -10038,10 +10040,10 @@ packages:
     version: 0.0.0
   'file:projects/eslint-config-scalable-ts.tgz':
     dependencies:
-      '@typescript-eslint/eslint-plugin': 2.0.0_d51a29263799c2687000fd5b6fe704f3
-      '@typescript-eslint/experimental-utils': 2.0.0_eslint@6.2.2
-      '@typescript-eslint/parser': 2.0.0_eslint@6.2.2
-      '@typescript-eslint/typescript-estree': 2.0.0
+      '@typescript-eslint/eslint-plugin': 2.1.0_c10ced963ec7292cbfc7658a8880d356
+      '@typescript-eslint/experimental-utils': 2.1.0_eslint@6.2.2
+      '@typescript-eslint/parser': 2.1.0_eslint@6.2.2
+      '@typescript-eslint/typescript-estree': 2.1.0
       eslint: 6.2.2
       eslint-plugin-promise: 4.2.1
       eslint-plugin-react: 7.14.3_eslint@6.2.2
@@ -10050,7 +10052,7 @@ packages:
     dev: false
     name: '@rush-temp/eslint-config-scalable-ts'
     resolution:
-      integrity: sha512-fTj+JuyD3pIxy4Htj/aKVAkgId+mnTau9fUk65mxsRF0C0oq7wYvd4B4H8ugEvjAiSL8WKocrACifj2V5r05Dg==
+      integrity: sha512-+S5O3Hya0qGtGuIpTbiEJ4RUp6aOPz5p68ntQvqw0r5NlxRTLSV9++ii1NADgyuo/E3LG08XpJjbwbL8vAw58w==
       tarball: 'file:projects/eslint-config-scalable-ts.tgz'
     version: 0.0.0
   'file:projects/gulp-core-build-mocha.tgz':
@@ -10092,7 +10094,7 @@ packages:
     dev: false
     name: '@rush-temp/gulp-core-build-sass'
     resolution:
-      integrity: sha512-/GIU7ybgWUsdJPZ1J9eBDq6XZw4jAdk/sKwmYmXM40fXa4syubWnO+VrfER077IOYlj2QGZkTwSwYjBI5vsHEw==
+      integrity: sha512-1hvRKS8qDB67mkfQ4oAJT52MgZuDnGF+P/FEMCsn+2rCahYhMjzPbYkLjHCEOFrkjPsUU+HMgNeO36kCZW8gow==
       tarball: 'file:projects/gulp-core-build-sass.tgz'
     version: 0.0.0
   'file:projects/gulp-core-build-serve.tgz':
@@ -10118,7 +10120,7 @@ packages:
     dev: false
     name: '@rush-temp/gulp-core-build-serve'
     resolution:
-      integrity: sha512-0nif8o/vLt2Y9rkVbqDAcn7UBwnUQoFgOwn9jTokvySIk3xm1X6SgpysPird3lhinZ8f1rtXIGDznjcVj6nLPw==
+      integrity: sha512-Y3VmDzpaxx5AXrIyNZdrdHk8j/1iku2e4AqoQEspmiLQX7WiLCwrtirhRfMYQcG14oAxdKnhFa7eH7OY52McUw==
       tarball: 'file:projects/gulp-core-build-serve.tgz'
     version: 0.0.0
   'file:projects/gulp-core-build-typescript.tgz':
@@ -10138,7 +10140,7 @@ packages:
     dev: false
     name: '@rush-temp/gulp-core-build-typescript'
     resolution:
-      integrity: sha512-/LBnoHLDKPpZK6EGeG/Nn3smNipd2ZGF4mW+/wpTWzcpApuFddrbBg+e/V0ica2qh9EO95V8ItXqbPWbZfqO1A==
+      integrity: sha512-WzEpi0hhWbx6JKci62P2upvPeHUBO/MF6+fftJEX6DdPIdzcZlATST/xW48nUdyTQdD3T2KwzlDmtUb59c9tNA==
       tarball: 'file:projects/gulp-core-build-typescript.tgz'
     version: 0.0.0
   'file:projects/gulp-core-build-webpack.tgz':
@@ -10155,7 +10157,7 @@ packages:
     dev: false
     name: '@rush-temp/gulp-core-build-webpack'
     resolution:
-      integrity: sha512-xqPSqg7jOasv86Tblad20g6O52dORxjKdPJ5iRAYKA4ilwK58md1YeGYRHqclVD6FQrE3ZAtquZw5t/n29XCBA==
+      integrity: sha512-kTlAKaHrpfOl2tx4PgwErHJjhJ4AIMWDNXlgcTYaXpsW+6hf3G+1Mo3K1jo6rTr+KySr8MF9d75BAiUH6jbbpg==
       tarball: 'file:projects/gulp-core-build-webpack.tgz'
     version: 0.0.0
   'file:projects/gulp-core-build.tgz':
@@ -10215,7 +10217,7 @@ packages:
     dev: false
     name: '@rush-temp/load-themed-styles'
     resolution:
-      integrity: sha512-F7Tsur9QP0WlKAQJrLaXpldsWp4t18uSQolO0ZVVIQghSrUlFnlYM4zfZbTqsC1U6JneK+pP9ywt+4V0X96v+w==
+      integrity: sha512-nkkScLcXPYss3nl/MAOJDxK9fJW+ZoB6e/7SExqyXwvfzXI0Va7p/gAkLX2gx9mYfMBXbJcLygwwP1GzDzxqLg==
       tarball: 'file:projects/load-themed-styles.tgz'
     version: 0.0.0
   'file:projects/loader-load-themed-styles.tgz':
@@ -10230,7 +10232,7 @@ packages:
     dev: false
     name: '@rush-temp/loader-load-themed-styles'
     resolution:
-      integrity: sha512-LYMQW2asjmalfNhq0ldAFRlW4OBYIH1eHmILjqOqRFITX4AeJBgBvK04SeTsRchasl9NYIDdtxcf8eyWaRW4zQ==
+      integrity: sha512-CW22gM1ZOlsv4rbHmjkXf4zD5aHm6MxqqATI6HQ7uqm7xD8Xg3Ehpdk2rmFuG3LjSatqBP97WVXdchVih50STQ==
       tarball: 'file:projects/loader-load-themed-styles.tgz'
     version: 0.0.0
   'file:projects/loader-raw-script.tgz':
@@ -10244,7 +10246,7 @@ packages:
     dev: false
     name: '@rush-temp/loader-raw-script'
     resolution:
-      integrity: sha512-fk2hGquymSv127b+Ux1e6YMIEnL1CDSbF9LZAFdYMtxdThDFaF4vW1P7ipzlniUT9ernuitzd9nEICOc3YRIBw==
+      integrity: sha512-bL1MfpfGIQ2iZZmsHFF1CLf9MDf1PzEtcmKVrtb82ETQhXaLXgYNEShX5Ccn2fFFw45AfecMec8CW487vQRwZw==
       tarball: 'file:projects/loader-raw-script.tgz'
     version: 0.0.0
   'file:projects/loader-set-webpack-public-path.tgz':
@@ -10260,7 +10262,7 @@ packages:
     dev: false
     name: '@rush-temp/loader-set-webpack-public-path'
     resolution:
-      integrity: sha512-d/Yme0VipREkmwW8ly1Q+z0GO/WTmouN9sOjmYG1XlLXT+F5rlXwlfMmQGL3kPQl8gwVaLQygMWkSHPHXPd0Mw==
+      integrity: sha512-0n2VIg1wsw3wrH5LFq6CqmNfLSQHEnb+maUjf+htv3c996K/tInGNkJEZ8lZthOqOIpK2yFF7CZqfc3uqRqO1g==
       tarball: 'file:projects/loader-set-webpack-public-path.tgz'
     version: 0.0.0
   'file:projects/node-core-library.tgz':
@@ -10293,7 +10295,7 @@ packages:
     dev: false
     name: '@rush-temp/node-library-build-test'
     resolution:
-      integrity: sha512-Q7VqRpW+JL02nUdfp+PN+zJal0daCJYteSazGyuxKbahvL999KU9T+b883i6KQHxZn51TLAI4Y7Qvx0YlGlV+g==
+      integrity: sha512-P6WN3OEr80Lx8wlzCjkUnd+USa8Y3fQSYgnRw6GxPVyTqQyukoh5q9IZA/6lS+Tog6/lZAUbRqj9LkGYpPoekQ==
       tarball: 'file:projects/node-library-build-test.tgz'
     version: 0.0.0
   'file:projects/node-library-build.tgz':
@@ -10304,7 +10306,7 @@ packages:
     dev: false
     name: '@rush-temp/node-library-build'
     resolution:
-      integrity: sha512-RMCc3hQn+2ty3PDkr8wpGfm/KP68JsJD4P32rBawBLL0TEHOqSGqX0rqd8F87Bh6081QVqrAllOrADA7u/oXdg==
+      integrity: sha512-fDVxiJR7zP8wdKOJxa/lPAOsTiXQzpHXnVODbvEriV+Fd7TpO6OS6KN5AKOMkVYBF0UIVRLX6USur2mT8hbUfA==
       tarball: 'file:projects/node-library-build.tgz'
     version: 0.0.0
   'file:projects/package-deps-hash.tgz':
@@ -10317,7 +10319,7 @@ packages:
     dev: false
     name: '@rush-temp/package-deps-hash'
     resolution:
-      integrity: sha512-pOiihwcLZ3PxvFrXUkvpcrlL+EBWlVTiyNFz6KBHnN+sOfk75+YNClLZy4qaZOq4VSc5eZUgunefrYCjzHgQIg==
+      integrity: sha512-zWrGS8ovg1Cf1DeHXQmw2yMGut9YYCQqCff8fGkhEh8lh+nFRjrVwpV3t9pu2H9Lkq9ltHy/XMwEM0WQqVmLwQ==
       tarball: 'file:projects/package-deps-hash.tgz'
     version: 0.0.0
   'file:projects/resolve-chunk-plugin.tgz':
@@ -10330,7 +10332,7 @@ packages:
     dev: false
     name: '@rush-temp/resolve-chunk-plugin'
     resolution:
-      integrity: sha512-faZXEpqT9QjXqzLhNt0lZnHINi2L0VSYI6yQHuMcdUSBwYGQzN4Hl8DjD1iUq6776pqpZmyUIjZ7UkkaNmyCCQ==
+      integrity: sha512-0zf26hfPhE8/BCbY2wi4DbTikVlEvRj32V6yxekYEKDjuL/LXUKYLjhUMQHv02LYj5HowJEi0PpEvjal99pt/g==
       tarball: 'file:projects/resolve-chunk-plugin.tgz'
     version: 0.0.0
   'file:projects/rush-buildxl.tgz':
@@ -10341,7 +10343,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-buildxl'
     resolution:
-      integrity: sha512-swl/504xOPpK70/6UURyZHYDe4hbXdA7RBzNo6x0IySPlizz2RHM8+KHDYvXT2iNpjV/tOrDK2XKWXN/zyqk3g==
+      integrity: sha512-s3NQm634oyV71rKwhl7tt7uAhI0jtGXMUchU1PfoqYp6YyaO6g4Z2ILBym5B+78fSi6LQqsAhDdcqJ4E51oqww==
       tarball: 'file:projects/rush-buildxl.tgz'
     version: 0.0.0
   'file:projects/rush-lib.tgz':
@@ -10384,7 +10386,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-lib'
     resolution:
-      integrity: sha512-Q0URCZTIYmtWJ0L1y1wLiuMrROAe5Hn9RbDgqeoFY6ipfwCVUglUzN0f4aGGfn0nufp3AX8DYZDXmLq2qtIPMQ==
+      integrity: sha512-Njd7pn5YQfb6W+fowcHIIhHDT67qd+obd62rbTG4PQduM2w3X9pqtxgDOy810lLe1Pw2U5RbdC2lDTibu0eJ6w==
       tarball: 'file:projects/rush-lib.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-2.4-library-test.tgz':
@@ -10394,7 +10396,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-2.4-library-test'
     resolution:
-      integrity: sha512-Xowayqh4BPN6z9DN/afv9zvhSsIERTjnx/QynOUZP6RQ7hj8k3qyPRYVkdAo4ClRyviN8+Nf3h0aNJfIDhabmg==
+      integrity: sha512-/d11wHBj1rot0ceOaEyXhuIN6z+ViiRndii48TWMTDMey7hVCFufXmvCXm9RhabOvryOjfXV3kOXCRzcf8I3nA==
       tarball: 'file:projects/rush-stack-compiler-2.4-library-test.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-2.4.tgz':
@@ -10409,7 +10411,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-2.4'
     resolution:
-      integrity: sha512-xtw2qzVKHXwe9u7byl3QCYy+YsXqOIfCj3YYi5O87oernU9/9ITQ5eMolpbTuFfCbuhXwLnB7ReQriesys5L6A==
+      integrity: sha512-Vk6C409VHejQxfA99zT3ENXJnXNwScZRLUNMtY3ZmVxIDuhZcI8PO/A41Zb6IH3Kdw4mGkuDKxDsSuy03ygeBQ==
       tarball: 'file:projects/rush-stack-compiler-2.4.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-2.7-library-test.tgz':
@@ -10419,7 +10421,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-2.7-library-test'
     resolution:
-      integrity: sha512-e1E/ZwRYFiYZ7vzqPJYwd5Vw9nOuOHMcrjLS79U3HFGdTjEAv06Vm2/6iGV956KHzOI9Ob6/4qVZfW8c1InMgg==
+      integrity: sha512-XWECMxUkDblLyy/AMBjpsRtGFlDZ/LSC4WYGK5Qf9UMjQrzNsthd/tfA7kxxjWkj1LkB+7x+ednvDezly70w8Q==
       tarball: 'file:projects/rush-stack-compiler-2.7-library-test.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-2.7.tgz':
@@ -10434,7 +10436,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-2.7'
     resolution:
-      integrity: sha512-zH2e1tmSKTl8t7XMI/tIkmg8sdljJzIvXrzfKpKAnKooVfZvGKgA/t6iW1qSyrtQ2GTBoepXDpRWLEItZHTHkg==
+      integrity: sha512-FEO2v85CBDsB6lp9lypqVxJGJQxTapZ0GOi/eYnoEr0lChUn78fNFF9SL3owvIWRnBCaXUutwMaYoZf2HcYHFw==
       tarball: 'file:projects/rush-stack-compiler-2.7.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-2.8-library-test.tgz':
@@ -10444,7 +10446,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-2.8-library-test'
     resolution:
-      integrity: sha512-wG6i6R3QGe4VfVzO9awsyOe/GXeaOzev8KfC3c8VJZ1cbR5d19jMMt7fkuTTBExZsDJgrBW30W6zoBEF0YI8LQ==
+      integrity: sha512-71hAfUQ/3dh5aHQZDAE5N3/1MxebEHz/cM7zT+uaqT1YasPwN/oezdHYtt/GYm2SqM+XkIv5MYJW5nLOim5Oig==
       tarball: 'file:projects/rush-stack-compiler-2.8-library-test.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-2.8.tgz':
@@ -10459,7 +10461,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-2.8'
     resolution:
-      integrity: sha512-gLpdh5Bj6wM3HblBz0PcmdT/ppZfTswPbhSS/DPUkY5Rh28b+l46gbgRP9mpwbr2GRfHt+J+HrMFo1EuHtEW1A==
+      integrity: sha512-T+4Z1rpYiMzh2fmZspdBAwlyYaOyX0yaTZHXjn15iCP1jRjYEmkAvP4xI1SxHn4a9ugLy0GHY6tPBhst4lUueg==
       tarball: 'file:projects/rush-stack-compiler-2.8.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-2.9-library-test.tgz':
@@ -10469,7 +10471,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-2.9-library-test'
     resolution:
-      integrity: sha512-KFmfDxmIaa5mrhhfMWPLnB9RzpatQQoTPrdUEWUGTLu5YDi2OSw0lPKLVb59M1KHrV7giyULuGzlIA6XpCfm8Q==
+      integrity: sha512-OJ8yMjVt9Uzqkywali9M4Ro9tZkiXaAg6RgaxnbSawSmr+Sigk+En8hNSfi1QvPvxG9efRK/imZNPOvoF7MrTA==
       tarball: 'file:projects/rush-stack-compiler-2.9-library-test.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-2.9.tgz':
@@ -10484,7 +10486,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-2.9'
     resolution:
-      integrity: sha512-xSIlQrzIrC+tMK5jCOfhvndK597BiAtoKfZLmeyogq0+lhcdiIsaBaK1g213JQI1WNXVKtN49p+Y3brlMaFeIQ==
+      integrity: sha512-L9SQawG2c09WUlkFRl78Pw7YpGuqRHrYxHJiKMfWf2Qc7/UPNQ1kR049TPOnXMzWSR5YMLoVWfikUZ0m2bELEQ==
       tarball: 'file:projects/rush-stack-compiler-2.9.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-3.0-library-test.tgz':
@@ -10494,7 +10496,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-3.0-library-test'
     resolution:
-      integrity: sha512-Y93xnqS8GczrOr67Ds0TYv2g+B45nLUzrxMbqeFWlekDKnlHhyFEsPsI1ha5sCa0yB5rHKCOIUe3TPTbWS0+ew==
+      integrity: sha512-Hhui6npOHdr4ayFPKMIx1rGCUU9X08MvkKV2UJnzgK1ejwEOznfuzfuGUCg1PU/N72dQPRlw6R7rarwumneIQQ==
       tarball: 'file:projects/rush-stack-compiler-3.0-library-test.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-3.0.tgz':
@@ -10509,7 +10511,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-3.0'
     resolution:
-      integrity: sha512-kmjbVvIRb815VoDJ3VjOdakT2uloF9KX5T9F23+Fwb/kVuZkCqtRxVHpUW0bG+MVlW63iAA88fvrK/vFT0Do5A==
+      integrity: sha512-LrRLlCzeYkGNVr26Icn7FPtYbdUCokM1bc8lKklju0XGVvXFVB3FjCFl4j4YdavyCa+gkZnfTjm7Z5bc32Nj/g==
       tarball: 'file:projects/rush-stack-compiler-3.0.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-3.1-library-test.tgz':
@@ -10519,7 +10521,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-3.1-library-test'
     resolution:
-      integrity: sha512-nbpIG+GdcdYQs6hecdyw01hzidDboP8XvUfEq+n5O7S1IduJeoLAjmiUg7DV7Yz7hQ3JOLzjn7BdUCZLYdinCA==
+      integrity: sha512-GML0ezfAPozV1sSMR86pMhxEEgTLT63H0ek4KTLjqdyhZtL6sAdTg0/IZAvZyS6wjcAq+byQ8eWT17x4tFCdag==
       tarball: 'file:projects/rush-stack-compiler-3.1-library-test.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-3.1.tgz':
@@ -10534,7 +10536,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-3.1'
     resolution:
-      integrity: sha512-hgTTmgyS370t2g/OvtVRFo0nlmYyB0S97HMgH/Psw6rAaF9oF9fWsoiwZ9q8byJN8APuBRGO88RmYKUIrqtQEw==
+      integrity: sha512-EUUTIZlBHz8l9NvJ30ISdsidXoMlG06WST06qJOUpqoscq0GmkiBa/OAYWzGeseZKhaa/XkIB6Mz9zDO6kQQ7w==
       tarball: 'file:projects/rush-stack-compiler-3.1.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-3.2-library-test.tgz':
@@ -10544,7 +10546,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-3.2-library-test'
     resolution:
-      integrity: sha512-h1fU85j7D2EtstXwDWW4T7v9kyYMoK+TsSsvyAlfTBRusqNCLoetdyLx7jApfZvJq9n8jhYV3mCUY3ytbXwWUg==
+      integrity: sha512-61js+UlSbWbE3tPHVhOPFAzPl0nER/GRKidZ5KrD3CnP7w68Aa2Jf40rCr3739t8EeTUxpok/s+gJl9grkvbJQ==
       tarball: 'file:projects/rush-stack-compiler-3.2-library-test.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-3.2.tgz':
@@ -10559,7 +10561,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-3.2'
     resolution:
-      integrity: sha512-f22Y/CpSZpv2dZwpGVFF8m1YuypLO9vDAZLTrDzIHSbNwONzszaHrc6QRGjQSkTzBwucFSQyRiwhI8xo+cAjkw==
+      integrity: sha512-HdgrZPvgqUMuo/HIRhVvUlK9omVzXXSnADp7lwhcBKUUZLDKnF8htvxC2Mm65acjc1A17m3BQ/my2E2iRbjFhg==
       tarball: 'file:projects/rush-stack-compiler-3.2.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-3.3-library-test.tgz':
@@ -10569,7 +10571,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-3.3-library-test'
     resolution:
-      integrity: sha512-grQtOYKbqxDHzFlJejCjM3Z6dTzj8usJzYrr5GJ767ogZOW0YKiRvDG+Sv2POeAYbmLQRID7gLqFRusDPcp2UQ==
+      integrity: sha512-U/rtawDPAReJeG1Nq1UXUtSjOosSy+5eCDpgufb2XfuTujpmh0Y0Sva0CacSqmnu/HuWZlhXhxRo0TtUjRyMAw==
       tarball: 'file:projects/rush-stack-compiler-3.3-library-test.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-3.3.tgz':
@@ -10584,7 +10586,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-3.3'
     resolution:
-      integrity: sha512-FTwg6sxKigjjeRt3f/GFKeejVBbbEtbmSSwsk0bm8WNPO+2QIi63/cE+hemFjoWOXw4l2gauOavO9SHxLyofyA==
+      integrity: sha512-R/Mr2SRYGzXQeMQSizaZ2az2OXxwFvo8XdbnvL+DjFEjM0pFtjXHzNM1VsfSaH2VtzoFQs76pUeL8zzGpWjqpQ==
       tarball: 'file:projects/rush-stack-compiler-3.3.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-3.4-library-test.tgz':
@@ -10594,7 +10596,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-3.4-library-test'
     resolution:
-      integrity: sha512-WY1PsEOCBcFn5j/pwBCgEcolaLDqKk02Zz2HRxnEmWwAhXjkhecrB6XMHEx4Hw8VebM6EH+A5Jfl8qBrcKTTXA==
+      integrity: sha512-rpkQ/+bLR0P9KerE5nahirL4bKqIjWO2CE3JNyrgTU1uEhQZ7qpDRC5zGxQ14uYB+6NvLojmfCM+A4F7zfnUng==
       tarball: 'file:projects/rush-stack-compiler-3.4-library-test.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-3.4.tgz':
@@ -10609,7 +10611,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-3.4'
     resolution:
-      integrity: sha512-lxfdeebacL7fR/uiSHuPdomKcEQwnPKDAEaTV2R8A3tPV0+KJvznaKb7XToyvl8qN70piy2Q6yD+fNtLHrPRDQ==
+      integrity: sha512-MiGeCCVR5mZ48M8Otcvomm9S3cW+PasP1rAK0BepgMIUTBjZJGfIXLxHksO7F4Sd5huSlipj51GqWYokVTWuYw==
       tarball: 'file:projects/rush-stack-compiler-3.4.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-3.5-library-test.tgz':
@@ -10619,7 +10621,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-3.5-library-test'
     resolution:
-      integrity: sha512-0oaG7OjfAKjNaAvwhbfRxPUTrLTSwCDZ+OsO478URpMZ67+k/qU2ORh6Q/NoOb2VzCvFDUJyixKf5vJcHc//RA==
+      integrity: sha512-6ZgoYX55AH0IqK6H7Xgm2wn4BD92+YINMpg5tNwzRfGIsXL2fTGAQVAyZxY/1rBeMaqRImu4VU21HMj7CaEFVA==
       tarball: 'file:projects/rush-stack-compiler-3.5-library-test.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-3.5.tgz':
@@ -10634,7 +10636,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-compiler-3.5'
     resolution:
-      integrity: sha512-8nQvIzqStzXKYshMqD10IbtLoJJox4l4q9mKhPydUwdyqSMYz/oG/g8c2pB/DfvlvuLsUHLCmSAZ6ayf+beEow==
+      integrity: sha512-dGamOaZW++3B+fW7TDzifIRvk2yM8BPMsUX9DpoB8eT1i+AWAa05jHokxdBMT7bsHX3Yul07IoCMazGLa19kWw==
       tarball: 'file:projects/rush-stack-compiler-3.5.tgz'
     version: 0.0.0
   'file:projects/rush-stack-compiler-shared.tgz':
@@ -10648,7 +10650,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack-library-test'
     resolution:
-      integrity: sha512-ihdMKfSx903gAkBcA2E6aZFM+ZY4gHYHYxeoUnYldkI6QJU73M7kdNGxFFx2hJ+qht67rL4+D0BHYwndj5kacw==
+      integrity: sha512-OSpxvfwmzyy7qbRCS/5ZQKcpJ6TCZOQGC2F5H6c39zN0+MbRFTGI54dI/0TBaDB2iLJS8wLklIU92Kw66BLOsw==
       tarball: 'file:projects/rush-stack-library-test.tgz'
     version: 0.0.0
   'file:projects/rush-stack.tgz':
@@ -10659,7 +10661,7 @@ packages:
     dev: false
     name: '@rush-temp/rush-stack'
     resolution:
-      integrity: sha512-iyToEi4c077p4qdk6WUUD11kxnmxnr+kyNC26fMsO9QLCyRsV27jU35i5Fzp3hjSUf3ppoWM1nYrDl3WWxAMLg==
+      integrity: sha512-rAh3PG7ZX5StFj8qfIVQntYhS0xjvgFwcnP6oeS3Wfg63lQqxFKCjID89l/6iT4mhU1PMrWOBJFC1Al3Zec0hg==
       tarball: 'file:projects/rush-stack.tgz'
     version: 0.0.0
   'file:projects/rush.tgz':
@@ -10677,7 +10679,7 @@ packages:
     dev: false
     name: '@rush-temp/rush'
     resolution:
-      integrity: sha512-8cfs0MC01aQ3cQLSQIDQ3zC7873v5iMh0d8Ay2XS0kcypV5mhlgQL7d54GhbweBE3ryT/qYSdUlfF0YtAA0yEQ==
+      integrity: sha512-IUfA6At0L5d2RtaTJYPLY4U3SR1jbIrm3ou5HmfLbwebFffKl+/zNY+aW7GxXc+lU/JiPCDyzKnH5M1tFAxIKg==
       tarball: 'file:projects/rush.tgz'
     version: 0.0.0
   'file:projects/rushell.tgz':
@@ -10690,7 +10692,7 @@ packages:
     dev: false
     name: '@rush-temp/rushell'
     resolution:
-      integrity: sha512-wEtok2Sj2W71vwhEi9PPzIkSHrv7JDLIDxkqIsFFwfQgS1s2G4jvOwRKUgvauyO47ATtuS5mnc3Tm9/Ua69CKQ==
+      integrity: sha512-1DwhQ6nDSTFKDQ1gIJ7+QcpHwItFw3BURV/vSq1Gp73mnO0hTSgK4CS/3FzoQEp9aXPU51U76PjDgTx0Tdco6g==
       tarball: 'file:projects/rushell.tgz'
     version: 0.0.0
   'file:projects/set-webpack-public-path-plugin.tgz':
@@ -10709,7 +10711,7 @@ packages:
     dev: false
     name: '@rush-temp/set-webpack-public-path-plugin'
     resolution:
-      integrity: sha512-mLm52mjIC7fqaM3I+rm2x7iLX6vC9PtZ/7w/VIHNBJNX4mPZp1HJNI9wz1rqsLfaIZyYzMNMLoVAuoZdwbU/9Q==
+      integrity: sha512-GOnZfyumtv+6NMz0moz/it4WRihljh/oxw4XShio74xS+nkdS9Gns43Tt1uQS335V3PbYoNQNIXaEwwnsSpCLQ==
       tarball: 'file:projects/set-webpack-public-path-plugin.tgz'
     version: 0.0.0
   'file:projects/stream-collator.tgz':
@@ -10724,7 +10726,7 @@ packages:
     dev: false
     name: '@rush-temp/stream-collator'
     resolution:
-      integrity: sha512-OScdbjOHIPeGhH23sDmRq+KqXcCUw1Q/MIYW5bMFC/QhpDG6z3CorCJ6279EK84KjEhRUxmuZAJMtZVzBCI3VA==
+      integrity: sha512-NkNzPGrjBaZgX/GvOUowuyEa2SVMlepQh2CH5nZo1oAeHvj4kNxTNV15II1kf4sUJIxzJNzT0BWn716T51To9w==
       tarball: 'file:projects/stream-collator.tgz'
     version: 0.0.0
   'file:projects/ts-command-line.tgz':
@@ -10751,7 +10753,7 @@ packages:
     dev: false
     name: '@rush-temp/web-library-build-test'
     resolution:
-      integrity: sha512-qwrTHE3EcrckkH2WwGOThpN1L45jypkf0zMGay6xtiH9O6XUWiCl+JSF4Kkjfs5TEDkSjhbL5Wg0faXSizYsBw==
+      integrity: sha512-FJ3CtSmrDExYdjlmeQQeSHtzWgu2WHBV7d2++K8GZyCZsSsWy5ZP/wI82nSdvdWZa8uTXhefODGeGgPizUFSqQ==
       tarball: 'file:projects/web-library-build-test.tgz'
     version: 0.0.0
   'file:projects/web-library-build.tgz':
@@ -10763,9 +10765,10 @@ packages:
     dev: false
     name: '@rush-temp/web-library-build'
     resolution:
-      integrity: sha512-lSWR7HNAKTr2dJdVMgznHqVy5iffGhJYtuN0TIFVYNoSCvWWzBXHr0SyzISeEAYexAQ7Zs6bSjONYHyFw9kb6A==
+      integrity: sha512-2yfv7WRHnlE+u4su6lCUMvJIKVJwtqx/J0pemUmtRvYaWNm+vphJ0CldSwS3vz9uJ8lkNOsBcNR9vARWbacG4g==
       tarball: 'file:projects/web-library-build.tgz'
     version: 0.0.0
+registry: ''
 specifiers:
   '@microsoft/node-library-build': 6.1.2
   '@microsoft/rush-stack-compiler-3.4': 0.1.15
@@ -10874,10 +10877,10 @@ specifiers:
   '@types/webpack-env': 1.13.0
   '@types/yargs': 0.0.34
   '@types/z-schema': 3.16.31
-  '@typescript-eslint/eslint-plugin': 2.0.0
-  '@typescript-eslint/experimental-utils': 2.0.0
-  '@typescript-eslint/parser': 2.0.0
-  '@typescript-eslint/typescript-estree': 2.0.0
+  '@typescript-eslint/eslint-plugin': 2.1.0
+  '@typescript-eslint/experimental-utils': 2.1.0
+  '@typescript-eslint/parser': 2.1.0
+  '@typescript-eslint/typescript-estree': 2.1.0
   '@yarnpkg/lockfile': ~1.0.2
   argparse: ~1.0.9
   autoprefixer: ~9.1.3

--- a/libraries/eslint-config-scalable-ts/package.json
+++ b/libraries/eslint-config-scalable-ts/package.json
@@ -19,10 +19,10 @@
     "typescript": ">=3.0.0"
   },
   "dependencies": {
-    "@typescript-eslint/eslint-plugin": "2.0.0",
-    "@typescript-eslint/experimental-utils": "2.0.0",
-    "@typescript-eslint/parser": "2.0.0",
-    "@typescript-eslint/typescript-estree": "2.0.0",
+    "@typescript-eslint/eslint-plugin": "2.1.0",
+    "@typescript-eslint/experimental-utils": "2.1.0",
+    "@typescript-eslint/parser": "2.1.0",
+    "@typescript-eslint/typescript-estree": "2.1.0",
     "eslint-plugin-promise": "~4.2.1",
     "eslint-plugin-react": "~7.14.3",
     "eslint-plugin-security": "~1.4.0"


### PR DESCRIPTION
This upgrade fixes an incompatibility with the latest TypeScript compiler.  It also includes the fix for https://github.com/typescript-eslint/typescript-eslint/issues/788