### PR TITLE
Collapse manual redirect chain for news

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 _**This repo hosts a collection of tools and libraries used to build web projects at Microsoft.**_
 
-- **[CURRENT NEWS](https://github.com/Microsoft/web-build-tools/wiki)**:  See what's happening with the **web-build-tools** projects!
+- **[CURRENT NEWS](https://github.com/Microsoft/web-build-tools/blob/master/apps/rush/CHANGELOG.md)**:  See what's happening with the **web-build-tools** projects!
 
 Highlighted projects:
 


### PR DESCRIPTION
Really incredibly simple one, but I keep on having to click through each iteration of the changelog page, each linking to a new location for the changelog. It appears that `https://github.com/Microsoft/web-build-tools/blob/master/apps/rush/CHANGELOG.md` is the current version.