### PR TITLE
[ts-command-line] Add a missing dependency to ts-command-line.

### DIFF
--- a/common/changes/@microsoft/ts-command-line/ianc-fix-argparse-types_2019-09-24-02-26.json
+++ b/common/changes/@microsoft/ts-command-line/ianc-fix-argparse-types_2019-09-24-02-26.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/ts-command-line",
+      "comment": "Add back a missing dependency.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/ts-command-line",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/libraries/ts-command-line/package.json
+++ b/libraries/ts-command-line/package.json
@@ -13,11 +13,11 @@
   },
   "license": "MIT",
   "dependencies": {
+    "@types/argparse": "1.0.33",
     "argparse": "~1.0.9",
     "colors": "~1.2.1"
   },
   "devDependencies": {
-    "@types/argparse": "1.0.33",
     "@types/jest": "23.3.11",
     "@types/node": "8.10.54",
     "gulp": "~4.0.2",


### PR DESCRIPTION
This fixes https://github.com/microsoft/web-build-tools/issues/1539.