### PR TITLE
[api-documenter] Adjusting package name parser in OfficeYamlDocumenter

### DIFF
--- a/apps/api-documenter/src/documenters/OfficeYamlDocumenter.ts
+++ b/apps/api-documenter/src/documenters/OfficeYamlDocumenter.ts
@@ -73,7 +73,7 @@ export class OfficeYamlDocumenter extends YamlDocumenter {
 
   /** @override */
   protected onCustomizeYamlItem(yamlItem: IYamlItem): void {
-    const nameWithoutPackage: string = yamlItem.uid.replace(/^[^.]+\./, '');
+    const nameWithoutPackage: string = yamlItem.uid.replace(/^[^.]+\!/, '');
     if (yamlItem.summary) {
       yamlItem.summary = this._fixupApiSet(yamlItem.summary, yamlItem.uid);
       yamlItem.summary = this._fixBoldAndItalics(yamlItem.summary);

--- a/common/changes/@microsoft/api-documenter/AlexJ-YAML_2019-09-11-16-31.json
+++ b/common/changes/@microsoft/api-documenter/AlexJ-YAML_2019-09-11-16-31.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-documenter",
+      "comment": "Updating OfficeYamlDocumenter to account for new deeply linked types",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/api-documenter",
+  "email": "AlexJerabek@users.noreply.github.com"
+}


### PR DESCRIPTION
PR #1337 changed the format of UIDs. We currently parse out the package name in the OfficeYamlDocumenter. The syntax changed from `excel.Excel.foo` to `excel!Excel.foo`, so the regex needs to changed accordingly.