### PR TITLE
[rush-lib] Fixing issue in publishing when using --pack and --apply-git-tags-on-pack

### DIFF
--- a/apps/rush-lib/src/cli/actions/PublishAction.ts
+++ b/apps/rush-lib/src/cli/actions/PublishAction.ts
@@ -327,6 +327,11 @@ export class PublishAction extends BaseRushAction {
             return;
           }
 
+          // Do not tag packages that already exist. This will fail with a fatal error.
+          if (!this._packageExists(packageConfig)) {
+            return;
+          }
+
           git.addTag(!!this._publish.value && !this._registryUrl.value, packageName, packageConfig.packageJson.version);
           updated = true;
         };

--- a/apps/rush-lib/src/cli/actions/PublishAction.ts
+++ b/apps/rush-lib/src/cli/actions/PublishAction.ts
@@ -328,7 +328,7 @@ export class PublishAction extends BaseRushAction {
           }
 
           // Do not tag packages that already exist. This will fail with a fatal error.
-          if (!this._packageExists(packageConfig)) {
+          if (this._packageExists(packageConfig)) {
             return;
           }
 

--- a/common/changes/@microsoft/rush/master_2019-09-09-18-25.json
+++ b/common/changes/@microsoft/rush/master_2019-09-09-18-25.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Fixing apply git tags during publish when using --pack and the tag already exists (existing tags not re-tagged, same as non --pack publish)",
+      "packageName": "@microsoft/rush",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "chaseholland@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush/master_2019-09-09-18-25.json
+++ b/common/changes/@microsoft/rush/master_2019-09-09-18-25.json
@@ -1,7 +1,7 @@
 {
   "changes": [
     {
-      "comment": "Fix an issue where Rush attempted to add Git tags for packages that had already been published when the publish command is run with the --pack and --apply-git-tags-on-pack flag. This caused a fatal error when tags already existed.",
+      "comment": "Fix an issue where Rush attempted to add Git tags for packages that had already been published when the publish command is run with the --pack and --apply-git-tags-on-pack flags. This caused a fatal error when tags already existed.",
       "packageName": "@microsoft/rush",
       "type": "none"
     }

--- a/common/changes/@microsoft/rush/master_2019-09-09-18-25.json
+++ b/common/changes/@microsoft/rush/master_2019-09-09-18-25.json
@@ -1,7 +1,7 @@
 {
   "changes": [
     {
-      "comment": "Fixing apply git tags during publish when using --pack and the tag already exists (existing tags not re-tagged, same as non --pack publish)",
+      "comment": "ix an issue where Rush attempted to add Git tags for packages that had already been published when the publish command is run with the --pack and --apply-git-tags-on-pack flag. This caused a fatal error when tags already existed.",
       "packageName": "@microsoft/rush",
       "type": "none"
     }

--- a/common/changes/@microsoft/rush/master_2019-09-09-18-25.json
+++ b/common/changes/@microsoft/rush/master_2019-09-09-18-25.json
@@ -1,7 +1,7 @@
 {
   "changes": [
     {
-      "comment": "ix an issue where Rush attempted to add Git tags for packages that had already been published when the publish command is run with the --pack and --apply-git-tags-on-pack flag. This caused a fatal error when tags already existed.",
+      "comment": "Fix an issue where Rush attempted to add Git tags for packages that had already been published when the publish command is run with the --pack and --apply-git-tags-on-pack flag. This caused a fatal error when tags already existed.",
       "packageName": "@microsoft/rush",
       "type": "none"
     }


### PR DESCRIPTION
Resolving an issue where publish would fail when using `--pack` and `--apply-git-tags-on-pack` if the git tag already existed. Now skipping tags for packages that are already published using the same check as non-pack publish flow.