### PR TITLE
[eslint-config-scalable-ts] Fix rule that broke compatibility with older TypeScript versions

### DIFF
--- a/common/changes/@microsoft/eslint-config-scalable-ts/octogonz-ecst-fix-array-type_2019-09-04-01-11.json
+++ b/common/changes/@microsoft/eslint-config-scalable-ts/octogonz-ecst-fix-array-type_2019-09-04-01-11.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/eslint-config-scalable-ts",
+      "comment": "Fix an issue where the @typescript-eslint/array-type rule required a syntax that broke compatibility with TypeScript versions prior to 3.4",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@microsoft/eslint-config-scalable-ts",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/libraries/eslint-config-scalable-ts/index.js
+++ b/libraries/eslint-config-scalable-ts/index.js
@@ -33,8 +33,19 @@ module.exports = {
         // STANDARDIZED BY:   @typescript-eslint\eslint-plugin\dist\configs\recommended.json
         "@typescript-eslint/adjacent-overload-signatures": "error",
 
-        // STANDARDIZED BY:   @typescript-eslint\eslint-plugin\dist\configs\recommended.json
-        "@typescript-eslint/array-type": "error",
+        // RATIONALE:         We require "string[]" (instead of "Array<string>") because it is idiomatic TypeScript.
+        //                    We require "ReadonlyArray<string>" (instead of "readonly string[]") because, although
+        //                    the latter form is nicer, it is not supported by TypeScript version prior to 3.4.
+        //                    It can be expensive to upgrade a large code base to use the latest compiler, so our
+        //                    lint rules should not require usage of bleeding edge language features.  In the future
+        //                    when TypeScript 3 is obsolete, we'll change this rule to require "readonly string[]".
+        "@typescript-eslint/array-type": [
+          "error",
+          {
+            default: "array",
+            readonly: "generic"
+          }
+        ],
 
         // STANDARDIZED BY:   @typescript-eslint\eslint-plugin\dist\configs\recommended.json
         //


### PR DESCRIPTION
This fix will help to unblock https://github.com/microsoft/web-build-tools/pull/1496